### PR TITLE
chore: add PR template and update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,33 +1,37 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a bug to help us improve dockview
 title: ''
-labels: ''
+labels: bug
 assignees: ''
 
 ---
 
+**Dockview version**
+<!-- e.g. 4.3.1 -->
+
+**Framework**
+<!-- e.g. React 18, Vue 3, Angular 17, Vanilla JS -->
+
+**Browser**
+<!-- e.g. Chrome 124, Safari 17, Firefox 125 -->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-[dockview.dev](https://dockview.dev) provides a number of examples with Code Sandbox templates. Are you able to produce the bug by forking one of those templates? Sharing a link to the forked sandbox with the bug would be extremely helpful.
+**Reproduction**
+[dockview.dev](https://dockview.dev) provides examples with CodeSandbox templates. Please try to reproduce the bug by forking one of those templates and sharing the link here — this is the fastest way to get your issue resolved.
 
-Steps to reproduce the behavior:
+If a sandbox isn't possible, provide steps to reproduce:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+2. Click on '...'
+3. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+What you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Screenshots / recordings**
+If applicable, add screenshots or screen recordings.
 
 **Additional context**
-Add any other context about the problem here.
+Any other relevant context (error messages, stack traces, related issues).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,27 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for dockview
 title: ''
-labels: ''
+labels: enhancement
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Problem**
+What problem does this feature solve? e.g. "I'm trying to do X but there's no way to..."
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Framework**
+<!-- Which framework(s) does this apply to? e.g. All, React, Vue, Angular, Vanilla JS -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Proposed solution**
+Describe what you'd like to happen. If you have ideas about the API surface, sketch them out:
+
+```ts
+// example usage
+```
+
+**Alternatives considered**
+Any workarounds or alternative approaches you've tried or thought about.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Any other context, screenshots, or links to related issues/discussions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Description
+
+<!-- What does this PR do and why? -->
+
+## Type of change
+
+<!-- Check the one that applies -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+- [ ] Refactor / cleanup
+- [ ] Build / CI / tooling
+
+## Affected packages
+
+<!-- Check all that apply -->
+
+- [ ] `dockview-core`
+- [ ] `dockview` (vanilla JS)
+- [ ] `dockview-react`
+- [ ] `dockview-vue`
+- [ ] `dockview-angular`
+- [ ] `docs`
+
+## How to test
+
+<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->
+
+## Checklist
+
+- [ ] `yarn lint:fix` passes
+- [ ] `yarn format` passes
+- [ ] `npm run gen` has been run and generated files are up to date
+- [ ] `yarn test` passes
+- [ ] I have added or updated tests where applicable
+- [ ] Breaking changes are documented


### PR DESCRIPTION
Add a pull request template with monorepo-aware checklist (affected packages, gen check, lint, format, tests). Update bug report to ask for dockview version, framework, and browser up front. Update feature request to include framework field and API sketch section.