### PR TITLE
Do not close groups if they're the only group

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1793,6 +1793,10 @@ export class DockviewComponent
               }
             | undefined
     ): DockviewGroupPanel {
+        if (this.groups.length <= 1) {
+            return false;
+        }
+
         const panels = [...group.panels]; // reassign since group panels will mutate
 
         if (!options?.skipDispose) {


### PR DESCRIPTION
I created [this issue](https://github.com/mathuo/dockview/issues/777) earlier.

After a lot of digging, with these changes I was able to get the behaviour I needed from Dockview. I can't seem to think of a viable reason why you would ever not want to have at least one group showing? At least not for my use cases.
The watermark still shows when there are no tabs - so I'm not sure if there's a technical reason that I'm not thinking about.

I've patched these changes into my project and all seems to be working perfectly.