### PR TITLE
Allow right and bottom anchored floating groups

### DIFF
--- a/packages/dockview-core/src/__tests__/dnd/overlay.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/overlay.spec.ts
@@ -1,7 +1,14 @@
 import { Overlay } from '../../dnd/overlay';
 
+const mockGetBoundingClientRect = ({ left, top, height, width }: { left: number, top: number, height: number, width: number }) => {
+    const result = { left, top, height, width, right: left + width, bottom: top + height, x: left, y: top };
+    return {
+        ...result, toJSON: () => (result)
+    }
+}
+
 describe('overlay', () => {
-    test('toJSON', () => {
+    test('toJSON, top left', () => {
         const container = document.createElement('div');
         const content = document.createElement('div');
 
@@ -23,11 +30,11 @@ describe('overlay', () => {
             container.childNodes.item(0) as HTMLElement,
             'getBoundingClientRect'
         ).mockImplementation(() => {
-            return { left: 80, top: 100, width: 40, height: 50 } as any;
+            return mockGetBoundingClientRect({ left: 80, top: 100, width: 40, height: 50 });
         });
         jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
             () => {
-                return { left: 20, top: 30, width: 100, height: 100 } as any;
+                return mockGetBoundingClientRect({ left: 20, top: 30, width: 100, height: 100 });
             }
         );
 
@@ -39,7 +46,45 @@ describe('overlay', () => {
         });
     });
 
-    test('that out-of-bounds dimensions are fixed', () => {
+    test('toJSON, bottom right', () => {
+        const container = document.createElement('div');
+        const content = document.createElement('div');
+
+        document.body.appendChild(container);
+        container.appendChild(content);
+
+        const cut = new Overlay({
+            height: 200,
+            width: 100,
+            right: 10,
+            bottom: 20,
+            minimumInViewportWidth: 0,
+            minimumInViewportHeight: 0,
+            container,
+            content,
+        });
+
+        jest.spyOn(
+            container.childNodes.item(0) as HTMLElement,
+            'getBoundingClientRect'
+        ).mockImplementation(() => {
+            return mockGetBoundingClientRect({ left: 80, top: 100, width: 40, height: 50 });
+        });
+        jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+            () => {
+                return mockGetBoundingClientRect({ left: 20, top: 30, width: 100, height: 100 });
+            }
+        );
+
+        expect(cut.toJSON()).toEqual({
+            bottom: -20,
+            right: 0,
+            width: 40,
+            height: 50,
+        });
+    });
+
+    test('that out-of-bounds dimensions are fixed, top left', () => {
         const container = document.createElement('div');
         const content = document.createElement('div');
 
@@ -61,11 +106,11 @@ describe('overlay', () => {
             container.childNodes.item(0) as HTMLElement,
             'getBoundingClientRect'
         ).mockImplementation(() => {
-            return { left: 80, top: 100, width: 40, height: 50 } as any;
+            return mockGetBoundingClientRect({ left: 80, top: 100, width: 40, height: 50 });
         });
         jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
             () => {
-                return { left: 20, top: 30, width: 100, height: 100 } as any;
+                return mockGetBoundingClientRect({ left: 20, top: 30, width: 100, height: 100 });
             }
         );
 
@@ -77,7 +122,45 @@ describe('overlay', () => {
         });
     });
 
-    test('setBounds', () => {
+    test('that out-of-bounds dimensions are fixed, bottom right', () => {
+        const container = document.createElement('div');
+        const content = document.createElement('div');
+
+        document.body.appendChild(container);
+        container.appendChild(content);
+
+        const cut = new Overlay({
+            height: 200,
+            width: 100,
+            bottom: -1000,
+            right: -1000,
+            minimumInViewportWidth: 0,
+            minimumInViewportHeight: 0,
+            container,
+            content,
+        });
+
+        jest.spyOn(
+            container.childNodes.item(0) as HTMLElement,
+            'getBoundingClientRect'
+        ).mockImplementation(() => {
+            return mockGetBoundingClientRect({ left: 80, top: 100, width: 40, height: 50 });
+        });
+        jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+            () => {
+                return mockGetBoundingClientRect({ left: 20, top: 30, width: 100, height: 100 });
+            }
+        );
+
+        expect(cut.toJSON()).toEqual({
+            bottom: -20,
+            right: 0,
+            width: 40,
+            height: 50,
+        });
+    });
+
+    test('setBounds, top left', () => {
         const container = document.createElement('div');
         const content = document.createElement('div');
 
@@ -101,11 +184,11 @@ describe('overlay', () => {
         expect(element).toBeTruthy();
 
         jest.spyOn(element, 'getBoundingClientRect').mockImplementation(() => {
-            return { left: 300, top: 400, width: 1000, height: 1000 } as any;
+            return mockGetBoundingClientRect({ left: 300, top: 400, width: 200, height: 100 });
         });
         jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
             () => {
-                return { left: 0, top: 0, width: 1000, height: 1000 } as any;
+                return mockGetBoundingClientRect({ left: 0, top: 0, width: 1000, height: 1000 });
             }
         );
 
@@ -115,6 +198,46 @@ describe('overlay', () => {
         expect(element.style.width).toBe('200px');
         expect(element.style.left).toBe('300px');
         expect(element.style.top).toBe('400px');
+    });
+
+    test('setBounds, bottom right', () => {
+        const container = document.createElement('div');
+        const content = document.createElement('div');
+
+        document.body.appendChild(container);
+        container.appendChild(content);
+
+        const cut = new Overlay({
+            height: 1000,
+            width: 1000,
+            right: 0,
+            bottom: 0,
+            minimumInViewportWidth: 0,
+            minimumInViewportHeight: 0,
+            container,
+            content,
+        });
+
+        const element: HTMLElement = container.querySelector(
+            '.dv-resize-container'
+        )!;
+        expect(element).toBeTruthy();
+
+        jest.spyOn(element, 'getBoundingClientRect').mockImplementation(() => {
+            return mockGetBoundingClientRect({ left: 500, top: 500, width: 200, height: 100 });
+        });
+        jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+            () => {
+                return mockGetBoundingClientRect({ left: 0, top: 0, width: 1000, height: 1000 });
+            }
+        );
+
+        cut.setBounds({ height: 100, width: 200, right: 300, bottom: 400 });
+
+        expect(element.style.height).toBe('100px');
+        expect(element.style.width).toBe('200px');
+        expect(element.style.right).toBe('300px');
+        expect(element.style.bottom).toBe('400px');
     });
 
     test('that the resize handles are added', () => {

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -42,7 +42,7 @@ import {
     GroupDragEvent,
     TabDragEvent,
 } from '../dockview/components/titlebar/tabsContainer';
-import { Box } from '../types';
+import { AnchoredBox, Box } from '../types';
 import {
     DockviewDidDropEvent,
     DockviewWillDropEvent,
@@ -139,7 +139,7 @@ export class SplitviewApi implements CommonApi<SerializedSplitview> {
         return this.component.onDidRemoveView;
     }
 
-    constructor(private readonly component: ISplitviewComponent) {}
+    constructor(private readonly component: ISplitviewComponent) { }
 
     /**
      * Update configuratable options.
@@ -295,7 +295,7 @@ export class PaneviewApi implements CommonApi<SerializedPaneview> {
         return emitter.event;
     }
 
-    constructor(private readonly component: IPaneviewComponent) {}
+    constructor(private readonly component: IPaneviewComponent) { }
 
     /**
      * Remove a panel given the panel object.
@@ -459,7 +459,7 @@ export class GridviewApi implements CommonApi<SerializedGridviewComponent> {
         this.component.updateOptions({ orientation: value });
     }
 
-    constructor(private readonly component: IGridviewComponent) {}
+    constructor(private readonly component: IGridviewComponent) { }
 
     /**
      *  Focus the component. Will try to focus an active panel if one exists.
@@ -728,7 +728,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         return this.component.activeGroup;
     }
 
-    constructor(private readonly component: IDockviewComponent) {}
+    constructor(private readonly component: IDockviewComponent) { }
 
     /**
      *  Focus the component. Will try to focus an active panel if one exists.
@@ -800,9 +800,15 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      */
     addFloatingGroup(
         item: IDockviewPanel | DockviewGroupPanel,
-        coord?: { x: number; y: number }
+        coord?: { x: number; y: number },
+        options?: {
+            position?: AnchoredBox;
+            skipRemoveGroup?: boolean;
+            inDragMode?: boolean;
+            skipActiveGroup?: boolean;
+        }
     ): void {
-        return this.component.addFloatingGroup(item, coord);
+        return this.component.addFloatingGroup(item, coord, options);
     }
 
     /**

--- a/packages/dockview-core/src/constants.ts
+++ b/packages/dockview-core/src/constants.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE = 100;
 
-export const DEFAULT_FLOATING_GROUP_POSITION = { left: 100, top: 100 };
+export const DEFAULT_FLOATING_GROUP_POSITION = { left: 100, top: 100, width: 300, height: 300 };

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -57,7 +57,7 @@ import {
     GroupDragEvent,
     TabDragEvent,
 } from './components/titlebar/tabsContainer';
-import { Box } from '../types';
+import { AnchoredBox, Box } from '../types';
 import {
     DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE,
     DEFAULT_FLOATING_GROUP_POSITION,
@@ -126,7 +126,7 @@ export interface PanelReference {
 
 export interface SerializedFloatingGroup {
     data: GroupPanelViewState;
-    position: Box;
+    position: AnchoredBox;
 }
 
 export interface SerializedPopoutGroup {
@@ -208,7 +208,10 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     //
     addFloatingGroup(
         item: IDockviewPanel | DockviewGroupPanel,
-        coord?: { x: number; y: number }
+        coord?: { x: number; y: number },
+        options?: {
+            position?: AnchoredBox
+        }
     ): void;
     addPopoutGroup(
         item: IDockviewPanel | DockviewGroupPanel,
@@ -223,8 +226,7 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
 
 export class DockviewComponent
     extends BaseGrid<DockviewGroupPanel>
-    implements IDockviewComponent
-{
+    implements IDockviewComponent {
     private readonly nextGroupId = sequentialNumberGenerator();
     private readonly _deserializer = new DefaultDockviewDeserialzier(this);
     private readonly _api: DockviewApi;
@@ -750,6 +752,7 @@ export class DockviewComponent
         item: DockviewPanel | DockviewGroupPanel,
         coord?: { x?: number; y?: number; height?: number; width?: number },
         options?: {
+            position?: AnchoredBox;
             skipRemoveGroup?: boolean;
             inDragMode: boolean;
             skipActiveGroup?: boolean;
@@ -814,34 +817,70 @@ export class DockviewComponent
 
         group.model.location = { type: 'floating' };
 
-        const overlayLeft =
-            typeof coord?.x === 'number'
-                ? Math.max(coord.x, 0)
-                : DEFAULT_FLOATING_GROUP_POSITION.left;
-        const overlayTop =
-            typeof coord?.y === 'number'
-                ? Math.max(coord.y, 0)
-                : DEFAULT_FLOATING_GROUP_POSITION.top;
+        function getAnchoredBox(): AnchoredBox {
+            if (options?.position) {
+                const result: any = {};
+                if ("left" in options.position) {
+                    result.left = Math.max(options.position.left, 0)
+                } else if ("right" in options.position) {
+                    result.right = Math.max(options.position.right, 0)
+                } else {
+                    result.left = DEFAULT_FLOATING_GROUP_POSITION.left;
+                }
+                if ("top" in options.position) {
+                    result.top = Math.max(options.position.top, 0)
+                } else if ("bottom" in options.position) {
+                    result.bottom = Math.max(options.position.bottom, 0)
+                } else {
+                    result.top = DEFAULT_FLOATING_GROUP_POSITION.top;
+                }
+                if ("width" in options.position) {
+                    result.width = Math.max(options.position.width, 0)
+                } else {
+                    result.width = DEFAULT_FLOATING_GROUP_POSITION.width;
+                }
+                if ("height" in options.position) {
+                    result.height = Math.max(options.position.height, 0)
+                } else {
+                    result.height = DEFAULT_FLOATING_GROUP_POSITION.height;
+                }
+                return result as AnchoredBox;
+            }
+
+            return {
+                left: typeof coord?.x === 'number'
+                    ? Math.max(coord.x, 0)
+                    : DEFAULT_FLOATING_GROUP_POSITION.left,
+                top: typeof coord?.y === 'number'
+                    ? Math.max(coord.y, 0)
+                    : DEFAULT_FLOATING_GROUP_POSITION.top,
+                width: typeof coord?.width === 'number'
+                    ? Math.max(coord.width, 0)
+                    : DEFAULT_FLOATING_GROUP_POSITION.width,
+                height: typeof coord?.height === 'number'
+                    ? Math.max(coord.height, 0)
+                    : DEFAULT_FLOATING_GROUP_POSITION.height,
+            }
+        }
+
+        const anchoredBox = getAnchoredBox();
 
         const overlay = new Overlay({
             container: this.gridview.element,
             content: group.element,
-            height: coord?.height ?? 300,
-            width: coord?.width ?? 300,
-            left: overlayLeft,
-            top: overlayTop,
+            ...anchoredBox,
             minimumInViewportWidth:
                 this.options.floatingGroupBounds === 'boundedWithinViewport'
                     ? undefined
                     : this.options.floatingGroupBounds
-                          ?.minimumWidthWithinViewport ??
-                      DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE,
+                        ?.minimumWidthWithinViewport ??
+                    DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE,
             minimumInViewportHeight:
                 this.options.floatingGroupBounds === 'boundedWithinViewport'
                     ? undefined
                     : this.options.floatingGroupBounds
-                          ?.minimumHeightWithinViewport ??
-                      DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE,
+                        ?.minimumHeightWithinViewport ??
+                    DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE,
         });
 
         const el = group.element.querySelector('.void-container');
@@ -1194,13 +1233,8 @@ export class DockviewComponent
 
                 this.addFloatingGroup(
                     group,
-                    {
-                        x: position.left,
-                        y: position.top,
-                        height: position.height,
-                        width: position.width,
-                    },
-                    { skipRemoveGroup: true, inDragMode: false }
+                    undefined,
+                    { position: position, skipRemoveGroup: true, inDragMode: false }
                 );
             }
 
@@ -1338,7 +1372,7 @@ export class DockviewComponent
                 referenceGroup =
                     typeof options.position.referenceGroup === 'string'
                         ? this._groups.get(options.position.referenceGroup)
-                              ?.value
+                            ?.value
                         : options.position.referenceGroup;
 
                 if (!referenceGroup) {
@@ -1380,7 +1414,7 @@ export class DockviewComponent
 
                 const o =
                     typeof options.floating === 'object' &&
-                    options.floating !== null
+                        options.floating !== null
                         ? options.floating
                         : {};
 
@@ -1433,7 +1467,7 @@ export class DockviewComponent
 
             const coordinates =
                 typeof options.floating === 'object' &&
-                options.floating !== null
+                    options.floating !== null
                     ? options.floating
                     : {};
 
@@ -1471,9 +1505,9 @@ export class DockviewComponent
             skipDispose: boolean;
             skipSetActiveGroup?: boolean;
         } = {
-            removeEmptyGroup: true,
-            skipDispose: false,
-        }
+                removeEmptyGroup: true,
+                skipDispose: false,
+            }
     ): void {
         const group = panel.group;
 
@@ -1538,8 +1572,8 @@ export class DockviewComponent
                 const referencePanel =
                     typeof options.referencePanel === 'string'
                         ? this.panels.find(
-                              (panel) => panel.id === options.referencePanel
-                          )
+                            (panel) => panel.id === options.referencePanel
+                        )
                         : options.referencePanel;
 
                 if (!referencePanel) {
@@ -1604,11 +1638,11 @@ export class DockviewComponent
         group: DockviewGroupPanel,
         options?:
             | {
-                  skipActive?: boolean;
-                  skipDispose?: boolean;
-                  skipPopoutAssociated?: boolean;
-                  skipPopoutReturn?: boolean;
-              }
+                skipActive?: boolean;
+                skipDispose?: boolean;
+                skipPopoutAssociated?: boolean;
+                skipPopoutReturn?: boolean;
+            }
             | undefined
     ): void {
         this.doRemoveGroup(group, options);
@@ -1618,11 +1652,11 @@ export class DockviewComponent
         group: DockviewGroupPanel,
         options?:
             | {
-                  skipActive?: boolean;
-                  skipDispose?: boolean;
-                  skipPopoutAssociated?: boolean;
-                  skipPopoutReturn?: boolean;
-              }
+                skipActive?: boolean;
+                skipDispose?: boolean;
+                skipPopoutAssociated?: boolean;
+                skipPopoutReturn?: boolean;
+            }
             | undefined
     ): DockviewGroupPanel {
         const panels = [...group.panels]; // reassign since group panels will mutate

--- a/packages/dockview-core/src/dockview/dockviewFloatingGroupPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewFloatingGroupPanel.ts
@@ -1,37 +1,22 @@
 import { Overlay } from '../dnd/overlay';
 import { CompositeDisposable } from '../lifecycle';
+import { AnchoredBox } from '../types';
 import { DockviewGroupPanel, IDockviewGroupPanel } from './dockviewGroupPanel';
 
 export interface IDockviewFloatingGroupPanel {
     readonly group: IDockviewGroupPanel;
-    position(
-        bounds: Partial<{
-            top: number;
-            left: number;
-            height: number;
-            width: number;
-        }>
-    ): void;
+    position(bounds: Partial<AnchoredBox>): void;
 }
 
 export class DockviewFloatingGroupPanel
     extends CompositeDisposable
-    implements IDockviewFloatingGroupPanel
-{
+    implements IDockviewFloatingGroupPanel {
     constructor(readonly group: DockviewGroupPanel, readonly overlay: Overlay) {
         super();
-
         this.addDisposables(overlay);
     }
 
-    position(
-        bounds: Partial<{
-            top: number;
-            left: number;
-            height: number;
-            width: number;
-        }>
-    ): void {
+    position(bounds: Partial<AnchoredBox>): void {
         this.overlay.setBounds(bounds);
     }
 }

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -14,6 +14,7 @@ import {
 import { IDockviewPanel } from './dockviewPanel';
 import { DockviewPanelRenderer } from '../overlayRenderContainer';
 import { IGroupHeaderProps } from './framework';
+import { AnchoredBox } from '../types';
 
 export interface IHeaderActionsRenderer extends IDisposable {
     readonly element: HTMLElement;
@@ -37,11 +38,11 @@ export interface DockviewOptions {
     singleTabMode?: 'fullwidth' | 'default';
     disableFloatingGroups?: boolean;
     floatingGroupBounds?:
-        | 'boundedWithinViewport'
-        | {
-              minimumHeightWithinViewport?: number;
-              minimumWidthWithinViewport?: number;
-          };
+    | 'boundedWithinViewport'
+    | {
+        minimumHeightWithinViewport?: number;
+        minimumWidthWithinViewport?: number;
+    };
     popoutUrl?: string;
     defaultRenderer?: DockviewPanelRenderer;
     debug?: boolean;
@@ -74,7 +75,7 @@ export class DockviewUnhandledDragOverEvent implements DockviewDndOverlayEvent {
         readonly position: Position,
         readonly getData: () => PanelTransfer | undefined,
         readonly group?: DockviewGroupPanel
-    ) {}
+    ) { }
 
     accept(): void {
         this._isAccepted = true;
@@ -176,13 +177,8 @@ export function isPanelOptionsWithGroup(
 
 type AddPanelFloatingGroupUnion = {
     floating:
-        | {
-              height?: number;
-              width?: number;
-              x?: number;
-              y?: number;
-          }
-        | true;
+    | Partial<AnchoredBox>
+    | true;
     position: never;
 };
 

--- a/packages/dockview-core/src/types.ts
+++ b/packages/dockview-core/src/types.ts
@@ -8,3 +8,7 @@ export interface Box {
     height: number;
     width: number;
 }
+
+export type AnchoredBox =
+    ({ top: number, height: number } | { bottom: number, height: number }) &
+    ({ left: number, width: number } | { right: number, width: number });

--- a/packages/docs/docs/core/panels/add.mdx
+++ b/packages/docs/docs/core/panels/add.mdx
@@ -165,6 +165,6 @@ api.addPanel({
 api.addPanel({
     id: 'panel_2',
     component: 'default',
-    floating: { x: 10, y: 10, width: 300, height: 300 },
+    floating: { left: 10, top: 10, width: 300, height: 300 },
 });
 ```

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/groupActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/groupActions.tsx
@@ -65,7 +65,14 @@ const GroupAction = (props: {
                     }
                     onClick={() => {
                         if (group) {
-                            props.api.addFloatingGroup(group);
+                            props.api.addFloatingGroup(group, undefined, {
+                                position: {
+                                    width: 400,
+                                    height: 300,
+                                    top: 50,
+                                    right: 50,
+                                }
+                            });
                         }
                     }}
                 >

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelActions.tsx
@@ -29,7 +29,14 @@ const PanelAction = (props: {
                     onClick={() => {
                         const panel = props.api.getPanel(props.panelId);
                         if (panel) {
-                            props.api.addFloatingGroup(panel);
+                            props.api.addFloatingGroup(panel, undefined, {
+                                position: {
+                                    width: 400,
+                                    height: 300,
+                                    bottom: 20,
+                                    right: 20,
+                                }
+                            });
                         }
                     }}
                 >

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelActions.tsx
@@ -33,8 +33,8 @@ const PanelAction = (props: {
                                 position: {
                                     width: 400,
                                     height: 300,
-                                    bottom: 20,
-                                    right: 20,
+                                    bottom: 50,
+                                    right: 50,
                                 }
                             });
                         }

--- a/packages/docs/sandboxes/react/dockview/floating-groups/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/floating-groups/src/app.tsx
@@ -84,7 +84,7 @@ function addFloatingPanel2(api: DockviewApi) {
         id: (++panelCount).toString(),
         title: `Tab ${panelCount}`,
         component: 'default',
-        floating: { width: 250, height: 150, x: 50, y: 50 },
+        floating: { width: 250, height: 150, left: 50, top: 50 },
     });
 }
 
@@ -217,9 +217,8 @@ export const DockviewPersistence = (props: { theme?: string }) => {
                         setDisableFloatingGroups((x) => !x);
                     }}
                 >
-                    {`${
-                        disableFloatingGroups ? 'Enable' : 'Disable'
-                    } floating groups`}
+                    {`${disableFloatingGroups ? 'Enable' : 'Disable'
+                        } floating groups`}
                 </button>
             </div>
             <div
@@ -275,7 +274,14 @@ const RightComponent = (props: IDockviewHeaderActionsProps) => {
             const group = props.containerApi.addGroup();
             props.group.api.moveTo({ group });
         } else {
-            props.containerApi.addFloatingGroup(props.group);
+            props.containerApi.addFloatingGroup(props.group, undefined, {
+                position: {
+                    width: 400,
+                    height: 300,
+                    bottom: 50,
+                    right: 50,
+                }
+            });
         }
     };
 

--- a/packages/docs/src/generated/api.output.json
+++ b/packages/docs/src/generated/api.output.json
@@ -1,4 +1,59 @@
 {
+    "DockviewDisposable": {
+        "kind": "namespace",
+        "name": "DockviewDisposable",
+        "children": [
+            {
+                "name": "NONE",
+                "code": "",
+                "kind": "variable"
+            },
+            {
+                "name": "from",
+                "code": "(func: (): void): IDisposable",
+                "signature": {
+                    "name": "from",
+                    "typeParameters": [],
+                    "parameters": [
+                        {
+                            "name": "func",
+                            "code": "func: (): void",
+                            "type": {
+                                "type": "reflection",
+                                "value": {
+                                    "name": "__type",
+                                    "code": "(): void",
+                                    "kind": "typeLiteral",
+                                    "signatures": [
+                                        {
+                                            "name": "__type",
+                                            "typeParameters": [],
+                                            "parameters": [],
+                                            "returnType": {
+                                                "type": "intrinsic",
+                                                "value": "void"
+                                            },
+                                            "code": "(): void",
+                                            "kind": "callSignature"
+                                        }
+                                    ]
+                                }
+                            },
+                            "kind": "parameter"
+                        }
+                    ],
+                    "returnType": {
+                        "type": "reference",
+                        "value": "IDisposable",
+                        "source": "dockview-core"
+                    },
+                    "code": "(func: (): void): IDisposable",
+                    "kind": "callSignature"
+                },
+                "kind": "function"
+            }
+        ]
+    },
     "DockviewEvent": {
         "name": "DockviewEvent",
         "code": "",
@@ -2489,7 +2544,7 @@
                         "summary": [
                             {
                                 "kind": "text",
-                                "text": "Invoked before a group is dragged.\r\n\r\nCalling "
+                                "text": "Invoked before a group is dragged.\n\nCalling "
                             },
                             {
                                 "kind": "code",
@@ -2520,7 +2575,7 @@
                     "summary": [
                         {
                             "kind": "text",
-                            "text": "Invoked before a group is dragged.\r\n\r\nCalling "
+                            "text": "Invoked before a group is dragged.\n\nCalling "
                         },
                         {
                             "kind": "code",
@@ -2543,7 +2598,7 @@
                         "summary": [
                             {
                                 "kind": "text",
-                                "text": "Invoked before a panel is dragged.\r\n\r\nCalling "
+                                "text": "Invoked before a panel is dragged.\n\nCalling "
                             },
                             {
                                 "kind": "code",
@@ -2574,7 +2629,7 @@
                     "summary": [
                         {
                             "kind": "text",
-                            "text": "Invoked before a panel is dragged.\r\n\r\nCalling "
+                            "text": "Invoked before a panel is dragged.\n\nCalling "
                         },
                         {
                             "kind": "code",
@@ -2597,7 +2652,7 @@
                         "summary": [
                             {
                                 "kind": "text",
-                                "text": "Invoked when a Drag'n'Drop event occurs but before dockview handles it giving the user an opportunity to intecept and\r\nprevent the event from occuring using the standard "
+                                "text": "Invoked when a Drag'n'Drop event occurs but before dockview handles it giving the user an opportunity to intecept and\nprevent the event from occuring using the standard "
                             },
                             {
                                 "kind": "code",
@@ -2605,7 +2660,7 @@
                             },
                             {
                                 "kind": "text",
-                                "text": " syntax.\r\n\r\nPreventing certain events may causes unexpected behaviours, use carefully."
+                                "text": " syntax.\n\nPreventing certain events may causes unexpected behaviours, use carefully."
                             }
                         ]
                     },
@@ -2628,7 +2683,7 @@
                     "summary": [
                         {
                             "kind": "text",
-                            "text": "Invoked when a Drag'n'Drop event occurs but before dockview handles it giving the user an opportunity to intecept and\r\nprevent the event from occuring using the standard "
+                            "text": "Invoked when a Drag'n'Drop event occurs but before dockview handles it giving the user an opportunity to intecept and\nprevent the event from occuring using the standard "
                         },
                         {
                             "kind": "code",
@@ -2636,7 +2691,7 @@
                         },
                         {
                             "kind": "text",
-                            "text": " syntax.\r\n\r\nPreventing certain events may causes unexpected behaviours, use carefully."
+                            "text": " syntax.\n\nPreventing certain events may causes unexpected behaviours, use carefully."
                         }
                     ]
                 }
@@ -2651,7 +2706,7 @@
                         "summary": [
                             {
                                 "kind": "text",
-                                "text": "Invoked before an overlay is shown indicating a drop target.\r\n\r\nCalling "
+                                "text": "Invoked before an overlay is shown indicating a drop target.\n\nCalling "
                             },
                             {
                                 "kind": "code",
@@ -2659,7 +2714,7 @@
                             },
                             {
                                 "kind": "text",
-                                "text": " will prevent the overlay being shown and prevent\r\nthe any subsequent drop event."
+                                "text": " will prevent the overlay being shown and prevent\nthe any subsequent drop event."
                             }
                         ]
                     },
@@ -2682,7 +2737,7 @@
                     "summary": [
                         {
                             "kind": "text",
-                            "text": "Invoked before an overlay is shown indicating a drop target.\r\n\r\nCalling "
+                            "text": "Invoked before an overlay is shown indicating a drop target.\n\nCalling "
                         },
                         {
                             "kind": "code",
@@ -2690,7 +2745,7 @@
                         },
                         {
                             "kind": "text",
-                            "text": " will prevent the overlay being shown and prevent\r\nthe any subsequent drop event."
+                            "text": " will prevent the overlay being shown and prevent\nthe any subsequent drop event."
                         }
                     ]
                 }
@@ -2821,7 +2876,7 @@
             },
             {
                 "name": "addFloatingGroup",
-                "code": "(item: IDockviewPanel | DockviewGroupPanel, coord?: { x: number, y: number }): void",
+                "code": "(item: IDockviewPanel | DockviewGroupPanel, coord?: { x: number, y: number }, options?: { inDragMode?: boolean, position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -2890,13 +2945,337 @@
                                     }
                                 },
                                 "kind": "parameter"
+                            },
+                            {
+                                "name": "options",
+                                "code": "options?: { inDragMode?: boolean, position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }",
+                                "type": {
+                                    "type": "reflection",
+                                    "value": {
+                                        "name": "__type",
+                                        "code": "{ inDragMode?: boolean, position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }",
+                                        "kind": "typeLiteral",
+                                        "properties": [
+                                            {
+                                                "name": "inDragMode",
+                                                "code": "boolean",
+                                                "kind": "property",
+                                                "type": {
+                                                    "type": "intrinsic",
+                                                    "value": "boolean"
+                                                },
+                                                "flags": {
+                                                    "isOptional": true
+                                                }
+                                            },
+                                            {
+                                                "name": "position",
+                                                "code": "{ right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }",
+                                                "kind": "property",
+                                                "type": {
+                                                    "type": "or",
+                                                    "values": [
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ right: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "right",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ bottom: number, height: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "bottom",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ left: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "left",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ bottom: number, height: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "bottom",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ right: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "right",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ height: number, top: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "top",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ left: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "left",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ height: number, top: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "top",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "flags": {
+                                                    "isOptional": true
+                                                }
+                                            },
+                                            {
+                                                "name": "skipActiveGroup",
+                                                "code": "boolean",
+                                                "kind": "property",
+                                                "type": {
+                                                    "type": "intrinsic",
+                                                    "value": "boolean"
+                                                },
+                                                "flags": {
+                                                    "isOptional": true
+                                                }
+                                            },
+                                            {
+                                                "name": "skipRemoveGroup",
+                                                "code": "boolean",
+                                                "kind": "property",
+                                                "type": {
+                                                    "type": "intrinsic",
+                                                    "value": "boolean"
+                                                },
+                                                "flags": {
+                                                    "isOptional": true
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "kind": "parameter"
                             }
                         ],
                         "returnType": {
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(item: IDockviewPanel | DockviewGroupPanel, coord?: { x: number, y: number }): void",
+                        "code": "(item: IDockviewPanel | DockviewGroupPanel, coord?: { x: number, y: number }, options?: { inDragMode?: boolean, position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }): void",
                         "kind": "callSignature"
                     }
                 ],
@@ -4818,7 +5197,7 @@
             },
             {
                 "name": "addFloatingGroup",
-                "code": "(item: DockviewPanel | DockviewGroupPanel, coord?: { height?: number, width?: number, x?: number, y?: number }, options?: { inDragMode: boolean, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }): void",
+                "code": "(item: DockviewPanel | DockviewGroupPanel, coord?: { height?: number, width?: number, x?: number, y?: number }, options?: { inDragMode: boolean, position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -4910,12 +5289,12 @@
                             },
                             {
                                 "name": "options",
-                                "code": "options?: { inDragMode: boolean, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }",
+                                "code": "options?: { inDragMode: boolean, position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }",
                                 "type": {
                                     "type": "reflection",
                                     "value": {
                                         "name": "__type",
-                                        "code": "{ inDragMode: boolean, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }",
+                                        "code": "{ inDragMode: boolean, position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }",
                                         "kind": "typeLiteral",
                                         "properties": [
                                             {
@@ -4927,6 +5306,279 @@
                                                     "value": "boolean"
                                                 },
                                                 "flags": {}
+                                            },
+                                            {
+                                                "name": "position",
+                                                "code": "{ right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }",
+                                                "kind": "property",
+                                                "type": {
+                                                    "type": "or",
+                                                    "values": [
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ right: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "right",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ bottom: number, height: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "bottom",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ left: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "left",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ bottom: number, height: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "bottom",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ right: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "right",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ height: number, top: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "top",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ left: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "left",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ height: number, top: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "top",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "flags": {
+                                                    "isOptional": true
+                                                }
                                             },
                                             {
                                                 "name": "skipActiveGroup",
@@ -4962,7 +5614,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(item: DockviewPanel | DockviewGroupPanel, coord?: { height?: number, width?: number, x?: number, y?: number }, options?: { inDragMode: boolean, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }): void",
+                        "code": "(item: DockviewPanel | DockviewGroupPanel, coord?: { height?: number, width?: number, x?: number, y?: number }, options?: { inDragMode: boolean, position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }, skipActiveGroup?: boolean, skipRemoveGroup?: boolean }): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -10867,7 +11519,7 @@
                             "summary": [
                                 {
                                     "kind": "text",
-                                    "text": "If the root is orientated as a VERTICAL node then nest the existing root within a new HORIZIONTAL root node\r\nIf the root is orientated as a HORIZONTAL node then nest the existing root within a new VERITCAL root node"
+                                    "text": "If the root is orientated as a VERTICAL node then nest the existing root within a new HORIZIONTAL root node\nIf the root is orientated as a HORIZONTAL node then nest the existing root within a new VERITCAL root node"
                                 }
                             ]
                         },
@@ -10885,7 +11537,7 @@
                     "summary": [
                         {
                             "kind": "text",
-                            "text": "If the root is orientated as a VERTICAL node then nest the existing root within a new HORIZIONTAL root node\r\nIf the root is orientated as a HORIZONTAL node then nest the existing root within a new VERITCAL root node"
+                            "text": "If the root is orientated as a VERTICAL node then nest the existing root within a new HORIZIONTAL root node\nIf the root is orientated as a HORIZONTAL node then nest the existing root within a new VERITCAL root node"
                         }
                     ]
                 }
@@ -19206,7 +19858,7 @@
                         "summary": [
                             {
                                 "kind": "text",
-                                "text": "Invoked whenever any aspect of the layout changes.\r\nIf listening to this event it may be worth debouncing ouputs."
+                                "text": "Invoked whenever any aspect of the layout changes.\nIf listening to this event it may be worth debouncing ouputs."
                             }
                         ]
                     },
@@ -19228,7 +19880,7 @@
                     "summary": [
                         {
                             "kind": "text",
-                            "text": "Invoked whenever any aspect of the layout changes.\r\nIf listening to this event it may be worth debouncing ouputs."
+                            "text": "Invoked whenever any aspect of the layout changes.\nIf listening to this event it may be worth debouncing ouputs."
                         }
                     ]
                 }
@@ -19790,7 +20442,7 @@
                                 },
                                 {
                                     "kind": "text",
-                                    "text": " method\r\nfor the subsequent resize."
+                                    "text": " method\nfor the subsequent resize."
                                 }
                             ]
                         },
@@ -19852,7 +20504,7 @@
                         },
                         {
                             "kind": "text",
-                            "text": " method\r\nfor the subsequent resize."
+                            "text": " method\nfor the subsequent resize."
                         }
                     ]
                 }
@@ -24337,7 +24989,7 @@
                     "summary": [
                         {
                             "kind": "text",
-                            "text": "The id of the tab component renderer\r\n\r\nUndefined if no custom tab renderer is provided"
+                            "text": "The id of the tab component renderer\n\nUndefined if no custom tab renderer is provided"
                         }
                     ]
                 }
@@ -27987,7 +28639,7 @@
             },
             {
                 "name": "addFloatingGroup",
-                "code": "(item: IDockviewPanel | DockviewGroupPanel, coord?: { x: number, y: number }): void",
+                "code": "(item: IDockviewPanel | DockviewGroupPanel, coord?: { x: number, y: number }, options?: { position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number } }): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -28048,13 +28700,301 @@
                                     }
                                 },
                                 "kind": "parameter"
+                            },
+                            {
+                                "name": "options",
+                                "code": "options?: { position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number } }",
+                                "type": {
+                                    "type": "reflection",
+                                    "value": {
+                                        "name": "__type",
+                                        "code": "{ position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number } }",
+                                        "kind": "typeLiteral",
+                                        "properties": [
+                                            {
+                                                "name": "position",
+                                                "code": "{ right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number }",
+                                                "kind": "property",
+                                                "type": {
+                                                    "type": "or",
+                                                    "values": [
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ right: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "right",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ bottom: number, height: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "bottom",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ left: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "left",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ bottom: number, height: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "bottom",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ right: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "right",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ height: number, top: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "top",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "intersection",
+                                                            "values": [
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ left: number, width: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "left",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "width",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "reflection",
+                                                                    "value": {
+                                                                        "name": "__type",
+                                                                        "code": "{ height: number, top: number }",
+                                                                        "kind": "typeLiteral",
+                                                                        "properties": [
+                                                                            {
+                                                                                "name": "height",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            },
+                                                                            {
+                                                                                "name": "top",
+                                                                                "code": "number",
+                                                                                "kind": "property",
+                                                                                "type": {
+                                                                                    "type": "intrinsic",
+                                                                                    "value": "number"
+                                                                                },
+                                                                                "flags": {}
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                "flags": {
+                                                    "isOptional": true
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "kind": "parameter"
                             }
                         ],
                         "returnType": {
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(item: IDockviewPanel | DockviewGroupPanel, coord?: { x: number, y: number }): void",
+                        "code": "(item: IDockviewPanel | DockviewGroupPanel, coord?: { x: number, y: number }, options?: { position?: { right: number, width: number } & { bottom: number, height: number } | { left: number, width: number } & { bottom: number, height: number } | { right: number, width: number } & { height: number, top: number } | { left: number, width: number } & { height: number, top: number } }): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -38458,11 +39398,11 @@
             },
             {
                 "name": "position",
-                "code": "Box",
+                "code": "AnchoredBox",
                 "kind": "property",
                 "type": {
                     "type": "reference",
-                    "value": "Box",
+                    "value": "AnchoredBox",
                     "source": "dockview-core"
                 },
                 "flags": {}
@@ -39885,34 +40825,6 @@
             }
         ]
     },
-    "WatermarkConstructor": {
-        "kind": "interface",
-        "name": "WatermarkConstructor",
-        "children": [
-            {
-                "name": "constructor",
-                "kind": "constructor",
-                "code": ""
-            }
-        ]
-    },
-    "WatermarkPartInitParameters": {
-        "kind": "interface",
-        "name": "WatermarkPartInitParameters",
-        "children": [
-            {
-                "name": "accessor",
-                "code": "IDockviewComponent",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "IDockviewComponent",
-                    "source": "dockview-core"
-                },
-                "flags": {}
-            }
-        ]
-    },
     "WatermarkRendererInitParameters": {
         "kind": "interface",
         "name": "WatermarkRendererInitParameters",
@@ -40056,7 +40968,7 @@
                                     "summary": [
                                         {
                                             "kind": "text",
-                                            "text": "If true then add the panel without setting it as the active panel.\r\n\r\nDefaults to "
+                                            "text": "If true then add the panel without setting it as the active panel.\n\nDefaults to "
                                         },
                                         {
                                             "kind": "code",
@@ -40099,7 +41011,7 @@
                                     "summary": [
                                         {
                                             "kind": "text",
-                                            "text": "The rendering mode of the panel.\r\n\r\nThis dictates what happens to the HTML of the panel when it is hidden."
+                                            "text": "The rendering mode of the panel.\n\nThis dictates what happens to the HTML of the panel when it is hidden."
                                         }
                                     ]
                                 }
@@ -40139,7 +41051,7 @@
                                     "summary": [
                                         {
                                             "kind": "text",
-                                            "text": "The title for the panel which can be accessed within both the tab and component.\r\n\r\nIf using the default tab renderer this title will be displayed in the tab."
+                                            "text": "The title for the panel which can be accessed within both the tab and component.\n\nIf using the default tab renderer this title will be displayed in the tab."
                                         }
                                     ]
                                 }
@@ -40990,7 +41902,7 @@
                 "summary": [
                     {
                         "kind": "text",
-                        "text": "Find the grid location of a specific DOM element by traversing the parent\r\nchain and finding each child index on the way.\r\n\r\nThis will break as soon as DOM structures of the Splitview or Gridview change."
+                        "text": "Find the grid location of a specific DOM element by traversing the parent\nchain and finding each child index on the way.\n\nThis will break as soon as DOM structures of the Splitview or Gridview change."
                     }
                 ]
             },
@@ -43297,7 +44209,7 @@
                 "summary": [
                     {
                         "kind": "text",
-                        "text": "A React Hook that returns an array of portals to be rendered by the user of this hook\r\nand a disposable function to add a portal. Calling dispose removes this portal from the\r\nportal array"
+                        "text": "A React Hook that returns an array of portals to be rendered by the user of this hook\nand a disposable function to add a portal. Calling dispose removes this portal from the\nportal array"
                     }
                 ]
             },

--- a/packages/docs/templates/dockview/demo-dockview/react/src/defaultLayout.ts
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/defaultLayout.ts
@@ -14,7 +14,7 @@ export function defaultConfig(api: DockviewApi) {
         id: 'panel_1',
         component: 'default',
         renderer: 'always',
-        title: 'Panel 1',
+        title: 'Panel 1'
     });
 
     api.addPanel({

--- a/packages/docs/templates/dockview/demo-dockview/react/src/groupActions.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/groupActions.tsx
@@ -32,7 +32,14 @@ export const GroupActions = (props: {
                                 onClick={() => {
                                     const panel = props.api?.getGroup(x);
                                     if (panel) {
-                                        props.api?.addFloatingGroup(panel);
+                                        props.api?.addFloatingGroup(panel, undefined, {
+                                            position: {
+                                                width: 400,
+                                                height: 300,
+                                                bottom: 50,
+                                                right: 50,
+                                            }
+                                        });
                                     }
                                 }}
                             >

--- a/packages/docs/templates/dockview/demo-dockview/react/src/panelActions.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/panelActions.tsx
@@ -32,7 +32,14 @@ export const PanelActions = (props: {
                                 onClick={() => {
                                     const panel = props.api?.getPanel(x);
                                     if (panel) {
-                                        props.api?.addFloatingGroup(panel);
+                                        props.api?.addFloatingGroup(panel, undefined, {
+                                            position: {
+                                                width: 400,
+                                                height: 300,
+                                                bottom: 50,
+                                                right: 50,
+                                            }
+                                        });
                                     }
                                 }}
                             >

--- a/packages/docs/templates/dockview/floating-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/floating-groups/react/src/app.tsx
@@ -209,9 +209,8 @@ export const DockviewPersistence = (props: { theme?: string }) => {
                         setDisableFloatingGroups((x) => !x);
                     }}
                 >
-                    {`${
-                        disableFloatingGroups ? 'Enable' : 'Disable'
-                    } floating groups`}
+                    {`${disableFloatingGroups ? 'Enable' : 'Disable'
+                        } floating groups`}
                 </button>
             </div>
             <div
@@ -265,7 +264,14 @@ const RightComponent = (props: IDockviewHeaderActionsProps) => {
             const group = props.containerApi.addGroup();
             props.group.api.moveTo({ group });
         } else {
-            props.containerApi.addFloatingGroup(props.group);
+            props.containerApi.addFloatingGroup(props.group, undefined, {
+                position: {
+                    width: 400,
+                    height: 300,
+                    bottom: 50,
+                    right: 50,
+                }
+            });
         }
     };
 

--- a/packages/docs/templates/dockview/floating-groups/vue/src/index.ts
+++ b/packages/docs/templates/dockview/floating-groups/vue/src/index.ts
@@ -93,7 +93,14 @@ const RightAction = defineComponent({
                 const group = this.params.containerApi.addGroup();
                 this.group.api.moveTo({ group });
             } else {
-                this.containerApi.addFloatingGroup(this.params.group);
+                this.containerApi.addFloatingGroup(this.params.group, undefined, {
+                    position: {
+                        width: 400,
+                        height: 300,
+                        bottom: 50,
+                        right: 50,
+                    }
+                });
             }
         },
     },


### PR DESCRIPTION
Work done:
- Closes https://github.com/mathuo/dockview/issues/544
- New argument `options.position` for floating groups, just like for popout groups, that supports the full range of left/right/width and top/bottom/height settings of CSS absolute positioning
- Drag n Drop and Resizing of floating groups "anchors" the group to the nearest corner. (E.g. If user moves a floating window near the bottom right, it will follow bottom right if window is resized, and same for all 4 corners)
- Added relevant tests
- Updated docs

See Loom video for demo:

https://www.loom.com/share/5b24d26a68ea47548986c379156b9450?sid=104d2e26-41c5-40e5-9b53-534b1b5d346a 