### PR TITLE
feat: improve tab group context menu with inline rename, horizontal c…

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/popupService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/popupService.spec.ts
@@ -153,6 +153,47 @@ describe('PopupService', () => {
         });
     });
 
+    describe('keyboard', () => {
+        test('Escape closes the popover', () => {
+            const el = document.createElement('div');
+            el.className = 'my-popup';
+            service.openPopover(el, { x: 0, y: 0 });
+
+            window.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+            );
+
+            const anchor = root.querySelector('.dv-popover-anchor')!;
+            expect(anchor.querySelector('.my-popup')).toBeNull();
+        });
+
+        test('Enter closes the popover', () => {
+            const el = document.createElement('div');
+            el.className = 'my-popup';
+            service.openPopover(el, { x: 0, y: 0 });
+
+            window.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+            );
+
+            const anchor = root.querySelector('.dv-popover-anchor')!;
+            expect(anchor.querySelector('.my-popup')).toBeNull();
+        });
+
+        test('other keys do not close the popover', () => {
+            const el = document.createElement('div');
+            el.className = 'my-popup';
+            service.openPopover(el, { x: 0, y: 0 });
+
+            window.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+            );
+
+            const anchor = root.querySelector('.dv-popover-anchor')!;
+            expect(anchor.querySelector('.my-popup')).not.toBeNull();
+        });
+    });
+
     describe('window resize', () => {
         test('closes the popover', () => {
             const el = document.createElement('div');

--- a/packages/dockview-core/src/__tests__/dockview/popupService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/popupService.spec.ts
@@ -47,11 +47,21 @@ describe('PopupService', () => {
         expect(root.contains(el)).toBe(false);
     });
 
+    test('Enter key closes the popup', () => {
+        const { service, root } = makeService();
+        const el = openMenu(service);
+
+        expect(root.contains(el)).toBe(true);
+
+        fireEvent.keyDown(window, { key: 'Enter' });
+
+        expect(root.contains(el)).toBe(false);
+    });
+
     test('other keys do not close the popup', () => {
         const { service, root } = makeService();
         const el = openMenu(service);
 
-        fireEvent.keyDown(window, { key: 'Enter' });
         fireEvent.keyDown(window, { key: 'ArrowDown' });
 
         expect(root.contains(el)).toBe(true);

--- a/packages/dockview-core/src/__tests__/dockview/tabGroup.test.ts
+++ b/packages/dockview-core/src/__tests__/dockview/tabGroup.test.ts
@@ -249,6 +249,6 @@ describe('isValidTabGroupColor', () => {
     test('should reject invalid colors', () => {
         expect(isValidTabGroupColor('')).toBe(false);
         expect(isValidTabGroupColor('invalid')).toBe(false);
-        expect(isValidTabGroupColor('orange')).toBe(false);
+        expect(isValidTabGroupColor('orange')).toBe(true);
     });
 });

--- a/packages/dockview-core/src/dockview/components/popupService.ts
+++ b/packages/dockview-core/src/dockview/components/popupService.ts
@@ -83,7 +83,7 @@ export class PopupService extends CompositeDisposable {
                 this.close();
             }),
             addDisposableListener(window, 'keydown', (event) => {
-                if (event.key === 'Escape') {
+                if (event.key === 'Escape' || event.key === 'Enter') {
                     this.close();
                 }
             }),

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -465,13 +465,24 @@ export class TabGroupManager {
 
             if (hasNewCollapse) {
                 if (this._skipNextCollapseAnimation) {
-                    // Apply collapsed state instantly (no animation)
+                    // Apply collapsed state instantly (no animation).
+                    // Disable transitions so the CSS transition on
+                    // dv-tab--group-collapsed doesn't fire.
+                    const affected: HTMLElement[] = [];
                     for (const pid of tg.panelIds) {
                         const te = tabMap.get(pid);
                         if (te) {
+                            te.value.element.style.transition = 'none';
                             te.value.element.classList.add(
                                 'dv-tab--group-collapsed'
                             );
+                            affected.push(te.value.element);
+                        }
+                    }
+                    if (affected.length > 0) {
+                        void affected[0].offsetHeight; // single reflow
+                        for (const el of affected) {
+                            el.style.removeProperty('transition');
                         }
                     }
                 } else {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -197,7 +197,7 @@
 }
 
 // Color variants
-@each $color in grey, blue, red, yellow, green, pink, purple, cyan {
+@each $color in grey, blue, red, yellow, green, pink, purple, cyan, orange {
     .dv-tab-group-chip--#{$color} {
         background-color: var(--dv-tab-group-color-#{$color});
         color: white;

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -1560,6 +1560,7 @@ export class Tabs extends CompositeDisposable {
             this.group.model.moveTabGroup(sourceTabGroupId, insertionIndex);
             this.runFlipAnimation(firstPositions, '', false);
         } else {
+            this._tabGroupManager.skipNextCollapseAnimation = true;
             this.group.model.moveTabGroup(sourceTabGroupId, insertionIndex);
         }
     }

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -115,9 +115,15 @@ export class Tabs extends CompositeDisposable {
                 observer.onDidChange((event) => {
                     const hasOverflow = event.hasScrollX || event.hasScrollY;
                     this.toggleDropdown({ reset: !hasOverflow });
+                    if (this._tabGroupManager.groupUnderlines.size > 0) {
+                        this._tabGroupManager.positionUnderlines();
+                    }
                 }),
                 addDisposableListener(this._tabsList, 'scroll', () => {
                     this.toggleDropdown({ reset: false });
+                    if (this._tabGroupManager.groupUnderlines.size > 0) {
+                        this._tabGroupManager.positionUnderlines();
+                    }
                 })
             );
         }

--- a/packages/dockview-core/src/dockview/contextMenu.ts
+++ b/packages/dockview-core/src/dockview/contextMenu.ts
@@ -60,7 +60,9 @@ function buildRenameInput(tabGroup: ITabGroup): HTMLElement {
         tabGroup.setLabel(input.value);
     });
     input.addEventListener('keydown', (e) => {
-        e.stopPropagation();
+        if (e.key !== 'Escape' && e.key !== 'Enter') {
+            e.stopPropagation();
+        }
     });
     input.addEventListener('click', (e) => {
         e.stopPropagation();

--- a/packages/dockview-core/src/dockview/contextMenu.ts
+++ b/packages/dockview-core/src/dockview/contextMenu.ts
@@ -47,7 +47,36 @@ function buildSeparator(): HTMLElement {
     return el;
 }
 
-function buildColorPicker(tabGroup: ITabGroup, close: () => void): HTMLElement {
+function buildRenameInput(tabGroup: ITabGroup): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'dv-context-menu-rename';
+
+    const input = document.createElement('input');
+    input.className = 'dv-context-menu-rename-input';
+    input.type = 'text';
+    input.placeholder = 'Name This Group';
+    input.value = tabGroup.label;
+    input.addEventListener('input', () => {
+        tabGroup.setLabel(input.value);
+    });
+    input.addEventListener('keydown', (e) => {
+        e.stopPropagation();
+    });
+    input.addEventListener('click', (e) => {
+        e.stopPropagation();
+    });
+
+    wrapper.appendChild(input);
+
+    requestAnimationFrame(() => {
+        input.focus();
+        input.select();
+    });
+
+    return wrapper;
+}
+
+function buildColorPicker(tabGroup: ITabGroup): HTMLElement {
     const wrapper = document.createElement('div');
     wrapper.className = 'dv-context-menu-color-picker';
 
@@ -59,7 +88,6 @@ function buildColorPicker(tabGroup: ITabGroup, close: () => void): HTMLElement {
         }
         swatch.addEventListener('click', () => {
             tabGroup.setColor(color);
-            close();
         });
         wrapper.appendChild(swatch);
     }
@@ -185,8 +213,10 @@ export class ContextMenuController {
         for (const item of items) {
             if (item === 'separator') {
                 menuEl.appendChild(buildSeparator());
+            } else if (item === 'rename') {
+                menuEl.appendChild(buildRenameInput(tabGroup));
             } else if (item === 'colorPicker') {
-                menuEl.appendChild(buildColorPicker(tabGroup, close));
+                menuEl.appendChild(buildColorPicker(tabGroup));
             } else if (isItemConfig(item) && item.element) {
                 menuEl.appendChild(item.element);
             } else if (isItemConfig(item) && item.label) {

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -29,7 +29,7 @@ export type BuiltInContextMenuItem =
     | 'closeAll'
     | 'separator';
 
-export type BuiltInChipContextMenuItem = 'separator' | 'colorPicker';
+export type BuiltInChipContextMenuItem = 'separator' | 'colorPicker' | 'rename';
 
 export interface ContextMenuItemConfig {
     label?: string;

--- a/packages/dockview-core/src/dockview/tabGroup.ts
+++ b/packages/dockview-core/src/dockview/tabGroup.ts
@@ -9,7 +9,8 @@ export type DockviewTabGroupColor =
     | 'green'
     | 'pink'
     | 'purple'
-    | 'cyan';
+    | 'cyan'
+    | 'orange';
 
 export const DockviewTabGroupColors: Record<string, DockviewTabGroupColor> = {
     Grey: 'grey',
@@ -20,6 +21,7 @@ export const DockviewTabGroupColors: Record<string, DockviewTabGroupColor> = {
     Pink: 'pink',
     Purple: 'purple',
     Cyan: 'cyan',
+    Orange: 'orange',
 } as const;
 
 const VALID_COLORS: Set<string> = new Set<string>(

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -43,6 +43,7 @@
     --dv-tab-group-color-pink: #d01884;
     --dv-tab-group-color-purple: #a142f4;
     --dv-tab-group-color-cyan: #007b83;
+    --dv-tab-group-color-orange: #e8710a;
 
     // Tab group chip dimensions
     --dv-tab-group-chip-padding: 4px 8px;
@@ -1058,20 +1059,45 @@
     margin: 4px 0;
 }
 
+.dv-context-menu-rename {
+    padding: 8px 12px 4px;
+}
+
+.dv-context-menu-rename-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    border: 1px solid var(--dv-tab-divider-color);
+    border-radius: var(--dv-border-radius);
+    background: inherit;
+    color: var(--dv-activegroup-visiblepanel-tab-color);
+    font-size: var(--dv-tabs-and-actions-container-font-size);
+    outline: none;
+
+    &:focus {
+        border-color: var(--dv-activegroup-visiblepanel-tab-color);
+    }
+
+    &::placeholder {
+        color: var(--dv-activegroup-hiddenpanel-tab-color);
+    }
+}
+
 .dv-context-menu-color-picker {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 4px;
-    padding: 6px 8px;
-    justify-items: center;
+    display: flex;
+    flex-direction: row;
+    gap: 6px;
+    padding: 8px 12px;
+    align-items: center;
 }
 
 .dv-context-menu-color-swatch {
-    width: 16px;
-    height: 16px;
+    width: 20px;
+    height: 20px;
     border-radius: 50%;
     cursor: pointer;
     border: 2px solid transparent;
+    flex-shrink: 0;
 
     &:hover {
         opacity: 0.85;

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -629,25 +629,14 @@ const DockviewDemo = (props: {
         ({ group, tabGroup }: GetTabGroupChipContextMenuItemsParams) => {
             const items: (
                 | 'colorPicker'
+                | 'rename'
                 | 'separator'
                 | { label: string; action: () => void }
-            )[] = ['colorPicker'];
+            )[] = ['rename', 'colorPicker'];
 
             if (api) {
                 items.push(
                     'separator',
-                    {
-                        label: 'Rename group',
-                        action: () => {
-                            const label = window.prompt(
-                                'New group name:',
-                                tabGroup.label
-                            );
-                            if (label !== null) {
-                                tabGroup.setLabel(label);
-                            }
-                        },
-                    },
                     {
                         label: tabGroup.collapsed
                             ? 'Expand group'

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/defaultLayout.ts
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/defaultLayout.ts
@@ -14,13 +14,13 @@ export function defaultConfig(api: DockviewApi) {
         renderer: 'always',
     });
 
-    // Price alert as a floating panel
+    // Price alert in the same group as watchlist
     const pricealert = api.addPanel({
         id: 'pricealert',
         component: 'pricealert',
         title: 'Price Alert',
         renderer: 'always',
-        floating: { width: 360, height: 280, x: 60, y: 140 },
+        position: { referencePanel: watchlist },
     });
 
     // Centre column: order book (top) + orders grid (bottom)
@@ -78,6 +78,24 @@ export function defaultConfig(api: DockviewApi) {
         title: 'Panel Debug',
         renderer: 'always',
         position: { referencePanel: eventlog },
+    });
+
+    // Create a tab group in the watchlist group to demonstrate the feature
+    const watchlistGroupId = watchlist.api.group.id;
+    const marketData = api.createTabGroup({
+        groupId: watchlistGroupId,
+        label: 'Market Data',
+        color: 'blue',
+    });
+    api.addPanelToTabGroup({
+        groupId: watchlistGroupId,
+        tabGroupId: marketData.id,
+        panelId: 'watchlist',
+    });
+    api.addPanelToTabGroup({
+        groupId: watchlistGroupId,
+        tabGroupId: marketData.id,
+        panelId: 'pricealert',
     });
 
     // Set active panels

--- a/packages/docs/templates/dockview/tab-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/tab-groups/react/src/app.tsx
@@ -140,12 +140,13 @@ export default () => {
         ({ tabGroup, group }: GetTabGroupChipContextMenuItemsParams) => {
             const items = buildChipContextMenuItems(api!, group.id, tabGroup);
             return [
+                'rename' as const,
+                'colorPicker' as const,
+                'separator' as const,
                 ...items.map((item) => ({
                     label: item.label,
                     action: item.onClick,
                 })),
-                'separator' as const,
-                'colorPicker' as const,
             ];
         },
         [api]


### PR DESCRIPTION
…olor picker, and orange color

- Add built-in 'rename' context menu item with inline text input
- Change color picker layout from 4-column grid to horizontal row with larger swatches
- Add 'orange' as a new tab group color option
- Fix tab group underline not repositioning on scroll and container resize
- Update demo sandbox with a "Market Data" tab group in the watchlist area