### PR TITLE
Set width and height correctly when calling layout for floating panels

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -979,7 +979,7 @@ export class DockviewComponent
                 // this is either a resize or a move
                 // to inform the panels .layout(...) the group with it's current size
                 // don't care about resize since the above watcher handles that
-                group.layout(group.height, group.width);
+                group.layout(group.width, group.height);
             }),
             overlay.onDidChangeEnd(() => {
                 this._bufferOnDidLayoutChange.fire();


### PR DESCRIPTION
Width and height were swapped when calling layout for floating panels. This sometimes resulted in swapped width and height info from the API after resizing or moving floating panels (first is width, second is height in the image):

![mstsc_2024-04-18_11-43-46](https://github.com/mathuo/dockview/assets/304384/4833c89e-3fa0-477e-bbed-d06fb585453d)

This PR fixes the bug.