### PR TITLE
feat: add skipSetActive parameter to moveTo functions

### DIFF
--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -15,6 +15,10 @@ export interface DockviewGroupMoveParams {
      * The index to place the panel within a group, only applicable if the placement is within an existing group
      */
     index?: number;
+    /**
+     * Whether to skip setting the group as active after moving
+     */
+    skipSetActive?: boolean;
 }
 
 export interface DockviewGroupPanelApi extends GridviewPanelApi {
@@ -88,7 +92,7 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             options.group ??
             this.accessor.addGroup({
                 direction: positionToDirection(options.position ?? 'right'),
-                skipSetActive: true,
+                skipSetActive: options.skipSetActive ?? false,
             });
 
         this.accessor.moveGroupOrPanel({
@@ -100,6 +104,7 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
                     : 'center',
                 index: options.index,
             },
+            skipSetActive: options.skipSetActive,
         });
     }
 

--- a/packages/dockview-core/src/api/dockviewPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewPanelApi.ts
@@ -170,6 +170,7 @@ export class DockviewPanelApiImpl
                     : 'center',
                 index: options.index,
             },
+            skipSetActive: options.skipSetActive,
         });
     }
 


### PR DESCRIPTION
Add optional skipSetActive parameter to panel and group moveTo functions to prevent automatic activation when moving panels or groups. This allows programmatic layout changes without disrupting the current focus.

Changes:
- Add skipSetActive parameter to DockviewGroupMoveParams interface
- Update panel and group moveTo implementations to respect skipSetActive
- Update moveGroupOrPanel and moveGroup functions to handle skipSetActive
- Fix group merging logic to preserve target group's active panel
- Add comprehensive tests for both panel and group moveTo with skipSetActive

🤖 Generated with [Claude Code](https://claude.ai/code)