### PR TITLE
feat: add reuseExistingPanels

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -906,6 +906,8 @@ export class DockviewGroupPanelModel
         if (panel) {
             this.tabsContainer.setActivePanel(panel);
 
+            this.contentContainer.openPanel(panel);
+
             panel.layout(this._width, this._height);
 
             this.updateMru(panel);


### PR DESCRIPTION
Continues experimental work from @mathuo for persistent unused panels (always keep-alive). Adds `reuseExistingPanels` option to `fromJSON()` method to preserve existing panel instances.

Rebased from commit 97e8a95 (Nov 30, 2024) onto current master (v4.11.0) to resolve conflicts and integrate with latest codebase changes.

@mathuo - I had to replace `runWithSuppressedEvents` in favor of `movingLock` usage based on what I saw, it looks like that got renamed.

Related: https://github.com/mathuo/dockview/pull/778

cc: @crubier 