### PR TITLE
ci: run CI on pull requests from forked repos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+    push:
+        branches: [master]
+    pull_request:
 
 jobs:
     build:
@@ -28,6 +31,7 @@ jobs:
             - run: npm run build:bundle
             - run: npm run test:cov
             - name: SonarCloud Scan
+              if: env.SONAR_TOKEN != ''
               uses: sonarsource/sonarqube-scan-action@v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any


### PR DESCRIPTION
Given the increasing number of external contributors raising PRs, enable CI to run on fork PRs so they get build/test feedback.

SonarCloud scan is guarded to only run when secrets are available, keeping it safe from untrusted fork PRs.