### PR TITLE
feat: add header position support to dockview group panel

### DIFF
--- a/packages/dockview-core/src/dockview/components/tab/defaultTab.scss
+++ b/packages/dockview-core/src/dockview/components/tab/defaultTab.scss
@@ -57,6 +57,7 @@
     .dv-default-tab {
         position: relative;
         height: 100%;
+        width: 100%;
         display: flex;
         align-items: center;
         white-space: nowrap;

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -4,7 +4,8 @@
     overflow: auto;
     scrollbar-width: thin; // firefox
 
-    &.dv-horizontal {
+    &.dv-horizontal,
+    &.dv-vertical {
         .dv-tab {
             &:not(:first-child)::before {
                 content: ' ';
@@ -14,10 +15,18 @@
                 z-index: 5;
                 pointer-events: none;
                 background-color: var(--dv-tab-divider-color);
-                width: 1px;
-                height: 100%;
             }
         }
+    }
+
+    &.dv-horizontal .dv-tab:not(:first-child)::before {
+        width: 1px;
+        height: 100%;
+    }
+
+    &.dv-vertical .dv-tab:not(:first-child)::before {
+        width: 100%;
+        height: 1px;
     }
 
     &::-webkit-scrollbar {
@@ -32,6 +41,15 @@
     /* Handle */
     &::-webkit-scrollbar-thumb {
         background: var(--dv-tabs-container-scrollbar-color);
+    }
+
+    &.dv-tabs-container-vertical {
+        flex-direction: column;
+
+        .dv-tab {
+          writing-mode: vertical-rl;
+          transform: rotate(180deg);
+        }
     }
 }
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -4,6 +4,13 @@
     overflow: auto;
     scrollbar-width: thin; // firefox
 
+    &.dv-tabs-container-vertical {
+        width: 100%;
+        height: fit-content;
+        max-height: 100%;
+        writing-mode: vertical-rl;
+    }
+
     &.dv-horizontal,
     &.dv-vertical {
         .dv-tab {
@@ -19,14 +26,21 @@
         }
     }
 
-    &.dv-horizontal .dv-tab:not(:first-child)::before {
-        width: 1px;
-        height: 100%;
+    &.dv-horizontal {
+        .dv-tab {
+            &:not(:first-child)::before {
+                width: 1px;
+                height: 100%;
+            }
+        }
     }
-
-    &.dv-vertical .dv-tab:not(:first-child)::before {
-        width: 100%;
-        height: 1px;
+    &.dv-vertical {
+        .dv-tab {
+            &:not(:first-child)::before {
+                width: 100%;
+                height: 1px;
+            }
+        }
     }
 
     &::-webkit-scrollbar {
@@ -43,14 +57,6 @@
         background: var(--dv-tabs-container-scrollbar-color);
     }
 
-    &.dv-tabs-container-vertical {
-        flex-direction: column;
-
-        .dv-tab {
-          writing-mode: vertical-rl;
-          transform: rotate(180deg);
-        }
-    }
 }
 
 .dv-scrollable {
@@ -68,6 +74,12 @@
     box-sizing: border-box;
     font-size: var(--dv-tab-font-size);
     margin: var(--dv-tab-margin);
+}
+
+.dv-tabs-container-vertical {
+    .dv-tab {
+        padding: 0.5rem 0.25rem;
+    }
 }
 
 .dv-tabs-overflow-container {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -1,7 +1,9 @@
 import { getPanelData } from '../../../dnd/dataTransfer';
 import {
+  addClasses,
     isChildEntirelyVisibleWithinParent,
     OverflowObserver,
+    removeClasses,
 } from '../../../dom';
 import { addDisposableListener, Emitter, Event } from '../../../events';
 import {
@@ -15,6 +17,7 @@ import { DockviewComponent } from '../../dockviewComponent';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import { WillShowOverlayLocationEvent } from '../../dockviewGroupPanelModel';
 import { DockviewPanel, IDockviewPanel } from '../../dockviewPanel';
+import { IHeaderDirection } from '../../options';
 import { Tab } from '../tab/tab';
 import { TabDragEvent, TabDropIndexEvent } from './tabsContainer';
 
@@ -26,6 +29,7 @@ export class Tabs extends CompositeDisposable {
     private _tabs: IValueDisposable<Tab>[] = [];
     private selectedIndex = -1;
     private _showTabsOverflowControl = false;
+    private _direction: IHeaderDirection = 'horizontal';
 
     private readonly _onTabDragStart = new Emitter<TabDragEvent>();
     readonly onTabDragStart: Event<TabDragEvent> = this._onTabDragStart.event;
@@ -87,6 +91,21 @@ export class Tabs extends CompositeDisposable {
         return this._tabs.map((_) => _.value);
     }
 
+    get direction(): IHeaderDirection {
+        return this._direction;
+    }
+
+    set direction(value: IHeaderDirection) {
+        this._direction = value;
+        removeClasses(this._tabsList, 'dv-horizontal', 'dv-vertical');
+        if(value === 'vertical') {
+            addClasses(this._tabsList, 'dv-tabs-container-vertical', 'dv-vertical');
+        } else {
+            removeClasses(this._tabsList, 'dv-tabs-container-vertical');
+            addClasses(this._tabsList, 'dv-horizontal');
+        }
+    }
+
     constructor(
         private readonly group: DockviewGroupPanel,
         private readonly accessor: DockviewComponent,
@@ -97,7 +116,7 @@ export class Tabs extends CompositeDisposable {
         super();
 
         this._tabsList = document.createElement('div');
-        this._tabsList.className = 'dv-tabs-container dv-horizontal';
+        this._tabsList.className = 'dv-tabs-container';
 
         this.showTabsOverflowControl = options.showTabsOverflowControl;
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -25,6 +25,7 @@ export class Tabs extends CompositeDisposable {
     private readonly _element: HTMLElement;
     private readonly _tabsList: HTMLElement;
     private readonly _observerDisposable = new MutableDisposable();
+    private readonly _scrollbar: Scrollbar | null = null;
 
     private _tabs: IValueDisposable<Tab>[] = [];
     private selectedIndex = -1;
@@ -96,7 +97,14 @@ export class Tabs extends CompositeDisposable {
     }
 
     set direction(value: IHeaderDirection) {
+        if(this._direction === value) {
+            return;
+        }
+
         this._direction = value;
+        if(this._scrollbar) {
+            this._scrollbar.orientation = value;
+        }
         removeClasses(this._tabsList, 'dv-horizontal', 'dv-vertical');
         if(value === 'vertical') {
             addClasses(this._tabsList, 'dv-tabs-container-vertical', 'dv-vertical');
@@ -123,9 +131,10 @@ export class Tabs extends CompositeDisposable {
         if (accessor.options.scrollbars === 'native') {
             this._element = this._tabsList;
         } else {
-            const scrollbar = new Scrollbar(this._tabsList);
-            this._element = scrollbar.element;
-            this.addDisposables(scrollbar);
+            this._scrollbar = new Scrollbar(this._tabsList);
+            this._scrollbar.orientation = this.direction
+            this._element = this._scrollbar.element;
+            this.addDisposables(this._scrollbar);
         }
 
         this.addDisposables(

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.scss
@@ -33,5 +33,15 @@
 
     .dv-right-actions-container {
         display: flex;
+
+        &.dv-right-actions-container-vertical {
+            flex-direction: column;
+        }
+    }
+
+    &.dv-groupview-header-vertical {
+        flex-direction: column;
+        height: auto;
+        width: var(--dv-tabs-and-actions-container-height);
     }
 }

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -8,7 +8,7 @@ import { addDisposableListener, Emitter, Event } from '../../../events';
 import { Tab } from '../tab/tab';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import { VoidContainer } from './voidContainer';
-import { findRelativeZIndexParent, toggleClass } from '../../../dom';
+import { addClasses, findRelativeZIndexParent, removeClasses, toggleClass } from '../../../dom';
 import { IDockviewPanel } from '../../dockviewPanel';
 import { DockviewComponent } from '../../dockviewComponent';
 import { WillShowOverlayLocationEvent } from '../../dockviewGroupPanelModel';
@@ -18,6 +18,7 @@ import {
     createDropdownElementHandle,
     DropdownElement,
 } from './tabOverflowControl';
+import { IHeaderDirection } from '../../options';
 
 export interface TabDropIndexEvent {
     readonly event: DragEvent;
@@ -43,6 +44,7 @@ export interface ITabsContainer extends IDisposable {
     readonly onGroupDragStart: Event<GroupDragEvent>;
     readonly onWillShowOverlay: Event<WillShowOverlayLocationEvent>;
     hidden: boolean;
+    direction: IHeaderDirection;
     delete(id: string): void;
     indexOf(id: string): number;
     setActive(isGroupActive: boolean): void;
@@ -73,6 +75,7 @@ export class TabsContainer
     private preActions: HTMLElement | undefined;
 
     private _hidden = false;
+    private _direction: IHeaderDirection = 'horizontal';
 
     private dropdownPart: DropdownElement | null = null;
     private _overflowTabs: string[] = [];
@@ -109,6 +112,23 @@ export class TabsContainer
     set hidden(value: boolean) {
         this._hidden = value;
         this.element.style.display = value ? 'none' : '';
+    }
+
+    get direction(): IHeaderDirection {
+        return this._direction;
+    }
+
+    set direction(value: IHeaderDirection) {
+        this._direction = value;
+        if(value === 'vertical') {
+          addClasses(this._element, 'dv-groupview-header-vertical');
+          addClasses(this.rightActionsContainer, 'dv-right-actions-container-vertical');
+          this.tabs.direction = value;
+        } else {
+          removeClasses(this._element, 'dv-groupview-header-vertical');
+          removeClasses(this.rightActionsContainer, 'dv-right-actions-container-vertical');
+          this.tabs.direction = value;
+        }
     }
 
     get element(): HTMLElement {

--- a/packages/dockview-core/src/dockview/dockviewGroupPanel.scss
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanel.scss
@@ -1,6 +1,5 @@
 .dv-groupview {
     display: flex;
-    flex-direction: column;
     height: 100%;
     background-color: var(--dv-group-view-background-color);
     overflow: hidden;
@@ -13,5 +12,21 @@
         flex-grow: 1;
         min-height: 0;
         outline: none;
+    }
+
+    &.dv-groupview-header-top {
+        flex-direction: column;
+    }
+
+    &.dv-groupview-header-bottom {
+        flex-direction: column-reverse;
+    }
+
+    &.dv-groupview-header-left {
+        flex-direction: row;
+    }
+
+    &.dv-groupview-header-right {
+        flex-direction: row-reverse;
     }
 }

--- a/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
@@ -13,6 +13,7 @@ import {
     DockviewGroupPanelApi,
     DockviewGroupPanelApiImpl,
 } from '../api/dockviewGroupPanelApi';
+import { IHeaderPosition } from './options';
 
 const MINIMUM_DOCKVIEW_GROUP_PANEL_WIDTH = 100;
 const MINIMUM_DOCKVIEW_GROUP_PANEL_HEIGHT = 100;
@@ -21,6 +22,7 @@ export interface IDockviewGroupPanel
     extends IGridviewPanel<DockviewGroupPanelApi> {
     model: IDockviewGroupPanelModel;
     locked: DockviewGroupPanelLocked;
+    headerPosition: IHeaderPosition;
     readonly size: number;
     readonly panels: IDockviewPanel[];
     readonly activePanel: IDockviewPanel | undefined;
@@ -92,6 +94,13 @@ export class DockviewGroupPanel
 
     get header(): IHeader {
         return this._model.header;
+    }
+
+    get headerPosition(): IHeaderPosition {
+        return this._model.headerPosition;
+    }
+    set headerPosition(value: IHeaderPosition) {
+        this._model.headerPosition = value;
     }
 
     constructor(

--- a/packages/dockview-core/src/dockview/framework.ts
+++ b/packages/dockview-core/src/dockview/framework.ts
@@ -4,6 +4,7 @@ import { DockviewPanelApi } from '../api/dockviewPanelApi';
 import { PanelParameters } from '../framwork';
 import { DockviewGroupPanel, IDockviewGroupPanel } from './dockviewGroupPanel';
 import { IDockviewPanel } from './dockviewPanel';
+import { IHeaderPosition } from './options';
 
 export interface IGroupPanelBaseProps<T extends { [index: string]: any } = any>
     extends PanelParameters<T> {
@@ -27,6 +28,7 @@ export interface IDockviewHeaderActionsProps {
     activePanel: IDockviewPanel | undefined;
     isGroupActive: boolean;
     group: DockviewGroupPanel;
+    headerPosition: IHeaderPosition;
 }
 
 export interface IGroupHeaderProps {

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -35,6 +35,9 @@ export interface ViewFactoryData {
     tab?: string;
 }
 
+export type IHeaderPosition = 'top' | 'bottom' | 'left' | 'right';
+export type IHeaderDirection = 'horizontal' | 'vertical';
+
 export interface DockviewOptions {
     /**
      * Disable the auto-resizing which is controlled through a `ResizeObserver`.

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -382,10 +382,10 @@ export function isChildEntirelyVisibleWithinParent(
     child: HTMLElement,
     parent: HTMLElement
 ): boolean {
-    //
     const childPosition = getDomNodePagePosition(child);
     const parentPosition = getDomNodePagePosition(parent);
 
+    // Check horizontal visibility
     if (childPosition.left < parentPosition.left) {
         return false;
     }
@@ -393,6 +393,18 @@ export function isChildEntirelyVisibleWithinParent(
     if (
         childPosition.left + childPosition.width >
         parentPosition.left + parentPosition.width
+    ) {
+        return false;
+    }
+
+    // Check vertical visibility
+    if (childPosition.top < parentPosition.top) {
+        return false;
+    }
+
+    if (
+        childPosition.top + childPosition.height >
+        parentPosition.top + parentPosition.height
     ) {
         return false;
     }

--- a/packages/dockview-core/src/lifecycle.ts
+++ b/packages/dockview-core/src/lifecycle.ts
@@ -24,7 +24,7 @@ export namespace Disposable {
 }
 
 export class CompositeDisposable {
-    private _disposables: IDisposable[];
+    private _disposables: Set<IDisposable>;
     private _isDisposed = false;
 
     get isDisposed(): boolean {
@@ -32,11 +32,14 @@ export class CompositeDisposable {
     }
 
     constructor(...args: IDisposable[]) {
-        this._disposables = args;
+        this._disposables = new Set(args);
     }
 
     public addDisposables(...args: IDisposable[]): void {
-        args.forEach((arg) => this._disposables.push(arg));
+        args.forEach((arg) => this._disposables.add(arg));
+    }
+    public removeDisposable(disposable: IDisposable): void {
+        this._disposables.delete(disposable);
     }
 
     public dispose(): void {
@@ -46,7 +49,7 @@ export class CompositeDisposable {
 
         this._isDisposed = true;
         this._disposables.forEach((arg) => arg.dispose());
-        this._disposables = [];
+        this._disposables.clear();
     }
 }
 

--- a/packages/dockview-core/src/scrollbar.scss
+++ b/packages/dockview-core/src/scrollbar.scss
@@ -2,11 +2,8 @@
     position: relative;
     overflow: hidden;
 
-    .dv-scrollbar-horizontal {
+    .dv-scrollbar {
         position: absolute;
-        bottom: 0px;
-        left: 0px;
-        height: 4px;
         border-radius: 2px;
         background-color: transparent;
         transition-property: background-color;
@@ -15,10 +12,23 @@
         transition-delay: 0s;
     }
 
+
+    .dv-scrollbar-horizontal {
+        bottom: 0px;
+        left: 0px;
+        height: 4px;
+    }
+
+    .dv-scrollbar-vertical {
+        right: 0px;
+        top: 0px;
+        width: 4px;
+    }
+
     &:hover,
     &.dv-scrollable-resizing,
     &.dv-scrollable-scrolling {
-        .dv-scrollbar-horizontal {
+        .dv-scrollbar {
             background-color: var(
                 --dv-scrollbar-background-color,
                 rgba(255, 255, 255, 0.25)

--- a/packages/dockview-core/src/scrollbar.ts
+++ b/packages/dockview-core/src/scrollbar.ts
@@ -1,18 +1,37 @@
-import { toggleClass, watchElementResize } from './dom';
+import { addClasses, removeClasses, toggleClass, watchElementResize } from './dom';
 import { addDisposableListener } from './events';
 import { CompositeDisposable } from './lifecycle';
 import { clamp } from './math';
 
 export class Scrollbar extends CompositeDisposable {
     private readonly _element: HTMLElement;
-    private readonly _horizontalScrollbar: HTMLElement;
-    private _scrollLeft: number = 0;
+    private readonly _scrollbar: HTMLElement;
+    private _scrollOffset: number = 0;
     private _animationTimer: any;
+    private _orientation: 'horizontal' | 'vertical' = 'horizontal';
     public static MouseWheelSpeed = 1;
 
     get element(): HTMLElement {
         return this._element;
     }
+
+    get orientation(): 'horizontal' | 'vertical' {
+        return this._orientation;
+    }
+    set orientation(value: 'horizontal' | 'vertical') {
+        if(this._orientation === value) {
+          return;
+        }
+        this._scrollOffset = 0;
+        this._orientation = value;
+        removeClasses(this._scrollbar, 'dv-scrollbar-vertical', 'dv-scrollbar-horizontal');
+        if(value === 'vertical') {
+            addClasses(this._scrollbar, 'dv-scrollbar-vertical');
+        } else {
+            addClasses(this._scrollbar, 'dv-scrollbar-horizontal');
+        }
+    }
+
 
     constructor(private readonly scrollableElement: HTMLElement) {
         super();
@@ -20,37 +39,42 @@ export class Scrollbar extends CompositeDisposable {
         this._element = document.createElement('div');
         this._element.className = 'dv-scrollable';
 
-        this._horizontalScrollbar = document.createElement('div');
-        this._horizontalScrollbar.className = 'dv-scrollbar-horizontal';
+        this._scrollbar = document.createElement('div');
+        this._scrollbar.className = 'dv-scrollbar dv-scrollbar-horizontal';
 
         this.element.appendChild(scrollableElement);
-        this.element.appendChild(this._horizontalScrollbar);
+        this.element.appendChild(this._scrollbar);
 
         this.addDisposables(
             addDisposableListener(this.element, 'wheel', (event) => {
-                this._scrollLeft += event.deltaY * Scrollbar.MouseWheelSpeed;
-
+                this._scrollOffset += event.deltaY * Scrollbar.MouseWheelSpeed;
                 this.calculateScrollbarStyles();
             }),
             addDisposableListener(
-                this._horizontalScrollbar,
+                this._scrollbar,
                 'pointerdown',
                 (event) => {
                     event.preventDefault();
 
                     toggleClass(this.element, 'dv-scrollable-scrolling', true);
 
-                    const originalClientX = event.clientX;
-                    const originalScrollLeft = this._scrollLeft;
+                    const originalClient = this._orientation === 'horizontal' ? event.clientX : event.clientY;
+                    const originalScrollOffset = this._scrollOffset;
 
                     const onPointerMove = (event: PointerEvent) => {
-                        const deltaX = event.clientX - originalClientX;
+                        const delta = this._orientation === 'horizontal'
+                            ? event.clientX - originalClient
+                            : event.clientY - originalClient;
 
-                        const { clientWidth } = this.element;
-                        const { scrollWidth } = this.scrollableElement;
-                        const p = clientWidth / scrollWidth;
+                        const clientSize = this._orientation === 'horizontal'
+                            ? this.element.clientWidth
+                            : this.element.clientHeight;
+                        const scrollSize = this._orientation === 'horizontal'
+                            ? this.scrollableElement.scrollWidth
+                            : this.scrollableElement.scrollHeight;
+                        const p = clientSize / scrollSize;
 
-                        this._scrollLeft = originalScrollLeft + deltaX / p;
+                        this._scrollOffset = originalScrollOffset + delta / p;
                         this.calculateScrollbarStyles();
                     };
 
@@ -78,7 +102,9 @@ export class Scrollbar extends CompositeDisposable {
                 this.calculateScrollbarStyles();
             }),
             addDisposableListener(this.scrollableElement, 'scroll', () => {
-                this._scrollLeft = this.scrollableElement.scrollLeft;
+                this._scrollOffset = this._orientation === 'horizontal'
+                    ? this.scrollableElement.scrollLeft
+                    : this.scrollableElement.scrollTop;
                 this.calculateScrollbarStyles();
             }),
             watchElementResize(this.element, () => {
@@ -99,33 +125,57 @@ export class Scrollbar extends CompositeDisposable {
     }
 
     private calculateScrollbarStyles(): void {
-        const { clientWidth } = this.element;
-        const { scrollWidth } = this.scrollableElement;
+        const clientSize = this._orientation === 'horizontal'
+            ? this.element.clientWidth
+            : this.element.clientHeight;
+        const scrollSize = this._orientation === 'horizontal'
+            ? this.scrollableElement.scrollWidth
+            : this.scrollableElement.scrollHeight;
 
-        const hasScrollbar = scrollWidth > clientWidth;
+        const hasScrollbar = scrollSize > clientSize;
 
         if (hasScrollbar) {
-            const px = clientWidth * (clientWidth / scrollWidth);
-            this._horizontalScrollbar.style.width = `${px}px`;
+            const px = clientSize * (clientSize / scrollSize);
 
-            this._scrollLeft = clamp(
-                this._scrollLeft,
+            if (this._orientation === 'horizontal') {
+                this._scrollbar.style.width = `${px}px`;
+                this._scrollbar.style.height = '';
+            } else {
+                this._scrollbar.style.height = `${px}px`;
+                this._scrollbar.style.width = '';
+            }
+
+            this._scrollOffset = clamp(
+                this._scrollOffset,
                 0,
-                this.scrollableElement.scrollWidth - clientWidth
+                scrollSize - clientSize
             );
 
-            this.scrollableElement.scrollLeft = this._scrollLeft;
+            if (this._orientation === 'horizontal') {
+                this.scrollableElement.scrollLeft = this._scrollOffset;
+            } else {
+                this.scrollableElement.scrollTop = this._scrollOffset;
+            }
 
             const percentageComplete =
-                this._scrollLeft / (scrollWidth - clientWidth);
+                this._scrollOffset / (scrollSize - clientSize);
 
-            this._horizontalScrollbar.style.left = `${
-                (clientWidth - px) * percentageComplete
-            }px`;
+            if (this._orientation === 'horizontal') {
+                this._scrollbar.style.left = `${(clientSize - px) * percentageComplete}px`;
+                this._scrollbar.style.top = '';
+            } else {
+                this._scrollbar.style.top = `${(clientSize - px) * percentageComplete}px`;
+                this._scrollbar.style.left = '';
+            }
         } else {
-            this._horizontalScrollbar.style.width = `0px`;
-            this._horizontalScrollbar.style.left = `0px`;
-            this._scrollLeft = 0;
+            if (this._orientation === 'horizontal') {
+                this._scrollbar.style.width = '0px';
+                this._scrollbar.style.left = '0px';
+            } else {
+                this._scrollbar.style.height = '0px';
+                this._scrollbar.style.top = '0px';
+            }
+            this._scrollOffset = 0;
         }
     }
 }

--- a/packages/dockview/src/dockview/headerActionsRenderer.ts
+++ b/packages/dockview/src/dockview/headerActionsRenderer.ts
@@ -65,6 +65,7 @@ export class ReactHeaderActionsRendererPart implements IHeaderActionsRenderer {
                 activePanel: this._group.model.activePanel,
                 isGroupActive: this._group.api.isActive,
                 group: this._group,
+                headerPosition: this._group.headerPosition,
             }
         );
     }

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/controls.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/controls.tsx
@@ -73,12 +73,16 @@ export const RightControls = (props: IDockviewHeaderActionsProps) => {
         }
     };
 
+    const vertical = props.group.headerPosition === 'left' || props.group.headerPosition === 'right';
+
     return (
         <div
             className="group-control"
             style={{
                 display: 'flex',
+                flexDirection: vertical ? 'column' : 'row',
                 alignItems: 'center',
+                justifyContent: 'center',
                 padding: '0px 8px',
                 height: '100%',
                 color: 'var(--dv-activegroup-hiddenpanel-tab-color)',
@@ -120,6 +124,7 @@ export const LeftControls = (props: IDockviewHeaderActionsProps) => {
             style={{
                 display: 'flex',
                 alignItems: 'center',
+                justifyContent: 'center',
                 padding: '0px 8px',
                 height: '100%',
                 color: 'var(--dv-activegroup-visiblepanel-tab-color)',
@@ -137,6 +142,7 @@ export const PrefixHeaderControls = (props: IDockviewHeaderActionsProps) => {
             style={{
                 display: 'flex',
                 alignItems: 'center',
+                justifyContent: 'center',
                 padding: '0px 8px',
                 height: '100%',
                 color: 'var(--dv-activegroup-visiblepanel-tab-color)',

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/groupActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/groupActions.tsx
@@ -104,6 +104,23 @@ const GroupAction = (props: {
                     <span className="material-symbols-outlined">ad_group</span>
                 </button>
                 <button
+                  className="demo-icon-button"
+                  onClick={() => {
+                      const panel = props.api?.getGroup(props.groupId);
+                            const dir = ['top', 'left', 'bottom', 'right']
+                            if (panel) {
+                              const index = ((dir.indexOf(panel.headerPosition) + 1) % dir.length)
+
+                              panel.headerPosition = dir[index] as IHeaderPosition
+                              console.log(props.groupId, panel.headerPosition)
+                            }
+                        }}
+                    >
+                      <span className="material-symbols-outlined">
+                        loop
+                      </span>
+                </button>
+                <button
                     className={
                         location?.type === 'popout'
                             ? 'demo-icon-button selected'


### PR DESCRIPTION
Resolve #894

Add `headerPosition` option to DockviewGroupPanel so that the user can change the position of the tab container in Dockview.

I have added a new action to `packages\docs\sandboxes\react\dockview\demo-dockview`, which allows the position field to loop through 'top', 'left', 'bottom', and 'right'.

| Position | Image |
|:-:|:-:|
| top | ![image](https://github.com/user-attachments/assets/36450990-25b2-45dc-b993-566953f037c8) |
| left | ![image](https://github.com/user-attachments/assets/161fd3e6-fc94-4c12-9fcc-46a1d758363d) |
| bottom | ![image](https://github.com/user-attachments/assets/512e65ad-e726-4d09-ad64-d51e070b9f05) |
| right | ![image](https://github.com/user-attachments/assets/bea943fe-89e4-49f7-85f4-8f28f4007c4d) |


Tested on firefox and chrome