### PR TITLE
Add window-lifecycle callbacks

### DIFF
--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -830,6 +830,8 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         options?: {
             position?: Box;
             popoutUrl?: string;
+            onOpened?: (id: string, window: Window) => void;
+            onClosing?: (id: string, window: Window) => void;
         }
     ): void {
         this.component.addPopoutGroup(item, options);

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -286,6 +286,8 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
         options?: {
             position?: Box;
             popoutUrl?: string;
+            onOpened?: (id: string, window: Window) => void;
+            onClosing?: (id: string, window: Window) => void;
         }
     ): void;
 }
@@ -513,6 +515,8 @@ export class DockviewComponent
             skipRemoveGroup?: boolean;
             position?: Box;
             popoutUrl?: string;
+            onOpened?: (id: string, window: Window) => void;
+            onClosing?: (id: string, window: Window) => void;
         }
     ): void {
         let group: DockviewGroupPanel;
@@ -561,6 +565,8 @@ export class DockviewComponent
                     width: box.width,
                     height: box.height,
                 },
+                onOpened: options?.onOpened,
+                onClosing: options?.onClosing
             }
         );
 

--- a/packages/dockview-core/src/dockview/dockviewPopoutGroupPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewPopoutGroupPanel.ts
@@ -13,6 +13,8 @@ export class DockviewPopoutGroupPanel extends CompositeDisposable {
             className: string;
             popoutUrl: string;
             box: Box;
+            onOpened?: (id: string, window: Window) => void;
+            onClosing?: (id: string, window: Window) => void;
         }
     ) {
         super();
@@ -23,6 +25,8 @@ export class DockviewPopoutGroupPanel extends CompositeDisposable {
             top: this.options.box.top,
             width: this.options.box.width,
             height: this.options.box.height,
+            onOpened: this.options.onOpened,
+            onClosing: this.options.onClosing,
         });
 
         group.model.location = 'popout';

--- a/packages/dockview-core/src/popoutWindow.ts
+++ b/packages/dockview-core/src/popoutWindow.ts
@@ -5,6 +5,8 @@ import { Box } from './types';
 
 export type PopoutWindowOptions = {
     url: string;
+    onOpened?: (id: string, window: Window) => void;
+    onClosing?: (id: string, window: Window) => void;
 } & Box;
 
 export class PopoutWindow extends CompositeDisposable {
@@ -42,6 +44,10 @@ export class PopoutWindow extends CompositeDisposable {
 
     close(): void {
         if (this._window) {
+            if (this.options.onClosing) {
+                this.options.onClosing(this.id, this._window.value);
+            }
+
             this._window.disposable.dispose();
             this._window.value.close();
             this._window = null;
@@ -114,5 +120,9 @@ export class PopoutWindow extends CompositeDisposable {
                 cleanUp();
             });
         });
+
+        if (this.options.onOpened) {
+            this.options.onOpened(this.id, externalWindow);
+        }
     }
 }


### PR DESCRIPTION
[[Copy of original PR](https://github.com/mathuo/dockview/pull/467); changed target from master to 469-add-window-lifecycle-callbacks]

This PR adds the ability for users to tap into window-lifecycle events associated with groups that are popped-out or popped-in. Specifically, the PR makes changes such that the user can provide handlers for when a window has opened, and when a window is about to close.

This is particularly useful when the user needs to get a handle to the Window object of the popped-out window.