### PR TITLE
fix: add missing headerPosition to Vue header actions props

### DIFF
--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -245,6 +245,7 @@ export class VueHeaderActionsRenderer
             activePanel: this.group.model.activePanel,
             isGroupActive: this.group.api.isActive,
             group: this.group,
+            headerPosition: this.group.model.headerPosition,
         };
 
         this._renderDisposable?.dispose();


### PR DESCRIPTION
The VueHeaderActionsRenderer was missing the headerPosition property when constructing IDockviewHeaderActionsProps, causing a TypeScript build error. This aligns the Vue implementation with the React package.