### PR TITLE
fix(dockview-core): prevent always-renderer flash at 0,0 on attach

### DIFF
--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -133,6 +133,9 @@ export class OverlayRenderContainer extends CompositeDisposable {
         if (!this.map[panel.api.id]) {
             const element = createFocusableElement();
             element.className = 'dv-render-overlay';
+            // Hide until the first RAF-based position is applied to prevent a
+            // one-frame flash at position 0,0 when the element is first attached.
+            element.style.visibility = 'hidden';
 
             this.map[panel.api.id] = {
                 panel,
@@ -184,6 +187,11 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 focusContainer.style.top = `${top}px`;
                 focusContainer.style.width = `${width}px`;
                 focusContainer.style.height = `${height}px`;
+                // Reveal after the first position is applied (was hidden to
+                // prevent a flash at 0,0 before the initial layout fires).
+                if (focusContainer.style.visibility === 'hidden') {
+                    focusContainer.style.visibility = '';
+                }
 
                 toggleClass(
                     focusContainer,


### PR DESCRIPTION
Panels with renderer='always' are positioned via an overlay element that is appended to the DOM immediately on attach but positioned asynchronously via requestAnimationFrame. This caused a one-frame flash at position 0,0 each time the panel was attached — most visibly after fromJSON which detaches and re-attaches all always-rendered panels.

Fix: start the overlay element as visibility:hidden on creation and clear it after the first successful RAF-based position is applied.