### PR TITLE
[896] Restore Popout content for blocked popouts and emit onDidBlockPopout event

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -5791,6 +5791,54 @@ describe('dockviewComponent', () => {
             ]);
         });
 
+        describe('when browsers block popups', () => {
+            let container: HTMLDivElement;
+            let dockview: DockviewComponent;
+            let panel: DockviewPanel;
+
+            beforeEach(() => {
+                jest.spyOn(window, 'open').mockReturnValue(null);
+
+                container = document.createElement('div');
+
+                dockview = new DockviewComponent(container, {
+                    createComponent(options) {
+                        switch (options.name) {
+                            case 'default':
+                                return new PanelContentPartTest(
+                                    options.id,
+                                    options.name
+                                );
+                            default:
+                                throw new Error(`unsupported`);
+                        }
+                    },
+                });
+
+                dockview.layout(1000, 500);
+
+                panel = dockview.addPanel({
+                    id: 'panel_1',
+                    component: 'default',
+                });
+            });
+
+            test('onDidBlockPopout event is emitted', async () => {
+                const onDidBlockPopoutHandler = jest.fn();
+                dockview.onDidBlockPopout(onDidBlockPopoutHandler);
+
+                await dockview.addPopoutGroup(panel.group);
+
+                expect(onDidBlockPopoutHandler).toHaveBeenCalledTimes(1);
+            });
+
+            test('popout group is restored to its original position', async () => {
+                await dockview.addPopoutGroup(panel.group);
+
+                expect(panel.group.api.location.type).toBe('grid');
+            });
+        });
+
         test('dispose of dockview instance when popup is open', async () => {
             const container = document.createElement('div');
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -251,6 +251,9 @@ export class Tabs extends CompositeDisposable {
     delete(id: string): void {
         const index = this.indexOf(id);
         const tabToRemove = this._tabs.splice(index, 1)[0];
+        if (!tabToRemove) {
+            return;
+        }
 
         const { value, disposable } = tabToRemove;
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -718,26 +718,10 @@ export class DockviewComponent
                     return false;
                 }
 
-                if (popoutContainer === null) {
-                    popoutWindowDisposable.dispose();
-                    this._onDidBlockPopout.fire();
-                    return false;
-                }
-
-                const gready = document.createElement('div');
-                gready.className = 'dv-overlay-render-container';
-
-                const overlayRenderContainer = new OverlayRenderContainer(
-                    gready,
-                    this
-                );
-
                 const referenceGroup =
                     itemToPopout instanceof DockviewPanel
                         ? itemToPopout.group
                         : itemToPopout;
-
-                const referenceLocation = itemToPopout.api.location.type;
 
                 /**
                  * The group that is being added doesn't already exist within the DOM, the most likely occurrence
@@ -756,6 +740,36 @@ export class DockviewComponent
                     group = this.createGroup({ id: groupId });
                     this._onDidAddGroup.fire(group);
                 }
+
+                if (popoutContainer === null) {
+                    popoutWindowDisposable.dispose();
+                    this._onDidBlockPopout.fire();
+
+                    // if the popout window was blocked, we need to move the group back to the reference group
+                    // and set it to visible
+                    this.movingLock(() =>
+                        moveGroupWithoutDestroying({
+                            from: group,
+                            to: referenceGroup,
+                        })
+                    );
+
+                    if (!referenceGroup.api.isVisible) {
+                        referenceGroup.api.setVisible(true);
+                    }
+
+                    return false;
+                }
+
+                const gready = document.createElement('div');
+                gready.className = 'dv-overlay-render-container';
+
+                const overlayRenderContainer = new OverlayRenderContainer(
+                    gready,
+                    this
+                );
+
+                const referenceLocation = itemToPopout.api.location.type;
 
                 group.model.renderContainer = overlayRenderContainer;
                 group.layout(

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -738,7 +738,9 @@ export class DockviewComponent
                     group = options.overridePopoutGroup;
                 } else {
                     group = this.createGroup({ id: groupId });
-                    this._onDidAddGroup.fire(group);
+                    if (popoutContainer) {
+                      this._onDidAddGroup.fire(group);
+                    }
                 }
 
                 if (popoutContainer === null) {


### PR DESCRIPTION
If you restore a stored layout from JSON that includes a popout on page load, most browser will block it from opening since the user didn't initiate opening the new popup window. Currently it is hard to determine if this happens and to handle it so that pop out content isn't lost.

This adds an event that triggers if the popout fails to open because of window.open failing to return a window object (most likely blocked by browsers popup blocker) and it also adds the popout group back into grid in the same way as if you would have closed the popout window manually. Hopefully this makes sense.

This is my suggestion for how to improve the behaviour when the browsers blocks the popout from opening and I'm happy to create some settings/props to make it optional.

### Todo

- [x] Add tests