### PR TITLE
Fix provenance npm link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Please see the website: https://dockview.dev
 -   Transparent builds and Code Analysis
 -   Security at mind - verifed publishing and builds through GitHub Actions
 
-Want to verify our builds? Go [here](https://www.npmjs.com/package/dockview#Provenance).
+Want to verify our builds? Go [here](https://www.npmjs.com/package/dockview#user-content-provenance).


### PR DESCRIPTION
npm on the package page now adds some prefix/suffix to IDs generated from markdown headers, therefore the link in the repo README wasn't scrolling the page to the Provenance section when clicked, but that was obviously an intention

this PR fixes the link
![image](https://github.com/user-attachments/assets/d90488cc-8213-4ed4-8674-d01a7b64c0b6)
