### PR TITLE
Fixing duplicate state in React-Dockview-Demo caused by strict mode

### DIFF
--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -178,6 +178,11 @@ const DockviewDemo = (props: { theme?: string }) => {
 
     const onReady = (event: DockviewReadyEvent) => {
         setApi(event.api);
+        setPanels([]);
+        setGroups([]);
+        setActivePanel(undefined);
+        setActiveGroup(undefined);
+        addLogLine(`Dockview Is Ready`);
 
         event.api.onDidAddPanel((event) => {
             setPanels((_) => [..._, event.id]);

--- a/packages/docs/templates/dockview/demo-dockview/react/src/app.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/app.tsx
@@ -124,6 +124,11 @@ const DockviewDemo = (props: { theme?: string }) => {
 
     const onReady = (event: DockviewReadyEvent) => {
         setApi(event.api);
+        setPanels([]);
+        setGroups([]);
+        setActivePanel(undefined);
+        setActiveGroup(undefined);
+        addLogLine(`Dockview Is Ready`);
     };
 
     React.useEffect(() => {


### PR DESCRIPTION
Currently, the Dockview-Demo on CodeSandbox looks like this:
![image](https://github.com/user-attachments/assets/1221ab77-b882-4e4d-958e-bc248a0ccb84)

As far as I can tell, This seems to be because strict mode causes the Dockview to load, unload, then load again, which causes onReady to be called twice, which causes DefaultLayout to be called twice, which puts two copies of the default layout into state. (Groups state & Panels state)

As I see it, there are a few possible solutions here:

1. Dockview could be changed to call each onDidRemoveGroup and onDidRemovePanel hook while unloading, causing Group and Panel state to update naturally in their associated hooks.

2. Dockview could expose an onWillUnload hook, mirror to the onReady hook, that gets called when Dockview starts unloading. Then, state resets could be placed in there.

3. You can just place your state resets in onReady. This is the band-aid fix I'm proposing here.

Either way, at the end of it the Dockview-Demo codesandbox should look like this. This is the intent of this pull request.

![image](https://github.com/user-attachments/assets/183b2577-2256-47d6-92fc-8b3090d9a941)
