### PR TITLE
fix: close tab overflow popover on window resize

### DIFF
--- a/packages/dockview-core/src/dockview/components/popupService.ts
+++ b/packages/dockview-core/src/dockview/components/popupService.ts
@@ -69,6 +69,9 @@ export class PopupService extends CompositeDisposable {
                 }
 
                 this.close();
+            }),
+            addDisposableListener(window, 'resize', () => {
+                this.close();
             })
         );
 


### PR DESCRIPTION
When the window is resized while the tab overflow popover is open, the popover would shift to the wrong position and no longer align correctly. This change automatically closes the popover on window resize, which is the standard UX pattern used by most UI libraries.

Fixes #1029

🤖 Generated with [Claude Code](https://claude.ai/code)