### PR TITLE
feat: (Angular) flexible component resolve

### DIFF
--- a/packages/dockview-angular/src/__tests__/angular-renderer.spec.ts
+++ b/packages/dockview-angular/src/__tests__/angular-renderer.spec.ts
@@ -43,7 +43,7 @@ describe('AngularRenderer', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [TestComponent],
+            declarations: [TestComponent, TestUpdateComponent]
         }).compileComponents();
 
         injector = TestBed.inject(Injector);

--- a/packages/dockview-angular/src/__tests__/angular-renderer.spec.ts
+++ b/packages/dockview-angular/src/__tests__/angular-renderer.spec.ts
@@ -43,7 +43,7 @@ describe('AngularRenderer', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [TestComponent, TestUpdateComponent]
+            declarations: [TestComponent, TestUpdateComponent],
         }).compileComponents();
 
         injector = TestBed.inject(Injector);

--- a/packages/dockview-angular/src/__tests__/component-factory.spec.ts
+++ b/packages/dockview-angular/src/__tests__/component-factory.spec.ts
@@ -268,11 +268,12 @@ describe('AngularFrameworkComponentFactory', () => {
         });
 
         it('should throw error when no watermark component provided', () => {
-            const factoryWithoutWatermark = new AngularFrameworkComponentFactory(
-                resolver,
-                injector,
-                environmentInjector
-            );
+            const factoryWithoutWatermark =
+                new AngularFrameworkComponentFactory(
+                    resolver,
+                    injector,
+                    environmentInjector
+                );
 
             expect(() => {
                 factoryWithoutWatermark.createWatermarkComponent();

--- a/packages/dockview-angular/src/__tests__/component-factory.spec.ts
+++ b/packages/dockview-angular/src/__tests__/component-factory.spec.ts
@@ -2,6 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { Component, Injector, EnvironmentInjector } from '@angular/core';
 import { AngularFrameworkComponentFactory } from '../lib/utils/component-factory';
 import { CreateComponentOptions } from 'dockview-core';
+import { ComponentRegistryService } from '../lib/utils/component-registry.service';
 
 @Component({
     selector: 'test-dockview-component',
@@ -53,6 +54,7 @@ describe('AngularFrameworkComponentFactory', () => {
     let injector: Injector;
     let environmentInjector: EnvironmentInjector;
     let factory: AngularFrameworkComponentFactory;
+    let resolver: ComponentRegistryService;
 
     const components = {
         'dockview-test': TestDockviewComponent,
@@ -84,9 +86,11 @@ describe('AngularFrameworkComponentFactory', () => {
 
         injector = TestBed.inject(Injector);
         environmentInjector = TestBed.inject(EnvironmentInjector);
+        resolver = TestBed.inject(ComponentRegistryService);
+        resolver.registerComponents(components);
 
         factory = new AngularFrameworkComponentFactory(
-            components,
+            resolver,
             injector,
             environmentInjector,
             tabComponents,
@@ -237,7 +241,7 @@ describe('AngularFrameworkComponentFactory', () => {
 
         it('should return undefined when no component and no default', () => {
             const factoryWithoutDefault = new AngularFrameworkComponentFactory(
-                components,
+                resolver,
                 injector,
                 environmentInjector,
                 {}
@@ -264,12 +268,11 @@ describe('AngularFrameworkComponentFactory', () => {
         });
 
         it('should throw error when no watermark component provided', () => {
-            const factoryWithoutWatermark =
-                new AngularFrameworkComponentFactory(
-                    components,
-                    injector,
-                    environmentInjector
-                );
+            const factoryWithoutWatermark = new AngularFrameworkComponentFactory(
+                resolver,
+                injector,
+                environmentInjector
+            );
 
             expect(() => {
                 factoryWithoutWatermark.createWatermarkComponent();
@@ -299,7 +302,7 @@ describe('AngularFrameworkComponentFactory', () => {
         it('should return undefined when no header actions components provided', () => {
             const factoryWithoutHeaderActions =
                 new AngularFrameworkComponentFactory(
-                    components,
+                    resolver,
                     injector,
                     environmentInjector
                 );

--- a/packages/dockview-angular/src/__tests__/component-registry.spec.ts
+++ b/packages/dockview-angular/src/__tests__/component-registry.spec.ts
@@ -1,0 +1,120 @@
+import { TestBed } from '@angular/core/testing';
+import { Type } from '@angular/core';
+import { ComponentRegistryService, ComponentResolver } from '../lib/utils/component-registry.service';
+
+describe( 'ComponentRegistryService', () =>
+{
+    let service: ComponentRegistryService;
+
+    beforeEach( () =>
+    {
+        TestBed.configureTestingModule( {
+            providers: [ ComponentRegistryService ],
+        } );
+        service = TestBed.inject( ComponentRegistryService );
+    } );
+
+    describe( 'registerComponent', () =>
+    {
+        it( 'should register a component with a valid name and reference', () =>
+        {
+            const mockComponent = {} as Type<unknown>;
+            service.registerComponent( 'testComponent', mockComponent );
+
+            expect( service.resolveComponent( 'testComponent' ) ).toBe( mockComponent );
+        } );
+
+        it( 'should throw an error if component name or reference is not provided', () =>
+        {
+            expect( () => service.registerComponent( '', {} as Type<unknown> ) ).toThrow(
+                'Component and reference must be provided',
+            );
+        } );
+    } );
+
+    describe( 'registerComponents', () =>
+    {
+        it( 'should register multiple components from a record', () =>
+        {
+            const components = {
+                componentA: {} as Type<unknown>,
+                componentB: {} as Type<unknown>,
+            };
+
+            service.registerComponents( components );
+
+            expect( service.resolveComponent( 'componentA' ) ).toBe( components.componentA );
+            expect( service.resolveComponent( 'componentB' ) ).toBe( components.componentB );
+        } );
+    } );
+
+    describe( 'resolveComponent', () =>
+    {
+        it( 'should return a registered component reference', () =>
+        {
+            const mockComponent = {} as Type<unknown>;
+            service.registerComponent( 'testComponent', mockComponent );
+
+            const resolved = service.resolveComponent( 'testComponent' );
+            expect( resolved ).toBe( mockComponent );
+        } );
+
+        it( 'should throw an error if component name is not provided', () =>
+        {
+            expect( () => service.resolveComponent( '' ) ).toThrow(
+                'Component must be provided',
+            );
+        } );
+
+        it( 'should resolve a component dynamically through a resolver', () =>
+        {
+            const dynamicComponent = {} as Type<unknown>;
+            const resolver: ComponentResolver = ( component ) =>
+                component === 'dynamicComponent' ? dynamicComponent : undefined;
+
+            service.registerResolver( resolver );
+
+            expect( service.resolveComponent( 'dynamicComponent' ) ).toBe( dynamicComponent );
+        } );
+
+        it( 'should fallback to static registration if no resolver matches', () =>
+        {
+            const staticComponent = {} as Type<unknown>;
+            service.registerComponent( 'staticComponent', staticComponent );
+
+            const resolver: ComponentResolver = () => undefined;
+            service.registerResolver( resolver );
+
+            expect( service.resolveComponent( 'staticComponent' ) ).toBe( staticComponent );
+        } );
+    } );
+
+    describe( 'registerResolver', () =>
+    {
+        it( 'should register a new resolver for dynamic component resolution', () =>
+        {
+            const dynamicComponent = {} as Type<unknown>;
+            const resolver: ComponentResolver = ( component ) =>
+                component === 'dynamicComponent' ? dynamicComponent : undefined;
+
+            service.registerResolver( resolver );
+
+            expect( service.resolveComponent( 'dynamicComponent' ) ).toBe( dynamicComponent );
+        } );
+    } );
+
+    describe( 'unregisterResolver', () =>
+    {
+        it( 'should unregister a resolver', () =>
+        {
+            const dynamicComponent = {} as Type<unknown>;
+            const resolver: ComponentResolver = ( component ) =>
+                component === 'dynamicComponent' ? dynamicComponent : undefined;
+
+            service.registerResolver( resolver );
+            service.unregisterResolver( resolver );
+
+            expect( service.resolveComponent( 'dynamicComponent' ) ).toBeUndefined();
+        } );
+    } );
+} );

--- a/packages/dockview-angular/src/__tests__/component-registry.spec.ts
+++ b/packages/dockview-angular/src/__tests__/component-registry.spec.ts
@@ -1,120 +1,121 @@
 import { TestBed } from '@angular/core/testing';
 import { Type } from '@angular/core';
-import { ComponentRegistryService, ComponentResolver } from '../lib/utils/component-registry.service';
+import {
+    ComponentRegistryService,
+    ComponentResolver,
+} from '../lib/utils/component-registry.service';
 
-describe( 'ComponentRegistryService', () =>
-{
+describe('ComponentRegistryService', () => {
     let service: ComponentRegistryService;
 
-    beforeEach( () =>
-    {
-        TestBed.configureTestingModule( {
-            providers: [ ComponentRegistryService ],
-        } );
-        service = TestBed.inject( ComponentRegistryService );
-    } );
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [ComponentRegistryService],
+        });
+        service = TestBed.inject(ComponentRegistryService);
+    });
 
-    describe( 'registerComponent', () =>
-    {
-        it( 'should register a component with a valid name and reference', () =>
-        {
+    describe('registerComponent', () => {
+        it('should register a component with a valid name and reference', () => {
             const mockComponent = {} as Type<unknown>;
-            service.registerComponent( 'testComponent', mockComponent );
+            service.registerComponent('testComponent', mockComponent);
 
-            expect( service.resolveComponent( 'testComponent' ) ).toBe( mockComponent );
-        } );
-
-        it( 'should throw an error if component name or reference is not provided', () =>
-        {
-            expect( () => service.registerComponent( '', {} as Type<unknown> ) ).toThrow(
-                'Component and reference must be provided',
+            expect(service.resolveComponent('testComponent')).toBe(
+                mockComponent
             );
-        } );
-    } );
+        });
 
-    describe( 'registerComponents', () =>
-    {
-        it( 'should register multiple components from a record', () =>
-        {
+        it('should throw an error if component name or reference is not provided', () => {
+            expect(() =>
+                service.registerComponent('', {} as Type<unknown>)
+            ).toThrow('Component and reference must be provided');
+        });
+    });
+
+    describe('registerComponents', () => {
+        it('should register multiple components from a record', () => {
             const components = {
                 componentA: {} as Type<unknown>,
                 componentB: {} as Type<unknown>,
             };
 
-            service.registerComponents( components );
+            service.registerComponents(components);
 
-            expect( service.resolveComponent( 'componentA' ) ).toBe( components.componentA );
-            expect( service.resolveComponent( 'componentB' ) ).toBe( components.componentB );
-        } );
-    } );
-
-    describe( 'resolveComponent', () =>
-    {
-        it( 'should return a registered component reference', () =>
-        {
-            const mockComponent = {} as Type<unknown>;
-            service.registerComponent( 'testComponent', mockComponent );
-
-            const resolved = service.resolveComponent( 'testComponent' );
-            expect( resolved ).toBe( mockComponent );
-        } );
-
-        it( 'should throw an error if component name is not provided', () =>
-        {
-            expect( () => service.resolveComponent( '' ) ).toThrow(
-                'Component must be provided',
+            expect(service.resolveComponent('componentA')).toBe(
+                components.componentA
             );
-        } );
+            expect(service.resolveComponent('componentB')).toBe(
+                components.componentB
+            );
+        });
+    });
 
-        it( 'should resolve a component dynamically through a resolver', () =>
-        {
+    describe('resolveComponent', () => {
+        it('should return a registered component reference', () => {
+            const mockComponent = {} as Type<unknown>;
+            service.registerComponent('testComponent', mockComponent);
+
+            const resolved = service.resolveComponent('testComponent');
+            expect(resolved).toBe(mockComponent);
+        });
+
+        it('should throw an error if component name is not provided', () => {
+            expect(() => service.resolveComponent('')).toThrow(
+                'Component must be provided'
+            );
+        });
+
+        it('should resolve a component dynamically through a resolver', () => {
             const dynamicComponent = {} as Type<unknown>;
-            const resolver: ComponentResolver = ( component ) =>
+            const resolver: ComponentResolver = (component) =>
                 component === 'dynamicComponent' ? dynamicComponent : undefined;
 
-            service.registerResolver( resolver );
+            service.registerResolver(resolver);
 
-            expect( service.resolveComponent( 'dynamicComponent' ) ).toBe( dynamicComponent );
-        } );
+            expect(service.resolveComponent('dynamicComponent')).toBe(
+                dynamicComponent
+            );
+        });
 
-        it( 'should fallback to static registration if no resolver matches', () =>
-        {
+        it('should fallback to static registration if no resolver matches', () => {
             const staticComponent = {} as Type<unknown>;
-            service.registerComponent( 'staticComponent', staticComponent );
+            service.registerComponent('staticComponent', staticComponent);
 
             const resolver: ComponentResolver = () => undefined;
-            service.registerResolver( resolver );
+            service.registerResolver(resolver);
 
-            expect( service.resolveComponent( 'staticComponent' ) ).toBe( staticComponent );
-        } );
-    } );
+            expect(service.resolveComponent('staticComponent')).toBe(
+                staticComponent
+            );
+        });
+    });
 
-    describe( 'registerResolver', () =>
-    {
-        it( 'should register a new resolver for dynamic component resolution', () =>
-        {
+    describe('registerResolver', () => {
+        it('should register a new resolver for dynamic component resolution', () => {
             const dynamicComponent = {} as Type<unknown>;
-            const resolver: ComponentResolver = ( component ) =>
+            const resolver: ComponentResolver = (component) =>
                 component === 'dynamicComponent' ? dynamicComponent : undefined;
 
-            service.registerResolver( resolver );
+            service.registerResolver(resolver);
 
-            expect( service.resolveComponent( 'dynamicComponent' ) ).toBe( dynamicComponent );
-        } );
-    } );
+            expect(service.resolveComponent('dynamicComponent')).toBe(
+                dynamicComponent
+            );
+        });
+    });
 
-    describe( 'unregisterResolver', () =>
-    {
-        it( 'should unregister a resolver', () =>
-        {
+    describe('unregisterResolver', () => {
+        it('should unregister a resolver', () => {
             const dynamicComponent = {} as Type<unknown>;
-            const resolver: ComponentResolver = ( component ) =>
+            const resolver: ComponentResolver = (component) =>
                 component === 'dynamicComponent' ? dynamicComponent : undefined;
 
-            service.registerResolver( resolver );
-            service.unregisterResolver( resolver );
+            service.registerResolver(resolver);
+            service.unregisterResolver(resolver);
 
-            expect( service.resolveComponent( 'dynamicComponent' ) ).toBeUndefined();
-        } );
-    } );
-} );
+            expect(
+                service.resolveComponent('dynamicComponent')
+            ).toBeUndefined();
+        });
+    });
+});

--- a/packages/dockview-angular/src/__tests__/dockview-angular.component.spec.ts
+++ b/packages/dockview-angular/src/__tests__/dockview-angular.component.spec.ts
@@ -33,14 +33,6 @@ describe('DockviewAngularComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should throw error if components input is not provided', () => {
-        component.components = undefined as any;
-
-        expect(() => {
-            component.ngOnInit();
-        }).toThrow('DockviewAngularComponent: components input is required');
-    });
-
     it('should initialize dockview api on ngOnInit', () => {
         component.ngOnInit();
 

--- a/packages/dockview-angular/src/__tests__/gridview-angular.component.spec.ts
+++ b/packages/dockview-angular/src/__tests__/gridview-angular.component.spec.ts
@@ -33,14 +33,6 @@ describe('GridviewAngularComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should throw error if components input is not provided', () => {
-        component.components = undefined as any;
-
-        expect(() => {
-            component.ngOnInit();
-        }).toThrow('GridviewAngularComponent: components input is required');
-    });
-
     it('should initialize gridview api on ngOnInit', () => {
         component.ngOnInit();
 

--- a/packages/dockview-angular/src/__tests__/paneview-angular.component.spec.ts
+++ b/packages/dockview-angular/src/__tests__/paneview-angular.component.spec.ts
@@ -33,14 +33,6 @@ describe('PaneviewAngularComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should throw error if components input is not provided', () => {
-        component.components = undefined as any;
-
-        expect(() => {
-            component.ngOnInit();
-        }).toThrow('PaneviewAngularComponent: components input is required');
-    });
-
     it('should initialize paneview api on ngOnInit', () => {
         component.ngOnInit();
 

--- a/packages/dockview-angular/src/__tests__/splitview-angular.component.spec.ts
+++ b/packages/dockview-angular/src/__tests__/splitview-angular.component.spec.ts
@@ -33,14 +33,6 @@ describe('SplitviewAngularComponent', () => {
         expect(component).toBeTruthy();
     });
 
-    it('should throw error if components input is not provided', () => {
-        component.components = undefined as any;
-
-        expect(() => {
-            component.ngOnInit();
-        }).toThrow('SplitviewAngularComponent: components input is required');
-    });
-
     it('should initialize splitview api on ngOnInit', () => {
         component.ngOnInit();
 

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -28,6 +28,7 @@ import {
 } from 'dockview-core';
 import { AngularFrameworkComponentFactory } from '../utils/component-factory';
 import { AngularLifecycleManager } from '../utils/lifecycle-utils';
+import { ComponentRegistryService } from '../utils/component-registry.service';
 
 export interface DockviewAngularOptions extends DockviewOptions {
     components: Record<string, Type<any>>;
@@ -60,7 +61,9 @@ export interface DockviewAngularOptions extends DockviewOptions {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
-    @ViewChild('dockviewContainer', { static: true })
+    private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
+
+    @ViewChild('dockviewContainer', { static: true }) 
     private containerRef!: ElementRef<HTMLDivElement>;
 
     @Input() components!: Record<string, Type<any>>;
@@ -178,7 +181,7 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
         }
 
         const componentFactory = new AngularFrameworkComponentFactory(
-            this.components,
+            this.componentRegistry,
             this.injector,
             this.environmentInjector,
             this.tabComponents,

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -61,7 +61,9 @@ export interface DockviewAngularOptions extends DockviewOptions {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
-    private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
+    private readonly componentRegistry: ComponentRegistryService = inject(
+        ComponentRegistryService
+    );
 
     @ViewChild('dockviewContainer', { static: true })
     private containerRef!: ElementRef<HTMLDivElement>;

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -133,10 +133,8 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     private initializeDockview(): void {
-        if (!this.components) {
-            throw new Error(
-                'DockviewAngularComponent: components input is required'
-            );
+        if (this.components) {
+            this.componentRegistry.registerComponents(this.components);
         }
 
         const coreOptions = this.extractCoreOptions();

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -63,10 +63,10 @@ export interface DockviewAngularOptions extends DockviewOptions {
 export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
 
-    @ViewChild('dockviewContainer', { static: true }) 
+    @ViewChild('dockviewContainer', { static: true })
     private containerRef!: ElementRef<HTMLDivElement>;
 
-    @Input() components!: Record<string, Type<any>>;
+    @Input() components?: Record<string, Type<any>>;
     @Input() tabComponents?: Record<string, Type<any>>;
     @Input() watermarkComponent?: Type<any>;
     @Input() defaultTabComponent?: Type<any>;

--- a/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
@@ -26,6 +26,7 @@ import {
 import { AngularFrameworkComponentFactory } from '../utils/component-factory';
 import { AngularLifecycleManager } from '../utils/lifecycle-utils';
 import { GridviewAngularReadyEvent } from './types';
+import { ComponentRegistryService } from '../utils/component-registry.service';
 
 export interface GridviewAngularOptions extends GridviewOptions {
     components: Record<string, Type<any>>;
@@ -52,7 +53,9 @@ export interface GridviewAngularOptions extends GridviewOptions {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
-    @ViewChild('gridviewContainer', { static: true })
+    private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
+
+    @ViewChild('gridviewContainer', { static: true }) 
     private containerRef!: ElementRef<HTMLDivElement>;
 
     @Input() components!: Record<string, Type<any>>;
@@ -140,7 +143,7 @@ export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
 
     private createFrameworkOptions(): GridviewFrameworkOptions {
         const componentFactory = new AngularFrameworkComponentFactory(
-            this.components,
+            this.componentRegistry,
             this.injector,
             this.environmentInjector
         );

--- a/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
@@ -110,10 +110,8 @@ export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     private initializeGridview(): void {
-        if (!this.components) {
-            throw new Error(
-                'GridviewAngularComponent: components input is required'
-            );
+        if (this.components) {
+            this.componentRegistry.registerComponents(this.components);
         }
 
         const coreOptions = this.extractCoreOptions();

--- a/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
@@ -55,10 +55,10 @@ export interface GridviewAngularOptions extends GridviewOptions {
 export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
 
-    @ViewChild('gridviewContainer', { static: true }) 
+    @ViewChild('gridviewContainer', { static: true })
     private containerRef!: ElementRef<HTMLDivElement>;
 
-    @Input() components!: Record<string, Type<any>>;
+    @Input() components?: Record<string, Type<any>>;
 
     // Core gridview options as inputs
     @Input() className?: string;

--- a/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
@@ -53,7 +53,9 @@ export interface GridviewAngularOptions extends GridviewOptions {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
-    private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
+    private readonly componentRegistry: ComponentRegistryService = inject(
+        ComponentRegistryService
+    );
 
     @ViewChild('gridviewContainer', { static: true })
     private containerRef!: ElementRef<HTMLDivElement>;

--- a/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
@@ -56,7 +56,9 @@ export interface PaneviewAngularOptions extends PaneviewOptions {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
-    private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
+    private readonly componentRegistry: ComponentRegistryService = inject(
+        ComponentRegistryService
+    );
 
     @ViewChild('paneviewContainer', { static: true })
     private containerRef!: ElementRef<HTMLDivElement>;

--- a/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
@@ -28,6 +28,7 @@ import { AngularFrameworkComponentFactory } from '../utils/component-factory';
 import { AngularLifecycleManager } from '../utils/lifecycle-utils';
 import { PaneviewAngularReadyEvent } from './types';
 import { AngularPanePart } from './angular-pane-part';
+import { ComponentRegistryService } from '../utils/component-registry.service';
 
 export interface PaneviewAngularOptions extends PaneviewOptions {
     components: Record<string, Type<any>>;
@@ -55,7 +56,9 @@ export interface PaneviewAngularOptions extends PaneviewOptions {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
-    @ViewChild('paneviewContainer', { static: true })
+    private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
+
+    @ViewChild('paneviewContainer', { static: true }) 
     private containerRef!: ElementRef<HTMLDivElement>;
 
     @Input() components!: Record<string, Type<any>>;
@@ -147,7 +150,7 @@ export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
 
     private createFrameworkOptions(): PaneviewFrameworkOptions {
         const componentFactory = new AngularFrameworkComponentFactory(
-            this.components,
+            this.componentRegistry,
             this.injector,
             this.environmentInjector,
             this.headerComponents

--- a/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
@@ -58,10 +58,10 @@ export interface PaneviewAngularOptions extends PaneviewOptions {
 export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
 
-    @ViewChild('paneviewContainer', { static: true }) 
+    @ViewChild('paneviewContainer', { static: true })
     private containerRef!: ElementRef<HTMLDivElement>;
 
-    @Input() components!: Record<string, Type<any>>;
+    @Input() components?: Record<string, Type<any>>;
     @Input() headerComponents?: Record<string, Type<any>>;
 
     // Core paneview options as inputs

--- a/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
@@ -114,10 +114,8 @@ export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     private initializePaneview(): void {
-        if (!this.components) {
-            throw new Error(
-                'PaneviewAngularComponent: components input is required'
-            );
+        if (this.components) {
+            this.componentRegistry.registerComponents(this.components);
         }
 
         const coreOptions = this.extractCoreOptions();

--- a/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
@@ -55,10 +55,10 @@ export interface SplitviewAngularOptions extends SplitviewOptions {
 export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
 
-    @ViewChild('splitviewContainer', { static: true }) 
+    @ViewChild('splitviewContainer', { static: true })
     private containerRef!: ElementRef<HTMLDivElement>;
 
-    @Input() components!: Record<string, Type<any>>;
+    @Input() components?: Record<string, Type<any>>;
 
     // Core splitview options as inputs
     @Input() className?: string;

--- a/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
@@ -26,6 +26,7 @@ import {
 import { AngularFrameworkComponentFactory } from '../utils/component-factory';
 import { AngularLifecycleManager } from '../utils/lifecycle-utils';
 import { SplitviewAngularReadyEvent } from './types';
+import { ComponentRegistryService } from '../utils/component-registry.service';
 
 export interface SplitviewAngularOptions extends SplitviewOptions {
     components: Record<string, Type<any>>;
@@ -52,7 +53,9 @@ export interface SplitviewAngularOptions extends SplitviewOptions {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
-    @ViewChild('splitviewContainer', { static: true })
+    private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
+
+    @ViewChild('splitviewContainer', { static: true }) 
     private containerRef!: ElementRef<HTMLDivElement>;
 
     @Input() components!: Record<string, Type<any>>;
@@ -140,7 +143,7 @@ export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
 
     private createFrameworkOptions(): SplitviewFrameworkOptions {
         const componentFactory = new AngularFrameworkComponentFactory(
-            this.components,
+            this.componentRegistry,
             this.injector,
             this.environmentInjector
         );

--- a/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
@@ -110,10 +110,8 @@ export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     private initializeSplitview(): void {
-        if (!this.components) {
-            throw new Error(
-                'SplitviewAngularComponent: components input is required'
-            );
+        if (this.components) {
+            this.componentRegistry.registerComponents(this.components);
         }
 
         const coreOptions = this.extractCoreOptions();

--- a/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
@@ -53,7 +53,9 @@ export interface SplitviewAngularOptions extends SplitviewOptions {
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
-    private readonly componentRegistry: ComponentRegistryService = inject(ComponentRegistryService);
+    private readonly componentRegistry: ComponentRegistryService = inject(
+        ComponentRegistryService
+    );
 
     @ViewChild('splitviewContainer', { static: true })
     private containerRef!: ElementRef<HTMLDivElement>;

--- a/packages/dockview-angular/src/lib/utils/component-factory.ts
+++ b/packages/dockview-angular/src/lib/utils/component-factory.ts
@@ -13,10 +13,11 @@ import { AngularRenderer } from './angular-renderer';
 import { AngularGridviewPanel } from '../gridview/angular-gridview-panel';
 import { AngularSplitviewPanel } from '../splitview/angular-splitview-panel';
 import { AngularPanePart } from '../paneview/angular-pane-part';
+import { ComponentRegistryService } from './component-registry.service';
 
 export class AngularFrameworkComponentFactory {
     constructor(
-        private components: Record<string, Type<any>>,
+        private componentResolver: ComponentRegistryService,
         private injector: Injector,
         private environmentInjector?: EnvironmentInjector,
         private tabComponents?: Record<string, Type<any>>,
@@ -27,7 +28,7 @@ export class AngularFrameworkComponentFactory {
 
     // For DockviewComponent
     createDockviewComponent(options: CreateComponentOptions): IContentRenderer {
-        const component = this.components[options.name];
+        const component = this.componentResolver.resolveComponent(options.name);
         if (!component) {
             throw new Error(
                 `Component '${options.name}' not found in component registry`
@@ -46,7 +47,7 @@ export class AngularFrameworkComponentFactory {
 
     // For GridviewComponent
     createGridviewComponent(options: CreateComponentOptions): GridviewPanel {
-        const component = this.components[options.name];
+        const component = this.componentResolver.resolveComponent(options.name);
         if (!component) {
             throw new Error(
                 `Component '${options.name}' not found in component registry`
@@ -64,7 +65,7 @@ export class AngularFrameworkComponentFactory {
 
     // For SplitviewComponent
     createSplitviewComponent(options: CreateComponentOptions): SplitviewPanel {
-        const component = this.components[options.name];
+        const component = this.componentResolver.resolveComponent(options.name);
         if (!component) {
             throw new Error(
                 `Component '${options.name}' not found in component registry`
@@ -82,7 +83,7 @@ export class AngularFrameworkComponentFactory {
 
     // For PaneviewComponent
     createPaneviewComponent(options: CreateComponentOptions): IPanePart {
-        const component = this.components[options.name];
+        const component = this.componentResolver.resolveComponent(options.name);
         if (!component) {
             throw new Error(
                 `Component '${options.name}' not found in component registry`

--- a/packages/dockview-angular/src/lib/utils/component-registry.service.ts
+++ b/packages/dockview-angular/src/lib/utils/component-registry.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, Type } from '@angular/core';
 
-export type ComponentResolver = (component: string) => Type<any> | undefined;
+export type ComponentResolver = (component: string) => Type<unknown> | undefined;
 
 @Injectable( { providedIn: 'root' } )
 export class ComponentRegistryService
 {
-    private readonly components: Map<string, Type<any>> = new Map();
+    private readonly components: Map<string, Type<unknown>> = new Map();
     private readonly resolver: ComponentResolver[] = [];
 
     public registerResolver(resolver: ComponentResolver)
@@ -18,14 +18,14 @@ export class ComponentRegistryService
         this.resolver.splice(this.resolver.indexOf(resolver), 1);
     }
 
-    public registerComponents(components: Record<string, Type<any>>)
+    public registerComponents(components: Record<string, Type<unknown>>)
     {
         for (const [component, reference] of Object.entries(components)) {
             this.registerComponent(component, reference);
         }
     }
 
-    public registerComponent(component: string, reference: Type<any>)
+    public registerComponent(component: string, reference: Type<unknown>)
     {
         if (!component || !reference) {
             throw new Error( 'Component and reference must be provided' );
@@ -34,7 +34,7 @@ export class ComponentRegistryService
         this.components.set( component, reference );
     }
 
-    public resolveComponent(component: string): Type<any> | undefined
+    public resolveComponent(component: string): Type<unknown> | undefined
     {
         if (!component) {
             throw new Error('Component must be provided');
@@ -43,7 +43,7 @@ export class ComponentRegistryService
        return this.getComponentReference(component);
     }
 
-    private getComponentReference(component: string): Type<any> | undefined
+    private getComponentReference(component: string): Type<unknown> | undefined
     {
         // first, try to get dynamic reference
         for (const resolver of this.resolver) {

--- a/packages/dockview-angular/src/lib/utils/component-registry.service.ts
+++ b/packages/dockview-angular/src/lib/utils/component-registry.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Type } from '@angular/core';
+
+export type ComponentResolver = (component: string) => Type<any> | undefined;
+
+@Injectable( { providedIn: 'root' } )
+export class ComponentRegistryService
+{
+    private readonly components: Map<string, Type<any>> = new Map();
+    private readonly resolver: ComponentResolver[] = [];
+
+    public registerResolver(resolver: ComponentResolver)
+    {
+        this.resolver.push(resolver);
+    }
+
+    public unregisterResolver(resolver: ComponentResolver)
+    {
+        this.resolver.splice(this.resolver.indexOf(resolver), 1);
+    }
+
+    public registerComponents(components: Record<string, Type<any>>)
+    {
+        for (const [component, reference] of Object.entries(components)) {
+            this.registerComponent(component, reference);
+        }
+    }
+
+    public registerComponent(component: string, reference: Type<any>)
+    {
+        if (!component || !reference) {
+            throw new Error( 'Component and reference must be provided' );
+        }
+
+        this.components.set( component, reference );
+    }
+
+    public resolveComponent(component: string): Type<any> | undefined
+    {
+        if (!component) {
+            throw new Error('Component must be provided');
+        }
+
+       return this.getComponentReference(component);
+    }
+
+    private getComponentReference(component: string): Type<any> | undefined
+    {
+        // first, try to get dynamic reference
+        for (const resolver of this.resolver) {
+            const reference = resolver(component);
+            if (reference) {
+                return reference;
+            }
+        }
+
+        // last, try to get static reference
+        return this.components.get(component);
+    }
+}

--- a/packages/dockview-angular/src/lib/utils/component-registry.service.ts
+++ b/packages/dockview-angular/src/lib/utils/component-registry.service.ts
@@ -1,50 +1,47 @@
 import { Injectable, Type } from '@angular/core';
 
-export type ComponentResolver = (component: string) => Type<unknown> | undefined;
+export type ComponentResolver = (
+    component: string
+) => Type<unknown> | undefined;
 
-@Injectable( { providedIn: 'root' } )
-export class ComponentRegistryService
-{
+@Injectable({ providedIn: 'root' })
+export class ComponentRegistryService {
     private readonly components: Map<string, Type<unknown>> = new Map();
     private readonly resolver: ComponentResolver[] = [];
 
-    public registerResolver(resolver: ComponentResolver)
-    {
+    public registerResolver(resolver: ComponentResolver) {
         this.resolver.push(resolver);
     }
 
-    public unregisterResolver(resolver: ComponentResolver)
-    {
+    public unregisterResolver(resolver: ComponentResolver) {
         this.resolver.splice(this.resolver.indexOf(resolver), 1);
     }
 
-    public registerComponents(components: Record<string, Type<unknown>>)
-    {
+    public registerComponents(components: Record<string, Type<unknown>>) {
         for (const [component, reference] of Object.entries(components)) {
             this.registerComponent(component, reference);
         }
     }
 
-    public registerComponent(component: string, reference: Type<unknown>)
-    {
+    public registerComponent(component: string, reference: Type<unknown>) {
         if (!component || !reference) {
-            throw new Error( 'Component and reference must be provided' );
+            throw new Error('Component and reference must be provided');
         }
 
-        this.components.set( component, reference );
+        this.components.set(component, reference);
     }
 
-    public resolveComponent(component: string): Type<unknown> | undefined
-    {
+    public resolveComponent(component: string): Type<unknown> | undefined {
         if (!component) {
             throw new Error('Component must be provided');
         }
 
-       return this.getComponentReference(component);
+        return this.getComponentReference(component);
     }
 
-    private getComponentReference(component: string): Type<unknown> | undefined
-    {
+    private getComponentReference(
+        component: string
+    ): Type<unknown> | undefined {
         // first, try to get dynamic reference
         for (const resolver of this.resolver) {
             const reference = resolver(component);

--- a/packages/dockview-angular/src/public-api.ts
+++ b/packages/dockview-angular/src/public-api.ts
@@ -44,3 +44,4 @@ export {
 export * from './lib/utils/angular-renderer';
 export * from './lib/utils/component-factory';
 export * from './lib/utils/lifecycle-utils';
+export * from './lib/utils/component-registry.service';


### PR DESCRIPTION
Components are statically registered on component creation with a fixed structure. This prevents the use of existing data - and limit the use for dynamic elements (that will be supported with future changes)

This PR replace the static components with a centralized component registry service.

Changes:
* Create component registry service (singleton)
* Resolve component from component registry in factory
* Make components inputs optional

Backward compatibility is guaranteed by auto register static components input on initialization.