### PR TITLE
docs: add the splash-screen to the dockview package

### DIFF
--- a/packages/dockview/README.md
+++ b/packages/dockview/README.md
@@ -16,6 +16,8 @@
 
 ##
 
+![](https://github.com/mathuo/dockview/blob/HEAD/packages/docs/static/img/splashscreen.gif?raw=true)
+
 Please see the website: https://dockview.dev
 
 ## Features


### PR DESCRIPTION
This will hopefully make the image show up on the npm page