### PR TITLE
security: Update Angular peer dependencies to address CVE-2025-66412

### DIFF
--- a/packages/dockview-angular/package.json
+++ b/packages/dockview-angular/package.json
@@ -56,8 +56,8 @@
     "dockview-core": "^4.12.0"
   },
   "peerDependencies": {
-    "@angular/common": ">=14.0.0",
-    "@angular/core": ">=14.0.0",
+    "@angular/common": ">=21.0.6",
+    "@angular/core": ">=21.0.6",
     "rxjs": ">=7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Bump minimum Angular version from 14.0.0 to 21.0.6
- Addresses stored XSS vulnerability in Angular template compiler
- CVE-2025-66412 affects Angular versions prior to 21.0.2
- Vulnerability allows XSS through unsafe SVG animation attributes

🤖 Generated with [Claude Code](https://claude.ai/code)