### PR TITLE
fix: keep drag ghost horizontal when dragging from vertical tab groups

### DIFF
--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -52,6 +52,7 @@ export class Tab extends CompositeDisposable {
     private readonly dropTarget: Droptarget;
     private content: ITabRenderer | undefined = undefined;
     private readonly dragHandler: TabDragHandler;
+    private _direction: DockviewHeaderDirection = 'horizontal';
 
     private readonly _onPointDown = new Emitter<MouseEvent>();
     readonly onPointerDown: Event<MouseEvent> = this._onPointDown.event;
@@ -142,13 +143,60 @@ export class Tab extends CompositeDisposable {
                 if (event.dataTransfer) {
                     const style = getComputedStyle(this.element);
                     const newNode = this.element.cloneNode(true) as HTMLElement;
-                    Array.from(style).forEach((key) =>
+                    const isVertical = this._direction === 'vertical';
+
+                    /**
+                     * Properties to skip when copying computed styles for a
+                     * vertical tab ghost.  `writing-mode` is excluded so we
+                     * can force `horizontal-tb`.  Size and margin logical
+                     * properties are excluded because their physical meaning
+                     * flips when writing-mode changes, which would produce
+                     * incorrect dimensions.
+                     */
+                    const verticalSkip = new Set([
+                        'writing-mode',
+                        'inline-size',
+                        'block-size',
+                        'min-inline-size',
+                        'min-block-size',
+                        'max-inline-size',
+                        'max-block-size',
+                        'margin-inline',
+                        'margin-inline-start',
+                        'margin-inline-end',
+                        'margin-block',
+                        'margin-block-start',
+                        'margin-block-end',
+                        'padding-inline',
+                        'padding-inline-start',
+                        'padding-inline-end',
+                        'padding-block',
+                        'padding-block-start',
+                        'padding-block-end',
+                    ]);
+
+                    Array.from(style).forEach((key) => {
+                        if (isVertical && verticalSkip.has(key)) {
+                            return;
+                        }
                         newNode.style.setProperty(
                             key,
                             style.getPropertyValue(key),
                             style.getPropertyPriority(key)
-                        )
-                    );
+                        );
+                    });
+
+                    if (isVertical) {
+                        // Force horizontal text flow and swap the physical
+                        // dimensions so the ghost appears as a horizontal tab.
+                        newNode.style.setProperty(
+                            'writing-mode',
+                            'horizontal-tb'
+                        );
+                        newNode.style.setProperty('width', style.height);
+                        newNode.style.setProperty('height', style.width);
+                    }
+
                     newNode.style.position = 'absolute';
                     newNode.classList.add('dv-tab-ghost-drag');
 
@@ -223,6 +271,7 @@ export class Tab extends CompositeDisposable {
     }
 
     public setDirection(direction: DockviewHeaderDirection): void {
+        this._direction = direction;
         this.dropTarget.setTargetZones(
             direction === 'vertical' ? ['top', 'bottom'] : ['left', 'right']
         );

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -158,10 +158,25 @@ export class TabGroupManager {
         const groupPanelIds = new Set(tabGroup.panelIds);
         const underlineEl = this._groupUnderlines.get(tabGroup.id);
 
+        const isVertical = this._ctx.getDirection() === 'vertical';
+
         // Clone the entire tabs list so cloned nodes inherit all
         // theme styles, CSS variables and class-based rules.
         const clone = this._ctx.tabsList.cloneNode(true) as HTMLElement;
-        clone.style.height = `${this._ctx.tabsList.offsetHeight}px`;
+
+        if (isVertical) {
+            // Force horizontal orientation for the drag ghost by
+            // removing vertical CSS classes and overriding writing-mode.
+            clone.classList.remove(
+                'dv-tabs-container-vertical',
+                'dv-vertical'
+            );
+            clone.classList.add('dv-horizontal');
+            clone.style.writingMode = 'horizontal-tb';
+            clone.style.height = `${this._ctx.tabsList.offsetWidth}px`;
+        } else {
+            clone.style.height = `${this._ctx.tabsList.offsetHeight}px`;
+        }
         clone.style.width = 'auto';
         clone.style.overflow = 'visible';
         clone.style.pointerEvents = 'none';

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -167,10 +167,7 @@ export class TabGroupManager {
         if (isVertical) {
             // Force horizontal orientation for the drag ghost by
             // removing vertical CSS classes and overriding writing-mode.
-            clone.classList.remove(
-                'dv-tabs-container-vertical',
-                'dv-vertical'
-            );
+            clone.classList.remove('dv-tabs-container-vertical', 'dv-vertical');
             clone.classList.add('dv-horizontal');
             clone.style.writingMode = 'horizontal-tb';
             clone.style.height = `${this._ctx.tabsList.offsetWidth}px`;


### PR DESCRIPTION
The drag ghost for both individual tabs and tab groups now renders in horizontal orientation regardless of the tab group direction, providing a consistent drag experience.