### PR TITLE
Added support for custom overlay z-index

### DIFF
--- a/packages/dockview-core/src/overlay/overlay.ts
+++ b/packages/dockview-core/src/overlay/overlay.ts
@@ -13,8 +13,6 @@ import { CompositeDisposable, MutableDisposable } from '../lifecycle';
 import { clamp } from '../math';
 import { AnchoredBox } from '../types';
 
-export const DEFAULT_OVERLAY_Z_INDEX = 999;
-
 class AriaLevelTracker {
     private _orderedList: HTMLElement[] = [];
 
@@ -37,9 +35,9 @@ class AriaLevelTracker {
     private update(): void {
         for (let i = 0; i < this._orderedList.length; i++) {
             this._orderedList[i].setAttribute('aria-level', `${i}`);
-            this._orderedList[i].style.zIndex = `${
-                DEFAULT_OVERLAY_Z_INDEX + i * 2
-            }`;
+            this._orderedList[i].style.zIndex = `calc(var(--dv-floating-z-index) + ${
+                i * 2
+            })`;
         }
     }
 }

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -9,7 +9,6 @@ import {
 } from '../lifecycle';
 import { IDockviewPanel } from '../dockview/dockviewPanel';
 import { DockviewComponent } from '../dockview/dockviewComponent';
-import { DEFAULT_OVERLAY_Z_INDEX } from './overlay';
 
 export type DockviewPanelRenderer = 'onlyWhenVisible' | 'always';
 
@@ -137,9 +136,9 @@ export class OverlayRenderContainer extends CompositeDisposable {
                         const level = Number(
                             element.getAttribute('aria-level')
                         );
-                        focusContainer.style.zIndex = `${
-                            DEFAULT_OVERLAY_Z_INDEX + level * 2 + 1
-                        }`;
+                        focusContainer.style.zIndex = `calc(var(--dv-floating-z-index) + ${
+                            level * 2 + 1
+                        })`;
                     };
 
                     const observer = new MutationObserver(() => {

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -8,6 +8,7 @@
     --dv-tabs-container-scrollbar-color: #888;
     --dv-icon-hover-background-color: rgba(90, 93, 94, 0.31);
     --dv-floating-box-shadow: 8px 8px 8px 0px rgba(83, 89, 93, 0.5);
+    --dv-floating-z-index: 999;
 }
 
 @mixin dockview-theme-dark-mixin {


### PR DESCRIPTION
Replaced const with css variable `--dv-floating-z-index` to easily override. Related to #720