### PR TITLE
fix: enrich Vue header actions props to match React behavior

### DIFF
--- a/packages/dockview-vue/src/__tests__/utils.spec.ts
+++ b/packages/dockview-vue/src/__tests__/utils.spec.ts
@@ -1,4 +1,31 @@
-import { VuePart, findComponent, mountVueComponent } from '../utils';
+import {
+    DockviewEmitter,
+    DockviewGroupPanel,
+    DockviewGroupPanelApi,
+    DockviewGroupPanelModel,
+    IDockviewPanel,
+} from 'dockview-core';
+import {
+    VueHeaderActionsRenderer,
+    VuePart,
+    findComponent,
+    mountVueComponent,
+} from '../utils';
+
+const mockUpdate = jest.fn();
+const mockVueDispose = jest.fn();
+
+jest.mock('vue', () => ({
+    createVNode: jest.fn(() => ({})),
+    render: jest.fn(),
+    cloneVNode: jest.fn(() => ({})),
+}));
+
+// After mocking vue, mountVueComponent will return { update, dispose }
+// We need to get a reference to the render mock to track props
+import { createVNode, render as vueRender, cloneVNode } from 'vue';
+const createVNodeMock = createVNode as jest.Mock;
+const vueRenderMock = vueRender as jest.Mock;
 
 describe('Utils', () => {
     test('should export VuePart class', () => {
@@ -124,5 +151,309 @@ describe('VuePart', () => {
             // Vue mounting may fail in test environment, but VuePart should handle it
             expect(error).toBeDefined();
         }
+    });
+});
+
+describe('VueHeaderActionsRenderer', () => {
+    let onDidAddPanel: DockviewEmitter<any>;
+    let onDidRemovePanel: DockviewEmitter<any>;
+    let onDidActivePanelChange: DockviewEmitter<any>;
+    let onDidActiveChange: DockviewEmitter<any>;
+    let groupPanel: DockviewGroupPanel;
+    let mockParent: any;
+    let mockComponent: any;
+    let panels: IDockviewPanel[];
+    let activePanel: IDockviewPanel | undefined;
+    let isGroupActive: boolean;
+
+    beforeEach(() => {
+        onDidAddPanel = new DockviewEmitter();
+        onDidRemovePanel = new DockviewEmitter();
+        onDidActivePanelChange = new DockviewEmitter();
+        onDidActiveChange = new DockviewEmitter();
+
+        panels = [{ id: 'panel-1' } as IDockviewPanel];
+        activePanel = panels[0];
+        isGroupActive = true;
+
+        const groupModel = {
+            onDidAddPanel: onDidAddPanel.event,
+            onDidRemovePanel: onDidRemovePanel.event,
+            onDidActivePanelChange: onDidActivePanelChange.event,
+            get panels() {
+                return panels;
+            },
+            get activePanel() {
+                return activePanel;
+            },
+        } as Partial<DockviewGroupPanelModel> as DockviewGroupPanelModel;
+
+        const groupApi = {
+            onDidActiveChange: onDidActiveChange.event,
+            get isActive() {
+                return isGroupActive;
+            },
+        } as Partial<DockviewGroupPanelApi> as DockviewGroupPanelApi;
+
+        groupPanel = {
+            api: groupApi,
+            model: groupModel,
+        } as Partial<DockviewGroupPanel> as DockviewGroupPanel;
+
+        mockParent = {
+            appContext: { components: {}, provides: {} },
+            provides: {},
+        };
+
+        mockComponent = {
+            template: '<div>header actions</div>',
+            props: ['params'],
+        };
+    });
+
+    afterEach(() => {
+        onDidAddPanel.dispose();
+        onDidRemovePanel.dispose();
+        onDidActivePanelChange.dispose();
+        onDidActiveChange.dispose();
+        createVNodeMock.mockClear();
+        vueRenderMock.mockClear();
+        (cloneVNode as jest.Mock).mockClear();
+    });
+
+    test('should create element with correct class and styles', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        expect(renderer.element).toBeInstanceOf(HTMLElement);
+        expect(renderer.element.className).toBe('dv-vue-part');
+        expect(renderer.element.style.height).toBe('100%');
+        expect(renderer.element.style.width).toBe('100%');
+    });
+
+    test('should pass enriched IDockviewHeaderActionsProps on init', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        const mockContainerApi = {} as any;
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: mockContainerApi,
+            group: groupPanel as any,
+        });
+
+        expect(createVNodeMock).toHaveBeenCalledTimes(1);
+
+        const passedProps = createVNodeMock.mock.calls[0][1];
+        expect(passedProps.params).toEqual(
+            expect.objectContaining({
+                api: groupPanel.api,
+                containerApi: mockContainerApi,
+                panels: panels,
+                activePanel: activePanel,
+                isGroupActive: true,
+                group: groupPanel,
+            })
+        );
+
+        renderer.dispose();
+    });
+
+    test('should update panels reactively when onDidAddPanel fires', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        // Clear from init call
+        (cloneVNode as jest.Mock).mockClear();
+        vueRenderMock.mockClear();
+
+        const newPanel = { id: 'panel-2' } as IDockviewPanel;
+        panels = [...panels, newPanel];
+
+        onDidAddPanel.fire(undefined);
+
+        // cloneVNode should have been called for the update
+        expect(vueRenderMock).toHaveBeenCalled();
+
+        renderer.dispose();
+    });
+
+    test('should update panels reactively when onDidRemovePanel fires', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        vueRenderMock.mockClear();
+
+        panels = [];
+        onDidRemovePanel.fire(undefined);
+
+        expect(vueRenderMock).toHaveBeenCalled();
+
+        renderer.dispose();
+    });
+
+    test('should update activePanel reactively when onDidActivePanelChange fires', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        vueRenderMock.mockClear();
+
+        activePanel = undefined;
+        onDidActivePanelChange.fire(undefined);
+
+        expect(vueRenderMock).toHaveBeenCalled();
+
+        renderer.dispose();
+    });
+
+    test('should update isGroupActive reactively when onDidActiveChange fires', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        vueRenderMock.mockClear();
+
+        isGroupActive = false;
+        onDidActiveChange.fire(undefined);
+
+        expect(vueRenderMock).toHaveBeenCalled();
+
+        renderer.dispose();
+    });
+
+    test('should dispose event subscriptions on dispose', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        renderer.dispose();
+
+        vueRenderMock.mockClear();
+
+        // After dispose, firing events should not trigger re-renders
+        onDidAddPanel.fire(undefined);
+        onDidRemovePanel.fire(undefined);
+        onDidActivePanelChange.fire(undefined);
+        onDidActiveChange.fire(undefined);
+
+        // Only the dispose render(null) call, no update re-renders
+        expect(vueRenderMock).not.toHaveBeenCalled();
+    });
+
+    test('should dispose previous subscriptions when init is called again', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        // Second init should dispose previous mount
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        // createVNode should have been called twice (once per init)
+        expect(createVNodeMock).toHaveBeenCalledTimes(2);
+
+        renderer.dispose();
+    });
+
+    test('should handle dispose before init gracefully', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        expect(() => renderer.dispose()).not.toThrow();
+    });
+
+    test('should subscribe to all four group events', () => {
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel
+        );
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        vueRenderMock.mockClear();
+
+        // Fire each event and check it triggers a render
+        onDidAddPanel.fire(undefined);
+        expect(vueRenderMock).toHaveBeenCalledTimes(1);
+
+        onDidRemovePanel.fire(undefined);
+        expect(vueRenderMock).toHaveBeenCalledTimes(2);
+
+        onDidActivePanelChange.fire(undefined);
+        expect(vueRenderMock).toHaveBeenCalledTimes(3);
+
+        onDidActiveChange.fire(undefined);
+        expect(vueRenderMock).toHaveBeenCalledTimes(4);
+
+        renderer.dispose();
     });
 });

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -3,6 +3,7 @@ import type {
     DockviewGroupPanel,
     DockviewPanelApi,
     IContentRenderer,
+    IDockviewHeaderActionsProps,
     IDockviewPanelHeaderProps,
     IGroupHeaderProps,
     IHeaderActionsRenderer,
@@ -13,6 +14,10 @@ import type {
     Parameters,
     TabPartInitParameters,
     WatermarkRendererInitParameters,
+} from 'dockview-core';
+import {
+    DockviewCompositeDisposable,
+    DockviewMutableDisposable,
 } from 'dockview-core';
 import {
     createVNode,
@@ -204,6 +209,7 @@ export class VueHeaderActionsRenderer
     private _renderDisposable:
         | { update: (props: any) => void; dispose: () => void }
         | undefined;
+    private readonly _mutableDisposable = new DockviewMutableDisposable();
 
     get element(): HTMLElement {
         return this._element;
@@ -212,23 +218,65 @@ export class VueHeaderActionsRenderer
     constructor(
         component: VueComponent,
         parent: ComponentInternalInstance,
-        group: DockviewGroupPanel
+        private readonly group: DockviewGroupPanel
     ) {
         super(component, parent);
     }
 
     init(props: IGroupHeaderProps): void {
+        this._mutableDisposable.value = new DockviewCompositeDisposable(
+            this.group.model.onDidAddPanel(() => {
+                this.updatePanels();
+            }),
+            this.group.model.onDidRemovePanel(() => {
+                this.updatePanels();
+            }),
+            this.group.model.onDidActivePanelChange(() => {
+                this.updateActivePanel();
+            }),
+            props.api.onDidActiveChange(() => {
+                this.updateGroupActive();
+            })
+        );
+
+        const enrichedProps: IDockviewHeaderActionsProps = {
+            ...props,
+            panels: this.group.model.panels,
+            activePanel: this.group.model.activePanel,
+            isGroupActive: this.group.api.isActive,
+            group: this.group,
+        };
+
         this._renderDisposable?.dispose();
         this._renderDisposable = mountVueComponent(
             this.component,
             this.parent,
-            { params: props },
+            { params: enrichedProps },
             this.element
         );
     }
 
     dispose(): void {
+        this._mutableDisposable.dispose();
         this._renderDisposable?.dispose();
+    }
+
+    private updatePanels(): void {
+        this._renderDisposable?.update({
+            params: { panels: this.group.model.panels },
+        });
+    }
+
+    private updateActivePanel(): void {
+        this._renderDisposable?.update({
+            params: { activePanel: this.group.model.activePanel },
+        });
+    }
+
+    private updateGroupActive(): void {
+        this._renderDisposable?.update({
+            params: { isGroupActive: this.group.api.isActive },
+        });
     }
 }
 


### PR DESCRIPTION
VueHeaderActionsRenderer now passes IDockviewHeaderActionsProps (panels, activePanel, isGroupActive) to components and reactively updates them, matching the React implementation. Fixes #1100.