### PR TITLE
Emitter: only store last event if replay is active

### DIFF
--- a/packages/dockview-core/src/events.ts
+++ b/packages/dockview-core/src/events.ts
@@ -160,7 +160,9 @@ export class Emitter<T> implements IDisposable {
     }
 
     public fire(e: T): void {
-        this._last = e;
+        if(this.options?.replay){
+            this._last = e;
+        }
         for (const listener of this._listeners) {
             listener.callback(e);
         }


### PR DESCRIPTION
Hello! Thank you for this library! I've been porting an app over to it and it has been very nice to work with.

I ran into the following situation:

I'm using Angular and am needing to manually trigger Angular's `ngOnDestroy` lifecycle event on a component inside a dockview panel. To do this, I'm listening to the dockview `onDidRemovePanel` event. When the event fires, I trigger the angular lifecycle event and dispose of some references to the component.

The issue is that, when I run chrome's profiler, it looks like dockview's event emitters _always_ retain a reference to the "last" thing to come out of the emitter, even if not in "replay" mode.

In my case, this component is fairly heavy memory-wise and I'd really like to let it be GC'd. This change should make the emitter only retain the "last" event when necessary for the "replay" behavior.

Thanks again for publishing this!