### PR TITLE
feat: add tabGroupIndicator theme property and extract wrap underline…

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -58,6 +58,7 @@ DockviewTabGroupChangeEvent
 DockviewTabGroupCollapsedChangeEvent
 DockviewTabGroupColor
 DockviewTabGroupColors
+DockviewTabGroupIndicator
 DockviewTabGroupPanelChangeEvent
 DockviewTheme
 DockviewUnhandledDragOverEvent

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -141,13 +141,13 @@ describe('dockviewComponent', () => {
             className: 'test-a test-b',
         });
         expect(dockview.element.className).toBe(
-            'test-a test-b dockview-theme-abyss'
+            'test-a test-b dockview-theme-abyss dv-tab-group-indicator-none'
         );
 
         dockview.updateOptions({ className: 'test-b test-c' });
 
         expect(dockview.element.className).toBe(
-            'dockview-theme-abyss test-b test-c'
+            'dockview-theme-abyss dv-tab-group-indicator-none test-b test-c'
         );
     });
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroupChip.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroupChip.ts
@@ -91,6 +91,10 @@ export class TabGroupChip
         for (const c of Object.values(DockviewTabGroupColors)) {
             toggleClass(this._element, `dv-tab-group-chip--${c}`, c === color);
         }
+        this._element.style.setProperty(
+            '--dv-tab-group-color',
+            `var(--dv-tab-group-color-${color})`
+        );
     }
 
     private updateLabel(label: string): void {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
@@ -1,0 +1,423 @@
+import { IValueDisposable } from '../../../lifecycle';
+import { DockviewHeaderDirection } from '../../options';
+import { Tab } from '../tab/tab';
+import { ITabGroup } from '../../tabGroup';
+
+export interface TabGroupIndicatorContext {
+    readonly tabsList: HTMLElement;
+    getTabGroups(): readonly ITabGroup[];
+    getActivePanelId(): string | undefined;
+    getTabMap(): Map<string, IValueDisposable<Tab>>;
+    getChipElement(groupId: string): HTMLElement | undefined;
+    getDirection(): DockviewHeaderDirection;
+}
+
+export interface ITabGroupIndicator {
+    readonly underlines: ReadonlyMap<string, HTMLElement>;
+    positionUnderlines(): void;
+    trackUnderlines(): void;
+    syncUnderlineElements(activeGroupIds: Set<string>): void;
+    getUnderline(groupId: string): HTMLElement | undefined;
+    dispose(): void;
+}
+
+export class WrapTabGroupIndicator implements ITabGroupIndicator {
+    private readonly _underlines = new Map<string, HTMLElement>();
+    private _rafId: number | null = null;
+
+    get underlines(): ReadonlyMap<string, HTMLElement> {
+        return this._underlines;
+    }
+
+    constructor(private readonly _ctx: TabGroupIndicatorContext) {}
+
+    positionUnderlines(): void {
+        requestAnimationFrame(() => {
+            this._positionUnderlinesSync();
+        });
+    }
+
+    /**
+     * Continuously reposition underlines every frame for the duration
+     * of a tab transition (~200ms), so the underline tracks tab sizes.
+     */
+    trackUnderlines(): void {
+        if (this._rafId !== null) {
+            cancelAnimationFrame(this._rafId);
+        }
+
+        const start = performance.now();
+        const duration = 250; // slightly longer than transition to ensure we catch the end
+
+        const tick = () => {
+            this._positionUnderlinesSync();
+            if (performance.now() - start < duration) {
+                this._rafId = requestAnimationFrame(tick);
+            } else {
+                this._rafId = null;
+            }
+        };
+
+        this._rafId = requestAnimationFrame(tick);
+    }
+
+    syncUnderlineElements(activeGroupIds: Set<string>): void {
+        // Ensure underline elements exist for active groups
+        for (const groupId of activeGroupIds) {
+            if (!this._underlines.has(groupId)) {
+                const underline = document.createElement('div');
+                underline.className = 'dv-tab-group-underline';
+                this._ctx.tabsList.appendChild(underline);
+                this._underlines.set(groupId, underline);
+            }
+        }
+
+        // Remove underlines for dissolved groups
+        for (const [groupId, el] of this._underlines) {
+            if (!activeGroupIds.has(groupId)) {
+                el.remove();
+                this._underlines.delete(groupId);
+            }
+        }
+    }
+
+    getUnderline(groupId: string): HTMLElement | undefined {
+        return this._underlines.get(groupId);
+    }
+
+    dispose(): void {
+        if (this._rafId !== null) {
+            cancelAnimationFrame(this._rafId);
+            this._rafId = null;
+        }
+
+        for (const [, el] of this._underlines) {
+            el.remove();
+        }
+        this._underlines.clear();
+    }
+
+    private _positionUnderlinesSync(): void {
+        const containerRect = this._ctx.tabsList.getBoundingClientRect();
+        const tabGroups = this._ctx.getTabGroups();
+        const isVertical = this._ctx.getDirection() === 'vertical';
+        const containerCrossSize = isVertical
+            ? containerRect.width
+            : containerRect.height;
+        const activePanelId = this._ctx.getActivePanelId();
+        const tabMap = this._ctx.getTabMap();
+
+        for (const tg of tabGroups) {
+            const underline = this._underlines.get(tg.id);
+            if (!underline) {
+                continue;
+            }
+
+            const panelIds = tg.panelIds;
+            if (panelIds.length === 0) {
+                underline.style.display = 'none';
+                continue;
+            }
+
+            underline.style.display = '';
+
+            const chipEl = this._ctx.getChipElement(tg.id);
+
+            // In vertical mode, compute top/bottom edges; in horizontal, left/right.
+            let startEdge: number;
+            if (chipEl) {
+                const chipRect = chipEl.getBoundingClientRect();
+                const chipStyle = getComputedStyle(chipEl);
+                const leadingMargin = isVertical
+                    ? Number.parseFloat(chipStyle.marginTop) || 0
+                    : Number.parseFloat(chipStyle.marginLeft) || 0;
+                startEdge = isVertical
+                    ? chipRect.top - containerRect.top - leadingMargin
+                    : chipRect.left - containerRect.left - leadingMargin;
+            } else {
+                const firstPanelId = panelIds[0];
+                const firstTabEntry = tabMap.get(firstPanelId);
+                if (firstTabEntry) {
+                    const firstRect =
+                        firstTabEntry.value.element.getBoundingClientRect();
+                    startEdge = isVertical
+                        ? firstRect.top - containerRect.top
+                        : firstRect.left - containerRect.left;
+                } else {
+                    startEdge = 0;
+                }
+            }
+
+            // Measure the actual last tab position (follows CSS transitions in real-time)
+            const lastPanelId = panelIds[panelIds.length - 1];
+            const lastTabEntry = tabMap.get(lastPanelId);
+
+            if (!lastTabEntry) {
+                if (isVertical) {
+                    underline.style.top = `${startEdge}px`;
+                    underline.style.height = '0px';
+                    underline.style.left = '';
+                    underline.style.width = '';
+                } else {
+                    underline.style.left = `${startEdge}px`;
+                    underline.style.width = '0px';
+                    underline.style.top = '';
+                    underline.style.height = '';
+                }
+                continue;
+            }
+
+            const lastTabRect =
+                lastTabEntry.value.element.getBoundingClientRect();
+            let endEdge = isVertical
+                ? lastTabRect.bottom - containerRect.top
+                : lastTabRect.right - containerRect.left;
+            let span = endEdge - startEdge;
+
+            // During collapse or expand: converge both edges toward chip center
+            const isAnimating =
+                tg.collapsed ||
+                tg.panelIds.some((pid) => {
+                    const te = tabMap.get(pid);
+                    return (
+                        te &&
+                        te.value.element.classList.contains(
+                            'dv-tab--group-expanding'
+                        )
+                    );
+                });
+
+            if (isAnimating && chipEl) {
+                const chipRect = chipEl.getBoundingClientRect();
+                const chipCenter = isVertical
+                    ? chipRect.top + chipRect.height / 2 - containerRect.top
+                    : chipRect.left + chipRect.width / 2 - containerRect.left;
+
+                // Sum of current visible tab sizes (shrinking or growing)
+                let currentTabSize = 0;
+                let fullTabSize = 0;
+                for (const pid of tg.panelIds) {
+                    const te = tabMap.get(pid);
+                    if (!te) continue;
+                    const el = te.value.element;
+                    if (isVertical) {
+                        currentTabSize += el.getBoundingClientRect().height;
+                        fullTabSize += el.scrollHeight;
+                    } else {
+                        currentTabSize += el.getBoundingClientRect().width;
+                        fullTabSize += el.scrollWidth;
+                    }
+                }
+
+                // progress: 0 when tabs at 0 size, 1 when fully open
+                const progress =
+                    fullTabSize > 0
+                        ? Math.min(1, currentTabSize / fullTabSize)
+                        : 0;
+
+                // Interpolate start and end edges toward chip center
+                startEdge = chipCenter + (startEdge - chipCenter) * progress;
+                endEdge = chipCenter + (endEdge - chipCenter) * progress;
+                span = Math.max(0, endEdge - startEdge);
+            }
+
+            if (isVertical) {
+                underline.style.top = `${startEdge}px`;
+                underline.style.height = `${Math.max(0, span)}px`;
+                // Clear horizontal properties
+                underline.style.left = '';
+                underline.style.width = '';
+            } else {
+                underline.style.left = `${startEdge}px`;
+                underline.style.width = `${Math.max(0, span)}px`;
+                // Clear vertical properties
+                underline.style.top = '';
+                underline.style.height = '';
+            }
+
+            // Chrome-style wrap-around contour
+            this._applyUnderlineShape(
+                underline,
+                tg,
+                startEdge,
+                span,
+                containerCrossSize,
+                activePanelId,
+                containerRect,
+                isVertical
+            );
+        }
+    }
+
+    /**
+     * Chrome-style wrap-around underline: a stroked SVG path that runs
+     * along the bottom (or left edge in vertical mode), curving up and
+     * over the active tab with rounded corners.
+     *
+     * The SVG and path elements are created once per underline and reused;
+     * only the `d`, `stroke`, and viewport attributes are updated each frame.
+     */
+    private _applyUnderlineShape(
+        underline: HTMLElement,
+        tg: ITabGroup,
+        groupStart: number,
+        groupSpan: number,
+        containerCrossSize: number,
+        activePanelId: string | undefined,
+        containerRect: DOMRect,
+        isVertical: boolean
+    ): void {
+        const t = 2; // line thickness in px
+        const crossSize = containerCrossSize;
+        const mainSize = groupSpan;
+        const color = `var(--dv-tab-group-color-${tg.color})`;
+
+        if (mainSize <= 0 || crossSize <= 0) {
+            underline.style.display = 'none';
+            return;
+        }
+        underline.style.display = '';
+
+        // Find the active tab within this group
+        let activeTabEntry: IValueDisposable<Tab> | undefined;
+        if (activePanelId && tg.panelIds.includes(activePanelId)) {
+            activeTabEntry = this._ctx.getTabMap().get(activePanelId);
+        }
+
+        // Ensure SVG + path child exists (created once, reused)
+        let svg = underline.firstElementChild as SVGSVGElement | null;
+        let path: SVGPathElement;
+        if (!svg || svg.tagName !== 'svg') {
+            underline.innerHTML = '';
+            svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+            svg.style.display = 'block';
+            path = document.createElementNS(
+                'http://www.w3.org/2000/svg',
+                'path'
+            );
+            path.setAttribute('fill', 'none');
+            svg.appendChild(path);
+            underline.appendChild(svg);
+        } else {
+            path = svg.firstElementChild as SVGPathElement;
+        }
+
+        path.setAttribute('stroke', color);
+        path.setAttribute('stroke-width', String(t));
+
+        if (!activeTabEntry) {
+            // No active tab: straight line along the edge
+            if (isVertical) {
+                svg.setAttribute('width', String(t));
+                svg.setAttribute('height', String(mainSize));
+                underline.style.width = `${t}px`;
+                underline.style.height = `${mainSize}px`;
+                path.setAttribute('d', `M ${t / 2},0 L ${t / 2},${mainSize}`);
+            } else {
+                svg.setAttribute('width', String(mainSize));
+                svg.setAttribute('height', String(t));
+                underline.style.width = `${mainSize}px`;
+                underline.style.height = `${t}px`;
+                path.setAttribute('d', `M 0,${t / 2} L ${mainSize},${t / 2}`);
+            }
+            return;
+        }
+
+        const activeRect = activeTabEntry.value.element.getBoundingClientRect();
+
+        // Compute active tab start/end relative to the group start
+        let aStart: number;
+        let aEnd: number;
+        if (isVertical) {
+            aStart = Math.max(
+                0,
+                activeRect.top - containerRect.top - groupStart
+            );
+            aEnd = Math.min(
+                mainSize,
+                activeRect.bottom - containerRect.top - groupStart
+            );
+        } else {
+            aStart = Math.max(
+                0,
+                activeRect.left - containerRect.left - groupStart
+            );
+            aEnd = Math.min(
+                mainSize,
+                activeRect.right - containerRect.left - groupStart
+            );
+        }
+
+        if (aEnd <= aStart) {
+            if (isVertical) {
+                svg.setAttribute('width', String(t));
+                svg.setAttribute('height', String(mainSize));
+                underline.style.width = `${t}px`;
+                underline.style.height = `${mainSize}px`;
+                path.setAttribute('d', `M ${t / 2},0 L ${t / 2},${mainSize}`);
+            } else {
+                svg.setAttribute('width', String(mainSize));
+                svg.setAttribute('height', String(t));
+                underline.style.width = `${mainSize}px`;
+                underline.style.height = `${t}px`;
+                path.setAttribute('d', `M 0,${t / 2} L ${mainSize},${t / 2}`);
+            }
+            return;
+        }
+
+        const r = 6; // corner radius
+        const half = t / 2;
+
+        if (isVertical) {
+            const svgW = crossSize;
+            const svgH = mainSize;
+            svg.setAttribute('width', String(svgW));
+            svg.setAttribute('height', String(svgH));
+            underline.style.width = `${svgW}px`;
+            underline.style.height = `${svgH}px`;
+
+            const xLeft = half;
+            const xRight = svgW - half;
+
+            const d = [
+                `M ${xLeft},0`,
+                `L ${xLeft},${aStart - r}`,
+                `Q ${xLeft},${aStart} ${xLeft + r},${aStart}`,
+                `L ${xRight - r},${aStart}`,
+                `Q ${xRight},${aStart} ${xRight},${aStart + r}`,
+                `L ${xRight},${aEnd - r}`,
+                `Q ${xRight},${aEnd} ${xRight - r},${aEnd}`,
+                `L ${xLeft + r},${aEnd}`,
+                `Q ${xLeft},${aEnd} ${xLeft},${aEnd + r}`,
+                `L ${xLeft},${svgH}`,
+            ].join(' ');
+
+            path.setAttribute('d', d);
+        } else {
+            const svgW = mainSize;
+            const svgH = crossSize;
+            svg.setAttribute('width', String(svgW));
+            svg.setAttribute('height', String(svgH));
+            underline.style.width = `${svgW}px`;
+            underline.style.height = `${svgH}px`;
+
+            const yBot = svgH - half;
+            const yTop = half;
+
+            const d = [
+                `M 0,${yBot}`,
+                `L ${aStart - r},${yBot}`,
+                `Q ${aStart},${yBot} ${aStart},${yBot - r}`,
+                `L ${aStart},${yTop + r}`,
+                `Q ${aStart},${yTop} ${aStart + r},${yTop}`,
+                `L ${aEnd - r},${yTop}`,
+                `Q ${aEnd},${yTop} ${aEnd},${yTop + r}`,
+                `L ${aEnd},${yBot - r}`,
+                `Q ${aEnd},${yBot} ${aEnd + r},${yBot}`,
+                `L ${svgW},${yBot}`,
+            ].join(' ');
+
+            path.setAttribute('d', d);
+        }
+    }
+}

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
@@ -249,6 +249,29 @@ export class WrapTabGroupIndicator implements ITabGroupIndicator {
         }
     }
 
+    private _applyStraightLine(
+        svg: SVGSVGElement,
+        path: SVGPathElement,
+        underline: HTMLElement,
+        t: number,
+        mainSize: number,
+        isVertical: boolean
+    ): void {
+        if (isVertical) {
+            svg.setAttribute('width', String(t));
+            svg.setAttribute('height', String(mainSize));
+            underline.style.width = `${t}px`;
+            underline.style.height = `${mainSize}px`;
+            path.setAttribute('d', `M ${t / 2},0 L ${t / 2},${mainSize}`);
+        } else {
+            svg.setAttribute('width', String(mainSize));
+            svg.setAttribute('height', String(t));
+            underline.style.width = `${mainSize}px`;
+            underline.style.height = `${t}px`;
+            path.setAttribute('d', `M 0,${t / 2} L ${mainSize},${t / 2}`);
+        }
+    }
+
     /**
      * Chrome-style wrap-around underline: a stroked SVG path that runs
      * along the bottom (or left edge in vertical mode), curving up and
@@ -306,20 +329,7 @@ export class WrapTabGroupIndicator implements ITabGroupIndicator {
         path.setAttribute('stroke-width', String(t));
 
         if (!activeTabEntry) {
-            // No active tab: straight line along the edge
-            if (isVertical) {
-                svg.setAttribute('width', String(t));
-                svg.setAttribute('height', String(mainSize));
-                underline.style.width = `${t}px`;
-                underline.style.height = `${mainSize}px`;
-                path.setAttribute('d', `M ${t / 2},0 L ${t / 2},${mainSize}`);
-            } else {
-                svg.setAttribute('width', String(mainSize));
-                svg.setAttribute('height', String(t));
-                underline.style.width = `${mainSize}px`;
-                underline.style.height = `${t}px`;
-                path.setAttribute('d', `M 0,${t / 2} L ${mainSize},${t / 2}`);
-            }
+            this._applyStraightLine(svg, path, underline, t, mainSize, isVertical);
             return;
         }
 
@@ -349,19 +359,7 @@ export class WrapTabGroupIndicator implements ITabGroupIndicator {
         }
 
         if (aEnd <= aStart) {
-            if (isVertical) {
-                svg.setAttribute('width', String(t));
-                svg.setAttribute('height', String(mainSize));
-                underline.style.width = `${t}px`;
-                underline.style.height = `${mainSize}px`;
-                path.setAttribute('d', `M ${t / 2},0 L ${t / 2},${mainSize}`);
-            } else {
-                svg.setAttribute('width', String(mainSize));
-                svg.setAttribute('height', String(t));
-                underline.style.width = `${mainSize}px`;
-                underline.style.height = `${t}px`;
-                path.setAttribute('d', `M 0,${t / 2} L ${mainSize},${t / 2}`);
-            }
+            this._applyStraightLine(svg, path, underline, t, mainSize, isVertical);
             return;
         }
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
@@ -329,7 +329,14 @@ export class WrapTabGroupIndicator implements ITabGroupIndicator {
         path.setAttribute('stroke-width', String(t));
 
         if (!activeTabEntry) {
-            this._applyStraightLine(svg, path, underline, t, mainSize, isVertical);
+            this._applyStraightLine(
+                svg,
+                path,
+                underline,
+                t,
+                mainSize,
+                isVertical
+            );
             return;
         }
 
@@ -359,7 +366,14 @@ export class WrapTabGroupIndicator implements ITabGroupIndicator {
         }
 
         if (aEnd <= aStart) {
-            this._applyStraightLine(svg, path, underline, t, mainSize, isVertical);
+            this._applyStraightLine(
+                svg,
+                path,
+                underline,
+                t,
+                mainSize,
+                isVertical
+            );
             return;
         }
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -12,10 +12,7 @@ import { Tab } from '../tab/tab';
 import { ITabGroup } from '../../tabGroup';
 import { TabGroupChip } from './tabGroupChip';
 import { ITabGroupChipRenderer } from '../../framework';
-import {
-    ITabGroupIndicator,
-    WrapTabGroupIndicator,
-} from './tabGroupIndicator';
+import { ITabGroupIndicator, WrapTabGroupIndicator } from './tabGroupIndicator';
 
 const EMPTY_MAP: ReadonlyMap<string, HTMLElement> = new Map();
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -12,6 +12,12 @@ import { Tab } from '../tab/tab';
 import { ITabGroup } from '../../tabGroup';
 import { TabGroupChip } from './tabGroupChip';
 import { ITabGroupChipRenderer } from '../../framework';
+import {
+    ITabGroupIndicator,
+    WrapTabGroupIndicator,
+} from './tabGroupIndicator';
+
+const EMPTY_MAP: ReadonlyMap<string, HTMLElement> = new Map();
 
 export interface TabGroupManagerContext {
     readonly group: DockviewGroupPanel;
@@ -36,8 +42,7 @@ export class TabGroupManager {
         string,
         { chip: ITabGroupChipRenderer; disposable: IDisposable }
     >();
-    private readonly _groupUnderlines = new Map<string, HTMLElement>();
-    private _underlineRafId: number | null = null;
+    private _indicator: ITabGroupIndicator | null = null;
     private _skipNextCollapseAnimation = false;
     private readonly _pendingTransitionCleanups = new Map<string, () => void>();
 
@@ -49,7 +54,7 @@ export class TabGroupManager {
     }
 
     get groupUnderlines(): ReadonlyMap<string, HTMLElement> {
-        return this._groupUnderlines;
+        return this._indicator?.underlines ?? EMPTY_MAP;
     }
 
     get skipNextCollapseAnimation(): boolean {
@@ -117,33 +122,11 @@ export class TabGroupManager {
     }
 
     positionUnderlines(): void {
-        requestAnimationFrame(() => {
-            this._positionUnderlinesSync();
-        });
+        this._indicator?.positionUnderlines();
     }
 
-    /**
-     * Continuously reposition underlines every frame for the duration
-     * of a tab transition (~200ms), so the underline tracks tab sizes.
-     */
     trackUnderlines(): void {
-        if (this._underlineRafId !== null) {
-            cancelAnimationFrame(this._underlineRafId);
-        }
-
-        const start = performance.now();
-        const duration = 250; // slightly longer than transition to ensure we catch the end
-
-        const tick = () => {
-            this._positionUnderlinesSync();
-            if (performance.now() - start < duration) {
-                this._underlineRafId = requestAnimationFrame(tick);
-            } else {
-                this._underlineRafId = null;
-            }
-        };
-
-        this._underlineRafId = requestAnimationFrame(tick);
+        this._indicator?.trackUnderlines();
     }
 
     setGroupDragImage(
@@ -156,7 +139,7 @@ export class TabGroupManager {
         }
 
         const groupPanelIds = new Set(tabGroup.panelIds);
-        const underlineEl = this._groupUnderlines.get(tabGroup.id);
+        const underlineEl = this._indicator?.getUnderline(tabGroup.id);
 
         const isVertical = this._ctx.getDirection() === 'vertical';
 
@@ -272,10 +255,8 @@ export class TabGroupManager {
     }
 
     disposeAll(): void {
-        if (this._underlineRafId !== null) {
-            cancelAnimationFrame(this._underlineRafId);
-            this._underlineRafId = null;
-        }
+        this._indicator?.dispose();
+        this._indicator = null;
 
         for (const [, cleanup] of this._pendingTransitionCleanups) {
             cleanup();
@@ -288,11 +269,31 @@ export class TabGroupManager {
             entry.disposable.dispose();
         }
         this._chipRenderers.clear();
+    }
 
-        for (const [, el] of this._groupUnderlines) {
-            el.remove();
+    private _ensureIndicator(): void {
+        const mode =
+            this._ctx.accessor.options.theme?.tabGroupIndicator ?? 'wrap';
+
+        if (mode === 'none') {
+            if (this._indicator) {
+                this._indicator.dispose();
+                this._indicator = null;
+            }
+            return;
         }
-        this._groupUnderlines.clear();
+
+        if (!this._indicator) {
+            this._indicator = new WrapTabGroupIndicator({
+                tabsList: this._ctx.tabsList,
+                getTabGroups: () => this._ctx.group.model.getTabGroups(),
+                getActivePanelId: () => this._ctx.group.activePanel?.id,
+                getTabMap: () => this._ctx.getTabMap(),
+                getChipElement: (id) =>
+                    this._chipRenderers.get(id)?.chip.element,
+                getDirection: () => this._ctx.getDirection(),
+            });
+        }
     }
 
     private _ensureChipForGroup(tabGroup: ITabGroup): void {
@@ -408,6 +409,13 @@ export class TabGroupManager {
                 toggleClass(tab.element, 'dv-tab--group-first', isFirst);
                 toggleClass(tab.element, 'dv-tab--group-last', isLast);
 
+                // Expose the resolved group color as a CSS custom property
+                // so pure-CSS themes can use it for borders, backgrounds, etc.
+                tab.element.style.setProperty(
+                    '--dv-tab-group-color',
+                    `var(--dv-tab-group-color-${tg.color})`
+                );
+
                 // Collapse / expand with animation
                 const isCollapsed = tab.element.classList.contains(
                     'dv-tab--group-collapsed'
@@ -443,24 +451,16 @@ export class TabGroupManager {
                     'dv-tab--group-expanding'
                 );
                 tab.element.style.removeProperty('width');
+                tab.element.style.removeProperty('--dv-tab-group-color');
             }
         }
 
-        // Track active group IDs for underline cleanup
+        // Track active group IDs for underline/collapse handling
         const activeGroupIds = new Set<string>();
 
-        // Handle collapse animation + underline per group
+        // Handle collapse animation per group
         for (const tg of tabGroups) {
             activeGroupIds.add(tg.id);
-
-            // Ensure underline element exists
-            let underline = this._groupUnderlines.get(tg.id);
-            if (!underline) {
-                underline = document.createElement('div');
-                underline.className = 'dv-tab-group-underline';
-                this._ctx.tabsList.appendChild(underline);
-                this._groupUnderlines.set(tg.id, underline);
-            }
 
             // Collapse animation
             const hasNewCollapse =
@@ -525,346 +525,17 @@ export class TabGroupManager {
             }
         }
 
-        // Remove underlines for dissolved groups
-        for (const [groupId, el] of this._groupUnderlines) {
-            if (!activeGroupIds.has(groupId)) {
-                el.remove();
-                this._groupUnderlines.delete(groupId);
-            }
-        }
-
         this._skipNextCollapseAnimation = false;
 
-        // Position underlines: use rAF loop during animations for fluid tracking
-        if (hasAnimation) {
-            this.trackUnderlines();
-        } else {
-            this.positionUnderlines();
-        }
-    }
-
-    private _positionUnderlinesSync(): void {
-        const containerRect = this._ctx.tabsList.getBoundingClientRect();
-        const tabGroups = this._ctx.group.model.getTabGroups();
-        const isVertical = this._ctx.getDirection() === 'vertical';
-        const containerCrossSize = isVertical
-            ? containerRect.width
-            : containerRect.height;
-        const activePanelId = this._ctx.group.activePanel?.id;
-        const tabMap = this._ctx.getTabMap();
-
-        for (const tg of tabGroups) {
-            const underline = this._groupUnderlines.get(tg.id);
-            if (!underline) {
-                continue;
-            }
-
-            const panelIds = tg.panelIds;
-            if (panelIds.length === 0) {
-                underline.style.display = 'none';
-                continue;
-            }
-
-            underline.style.display = '';
-
-            const chipEntry = this._chipRenderers.get(tg.id);
-            const chipEl = chipEntry?.chip.element;
-
-            // In vertical mode, compute top/bottom edges; in horizontal, left/right.
-            let startEdge: number;
-            if (chipEl) {
-                const chipRect = chipEl.getBoundingClientRect();
-                const chipStyle = getComputedStyle(chipEl);
-                const leadingMargin = isVertical
-                    ? Number.parseFloat(chipStyle.marginTop) || 0
-                    : Number.parseFloat(chipStyle.marginLeft) || 0;
-                startEdge = isVertical
-                    ? chipRect.top - containerRect.top - leadingMargin
-                    : chipRect.left - containerRect.left - leadingMargin;
+        // Sync indicator underlines and position them
+        this._ensureIndicator();
+        if (this._indicator) {
+            this._indicator.syncUnderlineElements(activeGroupIds);
+            if (hasAnimation) {
+                this._indicator.trackUnderlines();
             } else {
-                const firstPanelId = panelIds[0];
-                const firstTabEntry = tabMap.get(firstPanelId);
-                if (firstTabEntry) {
-                    const firstRect =
-                        firstTabEntry.value.element.getBoundingClientRect();
-                    startEdge = isVertical
-                        ? firstRect.top - containerRect.top
-                        : firstRect.left - containerRect.left;
-                } else {
-                    startEdge = 0;
-                }
+                this._indicator.positionUnderlines();
             }
-
-            // Measure the actual last tab position (follows CSS transitions in real-time)
-            const lastPanelId = panelIds[panelIds.length - 1];
-            const lastTabEntry = tabMap.get(lastPanelId);
-
-            if (!lastTabEntry) {
-                if (isVertical) {
-                    underline.style.top = `${startEdge}px`;
-                    underline.style.height = '0px';
-                    underline.style.left = '';
-                    underline.style.width = '';
-                } else {
-                    underline.style.left = `${startEdge}px`;
-                    underline.style.width = '0px';
-                    underline.style.top = '';
-                    underline.style.height = '';
-                }
-                continue;
-            }
-
-            const lastTabRect =
-                lastTabEntry.value.element.getBoundingClientRect();
-            let endEdge = isVertical
-                ? lastTabRect.bottom - containerRect.top
-                : lastTabRect.right - containerRect.left;
-            let span = endEdge - startEdge;
-
-            // During collapse or expand: converge both edges toward chip center
-            const isAnimating =
-                tg.collapsed ||
-                tg.panelIds.some((pid) => {
-                    const te = tabMap.get(pid);
-                    return (
-                        te &&
-                        te.value.element.classList.contains(
-                            'dv-tab--group-expanding'
-                        )
-                    );
-                });
-
-            if (isAnimating && chipEl) {
-                const chipRect = chipEl.getBoundingClientRect();
-                const chipCenter = isVertical
-                    ? chipRect.top + chipRect.height / 2 - containerRect.top
-                    : chipRect.left + chipRect.width / 2 - containerRect.left;
-
-                // Sum of current visible tab sizes (shrinking or growing)
-                let currentTabSize = 0;
-                let fullTabSize = 0;
-                for (const pid of tg.panelIds) {
-                    const te = tabMap.get(pid);
-                    if (!te) continue;
-                    const el = te.value.element;
-                    if (isVertical) {
-                        currentTabSize += el.getBoundingClientRect().height;
-                        fullTabSize += el.scrollHeight;
-                    } else {
-                        currentTabSize += el.getBoundingClientRect().width;
-                        fullTabSize += el.scrollWidth;
-                    }
-                }
-
-                // progress: 0 when tabs at 0 size, 1 when fully open
-                const progress =
-                    fullTabSize > 0
-                        ? Math.min(1, currentTabSize / fullTabSize)
-                        : 0;
-
-                // Interpolate start and end edges toward chip center
-                startEdge = chipCenter + (startEdge - chipCenter) * progress;
-                endEdge = chipCenter + (endEdge - chipCenter) * progress;
-                span = Math.max(0, endEdge - startEdge);
-            }
-
-            if (isVertical) {
-                underline.style.top = `${startEdge}px`;
-                underline.style.height = `${Math.max(0, span)}px`;
-                // Clear horizontal properties
-                underline.style.left = '';
-                underline.style.width = '';
-            } else {
-                underline.style.left = `${startEdge}px`;
-                underline.style.width = `${Math.max(0, span)}px`;
-                // Clear vertical properties
-                underline.style.top = '';
-                underline.style.height = '';
-            }
-
-            // Chrome-style wrap-around: contour the active tab if it belongs to this group
-            this._applyUnderlineShape(
-                underline,
-                tg,
-                startEdge,
-                span,
-                containerCrossSize,
-                activePanelId,
-                containerRect,
-                isVertical
-            );
-        }
-    }
-
-    /**
-     * Chrome-style wrap-around underline: a stroked SVG path that runs
-     * along the bottom (or left edge in vertical mode), curving up and
-     * over the active tab with rounded corners.
-     *
-     * The SVG and path elements are created once per underline and reused;
-     * only the `d`, `stroke`, and viewport attributes are updated each frame.
-     */
-    private _applyUnderlineShape(
-        underline: HTMLElement,
-        tg: ITabGroup,
-        groupStart: number,
-        groupSpan: number,
-        containerCrossSize: number,
-        activePanelId: string | undefined,
-        containerRect: DOMRect,
-        isVertical: boolean
-    ): void {
-        const t = 2; // line thickness in px
-        const crossSize = containerCrossSize;
-        const mainSize = groupSpan;
-        const color = `var(--dv-tab-group-color-${tg.color})`;
-
-        if (mainSize <= 0 || crossSize <= 0) {
-            underline.style.display = 'none';
-            return;
-        }
-        underline.style.display = '';
-
-        // Find the active tab within this group
-        let activeTabEntry: IValueDisposable<Tab> | undefined;
-        if (activePanelId && tg.panelIds.includes(activePanelId)) {
-            activeTabEntry = this._ctx.getTabMap().get(activePanelId);
-        }
-
-        // Ensure SVG + path child exists (created once, reused)
-        let svg = underline.firstElementChild as SVGSVGElement | null;
-        let path: SVGPathElement;
-        if (!svg || svg.tagName !== 'svg') {
-            underline.innerHTML = '';
-            svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-            svg.style.display = 'block';
-            path = document.createElementNS(
-                'http://www.w3.org/2000/svg',
-                'path'
-            );
-            path.setAttribute('fill', 'none');
-            svg.appendChild(path);
-            underline.appendChild(svg);
-        } else {
-            path = svg.firstElementChild as SVGPathElement;
-        }
-
-        path.setAttribute('stroke', color);
-        path.setAttribute('stroke-width', String(t));
-
-        if (!activeTabEntry) {
-            // No active tab: straight line along the edge
-            if (isVertical) {
-                svg.setAttribute('width', String(t));
-                svg.setAttribute('height', String(mainSize));
-                underline.style.width = `${t}px`;
-                underline.style.height = `${mainSize}px`;
-                path.setAttribute('d', `M ${t / 2},0 L ${t / 2},${mainSize}`);
-            } else {
-                svg.setAttribute('width', String(mainSize));
-                svg.setAttribute('height', String(t));
-                underline.style.width = `${mainSize}px`;
-                underline.style.height = `${t}px`;
-                path.setAttribute('d', `M 0,${t / 2} L ${mainSize},${t / 2}`);
-            }
-            return;
-        }
-
-        const activeRect = activeTabEntry.value.element.getBoundingClientRect();
-
-        // Compute active tab start/end relative to the group start
-        let aStart: number;
-        let aEnd: number;
-        if (isVertical) {
-            aStart = Math.max(
-                0,
-                activeRect.top - containerRect.top - groupStart
-            );
-            aEnd = Math.min(
-                mainSize,
-                activeRect.bottom - containerRect.top - groupStart
-            );
-        } else {
-            aStart = Math.max(
-                0,
-                activeRect.left - containerRect.left - groupStart
-            );
-            aEnd = Math.min(
-                mainSize,
-                activeRect.right - containerRect.left - groupStart
-            );
-        }
-
-        if (aEnd <= aStart) {
-            if (isVertical) {
-                svg.setAttribute('width', String(t));
-                svg.setAttribute('height', String(mainSize));
-                underline.style.width = `${t}px`;
-                underline.style.height = `${mainSize}px`;
-                path.setAttribute('d', `M ${t / 2},0 L ${t / 2},${mainSize}`);
-            } else {
-                svg.setAttribute('width', String(mainSize));
-                svg.setAttribute('height', String(t));
-                underline.style.width = `${mainSize}px`;
-                underline.style.height = `${t}px`;
-                path.setAttribute('d', `M 0,${t / 2} L ${mainSize},${t / 2}`);
-            }
-            return;
-        }
-
-        const r = 6; // corner radius
-        const half = t / 2;
-
-        if (isVertical) {
-            const svgW = crossSize;
-            const svgH = mainSize;
-            svg.setAttribute('width', String(svgW));
-            svg.setAttribute('height', String(svgH));
-            underline.style.width = `${svgW}px`;
-            underline.style.height = `${svgH}px`;
-
-            const xLeft = half;
-            const xRight = svgW - half;
-
-            const d = [
-                `M ${xLeft},0`,
-                `L ${xLeft},${aStart - r}`,
-                `Q ${xLeft},${aStart} ${xLeft + r},${aStart}`,
-                `L ${xRight - r},${aStart}`,
-                `Q ${xRight},${aStart} ${xRight},${aStart + r}`,
-                `L ${xRight},${aEnd - r}`,
-                `Q ${xRight},${aEnd} ${xRight - r},${aEnd}`,
-                `L ${xLeft + r},${aEnd}`,
-                `Q ${xLeft},${aEnd} ${xLeft},${aEnd + r}`,
-                `L ${xLeft},${svgH}`,
-            ].join(' ');
-
-            path.setAttribute('d', d);
-        } else {
-            const svgW = mainSize;
-            const svgH = crossSize;
-            svg.setAttribute('width', String(svgW));
-            svg.setAttribute('height', String(svgH));
-            underline.style.width = `${svgW}px`;
-            underline.style.height = `${svgH}px`;
-
-            const yBot = svgH - half;
-            const yTop = half;
-
-            const d = [
-                `M 0,${yBot}`,
-                `L ${aStart - r},${yBot}`,
-                `Q ${aStart},${yBot} ${aStart},${yBot - r}`,
-                `L ${aStart},${yTop + r}`,
-                `Q ${aStart},${yTop} ${aStart + r},${yTop}`,
-                `L ${aEnd - r},${yTop}`,
-                `Q ${aEnd},${yTop} ${aEnd},${yTop + r}`,
-                `L ${aEnd},${yBot - r}`,
-                `Q ${aEnd},${yBot} ${aEnd + r},${yBot}`,
-                `L ${svgW},${yBot}`,
-            ].join(' ');
-
-            path.setAttribute('d', d);
         }
     }
 }

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3458,8 +3458,7 @@ export class DockviewComponent
 
         // Toggle a CSS class so theme stylesheets can scope pure-CSS
         // tab group indicator rules to the 'none' mode only.
-        const indicatorNone =
-            (theme.tabGroupIndicator ?? 'wrap') === 'none';
+        const indicatorNone = (theme.tabGroupIndicator ?? 'wrap') === 'none';
         toggleClass(this.element, 'dv-tab-group-indicator-none', indicatorNone);
         if (this._shellManager) {
             toggleClass(

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3455,5 +3455,10 @@ export class DockviewComponent
                 this.rootDropTargetContainer.disabled = true;
                 break;
         }
+
+        // Re-render tab group indicators so the new tabGroupIndicator mode takes effect
+        for (const group of this.groups) {
+            group.model.updateTabGroups();
+        }
     }
 }

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3456,6 +3456,19 @@ export class DockviewComponent
                 break;
         }
 
+        // Toggle a CSS class so theme stylesheets can scope pure-CSS
+        // tab group indicator rules to the 'none' mode only.
+        const indicatorNone =
+            (theme.tabGroupIndicator ?? 'wrap') === 'none';
+        toggleClass(this.element, 'dv-tab-group-indicator-none', indicatorNone);
+        if (this._shellManager) {
+            toggleClass(
+                this._shellManager.element,
+                'dv-tab-group-indicator-none',
+                indicatorNone
+            );
+        }
+
         // Re-render tab group indicators so the new tabGroupIndicator mode takes effect
         for (const group of this.groups) {
             group.model.updateTabGroups();

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -954,6 +954,10 @@ export class DockviewGroupPanelModel
         return this._tabGroups;
     }
 
+    updateTabGroups(): void {
+        this.tabsContainer.updateTabGroups();
+    }
+
     getTabGroupForPanel(panelId: string): ITabGroup | undefined {
         return this._findTabGroupForPanel(panelId);
     }

--- a/packages/dockview-core/src/dockview/theme.ts
+++ b/packages/dockview-core/src/dockview/theme.ts
@@ -1,3 +1,5 @@
+export type DockviewTabGroupIndicator = 'wrap' | 'none';
+
 export interface DockviewTheme {
     /**
      *  The name of the theme
@@ -43,6 +45,17 @@ export interface DockviewTheme {
      * When unset the CSS variable is left to the stylesheet default (`none`).
      */
     dndOverlayBorder?: string;
+    /**
+     * Controls how tab groups are visually indicated in the tab bar.
+     *
+     * - `'wrap'` (default): Chrome-style SVG underline that wraps around the active tab
+     *   with rounded corners. Requires JavaScript for positioning and path computation.
+     * - `'none'`: No JS-drawn indicator. The theme relies purely on CSS using the
+     *   classes and custom property applied to tab elements:
+     *   `dv-tab--grouped`, `dv-tab--group-first`, `dv-tab--group-last`,
+     *   and `--dv-tab-group-color` (resolved color for the tab's group).
+     */
+    tabGroupIndicator?: DockviewTabGroupIndicator;
 }
 
 export const themeDark: DockviewTheme = {
@@ -70,6 +83,7 @@ export const themeAbyss: DockviewTheme = {
     name: 'abyss',
     className: 'dockview-theme-abyss',
     colorScheme: 'dark',
+    tabGroupIndicator: 'none',
 };
 
 export const themeDracula: DockviewTheme = {

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -221,6 +221,30 @@
     --dv-paneview-header-border-color: var(--dv-color-abyss-lighter);
 
     --dv-paneview-active-outline-color: #596f99;
+
+    // Pure-CSS tab group indicator (used with tabGroupIndicator: 'none')
+    .dv-tab.dv-tab--grouped {
+        box-shadow: inset 0 -2px 0 var(--dv-tab-group-color);
+    }
+
+    // The chip has no position:relative so ::after anchors to
+    // .dv-tabs-container, placing the line at the container bottom.
+    // The dot variant (:has(.dv-tab-group-chip-label--empty)) sets
+    // position:relative for its hit-area ::before — override it here
+    // so the line anchors correctly in both cases.
+    .dv-tab-group-chip {
+        position: static !important;
+
+        &::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background-color: var(--dv-tab-group-color);
+        }
+    }
 }
 
 @mixin dockview-theme-dracula-mixin {

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -222,29 +222,6 @@
 
     --dv-paneview-active-outline-color: #596f99;
 
-    // Pure-CSS tab group indicator (used with tabGroupIndicator: 'none')
-    .dv-tab.dv-tab--grouped {
-        box-shadow: inset 0 -2px 0 var(--dv-tab-group-color);
-    }
-
-    // The chip has no position:relative so ::after anchors to
-    // .dv-tabs-container, placing the line at the container bottom.
-    // The dot variant (:has(.dv-tab-group-chip-label--empty)) sets
-    // position:relative for its hit-area ::before — override it here
-    // so the line anchors correctly in both cases.
-    .dv-tab-group-chip {
-        position: static !important;
-
-        &::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            height: 2px;
-            background-color: var(--dv-tab-group-color);
-        }
-    }
 }
 
 @mixin dockview-theme-dracula-mixin {
@@ -1130,5 +1107,27 @@
     &.dv-context-menu-color-swatch--selected {
         outline: 2px solid var(--dv-tab-divider-color);
         outline-offset: 2px;
+    }
+}
+
+// Pure-CSS tab group indicator — active when tabGroupIndicator is 'none'.
+// Applied generically so any theme can opt in via the theme property.
+.dv-tab-group-indicator-none {
+    .dv-tab.dv-tab--grouped {
+        box-shadow: inset 0 -2px 0 var(--dv-tab-group-color);
+    }
+
+    .dv-tab-group-chip {
+        position: static !important;
+
+        &::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background-color: var(--dv-tab-group-color);
+        }
     }
 }

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilder.ts
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilder.ts
@@ -79,6 +79,7 @@ export interface ThemeBuilderState {
     dndPanelOverlay: 'content' | 'group';
     dndTabIndicator: 'line' | 'fill';
     dndOverlayBorder: string;
+    tabGroupIndicator: 'wrap' | 'none';
     cssOverrides: ThemeCssOverrides;
 }
 
@@ -91,6 +92,7 @@ export function getInitialStateFromTheme(
         dndPanelOverlay: theme.dndPanelOverlay ?? 'content',
         dndTabIndicator: theme.dndTabIndicator ?? 'fill',
         dndOverlayBorder: theme.dndOverlayBorder ?? '',
+        tabGroupIndicator: theme.tabGroupIndicator ?? 'wrap',
         cssOverrides: {},
     };
 }
@@ -106,6 +108,7 @@ export function buildEffectiveTheme(
         dndPanelOverlay: state.dndPanelOverlay,
         dndTabIndicator: state.dndTabIndicator,
         dndOverlayBorder: state.dndOverlayBorder || undefined,
+        tabGroupIndicator: state.tabGroupIndicator,
     };
 }
 
@@ -140,6 +143,14 @@ export function generateCodeSnippet(
     }
     if (state.dndOverlayBorder !== (baseTheme.dndOverlayBorder ?? '')) {
         themeFields.push(`  dndOverlayBorder: '${state.dndOverlayBorder}',`);
+    }
+    if (
+        state.tabGroupIndicator !==
+        (baseTheme.tabGroupIndicator ?? 'wrap')
+    ) {
+        themeFields.push(
+            `  tabGroupIndicator: '${state.tabGroupIndicator}',`
+        );
     }
 
     let out = `import { ${importName} } from 'dockview';\n\n`;

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilderModal.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilderModal.tsx
@@ -497,6 +497,23 @@ export const ThemeBuilderModal = (props: {
                 />
             </Section>
 
+            {/* Tab Groups */}
+            <Section title="Tab Groups">
+                <ToggleRow
+                    label="Group Indicator"
+                    value={props.state.tabGroupIndicator}
+                    options={[
+                        { value: 'wrap', label: 'wrap' },
+                        { value: 'none', label: 'none' },
+                    ]}
+                    onChange={(v) =>
+                        props.onChange({
+                            tabGroupIndicator: v as 'wrap' | 'none',
+                        })
+                    }
+                />
+            </Section>
+
             {/* DnD */}
             <Section title="Drag & Drop">
                 <ToggleRow


### PR DESCRIPTION
… logic

Add a `tabGroupIndicator` property to `DockviewTheme` that controls how tab groups are visually indicated: 'wrap' (default SVG wrap-around) or 'none' (pure CSS via tab classes and --dv-tab-group-color custom property).

Extract the ~480-line SVG wrap underline logic from TabGroupManager into a self-contained WrapTabGroupIndicator class behind an ITabGroupIndicator interface, reducing TabGroupManager from 892 to 541 lines.

Set the abyss theme to use 'none' mode with a pure CSS box-shadow indicator as a demonstration of CSS-only tab group styling.