### PR TITLE
docs: complete tab groups and edge groups documentation

### DIFF
--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -159,9 +159,10 @@ export interface DockviewOptions {
     /**
      * Return the items to display in the tab group chip context menu on right-click.
      *
-     * Use built-in string shortcuts (`'separator'`, `'colorPicker'`) or provide a
+     * Use built-in string shortcuts (`'separator'`, `'colorPicker'`, `'rename'`) or provide a
      * `ContextMenuItemConfig` object for custom items.
      * `'colorPicker'` renders a native grid of color swatches for the tab group.
+     * `'rename'` renders an inline text input to rename the tab group.
      *
      * If omitted, no context menu is shown on chip right-click.
      * Return an empty array to suppress the menu for specific cases.

--- a/packages/docs/docs/core/groups/edgeGroups.mdx
+++ b/packages/docs/docs/core/groups/edgeGroups.mdx
@@ -5,10 +5,18 @@ description: How to create and manage edge groups in Dockview — groups that ar
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
+import { CodeRunner } from '@site/src/components/ui/codeRunner';
+
 Edge groups are `DockviewGroupPanel` instances pinned to one of the four edges of the layout (`'left'`, `'right'`, `'top'`, `'bottom'`). They support tabs, drag-and-drop, overflow, and the full group panel API — and their state is included in `toJSON` / `fromJSON`.
+
+<CodeRunner id="dockview/edge-groups" height={500}/>
 
 :::info
 Edge groups **cannot** be maximized or converted into floating/popout windows. They are structural elements of the layout.
+:::
+
+:::tip
+The `dndEdges` prop controls the drag-and-drop overlay that appears when dragging panels to the far edges of the layout. See [Drag and Drop](/docs/core/dnd/dragAndDrop#drag-and-drop) for configuration details.
 :::
 
 ## Adding Edge Groups
@@ -113,19 +121,100 @@ const isCollapsed = groupApi?.isCollapsed(); // boolean
 
 The `collapsedSize` (the pixel height/width of the header when collapsed) defaults to 35px and can be configured per-group via `EdgeGroupOptions.collapsedSize`, or per-theme via `DockviewTheme.edgeGroupCollapsedSize`.
 
+Themes that set a custom `edgeGroupCollapsedSize`:
+
+| Theme | `edgeGroupCollapsedSize` |
+| --- | --- |
+| `themeVisualStudio` | `22` |
+| `themeAbyssSpaced` | `44` |
+| `themeGithubLightSpaced` | `44` |
+| All other themes | `35` (default) |
+
+:::tip
+When an edge group loses all of its panels it is automatically collapsed. Adding a new panel to it will expand it again.
+:::
+
 ## Custom Header Actions
 
-The `location` prop in `rightHeaderActionsComponent`, `leftHeaderActionsComponent`, and `prefixHeaderActionsComponent` updates reactively when a group moves. Use it to show controls specific to edge groups:
+The `location` prop in `rightHeaderActionsComponent`, `leftHeaderActionsComponent`, and `prefixHeaderActionsComponent` updates reactively when a group moves. Use it to show controls specific to edge groups.
 
-```tsx
-// React: show a collapse button only in edge groups
-const MyRightActions = (props: IDockviewGroupHeaderActionsProps) => {
-    if (props.location.type !== 'fixed') return null;
-    return <button onClick={() => props.api.collapse()}>Collapse</button>;
-};
+The `DockviewGroupLocation` type is a discriminated union:
+
+```ts
+type DockviewGroupLocation =
+    | { type: 'grid' }
+    | { type: 'floating' }
+    | { type: 'popout'; getWindow: () => Window }
+    | { type: 'edge'; position: EdgeGroupPosition }; // 'top' | 'bottom' | 'left' | 'right'
 ```
 
+Check `location.type` to distinguish edge groups, and `location.position` to know which edge:
+
+<FrameworkSpecific framework="React">
+```tsx
+const MyRightActions = (props: IDockviewHeaderActionsProps) => {
+    if (props.location?.type !== 'edge') return null;
+
+    const position = props.location.position; // 'left' | 'right' | 'top' | 'bottom'
+    return <button onClick={() => props.api.collapse()}>Collapse {position}</button>;
+};
+
+<DockviewReact rightHeaderActionsComponent={MyRightActions} />
+```
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Vue">
+```vue
+<template>
+    <button v-if="params?.location?.type === 'edge'" @click="params.api.collapse()">
+        Collapse {{ params.location.position }}
+    </button>
+</template>
+```
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Angular">
+```ts
+@Component({
+    selector: 'my-right-actions',
+    template: `
+        <button *ngIf="location?.type === 'edge'" (click)="api.collapse()">
+            Collapse {{ location.position }}
+        </button>
+    `,
+})
+export class MyRightActionsComponent {
+    @Input() api: DockviewGroupPanelApi;
+    @Input() location: DockviewGroupLocation;
+}
+```
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="JavaScript">
+```ts
+const api = createDockview(parentElement, {
+    createRightHeaderActionsElement: (group) => {
+        const element = document.createElement('div');
+        return {
+            element,
+            init(params) {
+                if (params.location?.type === 'edge') {
+                    const btn = document.createElement('button');
+                    btn.textContent = `Collapse ${params.location.position}`;
+                    btn.addEventListener('click', () => params.api.collapse());
+                    element.appendChild(btn);
+                }
+            },
+            dispose() {},
+        };
+    },
+});
+```
+</FrameworkSpecific>
+
 `DockviewGroupLocation` is exported from all framework packages.
+
+> See [Group Controls](/docs/core/groups/controls) for the full header actions reference.
 
 ## Serialization
 

--- a/packages/docs/docs/core/panels/tabs.mdx
+++ b/packages/docs/docs/core/panels/tabs.mdx
@@ -675,6 +675,13 @@ api.dissolveTabGroup({
     groupId: 'group-1',
     tabGroupId: tabGroup.id,
 });
+
+// Move a tab group to a new position in the tab bar
+api.moveTabGroup({
+    groupId: 'group-1',
+    tabGroupId: tabGroup.id,
+    index: 0, // move to the beginning
+});
 ```
 
 ### Querying Tab Groups
@@ -742,6 +749,150 @@ tabGroup.onDidDestroy(() => { });
 ```
 
 > See [Events](/docs/core/events#tab-groups) for the full event reference.
+
+### Chip Context Menu
+
+Right-clicking a tab group chip can show a context menu. This is opt-in — no menu is shown unless
+`getTabGroupChipContextMenuItems` is provided. Return an empty array to suppress the menu for specific chips.
+
+<FrameworkSpecific framework="React">
+  <DocRef declaration="IDockviewReactProps" methods={['getTabGroupChipContextMenuItems']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Vue">
+  <DocRef declaration="IDockviewVueProps" methods={['getTabGroupChipContextMenuItems']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Angular">
+  <DocRef declaration="IDockviewAngularProps" methods={['getTabGroupChipContextMenuItems']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="JavaScript">
+  <DocRef declaration="DockviewComponentOptions" methods={['getTabGroupChipContextMenuItems']} />
+</FrameworkSpecific>
+
+#### Built-in items
+
+Pass string shortcuts to render standard menu entries without any extra code:
+
+| Value | Behaviour |
+| --- | --- |
+| `'rename'` | An inline text input to rename the tab group |
+| `'colorPicker'` | A grid of color swatches to change the tab group color |
+| `'separator'` | Render a visual divider |
+
+#### Custom label items
+
+Provide an object with a `label` and `action` to add a simple clickable entry:
+
+```ts
+getTabGroupChipContextMenuItems: (params) => [
+    'rename',
+    'colorPicker',
+    'separator',
+    { label: 'Dissolve group', action: () => params.api.dissolveTabGroup({ groupId: params.group.id, tabGroupId: params.tabGroup.id }) },
+]
+```
+
+### Custom Chip Renderer
+
+To fully customize how tab group chips look, provide a `createTabGroupChipComponent` factory. It receives the `ITabGroup` and must return an `ITabGroupChipRenderer`.
+
+<FrameworkSpecific framework="React">
+  <DocRef declaration="IDockviewReactProps" methods={['createTabGroupChipComponent']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Vue">
+  <DocRef declaration="IDockviewVueProps" methods={['createTabGroupChipComponent']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Angular">
+  <DocRef declaration="IDockviewAngularProps" methods={['createTabGroupChipComponent']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="JavaScript">
+  <DocRef declaration="DockviewComponentOptions" methods={['createTabGroupChipComponent']} />
+</FrameworkSpecific>
+
+The renderer must implement:
+
+```ts
+interface ITabGroupChipRenderer {
+    readonly element: HTMLElement;   // the chip DOM element
+    init(params: { tabGroup: ITabGroup; api: DockviewApi }): void;
+    update?(params: { tabGroup: ITabGroup }): void; // called when label or color changes
+    dispose(): void;
+}
+```
+
+<FrameworkSpecific framework="JavaScript">
+```ts
+class MyChipRenderer {
+    readonly element = document.createElement('div');
+
+    init({ tabGroup, api }) {
+        this.element.className = 'my-chip';
+        this.element.textContent = tabGroup.label;
+    }
+
+    update({ tabGroup }) {
+        this.element.textContent = tabGroup.label;
+    }
+
+    dispose() {}
+}
+
+const api = createDockview(parentElement, {
+    createTabGroupChipComponent: (tabGroup) => new MyChipRenderer(),
+});
+```
+</FrameworkSpecific>
+
+### Styling
+
+Tab group appearance can be customized through CSS custom properties:
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `--dv-tab-group-color-grey` | `#5f6368` | Color for grey chips |
+| `--dv-tab-group-color-blue` | `#1a73e8` | Color for blue chips |
+| `--dv-tab-group-color-red` | `#d93025` | Color for red chips |
+| `--dv-tab-group-color-yellow` | `#f9ab00` | Color for yellow chips |
+| `--dv-tab-group-color-green` | `#188038` | Color for green chips |
+| `--dv-tab-group-color-pink` | `#d01884` | Color for pink chips |
+| `--dv-tab-group-color-purple` | `#a142f4` | Color for purple chips |
+| `--dv-tab-group-color-cyan` | `#007b83` | Color for cyan chips |
+| `--dv-tab-group-color-orange` | `#e8710a` | Color for orange chips |
+| `--dv-tab-group-chip-padding` | `4px 8px` | Chip padding |
+| `--dv-tab-group-chip-border-radius` | `6px` | Chip border radius |
+| `--dv-tab-group-chip-font-size` | `11px` | Chip font size |
+| `--dv-tab-group-line-height` | `2px` | Height of the colored underline beneath grouped tabs |
+| `--dv-tab-group-line-opacity` | `0.6` | Opacity of the colored underline |
+
+### Serialization
+
+Tab groups are included in `toJSON` / `fromJSON` automatically. Each tab group is serialized as:
+
+```ts
+interface SerializedTabGroup {
+    id: string;
+    label?: string;
+    color: DockviewTabGroupColor;
+    collapsed: boolean;
+    panelIds: string[];
+}
+```
+
+### Utilities
+
+Use `isValidTabGroupColor` to validate a string as a tab group color at runtime:
+
+```ts
+import { isValidTabGroupColor } from 'dockview';
+
+isValidTabGroupColor('blue');   // true
+isValidTabGroupColor('foo');    // false — type narrows to never
+```
 
 ## Tab Height
 

--- a/packages/docs/templates/dockview/edge-groups/angular/src/index.ts
+++ b/packages/docs/templates/dockview/edge-groups/angular/src/index.ts
@@ -1,0 +1,131 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { Component, Type, NgModule, Input } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { DockviewAngularModule } from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+// Default panel component
+@Component({
+    selector: 'default-panel',
+    template: `<div style="padding: 10px;">{{ title || 'Panel' }}</div>`
+})
+export class DefaultPanelComponent {
+    @Input() api: any;
+
+    get title() {
+        return this.api?.title || this.api?.id || 'Panel';
+    }
+
+    constructor() {}
+}
+
+// Main app component
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%;">
+            <dv-dockview
+                [components]="components"
+                className="dockview-theme-abyss"
+                (ready)="onReady($event)">
+            </dv-dockview>
+        </div>
+    `
+})
+export class AppComponent {
+    components: Record<string, Type<any>>;
+
+    constructor() {
+        this.components = {
+            default: DefaultPanelComponent,
+        };
+    }
+
+    onReady(event: any) {
+        const api = event.api;
+
+        api.addEdgeGroup('left', {
+            id: 'left',
+            initialSize: 220,
+            minimumSize: 150,
+        });
+
+        api.addEdgeGroup('bottom', {
+            id: 'bottom',
+            initialSize: 180,
+            minimumSize: 100,
+        });
+
+        api.addEdgeGroup('right', {
+            id: 'right',
+            initialSize: 220,
+            minimumSize: 150,
+            collapsed: true,
+        });
+
+        api.addPanel({
+            id: 'explorer',
+            component: 'default',
+            title: 'Explorer',
+            position: { referenceGroup: 'left' },
+        });
+
+        api.addPanel({
+            id: 'search',
+            component: 'default',
+            title: 'Search',
+            position: { referenceGroup: 'left' },
+        });
+
+        api.addPanel({
+            id: 'terminal',
+            component: 'default',
+            title: 'Terminal',
+            position: { referenceGroup: 'bottom' },
+        });
+
+        api.addPanel({
+            id: 'output',
+            component: 'default',
+            title: 'Output',
+            position: { referenceGroup: 'bottom' },
+        });
+
+        api.addPanel({
+            id: 'outline',
+            component: 'default',
+            title: 'Outline',
+            position: { referenceGroup: 'right' },
+        });
+
+        api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            title: 'Editor',
+        });
+
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            title: 'Preview',
+            position: {
+                direction: 'right',
+                referencePanel: 'panel_1',
+            },
+        });
+    }
+}
+
+// App module
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    providers: [],
+    bootstrap: [AppComponent]
+})
+export class AppModule { }
+
+// Bootstrap the application with JIT compilation
+platformBrowserDynamic().bootstrapModule(AppModule).catch(err => console.error(err));

--- a/packages/docs/templates/dockview/edge-groups/react/package.json
+++ b/packages/docs/templates/dockview/edge-groups/react/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "dockview.edge-groups",
+  "description": "",
+  "keywords": [
+    "dockview"
+  ],
+  "version": "1.0.0",
+  "main": "src/index.tsx",
+  "dependencies": {
+    "dockview": "*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^4.9.5",
+    "react-scripts": "*"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/packages/docs/templates/dockview/edge-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/edge-groups/react/src/app.tsx
@@ -1,0 +1,131 @@
+import {
+    DockviewReact,
+    DockviewReadyEvent,
+    IDockviewPanelProps,
+    IDockviewHeaderActionsProps,
+} from 'dockview';
+import React from 'react';
+
+const Default = (props: IDockviewPanelProps) => {
+    return (
+        <div style={{ padding: 10 }}>
+            <div>{props.api.title}</div>
+        </div>
+    );
+};
+
+const components = {
+    default: Default,
+};
+
+const RightActions = (props: IDockviewHeaderActionsProps) => {
+    if (props.location?.type !== 'edge') {
+        return null;
+    }
+
+    const [collapsed, setCollapsed] = React.useState(props.api.isCollapsed());
+
+    React.useEffect(() => {
+        const disposable = props.api.onDidCollapsedChange((isCollapsed) => {
+            setCollapsed(isCollapsed);
+        });
+        return () => disposable.dispose();
+    }, [props.api]);
+
+    return (
+        <button
+            style={{
+                cursor: 'pointer',
+                background: 'none',
+                border: 'none',
+                color: 'inherit',
+                padding: '0 4px',
+            }}
+            onClick={() =>
+                collapsed ? props.api.expand() : props.api.collapse()
+            }
+        >
+            {collapsed ? '+' : '-'}
+        </button>
+    );
+};
+
+export default () => {
+    const onReady = (event: DockviewReadyEvent) => {
+        event.api.addEdgeGroup('left', {
+            id: 'left',
+            initialSize: 220,
+            minimumSize: 150,
+        });
+
+        event.api.addEdgeGroup('bottom', {
+            id: 'bottom',
+            initialSize: 180,
+            minimumSize: 100,
+        });
+
+        event.api.addEdgeGroup('right', {
+            id: 'right',
+            initialSize: 220,
+            minimumSize: 150,
+            collapsed: true,
+        });
+
+        event.api.addPanel({
+            id: 'explorer',
+            component: 'default',
+            title: 'Explorer',
+            position: { referenceGroup: 'left' },
+        });
+
+        event.api.addPanel({
+            id: 'search',
+            component: 'default',
+            title: 'Search',
+            position: { referenceGroup: 'left' },
+        });
+
+        event.api.addPanel({
+            id: 'terminal',
+            component: 'default',
+            title: 'Terminal',
+            position: { referenceGroup: 'bottom' },
+        });
+
+        event.api.addPanel({
+            id: 'output',
+            component: 'default',
+            title: 'Output',
+            position: { referenceGroup: 'bottom' },
+        });
+
+        event.api.addPanel({
+            id: 'outline',
+            component: 'default',
+            title: 'Outline',
+            position: { referenceGroup: 'right' },
+        });
+
+        event.api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            title: 'Editor',
+        });
+
+        event.api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            title: 'Preview',
+            position: { direction: 'right', referencePanel: 'panel_1' },
+        });
+    };
+
+    return (
+        <DockviewReact
+            className={'dockview-theme-abyss'}
+            onReady={onReady}
+            components={components}
+            rightHeaderActionsComponent={RightActions}
+        />
+    );
+};

--- a/packages/docs/templates/dockview/edge-groups/react/src/index.tsx
+++ b/packages/docs/templates/dockview/edge-groups/react/src/index.tsx
@@ -1,0 +1,13 @@
+import ReactDOM from 'react-dom/client';
+import React from 'react';
+import 'dockview/dist/styles/dockview.css';
+
+import App from './app.tsx';
+
+const rootElement = document.getElementById('app');
+
+if (rootElement) {
+    const root = ReactDOM.createRoot(rootElement);
+
+    root.render(<App />);
+}

--- a/packages/docs/templates/dockview/edge-groups/react/tsconfig.json
+++ b/packages/docs/templates/dockview/edge-groups/react/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "outDir": "build/dist",
+        "module": "esnext",
+        "target": "es5",
+        "lib": ["es6", "dom"],
+        "sourceMap": true,
+        "allowJs": true,
+        "jsx": "react-jsx",
+        "moduleResolution": "node",
+        "rootDir": "src",
+        "forceConsistentCasingInFileNames": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true
+    }
+}

--- a/packages/docs/templates/dockview/edge-groups/typescript/src/index.ts
+++ b/packages/docs/templates/dockview/edge-groups/typescript/src/index.ts
@@ -1,0 +1,102 @@
+import 'dockview-core/dist/styles/dockview.css';
+import {
+    createDockview,
+    GroupPanelPartInitParameters,
+    IContentRenderer,
+    themeAbyss,
+} from 'dockview-core';
+
+class Panel implements IContentRenderer {
+    private readonly _element: HTMLElement;
+
+    get element(): HTMLElement {
+        return this._element;
+    }
+
+    constructor() {
+        this._element = document.createElement('div');
+        this._element.style.padding = '10px';
+        this._element.style.color = 'white';
+    }
+
+    init(parameters: GroupPanelPartInitParameters): void {
+        this._element.textContent = parameters.title ?? 'Panel';
+    }
+}
+
+const api = createDockview(document.getElementById('app'), {
+    theme: themeAbyss,
+    createComponent: (options) => {
+        switch (options.name) {
+            case 'default':
+                return new Panel();
+        }
+    },
+});
+
+api.addEdgeGroup('left', {
+    id: 'left',
+    initialSize: 220,
+    minimumSize: 150,
+});
+
+api.addEdgeGroup('bottom', {
+    id: 'bottom',
+    initialSize: 180,
+    minimumSize: 100,
+});
+
+api.addEdgeGroup('right', {
+    id: 'right',
+    initialSize: 220,
+    minimumSize: 150,
+    collapsed: true,
+});
+
+api.addPanel({
+    id: 'explorer',
+    component: 'default',
+    title: 'Explorer',
+    position: { referenceGroup: 'left' },
+});
+
+api.addPanel({
+    id: 'search',
+    component: 'default',
+    title: 'Search',
+    position: { referenceGroup: 'left' },
+});
+
+api.addPanel({
+    id: 'terminal',
+    component: 'default',
+    title: 'Terminal',
+    position: { referenceGroup: 'bottom' },
+});
+
+api.addPanel({
+    id: 'output',
+    component: 'default',
+    title: 'Output',
+    position: { referenceGroup: 'bottom' },
+});
+
+api.addPanel({
+    id: 'outline',
+    component: 'default',
+    title: 'Outline',
+    position: { referenceGroup: 'right' },
+});
+
+api.addPanel({
+    id: 'panel_1',
+    component: 'default',
+    title: 'Editor',
+});
+
+api.addPanel({
+    id: 'panel_2',
+    component: 'default',
+    title: 'Preview',
+    position: { direction: 'right', referencePanel: 'panel_1' },
+});

--- a/packages/docs/templates/dockview/edge-groups/vue/src/index.ts
+++ b/packages/docs/templates/dockview/edge-groups/vue/src/index.ts
@@ -1,0 +1,127 @@
+import 'dockview-vue/dist/styles/dockview.css';
+import { PropType, createApp, defineComponent } from 'vue';
+import {
+    DockviewVue,
+    DockviewReadyEvent,
+    IDockviewPanelProps,
+} from 'dockview-vue';
+
+const Panel = defineComponent({
+    name: 'Panel',
+    props: {
+        params: {
+            type: Object as PropType<IDockviewPanelProps>,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            title: '',
+        };
+    },
+    mounted() {
+        const disposable = this.params.api.onDidTitleChange(() => {
+            this.title = this.params.api.title;
+        });
+        this.title = this.params.api.title;
+
+        return () => {
+            disposable.dispose();
+        };
+    },
+    template: `
+    <div style="height:100%; padding: 10px; color: white;">
+      {{title}}
+    </div>`,
+});
+
+const App = defineComponent({
+    name: 'App',
+    components: {
+        'dockview-vue': DockviewVue,
+        panel: Panel,
+    },
+    methods: {
+        onReady(event: DockviewReadyEvent) {
+            event.api.addEdgeGroup('left', {
+                id: 'left',
+                initialSize: 220,
+                minimumSize: 150,
+            });
+
+            event.api.addEdgeGroup('bottom', {
+                id: 'bottom',
+                initialSize: 180,
+                minimumSize: 100,
+            });
+
+            event.api.addEdgeGroup('right', {
+                id: 'right',
+                initialSize: 220,
+                minimumSize: 150,
+                collapsed: true,
+            });
+
+            event.api.addPanel({
+                id: 'explorer',
+                component: 'panel',
+                title: 'Explorer',
+                position: { referenceGroup: 'left' },
+            });
+
+            event.api.addPanel({
+                id: 'search',
+                component: 'panel',
+                title: 'Search',
+                position: { referenceGroup: 'left' },
+            });
+
+            event.api.addPanel({
+                id: 'terminal',
+                component: 'panel',
+                title: 'Terminal',
+                position: { referenceGroup: 'bottom' },
+            });
+
+            event.api.addPanel({
+                id: 'output',
+                component: 'panel',
+                title: 'Output',
+                position: { referenceGroup: 'bottom' },
+            });
+
+            event.api.addPanel({
+                id: 'outline',
+                component: 'panel',
+                title: 'Outline',
+                position: { referenceGroup: 'right' },
+            });
+
+            event.api.addPanel({
+                id: 'panel_1',
+                component: 'panel',
+                title: 'Editor',
+            });
+
+            event.api.addPanel({
+                id: 'panel_2',
+                component: 'panel',
+                title: 'Preview',
+                position: { direction: 'right', referencePanel: 'panel_1' },
+            });
+        },
+    },
+    template: `
+      <dockview-vue
+        style="width:100%; height:100%"
+        class="dockview-theme-abyss"
+        @ready="onReady"
+      >
+      </dockview-vue>`,
+});
+
+const app = createApp(App);
+app.config.errorHandler = (err) => {
+    console.log(err);
+};
+app.mount(document.getElementById('app')!);


### PR DESCRIPTION
Fill documentation gaps for tab groups (moveTabGroup, custom chip renderers, CSS variables, serialization format, isValidTabGroupColor, chip context menu) and edge groups (live template, location.position, dndEdges cross-reference, theme collapsed sizes, auto-collapse behavior, framework-specific header action examples).