### PR TITLE
bug: fix passing through options for opening single panel in a popot window

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -563,7 +563,7 @@ export class DockviewComponent
             itemToPopout instanceof DockviewPanel &&
             itemToPopout.group.size === 1
         ) {
-            return this.addPopoutGroup(itemToPopout.group);
+            return this.addPopoutGroup(itemToPopout.group, options);
         }
 
         const theme = getDockviewTheme(this.gridview.element);


### PR DESCRIPTION
seems like they should be passed through here
correct me if I'm wrong