### PR TITLE
check tabToRemove is not undefined before access

### DIFF
--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -283,6 +283,9 @@ export class TabsContainer
 
         const tabToRemove = this.tabs.splice(index, 1)[0];
 
+        if (!tabToRemove)
+            return;
+
         const { value, disposable } = tabToRemove;
 
         disposable.dispose();


### PR DESCRIPTION
Check to ensure `tabToRemove` is not undefined before accessing, which appears to be the case when navigating away from/unmounting dockview with a popout open.