### PR TITLE
fix: add consistent 'dockview:' prefix to all console logs

### DIFF
--- a/packages/dockview-angular/src/lib/utils/angular-renderer.ts
+++ b/packages/dockview-angular/src/lib/utils/angular-renderer.ts
@@ -104,7 +104,7 @@ export class AngularRenderer<T = unknown>
                 this.setupComponent(this.options.component, parameters);
             }
         } catch (error) {
-            console.error('Error creating Angular component:', error);
+            console.error('dockview: error creating Angular component', error);
             throw error;
         }
     }

--- a/packages/dockview-angular/src/lib/utils/lifecycle-utils.ts
+++ b/packages/dockview-angular/src/lib/utils/lifecycle-utils.ts
@@ -28,7 +28,7 @@ export class AngularDisposable implements DockviewIDisposable {
             try {
                 callback();
             } catch (error) {
-                console.error('Error in dispose callback:', error);
+                console.error('dockview: error in dispose callback', error);
             }
         });
         this.disposeCallbacks = [];
@@ -59,7 +59,7 @@ export class AngularLifecycleManager {
             try {
                 disposable.dispose();
             } catch (error) {
-                console.error('Error disposing resource:', error);
+                console.error('dockview: error disposing resource', error);
             }
         });
         this.disposables = [];

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -230,7 +230,7 @@ export function addStyles(document: Document, styleSheetList: StyleSheetList) {
                 );
             }
         } catch (err) {
-            // security errors (lack of permissions), ignore
+            console.warn('dockview: failed to access stylesheet rules due to security restrictions', err);
         }
 
         for (const rule of cssTexts) {


### PR DESCRIPTION
Log the previously silent security exception in dom.ts and ensure all console messages across dockview-core and dockview-angular use the 'dockview:' prefix for consistency.