### PR TITLE
chore: update docs React examples to import from dockview-react

### DIFF
--- a/packages/docs/docs/core/panels/rendering.mdx
+++ b/packages/docs/docs/core/panels/rendering.mdx
@@ -78,7 +78,7 @@ You can listen to `onDidVisibilityChange` to gate expensive work, or conditional
 
 <FrameworkSpecific framework='React'>
 ```tsx title="Only rendering the React Component when the panel is visible, otherwise rendering a null React Component"
-import { IDockviewPanelProps } from 'dockview';
+import { IDockviewPanelProps } from 'dockview-react';
 import * as React from 'react';
 
 function RenderWhenVisible(

--- a/packages/docs/docs/core/panels/tabs.mdx
+++ b/packages/docs/docs/core/panels/tabs.mdx
@@ -362,7 +362,7 @@ default implementation as a base. This could include:
 
 <FrameworkSpecific framework='React'>
 ```tsx
-import { IDockviewPanelHeaderProps, DockviewDefaultTab } from 'dockview';
+import { IDockviewPanelHeaderProps, DockviewDefaultTab } from 'dockview-react';
 
 const MyCustomTab = (props: IDockviewPanelHeaderProps) => {
 const onContextMenu = (event: React.MouseEvent) => {
@@ -447,7 +447,7 @@ The component receives `panel`, `group`, `api`, `close`, and an optional `compon
 
 <FrameworkSpecific framework="React">
 ```tsx
-import { IContextMenuItemComponentProps } from 'dockview';
+import { IContextMenuItemComponentProps } from 'dockview-react';
 
 const FloatMenuItem = ({ panel, api, close }: IContextMenuItemComponentProps) => (
     <div
@@ -888,7 +888,7 @@ interface SerializedTabGroup {
 Use `isValidTabGroupColor` to validate a string as a tab group color at runtime:
 
 ```ts
-import { isValidTabGroupColor } from 'dockview';
+import { isValidTabGroupColor } from 'dockview-react';
 
 isValidTabGroupColor('blue');   // true
 isValidTabGroupColor('foo');    // false — type narrows to never

--- a/packages/docs/docs/core/theming.mdx
+++ b/packages/docs/docs/core/theming.mdx
@@ -39,7 +39,7 @@ const api = createDockview(element, {
 For dock components pass the theme object to the `theme` property. For other components such as split, pane, and grid views, set the theme's associated CSS class on the `className` property.
 
 ```tsx
-import { themeAbyss } from "dockview";
+import { themeAbyss } from "dockview-react";
 
 // For dock components
 theme={themeAbyss}

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -38,7 +38,7 @@
     "ag-grid-react": "^31.0.2",
     "axios": "^1.6.3",
     "clsx": "^2.1.0",
-    "dockview": "^5.0.0",
+    "dockview-react": "^5.0.0",
     "dockview-core": "^5.0.0",
     "prism-react-renderer": "^2.3.1",
     "react-dnd": "^16.0.1",

--- a/packages/docs/sandboxes/dockview-app/package.json
+++ b/packages/docs/sandboxes/dockview-app/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/dockview-app/src/app.tsx
+++ b/packages/docs/sandboxes/dockview-app/src/app.tsx
@@ -5,7 +5,7 @@ import {
     IPaneviewPanelProps,
     PaneviewReact,
     PaneviewReadyEvent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const paneComponents = {

--- a/packages/docs/sandboxes/editor-gridview/package.json
+++ b/packages/docs/sandboxes/editor-gridview/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/editor-gridview/src/app.tsx
+++ b/packages/docs/sandboxes/editor-gridview/src/app.tsx
@@ -6,7 +6,7 @@ import {
     LayoutPriority,
     Orientation,
     SerializedGridviewComponent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import './app.scss';
 

--- a/packages/docs/sandboxes/externaldnd-dockview/package.json
+++ b/packages/docs/sandboxes/externaldnd-dockview/package.json
@@ -8,7 +8,7 @@
   "main": "src/index.tsx",
   "dependencies": {
     "@minoru/react-dnd-treeview": "^3.4.3",
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dnd": "^16.0.1",
     "react-dom": "^18.2.0"

--- a/packages/docs/sandboxes/externaldnd-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/externaldnd-dockview/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import TreeComponent from './treeview';
 import { getBackendOptions, MultiBackend } from '@minoru/react-dnd-treeview';

--- a/packages/docs/sandboxes/fullwidthtab-dockview/package.json
+++ b/packages/docs/sandboxes/fullwidthtab-dockview/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/fullwidthtab-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/fullwidthtab-dockview/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IDockviewPanelProps,
     IDockviewPanelHeaderProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import './app.scss';
 

--- a/packages/docs/sandboxes/iframe-dockview/package.json
+++ b/packages/docs/sandboxes/iframe-dockview/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/iframe-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/iframe-dockview/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/keyboard-dockview/package.json
+++ b/packages/docs/sandboxes/keyboard-dockview/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.0"

--- a/packages/docs/sandboxes/keyboard-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/keyboard-dockview/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import './app.scss';
 import * as React from 'react';
 

--- a/packages/docs/sandboxes/nativeapp-dockview/package.json
+++ b/packages/docs/sandboxes/nativeapp-dockview/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/nativeapp-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/nativeapp-dockview/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IDockviewPanelProps,
     IDockviewPanelHeaderProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import './app.scss';
 

--- a/packages/docs/sandboxes/react/dockview/constraints/package.json
+++ b/packages/docs/sandboxes/react/dockview/constraints/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/constraints/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/constraints/src/app.tsx
@@ -4,7 +4,7 @@ import {
     DockviewReadyEvent,
     GridConstraintChangeEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/package.json
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.0"

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -12,7 +12,7 @@ import {
     GetTabGroupChipContextMenuItemsParams,
     DockviewTabGroupColors,
     DockviewTabGroupColor,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import './app.scss';

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/controls.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/controls.tsx
@@ -1,4 +1,4 @@
-import { IDockviewHeaderActionsProps } from 'dockview';
+import { IDockviewHeaderActionsProps } from 'dockview-react';
 import * as React from 'react';
 import { nextId } from './defaultLayout';
 

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/debugPanel.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/debugPanel.tsx
@@ -2,7 +2,7 @@ import {
     DockviewGroupLocation,
     DockviewPanelApi,
     DockviewPanelRenderer,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 export interface PanelApiMetadata {

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/defaultLayout.ts
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/defaultLayout.ts
@@ -1,4 +1,4 @@
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 
 export const nextId = (() => {
     let counter = 0;

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/eventLogPanel.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/eventLogPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 import { usePanelColors } from './panelTheme';
 
 type LogEntry = {

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
@@ -1,4 +1,4 @@
-import { DockviewApi, EdgeGroupPosition } from 'dockview';
+import { DockviewApi, EdgeGroupPosition } from 'dockview-react';
 import * as React from 'react';
 import { defaultConfig, nextId } from './defaultLayout';
 

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/groupActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/groupActions.tsx
@@ -3,7 +3,7 @@ import {
     DockviewGroupLocation,
     DockviewGroupPanel,
     DockviewHeaderPosition,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const GroupAction = (props: {

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/layoutInspectorPanel.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/layoutInspectorPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 import { usePanelColors } from './panelTheme';
 
 export const LayoutInspectorPanel: React.FC<{ api: DockviewApi }> = ({

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/mapboxPanel.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/mapboxPanel.tsx
@@ -1,4 +1,4 @@
-import { IDockviewPanelProps } from 'dockview';
+import { IDockviewPanelProps } from 'dockview-react';
 import * as React from 'react';
 import Map from 'react-map-gl';
 
@@ -14,7 +14,7 @@ export const MapboxPanel = (props: IDockviewPanelProps) => {
     return (
         <div style={{ overflow: 'auto', height: '100%' }}>
             <Map
-                mapboxAccessToken="pk.eyJ1IjoibWF0aHVvIiwiYSI6ImNrMXo4bnJ1ajA5OXUzaXA5ODg3Nnc1M3YifQ.Il7zfYd-sZ113W6Fmmagjg"
+                mapboxAccessToken={process.env.REACT_APP_MAPBOX_TOKEN ?? ''}
                 initialViewState={{
                     longitude: -122.4,
                     latitude: 37.8,

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelActions.tsx
@@ -1,4 +1,4 @@
-import { DockviewApi, IDockviewPanel } from 'dockview';
+import { DockviewApi, IDockviewPanel } from 'dockview-react';
 import * as React from 'react';
 
 const PanelAction = (props: {

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelBuilder.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelBuilder.tsx
@@ -1,4 +1,4 @@
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 import * as React from 'react';
 import { nextId } from './defaultLayout';
 

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelDebugPanel.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelDebugPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IDockviewPanelProps } from 'dockview';
+import { IDockviewPanelProps } from 'dockview-react';
 import { usePanelApiMetadata } from './debugPanel';
 import { usePanelColors } from './panelTheme';
 

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/settingsModal.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/settingsModal.tsx
@@ -1,4 +1,4 @@
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 import * as React from 'react';
 import { GridActions } from './gridActions';
 import { PanelActions } from './panelActions';

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilder.ts
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilder.ts
@@ -18,7 +18,7 @@ import {
     themeSolarizedLight,
     themeSolarizedLightSpaced,
     themeVisualStudio,
-} from 'dockview';
+} from 'dockview-react';
 
 export const BUILTIN_THEMES: { theme: DockviewTheme; label: string }[] = [
     { theme: themeDark, label: 'Dark' },
@@ -153,7 +153,7 @@ export function generateCodeSnippet(
         );
     }
 
-    let out = `import { ${importName} } from 'dockview';\n\n`;
+    let out = `import { ${importName} } from 'dockview-react';\n\n`;
 
     if (themeFields.length > 0) {
         out += `const myTheme = {\n  ...${importName},\n${themeFields.join('\n')}\n};\n`;

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilderModal.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilderModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DockviewTheme } from 'dockview';
+import { DockviewTheme } from 'dockview-react';
 import {
     ThemeBuilderState,
     ThemeCssOverrides,

--- a/packages/docs/sandboxes/react/dockview/dnd-events/package.json
+++ b/packages/docs/sandboxes/react/dockview/dnd-events/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/dnd-events/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/dnd-events/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/sandboxes/react/dockview/dnd-external/package.json
+++ b/packages/docs/sandboxes/react/dockview/dnd-external/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/dnd-external/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/dnd-external/src/app.tsx
@@ -6,7 +6,7 @@ import {
     DockviewReadyEvent,
     IDockviewPanelProps,
     positionToDirection,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/react/dockview/floating-groups/package.json
+++ b/packages/docs/sandboxes/react/dockview/floating-groups/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/floating-groups/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/floating-groups/src/app.tsx
@@ -6,7 +6,7 @@ import {
     IDockviewHeaderActionsProps,
     IDockviewPanelProps,
     SerializedDockview,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import { Icon } from './utils';
 

--- a/packages/docs/sandboxes/react/dockview/group-actions/package.json
+++ b/packages/docs/sandboxes/react/dockview/group-actions/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/group-actions/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/group-actions/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IDockviewHeaderActionsProps,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import './app.scss';
 

--- a/packages/docs/sandboxes/react/dockview/layout/package.json
+++ b/packages/docs/sandboxes/react/dockview/layout/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/layout/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/layout/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/react/dockview/locked/package.json
+++ b/packages/docs/sandboxes/react/dockview/locked/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/locked/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/locked/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/sandboxes/react/dockview/maximize-group/package.json
+++ b/packages/docs/sandboxes/react/dockview/maximize-group/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/maximize-group/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/maximize-group/src/app.tsx
@@ -6,7 +6,7 @@ import {
     IDockviewHeaderActionsProps,
     IDockviewPanelProps,
     SerializedDockview,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import { Icon } from './utils';
 

--- a/packages/docs/sandboxes/react/dockview/render-mode/package.json
+++ b/packages/docs/sandboxes/react/dockview/render-mode/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/render-mode/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/render-mode/src/app.tsx
@@ -6,7 +6,7 @@ import {
     DockviewPanelRenderer,
     DockviewApi,
     SerializedDockview,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import './app.scss';
 

--- a/packages/docs/sandboxes/react/dockview/resize-container/package.json
+++ b/packages/docs/sandboxes/react/dockview/resize-container/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/resize-container/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/resize-container/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/react/dockview/resize/package.json
+++ b/packages/docs/sandboxes/react/dockview/resize/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/resize/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/resize/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import './resize.scss';
 

--- a/packages/docs/sandboxes/react/dockview/scrollbars/package.json
+++ b/packages/docs/sandboxes/react/dockview/scrollbars/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.0"

--- a/packages/docs/sandboxes/react/dockview/scrollbars/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/scrollbars/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import './app.scss';
 
 const TEXT =

--- a/packages/docs/sandboxes/react/dockview/tabview/package.json
+++ b/packages/docs/sandboxes/react/dockview/tabview/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/tabview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/tabview/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/sandboxes/react/dockview/update-parameters/package.json
+++ b/packages/docs/sandboxes/react/dockview/update-parameters/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/update-parameters/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/update-parameters/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IDockviewPanelHeaderProps,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 interface CustomParams {

--- a/packages/docs/sandboxes/react/dockview/update-title/package.json
+++ b/packages/docs/sandboxes/react/dockview/update-title/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/update-title/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/update-title/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/react/dockview/watermark/package.json
+++ b/packages/docs/sandboxes/react/dockview/watermark/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/dockview/watermark/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/watermark/src/app.tsx
@@ -5,7 +5,7 @@ import {
     IDockviewPanelProps,
     IWatermarkPanelProps,
     Orientation,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/react/gridview/simple/package.json
+++ b/packages/docs/sandboxes/react/gridview/simple/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/gridview/simple/src/app.tsx
+++ b/packages/docs/sandboxes/react/gridview/simple/src/app.tsx
@@ -5,7 +5,7 @@ import {
     IGridviewPanelProps,
     LayoutPriority,
     Orientation,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/react/paneview/simple/package.json
+++ b/packages/docs/sandboxes/react/paneview/simple/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/paneview/simple/src/app.tsx
+++ b/packages/docs/sandboxes/react/paneview/simple/src/app.tsx
@@ -2,7 +2,7 @@ import {
     PaneviewReact,
     PaneviewReadyEvent,
     IPaneviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/react/splitview/simple/package.json
+++ b/packages/docs/sandboxes/react/splitview/simple/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/react/splitview/simple/src/app.tsx
+++ b/packages/docs/sandboxes/react/splitview/simple/src/app.tsx
@@ -2,7 +2,7 @@ import {
     SplitviewReact,
     SplitviewReadyEvent,
     ISplitviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/sandboxes/rendering-dockview/package.json
+++ b/packages/docs/sandboxes/rendering-dockview/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/sandboxes/rendering-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/rendering-dockview/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 import { atom, useRecoilState, useRecoilValue } from 'recoil';

--- a/packages/docs/src/components/dockview/customCss.tsx
+++ b/packages/docs/src/components/dockview/customCss.tsx
@@ -2,7 +2,7 @@
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 //

--- a/packages/docs/src/components/gridview/events.tsx
+++ b/packages/docs/src/components/gridview/events.tsx
@@ -4,7 +4,7 @@ import {
     GridviewReact,
     GridviewReadyEvent,
     GridviewApi,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import { Console, Line } from '../ui/console/console';
 

--- a/packages/docs/src/components/paneview/customHeader.tsx
+++ b/packages/docs/src/components/paneview/customHeader.tsx
@@ -2,7 +2,7 @@ import {
     IPaneviewPanelProps,
     PaneviewReact,
     PaneviewReadyEvent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/src/components/paneview/dragAndDrop.tsx
+++ b/packages/docs/src/components/paneview/dragAndDrop.tsx
@@ -3,7 +3,7 @@ import {
     PaneviewDropEvent,
     PaneviewReact,
     PaneviewReadyEvent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/src/components/paneview/sideBySide.tsx
+++ b/packages/docs/src/components/paneview/sideBySide.tsx
@@ -4,7 +4,7 @@ import {
     PaneviewReact,
     PaneviewReadyEvent,
     PaneviewDndOverlayEvent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 import { Console, Line } from '../ui/console/console';
 import './sideBySide.scss';

--- a/packages/docs/src/components/simpleGridview.tsx
+++ b/packages/docs/src/components/simpleGridview.tsx
@@ -3,7 +3,7 @@ import {
     Orientation,
     GridviewReact,
     GridviewReadyEvent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/src/components/simplePaneview.tsx
+++ b/packages/docs/src/components/simplePaneview.tsx
@@ -2,7 +2,7 @@ import {
     IPaneviewPanelProps,
     PaneviewReact,
     PaneviewReadyEvent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/src/components/simpleSplitview.tsx
+++ b/packages/docs/src/components/simpleSplitview.tsx
@@ -3,7 +3,7 @@ import {
     Orientation,
     SplitviewReact,
     SplitviewReadyEvent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/src/components/splitview/active.tsx
+++ b/packages/docs/src/components/splitview/active.tsx
@@ -4,7 +4,7 @@ import {
     Orientation,
     SplitviewReact,
     SplitviewReadyEvent,
-} from 'dockview';
+} from 'dockview-react';
 import * as React from 'react';
 
 const components = {

--- a/packages/docs/src/components/ui/exampleFrame.tsx
+++ b/packages/docs/src/components/ui/exampleFrame.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
-import { DockviewTheme } from 'dockview';
+import { DockviewTheme } from 'dockview-react';
 
 const ExampleFrame = (props: {
     framework: string;

--- a/packages/docs/src/config/theme.config.ts
+++ b/packages/docs/src/config/theme.config.ts
@@ -17,7 +17,7 @@ import {
     themeGithubDarkSpaced,
     themeGithubLight,
     themeGithubLightSpaced,
-} from 'dockview';
+} from 'dockview-react';
 
 export const themeConfig = [
     {

--- a/packages/docs/src/pages/demo.tsx
+++ b/packages/docs/src/pages/demo.tsx
@@ -4,7 +4,7 @@ import Head from '@docusaurus/Head';
 import { themeConfig } from '../config/theme.config';
 import ExampleFrame from '../components/ui/exampleFrame';
 import BrowserOnly from '@docusaurus/BrowserOnly';
-import { DockviewTheme, themeAbyss } from 'dockview';
+import { DockviewTheme, themeAbyss } from 'dockview-react';
 import styles from './demo.module.css';
 
 const CODESANDBOX_URL =

--- a/packages/docs/static/examples/dockview/next/main.tsx
+++ b/packages/docs/static/examples/dockview/next/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { DockviewReact } from 'dockview';
+import { DockviewReact } from 'dockview-react';
 import 'dockview/dist/styles/dockview.css';
 import './main.css';
 

--- a/packages/docs/static/examples/dockview/simple/index.tsx
+++ b/packages/docs/static/examples/dockview/simple/index.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import React from 'react';
 
-import { DockviewReact } from 'dockview';
+import { DockviewReact } from 'dockview-react';
 
 import 'dockview/dist/styles/dockview.css';
 

--- a/packages/docs/templates/dockview/basic/react/package.json
+++ b/packages/docs/templates/dockview/basic/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/basic/react/src/app.tsx
+++ b/packages/docs/templates/dockview/basic/react/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/templates/dockview/constraints/react/package.json
+++ b/packages/docs/templates/dockview/constraints/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/constraints/react/src/app.tsx
+++ b/packages/docs/templates/dockview/constraints/react/src/app.tsx
@@ -4,7 +4,7 @@ import {
     DockviewReadyEvent,
     GridConstraintChangeEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const components = {

--- a/packages/docs/templates/dockview/context-menu/react/package.json
+++ b/packages/docs/templates/dockview/context-menu/react/package.json
@@ -7,7 +7,7 @@
     "version": "1.0.0",
     "main": "src/index.tsx",
     "dependencies": {
-        "dockview": "*",
+        "dockview-react": "*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/packages/docs/templates/dockview/context-menu/react/src/app.tsx
+++ b/packages/docs/templates/dockview/context-menu/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IContextMenuItemComponentProps,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/templates/dockview/custom-header/react/package.json
+++ b/packages/docs/templates/dockview/custom-header/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/custom-header/react/src/app.tsx
+++ b/packages/docs/templates/dockview/custom-header/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IDockviewPanelHeaderProps,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 interface CustomParams {

--- a/packages/docs/templates/dockview/demo-dockview/react/package.json
+++ b/packages/docs/templates/dockview/demo-dockview/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.0"

--- a/packages/docs/templates/dockview/demo-dockview/react/src/app.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/app.tsx
@@ -6,7 +6,7 @@ import {
     IDockviewPanelProps,
     DockviewApi,
     IContextMenuItemComponentProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 import './app.css';
 import { defaultConfig } from './defaultLayout.ts';

--- a/packages/docs/templates/dockview/demo-dockview/react/src/controls.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/controls.tsx
@@ -1,4 +1,4 @@
-import { IDockviewHeaderActionsProps } from 'dockview';
+import { IDockviewHeaderActionsProps } from 'dockview-react';
 import React from 'react';
 import { nextId } from './defaultLayout.ts';
 

--- a/packages/docs/templates/dockview/demo-dockview/react/src/debugPanel.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/debugPanel.tsx
@@ -2,7 +2,7 @@ import {
     DockviewGroupLocation,
     DockviewPanelApi,
     DockviewPanelRenderer,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 export interface PanelApiMetadata {

--- a/packages/docs/templates/dockview/demo-dockview/react/src/defaultLayout.ts
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/defaultLayout.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 
 export const nextId = (() => {
     let counter = 0;

--- a/packages/docs/templates/dockview/demo-dockview/react/src/gridActions.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/gridActions.tsx
@@ -1,4 +1,4 @@
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 import React from 'react';
 import { defaultConfig, nextId } from './defaultLayout.ts';
 

--- a/packages/docs/templates/dockview/demo-dockview/react/src/groupActions.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/groupActions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 
 export const GroupActions = (props: {
     groups: string[];

--- a/packages/docs/templates/dockview/demo-dockview/react/src/panelActions.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/panelActions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DockviewApi } from 'dockview';
+import { DockviewApi } from 'dockview-react';
 
 export const PanelActions = (props: {
     panels: string[];

--- a/packages/docs/templates/dockview/dnd-events/react/package.json
+++ b/packages/docs/templates/dockview/dnd-events/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/dnd-events/react/src/app.tsx
+++ b/packages/docs/templates/dockview/dnd-events/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/templates/dockview/dnd-external/react/package.json
+++ b/packages/docs/templates/dockview/dnd-external/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/dnd-external/react/src/app.tsx
+++ b/packages/docs/templates/dockview/dnd-external/react/src/app.tsx
@@ -6,7 +6,7 @@ import {
     DockviewReadyEvent,
     IDockviewPanelProps,
     positionToDirection,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const components = {

--- a/packages/docs/templates/dockview/edge-groups/react/package.json
+++ b/packages/docs/templates/dockview/edge-groups/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/edge-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/edge-groups/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IDockviewPanelProps,
     IDockviewHeaderActionsProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/templates/dockview/floating-groups/react/package.json
+++ b/packages/docs/templates/dockview/floating-groups/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/floating-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/floating-groups/react/src/app.tsx
@@ -6,7 +6,7 @@ import {
     IDockviewHeaderActionsProps,
     IDockviewPanelProps,
     SerializedDockview,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 import { Icon } from './utils.tsx';
 

--- a/packages/docs/templates/dockview/group-actions/react/package.json
+++ b/packages/docs/templates/dockview/group-actions/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/group-actions/react/src/app.tsx
+++ b/packages/docs/templates/dockview/group-actions/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IDockviewHeaderActionsProps,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 import './app.css';
 

--- a/packages/docs/templates/dockview/layout/react/package.json
+++ b/packages/docs/templates/dockview/layout/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/layout/react/src/app.tsx
+++ b/packages/docs/templates/dockview/layout/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const components = {

--- a/packages/docs/templates/dockview/locked/react/package.json
+++ b/packages/docs/templates/dockview/locked/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/locked/react/src/app.tsx
+++ b/packages/docs/templates/dockview/locked/react/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/templates/dockview/maximize-group/react/package.json
+++ b/packages/docs/templates/dockview/maximize-group/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/maximize-group/react/src/app.tsx
+++ b/packages/docs/templates/dockview/maximize-group/react/src/app.tsx
@@ -5,7 +5,7 @@ import {
     IDockviewHeaderActionsProps,
     IDockviewPanelProps,
     SerializedDockview,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Icon = (props: {

--- a/packages/docs/templates/dockview/nested/react/package.json
+++ b/packages/docs/templates/dockview/nested/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/nested/react/src/app.tsx
+++ b/packages/docs/templates/dockview/nested/react/src/app.tsx
@@ -4,7 +4,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const InnerDockview = () => {

--- a/packages/docs/templates/dockview/popout-group/react/package.json
+++ b/packages/docs/templates/dockview/popout-group/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/popout-group/react/src/app.tsx
+++ b/packages/docs/templates/dockview/popout-group/react/src/app.tsx
@@ -6,7 +6,7 @@ import {
     IDockviewPanelProps,
     SerializedDockview,
     DockviewPanelApi,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 import { Icon } from './utils.tsx';
 import { PopoverMenu } from './popover.tsx';

--- a/packages/docs/templates/dockview/render-mode/react/package.json
+++ b/packages/docs/templates/dockview/render-mode/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/render-mode/react/src/app.tsx
+++ b/packages/docs/templates/dockview/render-mode/react/src/app.tsx
@@ -6,7 +6,7 @@ import {
     DockviewPanelRenderer,
     DockviewApi,
     SerializedDockview,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const useRenderer = (

--- a/packages/docs/templates/dockview/resize-container/react/package.json
+++ b/packages/docs/templates/dockview/resize-container/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/resize-container/react/src/app.tsx
+++ b/packages/docs/templates/dockview/resize-container/react/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const components = {

--- a/packages/docs/templates/dockview/resize/react/package.json
+++ b/packages/docs/templates/dockview/resize/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/resize/react/src/app.tsx
+++ b/packages/docs/templates/dockview/resize/react/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 import './resize.css';
 

--- a/packages/docs/templates/dockview/scrollbars/react/package.json
+++ b/packages/docs/templates/dockview/scrollbars/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.0"

--- a/packages/docs/templates/dockview/scrollbars/react/src/app.tsx
+++ b/packages/docs/templates/dockview/scrollbars/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 
 const TEXT =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';

--- a/packages/docs/templates/dockview/tab-groups/react/package.json
+++ b/packages/docs/templates/dockview/tab-groups/react/package.json
@@ -7,7 +7,7 @@
     "version": "1.0.0",
     "main": "src/index.tsx",
     "dependencies": {
-        "dockview": "*",
+        "dockview-react": "*",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/packages/docs/templates/dockview/tab-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/tab-groups/react/src/app.tsx
@@ -5,7 +5,7 @@ import {
     DockviewApi,
     GetTabContextMenuItemsParams,
     GetTabGroupChipContextMenuItemsParams,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 import {
     buildChipContextMenuItems,

--- a/packages/docs/templates/dockview/tab-groups/react/src/tabGroupActions.tsx
+++ b/packages/docs/templates/dockview/tab-groups/react/src/tabGroupActions.tsx
@@ -1,4 +1,4 @@
-import { DockviewApi, DockviewTabGroupColors, DockviewTabGroupColor } from 'dockview';
+import { DockviewApi, DockviewTabGroupColors, DockviewTabGroupColor } from 'dockview-react';
 
 export interface ContextMenuItem {
     label: string;

--- a/packages/docs/templates/dockview/tabview/react/package.json
+++ b/packages/docs/templates/dockview/tabview/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/tabview/react/src/app.tsx
+++ b/packages/docs/templates/dockview/tabview/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: IDockviewPanelProps) => {

--- a/packages/docs/templates/dockview/update-parameters/react/package.json
+++ b/packages/docs/templates/dockview/update-parameters/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/update-parameters/react/src/app.tsx
+++ b/packages/docs/templates/dockview/update-parameters/react/src/app.tsx
@@ -3,7 +3,7 @@ import {
     DockviewReadyEvent,
     IDockviewPanelHeaderProps,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 interface CustomParams {

--- a/packages/docs/templates/dockview/update-title/react/package.json
+++ b/packages/docs/templates/dockview/update-title/react/package.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "main": "src/index.tsx",
   "dependencies": {
-    "dockview": "*",
+    "dockview-react": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/templates/dockview/update-title/react/src/app.tsx
+++ b/packages/docs/templates/dockview/update-title/react/src/app.tsx
@@ -2,7 +2,7 @@ import {
     DockviewReact,
     DockviewReadyEvent,
     IDockviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const components = {

--- a/packages/docs/templates/dockview/watermark/react/src/app.tsx
+++ b/packages/docs/templates/dockview/watermark/react/src/app.tsx
@@ -5,7 +5,7 @@ import {
     IDockviewPanelProps,
     IWatermarkPanelProps,
     Orientation,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const components = {

--- a/packages/docs/templates/gridview/basic/react/src/app.tsx
+++ b/packages/docs/templates/gridview/basic/react/src/app.tsx
@@ -2,7 +2,7 @@ import {
     GridviewReact,
     GridviewReadyEvent,
     IGridviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: IGridviewPanelProps) => {

--- a/packages/docs/templates/paneview/basic/react/src/app.tsx
+++ b/packages/docs/templates/paneview/basic/react/src/app.tsx
@@ -2,7 +2,7 @@ import {
     PaneviewReact,
     PaneviewReadyEvent,
     IPaneviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: IPaneviewPanelProps) => {

--- a/packages/docs/templates/splitview/basic/react/src/app.tsx
+++ b/packages/docs/templates/splitview/basic/react/src/app.tsx
@@ -2,7 +2,7 @@ import {
     SplitviewReact,
     SplitviewReadyEvent,
     ISplitviewPanelProps,
-} from 'dockview';
+} from 'dockview-react';
 import React from 'react';
 
 const Default = (props: ISplitviewPanelProps) => {


### PR DESCRIPTION
All React examples and sandboxes now import from 'dockview-react' instead of 'dockview' to be consistent with the documented install instructions. Also removes hardcoded Mapbox token from sandbox.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
