### PR TITLE
feat: add styled examples page to docs

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -260,8 +260,7 @@ const config = {
                     },
                     // { to: '/blog', label: 'Blog', position: 'right' },
                     {
-                        href: '/templates',
-                        target: '_blank',
+                        to: '/examples',
                         label: 'Examples',
                         position: 'right',
                     },

--- a/packages/docs/src/pages/examples.scss
+++ b/packages/docs/src/pages/examples.scss
@@ -1,0 +1,132 @@
+.examples-page {
+    padding: 48px 0 80px;
+    background: var(--ifm-background-color);
+}
+
+.examples-hero {
+    text-align: center;
+    margin-bottom: 48px;
+
+    h1 {
+        font-size: clamp(1.75rem, 3.5vw, 2.25rem);
+        font-weight: 700;
+        margin: 0 0 12px;
+    }
+
+    p {
+        font-size: 1.05rem;
+        color: var(--ifm-color-content-secondary);
+        max-width: 560px;
+        margin: 0 auto;
+        line-height: 1.6;
+    }
+}
+
+// ─── Component sections ──────────────────────────────────────────────────────
+
+.examples-component-section {
+    margin-bottom: 48px;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.examples-component-header {
+    margin-bottom: 20px;
+}
+
+.examples-component-title {
+    font-size: 1.35rem;
+    font-weight: 600;
+    margin: 0 0 4px;
+}
+
+.examples-component-description {
+    font-size: 0.9rem;
+    color: var(--ifm-color-content-secondary);
+    margin: 0;
+    line-height: 1.5;
+}
+
+// ─── Cards grid ──────────────────────────────────────────────────────────────
+
+.examples-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+
+    @media (min-width: 640px) {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media (min-width: 996px) {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+.example-card {
+    background: var(--ifm-background-surface-color);
+    border: 1px solid var(--ifm-toc-border-color);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.example-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.example-card-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    margin: 0;
+}
+
+// ─── Framework links ─────────────────────────────────────────────────────────
+
+.example-card-frameworks {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.example-fw-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 10px;
+    border: 1px solid var(--ifm-toc-border-color);
+    border-radius: 5px;
+    background: var(--ifm-background-color);
+    color: var(--ifm-color-content);
+    font-size: 0.8rem;
+    font-weight: 500;
+    text-decoration: none;
+    transition: border-color 0.15s, background 0.15s;
+
+    &:hover {
+        border-color: var(--ifm-color-primary);
+        background: color-mix(
+            in srgb,
+            var(--ifm-color-primary) 12%,
+            transparent
+        );
+        color: var(--ifm-color-content);
+        text-decoration: none;
+    }
+
+    img {
+        flex-shrink: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .example-fw-link {
+        transition: none;
+    }
+}

--- a/packages/docs/src/pages/examples.tsx
+++ b/packages/docs/src/pages/examples.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import './examples.scss';
+
+type Framework = 'react' | 'vue' | 'angular' | 'typescript';
+
+interface Example {
+    name: string;
+    frameworks: Framework[];
+}
+
+interface ComponentGroup {
+    component: string;
+    label: string;
+    description: string;
+    examples: Example[];
+}
+
+const FRAMEWORK_META: Record<
+    Framework,
+    { label: string; icon: string; color: string }
+> = {
+    react: { label: 'React', icon: 'img/react-icon.svg', color: '#61dafb' },
+    vue: { label: 'Vue', icon: 'img/vue-icon.svg', color: '#42b883' },
+    angular: {
+        label: 'Angular',
+        icon: 'img/angular-icon.svg',
+        color: '#dd0031',
+    },
+    typescript: {
+        label: 'TypeScript',
+        icon: 'img/js-icon.svg',
+        color: '#f7df1e',
+    },
+};
+
+const COMPONENTS: ComponentGroup[] = [
+    {
+        component: 'dockview',
+        label: 'Dockview',
+        description:
+            'Full-featured docking layout with tabs, groups, drag & drop, floating panels, and popout windows.',
+        examples: [
+            { name: 'basic', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+            { name: 'constraints', frameworks: ['react', 'vue', 'angular'] },
+            { name: 'context-menu', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+            { name: 'custom-header', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+            { name: 'demo-dockview', frameworks: ['react'] },
+            { name: 'dnd-events', frameworks: ['react', 'vue'] },
+            { name: 'dnd-external', frameworks: ['react', 'vue'] },
+            { name: 'edge-groups', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+            { name: 'floating-groups', frameworks: ['react', 'vue', 'angular'] },
+            { name: 'group-actions', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+            { name: 'layout', frameworks: ['react', 'vue'] },
+            { name: 'locked', frameworks: ['react', 'vue', 'typescript'] },
+            { name: 'maximize-group', frameworks: ['react', 'vue'] },
+            { name: 'nested', frameworks: ['react', 'vue'] },
+            { name: 'popout-group', frameworks: ['react', 'vue'] },
+            { name: 'render-mode', frameworks: ['react', 'vue'] },
+            { name: 'resize', frameworks: ['react', 'vue'] },
+            { name: 'resize-container', frameworks: ['react', 'vue'] },
+            { name: 'scrollbars', frameworks: ['react', 'vue', 'typescript'] },
+            { name: 'tab-groups', frameworks: ['react'] },
+            { name: 'tabview', frameworks: ['react', 'vue', 'typescript'] },
+            { name: 'update-parameters', frameworks: ['react', 'vue', 'typescript'] },
+            { name: 'update-title', frameworks: ['react', 'vue', 'typescript'] },
+            { name: 'watermark', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+        ],
+    },
+    {
+        component: 'splitview',
+        label: 'Splitview',
+        description: 'Resizable split panels arranged horizontally or vertically.',
+        examples: [
+            { name: 'basic', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+        ],
+    },
+    {
+        component: 'gridview',
+        label: 'Gridview',
+        description: 'Grid-based layout with resizable rows and columns.',
+        examples: [
+            { name: 'basic', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+        ],
+    },
+    {
+        component: 'paneview',
+        label: 'Paneview',
+        description: 'Collapsible accordion-style pane layout.',
+        examples: [
+            { name: 'basic', frameworks: ['react', 'vue', 'angular', 'typescript'] },
+        ],
+    },
+];
+
+function formatName(name: string): string {
+    return name
+        .split('-')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+}
+
+function ExampleCard({ component, example }: { component: string; example: Example }) {
+    return (
+        <div className="example-card">
+            <div className="example-card-header">
+                <h3 className="example-card-title">{formatName(example.name)}</h3>
+            </div>
+            <div className="example-card-frameworks">
+                {example.frameworks.map((fw) => {
+                    const meta = FRAMEWORK_META[fw];
+                    return (
+                        <a
+                            key={fw}
+                            href={`/templates/${component}/${example.name}/${fw}/index.html`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="example-fw-link"
+                            title={`Open ${formatName(example.name)} in ${meta.label}`}
+                        >
+                            <img
+                                src={useBaseUrl(meta.icon)}
+                                width={16}
+                                height={16}
+                                alt=""
+                            />
+                            <span>{meta.label}</span>
+                        </a>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function ComponentSection({ group }: { group: ComponentGroup }) {
+    return (
+        <section className="examples-component-section">
+            <div className="examples-component-header">
+                <h2 className="examples-component-title">{group.label}</h2>
+                <p className="examples-component-description">
+                    {group.description}
+                </p>
+            </div>
+            <div className="examples-grid">
+                {group.examples.map((ex) => (
+                    <ExampleCard
+                        key={ex.name}
+                        component={group.component}
+                        example={ex}
+                    />
+                ))}
+            </div>
+        </section>
+    );
+}
+
+export default function Examples(): JSX.Element {
+    return (
+        <Layout
+            title="Examples"
+            description="Browse interactive examples for Dockview, Splitview, Gridview, and Paneview across React, Vue, Angular, and TypeScript."
+        >
+            <main className="examples-page">
+                <div className="container">
+                    <div className="examples-hero">
+                        <h1>Examples</h1>
+                        <p>
+                            Interactive examples for every component and
+                            framework. Each example opens in its own page where
+                            you can view the source or edit in CodeSandbox.
+                        </p>
+                    </div>
+                    {COMPONENTS.map((group) => (
+                        <ComponentSection key={group.component} group={group} />
+                    ))}
+                </div>
+            </main>
+        </Layout>
+    );
+}


### PR DESCRIPTION
Replace the unstyled /templates index with a proper Docusaurus page at /examples that uses the site layout, organizes examples by component, and shows framework links with icons.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
