### PR TITLE
Remove supressClosable option from docs

### DIFF
--- a/packages/docs/docs/components/dockview.mdx
+++ b/packages/docs/docs/components/dockview.mdx
@@ -162,7 +162,6 @@ const MyComponent = (props: IDockviewPanelProps<{ title: string }>) => {
 | group                  | `GroupPanel                                                 | undefined`       |
 | isGroupActive          | `boolean`                                                   |                  |
 | title                  | `string`                                                    |                  |
-| suppressClosable       | `boolean`                                                   |                  |
 | close                  | `(): void`                                                  |                  |
 | setTitle               | `(title: string): void`                                     |                  |
 


### PR DESCRIPTION
Removes unsupported option supressClosable from docs