### PR TITLE
🐛 fix: set initial size and use proper window on event

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -635,6 +635,7 @@ export class DockviewComponent
                     options?.overridePopoutGroup ??
                     this.createGroup({ id: groupId });
                 group.model.renderContainer = overlayRenderContainer;
+                group.layout(_window.window!.innerWidth, _window.window!.innerHeight);
 
                 if (!options?.overridePopoutGroup) {
                     this._onDidAddGroup.fire(group);
@@ -715,7 +716,7 @@ export class DockviewComponent
                         _window.window!,
                         'resize',
                         () => {
-                            group.layout(window.innerWidth, window.innerHeight);
+                            group.layout(_window.window!.innerWidth, _window.window!.innerHeight);
                         }
                     ),
                     overlayRenderContainer,


### PR DESCRIPTION
The initial `onDidDimensionsChange` event is fired with `{ width: 0, height: 0}` without the initial set size and the `resize` event still referenced the parent widow's sizing.