### PR TITLE
feat: add remainIfEmpty options to DockviewGroupPanel

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -754,6 +754,8 @@ export class DockviewComponent
                     hideHeader: !!hideHeader,
                 });
 
+                group.remainIfEmpty = data.remainIfEmpty;
+
                 const createdPanels: IDockviewPanel[] = [];
 
                 for (const child of views) {
@@ -1044,7 +1046,7 @@ export class DockviewComponent
             panel.dispose();
         }
 
-        if (group.size === 0 && options.removeEmptyGroup) {
+        if (group.size === 0 && options.removeEmptyGroup && !group.remainIfEmpty) {
             this.removeGroup(group);
         }
     }

--- a/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
@@ -59,6 +59,8 @@ export class DockviewGroupPanel
         return this._model.header;
     }
 
+    remainIfEmpty?: boolean
+
     constructor(
         accessor: DockviewComponent,
         id: string,

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -61,6 +61,7 @@ export interface GroupOptions extends CoreGroupOptions {
 }
 
 export interface GroupPanelViewState extends CoreGroupOptions {
+    remainIfEmpty?: boolean;
     views: string[];
     activeView?: string;
     id: string;

--- a/packages/docs/docs/components/dockview.mdx
+++ b/packages/docs/docs/components/dockview.mdx
@@ -28,6 +28,7 @@ import DockviewWithIFrames from '@site/sandboxes/iframe-dockview/src/app';
 import DockviewFloating from '@site/sandboxes/floatinggroup-dockview/src/app';
 import DockviewLockedGroup from '@site/sandboxes/lockedgroup-dockview/src/app';
 import DockviewKeyboard from '@site/sandboxes/keyboard-dockview/src/app';
+import DockviewRemainEmptyGroup from '@site/sandboxes/remain-emptygroup/src/app';
 
 import { DocRef, Markdown } from '@site/src/components/ui/reference/docRef';
 
@@ -814,6 +815,20 @@ api.group.api.setConstraints(...)
     height={500}
     sandboxId="constraints-dockview"
     react={DockviewConstraints}
+/>
+
+### Keep Empty Group
+
+Sometimes, you may want to keep the group when the last child of the group was removed. Just mark the group property `remainIfEmpty` to true.
+
+```tsx
+panel5.group.remainIfEmpty = true;
+```
+
+<MultiFrameworkContainer
+    height={500}
+    sandboxId="remain-emptygroup"
+    react={DockviewRemainEmptyGroup}
 />
 
 ## iFrames

--- a/packages/docs/sandboxes/remain-emptygroup/package.json
+++ b/packages/docs/sandboxes/remain-emptygroup/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "remain-emptygroup",
+  "description": "",
+  "keywords": [
+    "dockview"
+  ],
+  "version": "1.0.0",
+  "main": "src/index.tsx",
+  "dependencies": {
+    "dockview": "*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^4.9.5",
+    "react-scripts": "*"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/packages/docs/sandboxes/remain-emptygroup/public/index.html
+++ b/packages/docs/sandboxes/remain-emptygroup/public/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+	<meta name="theme-color" content="#000000">
+	<!--
+      manifest.json provides metadata used when your web app is added to the
+      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+    -->
+	<link rel="manifest" href="%PUBLIC_URL%/manifest.json">
+	<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+	<!--
+      Notice the use of %PUBLIC_URL% in the tags above.
+      It will be replaced with the URL of the `public` folder during the build.
+      Only files inside the `public` folder can be referenced from the HTML.
+
+      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      work correctly both with client-side routing and a non-root public URL.
+      Learn how to configure a non-root public URL by running `npm run build`.
+    -->
+	<title>React App</title>
+</head>
+
+<body>
+	<noscript>
+		You need to enable JavaScript to run this app.
+	</noscript>
+	<div id="root"></div>
+	<!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+
+      To begin the development, run `npm start` or `yarn start`.
+      To create a production bundle, use `npm run build` or `yarn build`.
+    -->
+</body>
+
+</html>

--- a/packages/docs/sandboxes/remain-emptygroup/src/app.tsx
+++ b/packages/docs/sandboxes/remain-emptygroup/src/app.tsx
@@ -1,0 +1,97 @@
+import {
+    DockviewReact,
+    DockviewReadyEvent,
+    IDockviewPanelProps,
+} from 'dockview';
+import * as React from 'react';
+
+const components = {
+    default: (props: IDockviewPanelProps<{ title: string }>) => {
+        return (
+            <div style={{ padding: '20px', color: 'white' }}>
+                {props.params.title}
+            </div>
+        );
+    },
+};
+
+export const App: React.FC = (props: { theme?: string }) => {
+    const onReady = (event: DockviewReadyEvent) => {
+        const panel = event.api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            params: {
+                title: 'Panel 1',
+            },
+        });
+
+        panel.group.locked = true;
+        panel.group.header.hidden = true;
+
+        event.api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            params: {
+                title: 'Panel 2',
+            },
+        });
+
+        event.api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            params: {
+                title: 'Panel 3',
+            },
+        });
+
+        event.api.addPanel({
+            id: 'panel_4',
+            component: 'default',
+            params: {
+                title: 'Panel 4',
+            },
+            position: { referencePanel: 'panel_1', direction: 'right' },
+        });
+
+        const panel5 = event.api.addPanel({
+            id: 'panel_5',
+            component: 'default',
+            params: {
+                title: 'Panel 5',
+            },
+            position: { referencePanel: 'panel_3', direction: 'right' },
+        });
+        panel5.group.remainIfEmpty = true;
+
+        // panel5.group!.model.header.hidden = true;
+        // panel5.group!.model.locked = true;
+
+        event.api.addPanel({
+            id: 'panel_6',
+            component: 'default',
+            params: {
+                title: 'Panel 6',
+            },
+            position: { referencePanel: 'panel_5', direction: 'below' },
+        });
+
+        event.api.addPanel({
+            id: 'panel_7',
+            component: 'default',
+            params: {
+                title: 'Panel 7',
+            },
+            position: { referencePanel: 'panel_6', direction: 'right' },
+        });
+    };
+
+    return (
+        <DockviewReact
+            components={components}
+            onReady={onReady}
+            className={props.theme || 'dockview-theme-abyss'}
+        />
+    );
+};
+
+export default App;

--- a/packages/docs/sandboxes/remain-emptygroup/src/index.tsx
+++ b/packages/docs/sandboxes/remain-emptygroup/src/index.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from 'react';
+import * as ReactDOMClient from 'react-dom/client';
+import './styles.css';
+import 'dockview/dist/styles/dockview.css';
+
+import App from './app';
+
+const rootElement = document.getElementById('root');
+
+if (rootElement) {
+    const root = ReactDOMClient.createRoot(rootElement);
+
+    root.render(
+        <StrictMode>
+            <div className="app">
+                <App />
+            </div>
+        </StrictMode>
+    );
+}

--- a/packages/docs/sandboxes/remain-emptygroup/src/styles.css
+++ b/packages/docs/sandboxes/remain-emptygroup/src/styles.css
@@ -1,0 +1,16 @@
+body {
+  margin: 0px;
+  color: white;
+  font-family: sans-serif;
+  text-align: center;
+}
+
+#root {
+  height: 100vh;
+  width: 100vw;
+}
+
+.app {
+  height: 100%;
+
+}

--- a/packages/docs/sandboxes/remain-emptygroup/tsconfig.json
+++ b/packages/docs/sandboxes/remain-emptygroup/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "outDir": "build/dist",
+        "module": "esnext",
+        "target": "es5",
+        "lib": ["es6", "dom"],
+        "sourceMap": true,
+        "allowJs": true,
+        "jsx": "react-jsx",
+        "moduleResolution": "node",
+        "rootDir": "src",
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true
+    }
+}


### PR DESCRIPTION
Make this removeEmptyGroup configurable via group model, with this pr, we can keep group remain when group has no children by set `group.remainIfEmpty = true`.

I'm not sure this new property will cause problem or not, can you do the review? @mathuo 

#402