### PR TITLE
Fix FocusTracker sync issue when adding panels from within panel content

### DIFF
--- a/packages/dockview-core/src/dockview/components/panel/content.ts
+++ b/packages/dockview-core/src/dockview/components/panel/content.ts
@@ -22,6 +22,7 @@ export interface IContentContainer extends IDisposable {
     show(): void;
     hide(): void;
     renderPanel(panel: IDockviewPanel, options: { asActive: boolean }): void;
+    refreshFocusState(): void;
 }
 
 export class ContentContainer
@@ -31,6 +32,7 @@ export class ContentContainer
     private readonly _element: HTMLElement;
     private panel: IDockviewPanel | undefined;
     private readonly disposable = new MutableDisposable();
+    private focusTracker: { refreshState?(): void } | undefined;
 
     private readonly _onDidFocus = new Emitter<void>();
     readonly onDidFocus: Event<void> = this._onDidFocus.event;
@@ -156,6 +158,7 @@ export class ContentContainer
 
         if (doRender) {
             const focusTracker = trackFocus(container);
+            this.focusTracker = focusTracker;
             const disposable = new CompositeDisposable();
 
             disposable.addDisposables(
@@ -194,5 +197,15 @@ export class ContentContainer
     public dispose(): void {
         this.disposable.dispose();
         super.dispose();
+    }
+
+    /**
+     * Refresh the focus tracker state to handle cases where focus state
+     * gets out of sync due to programmatic panel activation
+     */
+    public refreshFocusState(): void {
+        if (this.focusTracker?.refreshState) {
+            this.focusTracker.refreshState();
+        }
     }
 }

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -910,6 +910,9 @@ export class DockviewGroupPanelModel
 
             this.updateMru(panel);
 
+            // Refresh focus state to handle programmatic activation without DOM focus change
+            this.contentContainer.refreshFocusState();
+
             this._onDidActivePanelChange.fire({
                 panel,
             });


### PR DESCRIPTION
Resolves issue #1032 where group activation clicks stop working after calling addPanel from within panel content (e.g., button clicks).

The problem occurred when:
1. User clicks button in Panel A to add Panel B
2. DOM focus stays on Panel A but Panel B becomes active programmatically
3. FocusTracker thinks Panel A still has focus
4. Subsequent clicks on Panel A's group don't fire focus events
5. No focus event = no group activation

Solution:
- Add refreshFocusState() method to ContentContainer
- Call refreshState() on FocusTracker after programmatic panel activation
- Ensures FocusTracker state stays synchronized with actual active panel

🤖 Generated with [Claude Code](https://claude.ai/code)