### PR TITLE
fix: add scrollbar to tabs overflow dropdown list

### DIFF
--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -59,8 +59,27 @@
 .dv-tabs-overflow-container {
     flex-direction: column;
     height: unset;
+    max-height: min(50vh, 400px);
+    overflow-y: auto;
     border: 1px solid var(--dv-tab-divider-color);
     background-color: var(--dv-group-view-background-color);
+
+    /* Scrollbar styling for webkit browsers */
+    &::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: var(--dv-tabs-container-scrollbar-color);
+        border-radius: 3px;
+    }
+
+    /* Firefox scrollbar */
+    scrollbar-width: thin;
 
     .dv-tab {
         &:not(:last-child) {


### PR DESCRIPTION
## Summary

Fixes #1069 

When the number of tabs exceeds the visible area, the tab list dropdown was not scrollable because it lacked a `max-height` constraint. The container had `overflow: auto` set via JavaScript, but without a height limit, it would expand to fit all content.

## Changes

- Added `max-height: min(50vh, 400px)` to limit the dropdown height
- Added `overflow-y: auto` in CSS (complements the inline style from JS)
- Added consistent scrollbar styling for:
  - WebKit browsers (Chrome, Safari, Edge) via `::-webkit-scrollbar` pseudo-elements
  - Firefox via `scrollbar-width: thin`

## Testing

1. Open the Dockview demo
2. Create 30+ tabs
3. Click on the Tab List dropdown
4. Verify that the dropdown list now shows a scrollbar and is scrollable via mouse wheel

## Before
The dropdown would extend beyond the visible area with no way to scroll to hidden tabs.

## After
The dropdown is constrained to a max height and can be scrolled to access all tabs.