### PR TITLE
Check tabToRemove is not undefined prior to destructuring

### DIFF
--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -283,6 +283,9 @@ export class TabsContainer
 
         const tabToRemove = this.tabs.splice(index, 1)[0];
 
+        if (!tabToRemove)
+            return;
+
         const { value, disposable } = tabToRemove;
 
         disposable.dispose();


### PR DESCRIPTION
Prevent a crash when trying to destructure `tabToRemove` as dockview is unmounting with a popout open.