### PR TITLE
chore: remove specifierSource prompt from nx release config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -44,8 +44,7 @@
         "projectsRelationship": "fixed",
         "version": {
             "generatorOptions": {
-                "currentVersionSource": "git-tag",
-                "specifierSource": "prompt"
+                "currentVersionSource": "git-tag"
             },
             "git": {
                 "commit": true,


### PR DESCRIPTION
Version should resolve from git tags, not interactive prompts.