### PR TITLE
bug: --group-gap-size overflow fix

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.scss
+++ b/packages/dockview-core/src/dockview/dockviewComponent.scss
@@ -19,11 +19,15 @@
         &.horizontal {
             > .view-container > .view {
                 &:not(:last-child) {
-                    border-right: var(--dv-group-gap-size) solid transparent;
+                    .groupview {
+                        border-right: var(--dv-group-gap-size) solid transparent;
+                    }
                 }
 
                 &:not(:first-child) {
-                    border-left: var(--dv-group-gap-size) solid transparent;
+                    .groupview {
+                        border-left: var(--dv-group-gap-size) solid transparent;
+                    }
                 }
             }
         }
@@ -31,11 +35,16 @@
         &.vertical {
             > .view-container > .view {
                 &:not(:last-child) {
-                    border-bottom: var(--dv-group-gap-size) solid transparent;
+                    .groupview {
+                        border-bottom: var(--dv-group-gap-size) solid
+                            transparent;
+                    }
                 }
 
                 &:not(:first-child) {
-                    border-top: var(--dv-group-gap-size) solid transparent;
+                    .groupview {
+                        border-top: var(--dv-group-gap-size) solid transparent;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Quick attempt to fix. I think it works but need to confirm, applies the CSS to the "tab-group" which sits in a split-view view element rather than applying it to the view element directly 

<img width="1211" alt="image" src="https://github.com/mathuo/dockview/assets/6710312/74bff22f-a315-4322-9240-f086bbd3f7ae">
