### PR TITLE
chore: remove prepublishOnly scripts from all packages

### DIFF
--- a/packages/dockview-angular/package.json
+++ b/packages/dockview-angular/package.json
@@ -42,7 +42,6 @@
     "build:css": "node scripts/copy-css.js",
     "build": "npm run build:angular && npm run build:css",
     "clean": "rimraf dist/ .build/ .rollup.cache/",
-    "prepublishOnly": "npm run rebuild && npm run test",
     "rebuild": "npm run clean && npm run build",
     "test": "cross-env ../../node_modules/.bin/jest --selectProjects dockview-angular",
     "test:cov": "cross-env ../../node_modules/.bin/jest --selectProjects dockview-angular --coverage"

--- a/packages/dockview-core/package.json
+++ b/packages/dockview-core/package.json
@@ -47,7 +47,6 @@
     "build:esm": "cross-env ../../node_modules/.bin/tsc --build ./tsconfig.esm.json --verbose --extendedDiagnostics",
     "build": "npm run build:cjs && npm run build:esm && npm run build:css",
     "clean": "rimraf dist/ .build/ .rollup.cache/",
-    "prepublishOnly": "npm run rebuild && npm run build:bundle && npm run test",
     "rebuild": "npm run clean && npm run build",
     "test": "cross-env ../../node_modules/.bin/jest --selectProjects dockview-core",
     "test:cov": "cross-env ../../node_modules/.bin/jest --selectProjects dockview-core --coverage"

--- a/packages/dockview-react/package.json
+++ b/packages/dockview-react/package.json
@@ -47,7 +47,6 @@
     "build:esm": "cross-env ../../node_modules/.bin/tsc --build ./tsconfig.esm.json --verbose --extendedDiagnostics",
     "build": "npm run build:cjs && npm run build:esm && npm run build:css",
     "clean": "rimraf dist/ .build/ .rollup.cache/",
-    "prepublishOnly": "npm run rebuild && npm run build:bundle && npm run test",
     "rebuild": "npm run clean && npm run build",
     "test": "cross-env ../../node_modules/.bin/jest --selectProjects dockview-react",
     "test:cov": "cross-env ../../node_modules/.bin/jest --selectProjects dockview-react --coverage"

--- a/packages/dockview-vue/package.json
+++ b/packages/dockview-vue/package.json
@@ -47,7 +47,6 @@
     "build:css": "node scripts/copy-css.js",
     "build": "npm run build:js && npm run build:types && npm run build:css",
     "clean": "rimraf dist/ .build/ .rollup.cache/",
-    "prepublishOnly": "npm run rebuild && npm run build:bundle && npm run test",
     "rebuild": "npm run clean && npm run build",
     "test": "cross-env ../../node_modules/.bin/jest --selectProjects dockview-vue",
     "test:cov": "cross-env ../../node_modules/.bin/jest --selectProjects dockview-vue --coverage"

--- a/packages/dockview/package.json
+++ b/packages/dockview/package.json
@@ -47,7 +47,6 @@
     "build:esm": "cross-env ../../node_modules/.bin/tsc --build ./tsconfig.esm.json --verbose --extendedDiagnostics",
     "build": "npm run build:cjs && npm run build:esm && npm run build:css",
     "clean": "rimraf dist/ .build/ .rollup.cache/",
-    "prepublishOnly": "npm run rebuild && npm run build:bundle && npm run test",
     "rebuild": "npm run clean && npm run build",
     "test": "cross-env ../../node_modules/.bin/jest --selectProjects dockview",
     "test:cov": "cross-env ../../node_modules/.bin/jest --selectProjects dockview --coverage"


### PR DESCRIPTION
CI workflows already handle building and testing before publish. The prepublishOnly scripts caused npm publish to rebuild (wiping the versioned dist/) and pollute stdout with non-JSON output, breaking nx release publish's JSON parsing.