### PR TITLE
fix: properly dispose panel and group event subscriptions in effect cleanup

### DIFF
--- a/packages/docs/templates/dockview/demo-dockview/react/src/app.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/app.tsx
@@ -197,7 +197,9 @@ const DockviewDemo = (props: { theme?: string }) => {
             defaultConfig(api);
         }
 
-        return disposables.forEach((disposable) => disposable.dispose());
+        return () => {
+            disposables.forEach((disposable) => disposable.dispose());
+        };
     }, [api]);
 
     return (


### PR DESCRIPTION
### What
Wrap `disposables.forEach(disposable => disposable.dispose())` in the `useEffect` cleanup function instead of executing it immediately.

### Why
The disposal logic was executed directly in the effect body, which caused all previously registered listeners to be disposed right after registration, making them ineffective.

### Demo
https://codesandbox.io/p/sandbox/nostalgic-tdd-ypjjdv




