### PR TITLE
feat: move tabAnimation to theme object and combine sidebar

### DIFF
--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -26,7 +26,6 @@ import {
     PROPERTY_KEYS_DOCKVIEW,
     DockviewFrameworkOptions,
     DockviewComponentOptions,
-    TabAnimation,
     GetTabContextMenuItemsParams,
     GetTabGroupChipContextMenuItemsParams,
     BuiltInChipContextMenuItem,
@@ -98,7 +97,6 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Input() locked?: boolean;
     @Input() disableAutoResizing?: boolean;
     @Input() singleTabMode?: 'fullwidth' | 'default';
-    @Input() tabAnimation?: TabAnimation;
     @Input() getTabContextMenuItems?: (
         params: GetTabContextMenuItemsParams
     ) => (ContextMenuItem | { component: Type<any> | TemplateRef<any> })[];

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
@@ -29,7 +29,7 @@ function createMockPanel(id: string): IDockviewPanel {
 function createTabsForDropTest() {
     const accessor = fromPartial<DockviewComponent>({
         id: 'test-accessor-id',
-        options: {}, // tabAnimation: undefined = default (no smooth animation)
+        options: {}, // theme?.tabAnimation: undefined = default (no smooth animation)
         onDidOptionsChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
     });
     const group = fromPartial<DockviewGroupPanel>({
@@ -346,7 +346,7 @@ describe('tabs', () => {
         test('dragover on tab strip calls preventDefault, enabling drop on empty space', () => {
             const accessor = fromPartial<DockviewComponent>({
                 id: 'test-accessor-id',
-                options: { tabAnimation: 'smooth' },
+                options: { theme: { name: 'test', className: 'test', tabAnimation: 'smooth' } },
                 onDidOptionsChange: jest
                     .fn()
                     .mockReturnValue({ dispose: jest.fn() }),

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
@@ -346,7 +346,13 @@ describe('tabs', () => {
         test('dragover on tab strip calls preventDefault, enabling drop on empty space', () => {
             const accessor = fromPartial<DockviewComponent>({
                 id: 'test-accessor-id',
-                options: { theme: { name: 'test', className: 'test', tabAnimation: 'smooth' } },
+                options: {
+                    theme: {
+                        name: 'test',
+                        className: 'test',
+                        tabAnimation: 'smooth',
+                    },
+                },
                 onDidOptionsChange: jest
                     .fn()
                     .mockReturnValue({ dispose: jest.fn() }),

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -55,7 +55,11 @@ function createTabs(
     const accessor = fromPartial<DockviewComponent>({
         id: 'test-accessor',
         options: {
-            theme: { name: 'test', className: 'test', tabAnimation: options.tabAnimation },
+            theme: {
+                name: 'test',
+                className: 'test',
+                tabAnimation: options.tabAnimation,
+            },
             disableDnd: options.disableDnd,
         },
         onDidOptionsChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -55,7 +55,7 @@ function createTabs(
     const accessor = fromPartial<DockviewComponent>({
         id: 'test-accessor',
         options: {
-            tabAnimation: options.tabAnimation,
+            theme: { name: 'test', className: 'test', tabAnimation: options.tabAnimation },
             disableDnd: options.disableDnd,
         },
         onDidOptionsChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),

--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -108,7 +108,7 @@ export class Tab extends CompositeDisposable {
                 const data = getPanelData();
 
                 if (data && this.accessor.id === data.viewId) {
-                    if (this.accessor.options.tabAnimation === 'smooth') {
+                    if (this.accessor.options.theme?.tabAnimation === 'smooth') {
                         // When smooth reorder is enabled, the Tabs
                         // container handles all intra-accessor drops
                         // (both same-group and cross-group) via
@@ -208,7 +208,7 @@ export class Tab extends CompositeDisposable {
 
                 this._onDragStart.fire(event);
 
-                if (this.accessor.options.tabAnimation === 'smooth') {
+                if (this.accessor.options.theme?.tabAnimation === 'smooth') {
                     // Delay collapse to next frame so the browser
                     // captures the full drag image first
                     requestAnimationFrame(() => {

--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -108,7 +108,9 @@ export class Tab extends CompositeDisposable {
                 const data = getPanelData();
 
                 if (data && this.accessor.id === data.viewId) {
-                    if (this.accessor.options.theme?.tabAnimation === 'smooth') {
+                    if (
+                        this.accessor.options.theme?.tabAnimation === 'smooth'
+                    ) {
                         // When smooth reorder is enabled, the Tabs
                         // container handles all intra-accessor drops
                         // (both same-group and cross-group) via

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -293,7 +293,7 @@ export class Tabs extends CompositeDisposable {
                     if (!this._animState) {
                         // Check for external drag from another group
                         if (
-                            this.accessor.options.tabAnimation === 'default' ||
+                            this.accessor.options.theme?.tabAnimation === 'default' ||
                             this.accessor.options.disableDnd
                         ) {
                             return;
@@ -411,7 +411,7 @@ export class Tabs extends CompositeDisposable {
                     // In non-smooth mode only handle group drags here;
                     // individual tab drops are handled by tab Droptargets.
                     if (
-                        this.accessor.options.tabAnimation !== 'smooth' &&
+                        this.accessor.options.theme?.tabAnimation !== 'smooth' &&
                         !this._animState.sourceTabGroupId
                     ) {
                         return;
@@ -566,7 +566,7 @@ export class Tabs extends CompositeDisposable {
             tab.onDragStart((event) => {
                 this._onTabDragStart.fire({ nativeEvent: event, panel });
 
-                if (this.accessor.options.tabAnimation === 'smooth') {
+                if (this.accessor.options.theme?.tabAnimation === 'smooth') {
                     const tabWidth = tab.element.getBoundingClientRect().width;
                     const sourceIndex = this._tabs.findIndex(
                         (x) => x.value === tab
@@ -712,7 +712,7 @@ export class Tabs extends CompositeDisposable {
                         targetTabGroupId: animState.targetTabGroupId,
                     });
 
-                    if (this.accessor.options.tabAnimation === 'smooth') {
+                    if (this.accessor.options.theme?.tabAnimation === 'smooth') {
                         this.runFlipAnimation(
                             firstPositions,
                             animState.sourceTabId,
@@ -948,7 +948,7 @@ export class Tabs extends CompositeDisposable {
             }
         }
 
-        if (this.accessor.options.tabAnimation === 'smooth') {
+        if (this.accessor.options.theme?.tabAnimation === 'smooth') {
             // Collapse group tabs + chip after the browser
             // captures the drag image, then open the gap at the
             // source position — all instant (no transitions).
@@ -1299,7 +1299,7 @@ export class Tabs extends CompositeDisposable {
         this._animState.currentInsertionIndex = insertionIndex;
         this._animState.targetTabGroupId = targetTabGroupId;
 
-        if (this.accessor.options.tabAnimation === 'smooth') {
+        if (this.accessor.options.theme?.tabAnimation === 'smooth') {
             this.applyDragOverTransforms();
         }
     }
@@ -1553,7 +1553,7 @@ export class Tabs extends CompositeDisposable {
         this._chipDragCleanup?.dispose();
         this._chipDragCleanup = null;
 
-        if (this.accessor.options.tabAnimation === 'smooth') {
+        if (this.accessor.options.theme?.tabAnimation === 'smooth') {
             this._clearGroupDragClasses(sourceTabGroupId);
             const firstPositions = this.snapshotTabPositions();
             this.resetTabTransforms();

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -293,7 +293,8 @@ export class Tabs extends CompositeDisposable {
                     if (!this._animState) {
                         // Check for external drag from another group
                         if (
-                            this.accessor.options.theme?.tabAnimation === 'default' ||
+                            this.accessor.options.theme?.tabAnimation ===
+                                'default' ||
                             this.accessor.options.disableDnd
                         ) {
                             return;
@@ -411,7 +412,8 @@ export class Tabs extends CompositeDisposable {
                     // In non-smooth mode only handle group drags here;
                     // individual tab drops are handled by tab Droptargets.
                     if (
-                        this.accessor.options.theme?.tabAnimation !== 'smooth' &&
+                        this.accessor.options.theme?.tabAnimation !==
+                            'smooth' &&
                         !this._animState.sourceTabGroupId
                     ) {
                         return;
@@ -712,7 +714,9 @@ export class Tabs extends CompositeDisposable {
                         targetTabGroupId: animState.targetTabGroupId,
                     });
 
-                    if (this.accessor.options.theme?.tabAnimation === 'smooth') {
+                    if (
+                        this.accessor.options.theme?.tabAnimation === 'smooth'
+                    ) {
                         this.runFlipAnimation(
                             firstPositions,
                             animState.sourceTabId,

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -134,17 +134,6 @@ export interface DockviewOptions {
      */
     scrollbars?: 'native' | 'custom';
     /**
-     * Controls tab drag-and-drop reorder animation style.
-     *
-     * - `"smooth"`: tabs animate smoothly during drag-and-drop reorder —
-     *   tabs slide apart to reveal the insertion gap, then animate to their
-     *   final positions on drop (Chrome-like behavior).
-     * - `"default"`: standard tab reorder behavior without animation.
-     *
-     * Defaults to `"default"`.
-     */
-    tabAnimation?: TabAnimation;
-    /**
      * Return the items to display in the tab context menu on right-click.
      *
      * Use built-in string shortcuts (`'close'`, `'closeOthers'`, `'closeAll'`, `'separator'`)
@@ -180,7 +169,6 @@ export interface DockviewOptions {
 }
 
 export type TabAnimation = 'smooth' | 'default';
-const DEFAULT_TAB_ANIMATION: TabAnimation = 'default';
 
 export interface DockviewDndOverlayEvent extends IAcceptableEvent {
     nativeEvent: DragEvent;
@@ -229,7 +217,6 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         theme: undefined,
         disableTabsOverflowList: undefined,
         scrollbars: undefined,
-        tabAnimation: undefined,
         getTabContextMenuItems: undefined,
         getTabGroupChipContextMenuItems: undefined,
         createTabGroupChipComponent: undefined,

--- a/packages/dockview-core/src/dockview/theme.ts
+++ b/packages/dockview-core/src/dockview/theme.ts
@@ -1,3 +1,5 @@
+import { TabAnimation } from './options';
+
 export type DockviewTabGroupIndicator = 'wrap' | 'none';
 
 export interface DockviewTheme {
@@ -56,6 +58,17 @@ export interface DockviewTheme {
      *   and `--dv-tab-group-color` (resolved color for the tab's group).
      */
     tabGroupIndicator?: DockviewTabGroupIndicator;
+    /**
+     * Controls tab drag-and-drop reorder animation style.
+     *
+     * - `"smooth"`: tabs animate smoothly during drag-and-drop reorder —
+     *   tabs slide apart to reveal the insertion gap, then animate to their
+     *   final positions on drop (Chrome-like behavior).
+     * - `"default"`: standard tab reorder behavior without animation.
+     *
+     * Defaults to `"default"`.
+     */
+    tabAnimation?: TabAnimation;
 }
 
 export const themeDark: DockviewTheme = {

--- a/packages/docs/docs/core/panels/tabs.mdx
+++ b/packages/docs/docs/core/panels/tabs.mdx
@@ -592,48 +592,26 @@ Controls how tabs animate when reordered via drag-and-drop.
 
 <CodeRunner id="dockview/tabview" height={300} />
 
-<FrameworkSpecific framework="React">
-    <DocRef declaration="IDockviewReactProps" methods={['tabAnimation']} />
-</FrameworkSpecific>
-
-<FrameworkSpecific framework="Vue">
-    <DocRef declaration="IDockviewVueProps" methods={['tabAnimation']} />
-</FrameworkSpecific>
-
-<FrameworkSpecific framework="Angular">
-    <DocRef declaration="IDockviewAngularProps" methods={['tabAnimation']} />
-</FrameworkSpecific>
-
-<FrameworkSpecific framework="JavaScript">
-    <DocRef declaration="DockviewComponentOptions" methods={['tabAnimation']} />
-</FrameworkSpecific>
+<DocRef declaration="DockviewTheme" methods={['tabAnimation']} />
 
 <FrameworkSpecific framework="React">
-    ```tsx return <DockviewReactComponent tabAnimation="smooth" />
-    ```
-</FrameworkSpecific>
+```tsx
+import { themeAbyss } from 'dockview';
 
-<FrameworkSpecific framework="Vue">
-    ```html
-    <dockview-vue tabAnimation="smooth" />
-    ```
-</FrameworkSpecific>
+const myTheme = { ...themeAbyss, tabAnimation: 'smooth' };
 
-<FrameworkSpecific framework="Angular">
-    ```html
-    <dv-dockview tabAnimation="smooth"></dv-dockview>
-    ```
+return <DockviewReact theme={myTheme} />
+```
 </FrameworkSpecific>
 
 <FrameworkSpecific framework='JavaScript'>
 ```ts
 const api = createDockview(parentElement, {
-    tabAnimation: 'smooth',
+    theme: { ...themeAbyss, tabAnimation: 'smooth' },
 });
 
 // or toggle at runtime
-api.updateOptions({ tabAnimation: 'smooth' });
-
+api.updateOptions({ theme: { ...themeAbyss, tabAnimation: 'smooth' } });
 ```
 </FrameworkSpecific>
 

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -19,7 +19,6 @@ import './app.scss';
 import { defaultConfig } from './defaultLayout';
 import { LeftControls, PrefixHeaderControls, RightControls } from './controls';
 import { Table, usePanelApiMetadata } from './debugPanel';
-import { SettingsModal } from './settingsModal';
 import { OrdersPanel } from './ordersPanel';
 import { OrderBookPanel } from './orderBookPanel';
 import { EventLogPanel } from './eventLogPanel';
@@ -36,7 +35,7 @@ import {
     buildEffectiveTheme,
     getInitialStateFromTheme,
 } from './themeBuilder';
-import { ThemeBuilderModal } from './themeBuilderModal';
+import { Sidebar } from './themeBuilderModal';
 
 export const ApiContext = React.createContext<DockviewApi | undefined>(
     undefined
@@ -301,10 +300,8 @@ const ThemeContext = React.createContext<DockviewTheme | undefined>(undefined);
 
 const DockviewDemo = (props: {
     theme?: DockviewTheme;
-    showSettings?: boolean;
-    onCloseSettings?: () => void;
-    showThemeBuilder?: boolean;
-    onCloseThemeBuilder?: () => void;
+    showSidebar?: boolean;
+    onCloseSidebar?: () => void;
     onChangeTheme?: (theme: DockviewTheme) => void;
 }) => {
     const [logLines, setLogLines] = React.useState<
@@ -677,10 +674,6 @@ const DockviewDemo = (props: {
     const [showLogs, setShowLogs] = React.useState<boolean>(false);
     const [debug, setDebug] = React.useState<boolean>(false);
     const [useEdgeGroups, setUseEdgeGroups] = React.useState<boolean>(true);
-    const [tabAnimation, setTabAnimation] = React.useState<
-        'smooth' | 'default'
-    >('default');
-
     return (
         <div
             className="dockview-demo"
@@ -725,7 +718,6 @@ const DockviewDemo = (props: {
                                                     : 'no-shell'
                                             }
                                             components={components}
-                                            tabAnimation={tabAnimation}
                                             defaultTabComponent={
                                                 headerComponents.default
                                             }
@@ -837,9 +829,9 @@ const DockviewDemo = (props: {
                         </div>
                     </div>
                 )}
-                <ThemeBuilderModal
-                    open={props.showThemeBuilder ?? false}
-                    onClose={props.onCloseThemeBuilder ?? (() => {})}
+                <Sidebar
+                    open={props.showSidebar ?? false}
+                    onClose={props.onCloseSidebar ?? (() => {})}
                     state={builderState}
                     onChange={updateBuilder}
                     onCssChange={updateCss}
@@ -850,27 +842,20 @@ const DockviewDemo = (props: {
                     }
                     baseTheme={props.theme ?? themeAbyss}
                     containerEl={containerRef.current}
+                    api={api}
+                    panels={panels}
+                    groups={groups}
+                    activePanel={activePanel}
+                    activeGroup={activeGroup}
+                    hasCustomWatermark={watermark}
+                    toggleCustomWatermark={() => setWatermark(!watermark)}
+                    debug={debug}
+                    onToggleDebug={() => setDebug(!debug)}
+                    showLogs={showLogs}
+                    onToggleShowLogs={() => setShowLogs(!showLogs)}
+                    onClearLogs={() => setLogLines([])}
                 />
             </div>
-
-            <SettingsModal
-                open={props.showSettings ?? false}
-                onClose={props.onCloseSettings ?? (() => {})}
-                api={api}
-                panels={panels}
-                groups={groups}
-                activePanel={activePanel}
-                activeGroup={activeGroup}
-                hasCustomWatermark={watermark}
-                toggleCustomWatermark={() => setWatermark(!watermark)}
-                debug={debug}
-                onToggleDebug={() => setDebug(!debug)}
-                showLogs={showLogs}
-                onToggleShowLogs={() => setShowLogs(!showLogs)}
-                onClearLogs={() => setLogLines([])}
-                tabAnimation={tabAnimation}
-                onToggleTabAnimation={(v) => setTabAnimation(v)}
-            />
         </div>
     );
 };

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
@@ -2,6 +2,61 @@ import { DockviewApi, EdgeGroupPosition } from 'dockview';
 import * as React from 'react';
 import { defaultConfig, nextId } from './defaultLayout';
 
+const btnStyle: React.CSSProperties = {
+    padding: '4px 10px',
+    fontSize: 11,
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 4,
+    background: 'rgba(255,255,255,0.04)',
+    color: 'rgba(255,255,255,0.7)',
+    cursor: 'pointer',
+};
+
+const btnActiveStyle: React.CSSProperties = {
+    ...btnStyle,
+    background: 'rgba(72,100,220,0.25)',
+    borderColor: 'rgba(72,100,220,0.5)',
+    color: 'white',
+};
+
+const iconBtnStyle: React.CSSProperties = {
+    ...btnStyle,
+    padding: '3px 6px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+};
+
+const Row = (props: {
+    label?: string;
+    children: React.ReactNode;
+    style?: React.CSSProperties;
+}) => (
+    <div
+        style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '4px 16px',
+            minHeight: 30,
+            ...props.style,
+        }}
+    >
+        {props.label && (
+            <span
+                style={{
+                    flex: 1,
+                    fontSize: 11,
+                    color: 'rgba(255,255,255,0.5)',
+                }}
+            >
+                {props.label}
+            </span>
+        )}
+        {props.children}
+    </div>
+);
+
 const EDGE_POSITIONS: EdgeGroupPosition[] = ['top', 'bottom', 'left', 'right'];
 
 const EdgeGroupToggles = (props: { api: DockviewApi }) => {
@@ -38,17 +93,38 @@ const EdgeGroupToggles = (props: { api: DockviewApi }) => {
     };
 
     return (
-        <div className="action-row">
-            {EDGE_POSITIONS.map((pos) => (
-                <button
-                    key={pos}
-                    style={active[pos] ? { backgroundColor: '#4864dc' } : {}}
-                    onClick={() => toggle(pos)}
-                >
-                    {pos}
-                </button>
-            ))}
-        </div>
+        <Row label="Edge groups">
+            <div
+                style={{
+                    display: 'flex',
+                    background: 'rgba(255,255,255,0.05)',
+                    borderRadius: 4,
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    overflow: 'hidden',
+                }}
+            >
+                {EDGE_POSITIONS.map((pos) => (
+                    <button
+                        key={pos}
+                        onClick={() => toggle(pos)}
+                        style={{
+                            padding: '3px 8px',
+                            fontSize: 11,
+                            border: 'none',
+                            cursor: 'pointer',
+                            background: active[pos]
+                                ? 'rgba(255,255,255,0.15)'
+                                : 'transparent',
+                            color: active[pos]
+                                ? 'white'
+                                : 'rgba(255,255,255,0.5)',
+                        }}
+                    >
+                        {pos}
+                    </button>
+                ))}
+            </div>
+        </Row>
     );
 };
 
@@ -108,9 +184,11 @@ const PopoverComponent = (props: {
                     top: '50%',
                     left: '50%',
                     transform: 'translate(-50%,-50%)',
-                    backgroundColor: 'black',
+                    backgroundColor: '#161b22',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: 8,
                     color: 'white',
-                    padding: 10,
+                    padding: 16,
                 }}
             >
                 <props.component close={props.close} />
@@ -164,7 +242,6 @@ export const GridActions = (props: {
         if (props.api) {
             const state = props.api.toJSON();
             console.log(state);
-
             localStorage.setItem('dv-demo-state', JSON.stringify(state));
         }
     };
@@ -202,47 +279,52 @@ export const GridActions = (props: {
     };
 
     return (
-        <div className="action-container">
-            <div className="action-row">
-                <button className="text-button" onClick={onLoad}>
-                    Load
-                </button>
-                <button className="text-button" onClick={onSave}>
-                    Save
-                </button>
-                <button className="text-button" onClick={onClear}>
-                    Clear
-                </button>
-                <button className="text-button" onClick={onReset}>
-                    Reset
-                </button>
-            </div>
+        <div style={{ padding: '4px 0' }}>
+            <Row>
+                <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                    <button style={btnStyle} onClick={onLoad}>
+                        Load
+                    </button>
+                    <button style={btnStyle} onClick={onSave}>
+                        Save
+                    </button>
+                    <button style={btnStyle} onClick={onClear}>
+                        Clear
+                    </button>
+                    <button style={btnStyle} onClick={onReset}>
+                        Reset
+                    </button>
+                </div>
+            </Row>
             {props.api && <EdgeGroupToggles api={props.api} />}
-            <div className="action-row">
-                <div className="button-group">
-                    <button
-                        className="text-button"
-                        onClick={() => onAddPanel()}
-                    >
+            <Row>
+                <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                    <button style={btnStyle} onClick={() => onAddPanel()}>
                         Add Panel
                     </button>
                     <button
-                        className="demo-icon-button"
+                        style={iconBtnStyle}
                         onClick={() => onAddPanel({ advanced: true })}
+                        title="Advanced panel options"
                     >
-                        <span className="material-symbols-outlined">tune</span>
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
+                        >
+                            tune
+                        </span>
+                    </button>
+                    <button
+                        style={btnStyle}
+                        onClick={() => onAddPanel({ nested: true })}
+                    >
+                        Nested
+                    </button>
+                    <button style={btnStyle} onClick={onAddGroup}>
+                        Add Group
                     </button>
                 </div>
-                <button
-                    className="text-button"
-                    onClick={() => onAddPanel({ nested: true })}
-                >
-                    Add Nested Panel
-                </button>
-                <button className="text-button" onClick={onAddGroup}>
-                    Add Group
-                </button>
-            </div>
+            </Row>
         </div>
     );
 };

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/groupActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/groupActions.tsx
@@ -6,6 +6,32 @@ import {
 } from 'dockview';
 import * as React from 'react';
 
+const iconBtn = (active?: boolean): React.CSSProperties => ({
+    padding: '3px 6px',
+    fontSize: 11,
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 4,
+    background: active
+        ? 'rgba(72,100,220,0.25)'
+        : 'rgba(255,255,255,0.04)',
+    color: active ? 'white' : 'rgba(255,255,255,0.6)',
+    cursor: 'pointer',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+});
+
+const selectStyle: React.CSSProperties = {
+    padding: '3px 4px',
+    fontSize: 11,
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 4,
+    background: 'rgba(255,255,255,0.04)',
+    color: 'rgba(255,255,255,0.7)',
+    cursor: 'pointer',
+    outline: 'none',
+};
+
 const GroupAction = (props: {
     groupId: string;
     groups: string[];
@@ -29,9 +55,7 @@ const GroupAction = (props: {
 
         setGroup(props.api.getGroup(props.groupId));
 
-        return () => {
-            disposable.dispose();
-        };
+        return () => disposable.dispose();
     }, [props.api, props.groupId]);
 
     const [headerPosition, setHeaderPosition] =
@@ -72,43 +96,144 @@ const GroupAction = (props: {
     }, [group]);
 
     return (
-        <div className="button-action">
-            <div style={{ display: 'flex' }}>
+        <div style={{ padding: '3px 16px' }}>
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    minHeight: 28,
+                }}
+            >
                 <button
                     onClick={onClick}
-                    className={
-                        isActive ? 'demo-button selected' : 'demo-button'
-                    }
+                    style={{
+                        flex: 1,
+                        padding: '3px 8px',
+                        fontSize: 11,
+                        border: '1px solid rgba(255,255,255,0.12)',
+                        borderRadius: 4,
+                        background: isActive
+                            ? 'rgba(72,100,220,0.25)'
+                            : 'rgba(255,255,255,0.04)',
+                        color: isActive ? 'white' : 'rgba(255,255,255,0.7)',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    }}
                 >
                     {props.groupId}
                 </button>
+                <div style={{ display: 'flex', gap: 2 }}>
+                    <button
+                        style={iconBtn(location?.type === 'floating')}
+                        onClick={() => {
+                            if (group) {
+                                props.api.addFloatingGroup(group, {
+                                    width: 400,
+                                    height: 300,
+                                    x: 50,
+                                    y: 50,
+                                    position: { bottom: 50, right: 50 },
+                                });
+                            }
+                        }}
+                        title="Float"
+                    >
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
+                        >
+                            ad_group
+                        </span>
+                    </button>
+                    <button
+                        style={iconBtn(location?.type === 'popout')}
+                        onClick={() => {
+                            if (group) props.api.addPopoutGroup(group);
+                        }}
+                        title="Popout"
+                    >
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
+                        >
+                            open_in_new
+                        </span>
+                    </button>
+                    <button
+                        style={iconBtn(isMaximized)}
+                        onClick={() => {
+                            if (group) {
+                                if (group.api.isMaximized()) {
+                                    group.api.exitMaximized();
+                                } else {
+                                    group.api.maximize();
+                                }
+                            }
+                        }}
+                        title="Maximize"
+                    >
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
+                        >
+                            fullscreen
+                        </span>
+                    </button>
+                    <button
+                        style={iconBtn()}
+                        onClick={() => {
+                            if (group) {
+                                group.api.setVisible(!group.api.isVisible);
+                            }
+                        }}
+                        title="Toggle visibility"
+                    >
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
+                        >
+                            {isVisible ? 'visibility' : 'visibility_off'}
+                        </span>
+                    </button>
+                    <button
+                        style={iconBtn()}
+                        onClick={() => {
+                            props.api?.getGroup(props.groupId)?.api.close();
+                        }}
+                        title="Close"
+                    >
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
+                        >
+                            close
+                        </span>
+                    </button>
+                </div>
             </div>
-            <div style={{ display: 'flex' }}>
-                <button
-                    className={
-                        location?.type === 'floating'
-                            ? 'demo-icon-button selected'
-                            : 'demo-icon-button'
-                    }
-                    onClick={() => {
-                        if (group) {
-                            props.api.addFloatingGroup(group, {
-                                width: 400,
-                                height: 300,
-                                x: 50,
-                                y: 50,
-                                position: {
-                                    bottom: 50,
-                                    right: 50,
-                                },
-                            });
-                        }
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    paddingTop: 4,
+                    paddingBottom: 2,
+                }}
+            >
+                <span
+                    style={{
+                        fontSize: 11,
+                        color: 'rgba(255,255,255,0.4)',
                     }}
                 >
-                    <span className="material-symbols-outlined">ad_group</span>
-                </button>
+                    Header
+                </span>
                 <select
-                    className="demo-icon-button"
+                    style={selectStyle}
                     value={headerPosition}
                     onChange={(e) => {
                         const value = e.target.value as DockviewHeaderPosition;
@@ -123,68 +248,6 @@ const GroupAction = (props: {
                     <option value="left">left</option>
                     <option value="right">right</option>
                 </select>
-                <button
-                    className={
-                        location?.type === 'popout'
-                            ? 'demo-icon-button selected'
-                            : 'demo-icon-button'
-                    }
-                    onClick={() => {
-                        if (group) {
-                            props.api.addPopoutGroup(group);
-                        }
-                    }}
-                >
-                    <span className="material-symbols-outlined">
-                        open_in_new
-                    </span>
-                </button>
-                <button
-                    className={
-                        isMaximized
-                            ? 'demo-icon-button selected'
-                            : 'demo-icon-button'
-                    }
-                    onClick={() => {
-                        if (group) {
-                            if (group.api.isMaximized()) {
-                                group.api.exitMaximized();
-                            } else {
-                                group.api.maximize();
-                            }
-                        }
-                    }}
-                >
-                    <span className="material-symbols-outlined">
-                        fullscreen
-                    </span>
-                </button>
-                <button
-                    className="demo-icon-button"
-                    onClick={() => {
-                        console.log(group);
-                        if (group) {
-                            if (group.api.isVisible) {
-                                group.api.setVisible(false);
-                            } else {
-                                group.api.setVisible(true);
-                            }
-                        }
-                    }}
-                >
-                    <span className="material-symbols-outlined">
-                        {isVisible ? 'visibility' : 'visibility_off'}
-                    </span>
-                </button>
-                <button
-                    className="demo-icon-button"
-                    onClick={() => {
-                        const panel = props.api?.getGroup(props.groupId);
-                        panel?.api.close();
-                    }}
-                >
-                    <span className="material-symbols-outlined">close</span>
-                </button>
             </div>
         </div>
     );
@@ -196,12 +259,10 @@ export const GroupActions = (props: {
     activeGroup?: string;
 }) => {
     return (
-        <div className="action-container">
-            {props.groups.map((groupId) => {
-                return (
-                    <GroupAction key={groupId} {...props} groupId={groupId} />
-                );
-            })}
+        <div style={{ padding: '2px 0' }}>
+            {props.groups.map((groupId) => (
+                <GroupAction key={groupId} {...props} groupId={groupId} />
+            ))}
         </div>
     );
 };

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/panelActions.tsx
@@ -1,6 +1,19 @@
 import { DockviewApi, IDockviewPanel } from 'dockview';
 import * as React from 'react';
 
+const iconBtn: React.CSSProperties = {
+    padding: '3px 6px',
+    fontSize: 11,
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 4,
+    background: 'rgba(255,255,255,0.04)',
+    color: 'rgba(255,255,255,0.6)',
+    cursor: 'pointer',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+};
+
 const PanelAction = (props: {
     panels: string[];
     api: DockviewApi;
@@ -11,6 +24,11 @@ const PanelAction = (props: {
         props.api.getPanel(props.panelId)?.focus();
     };
 
+    const [panel, setPanel] = React.useState<IDockviewPanel | undefined>(
+        undefined
+    );
+    const [visible, setVisible] = React.useState<boolean>(true);
+
     React.useEffect(() => {
         const panel = props.api.getPanel(props.panelId);
         if (panel) {
@@ -18,16 +36,9 @@ const PanelAction = (props: {
                 setVisible(event.isVisible);
             });
             setVisible(panel.api.isVisible);
-
-            return () => {
-                disposable.dispose();
-            };
+            return () => disposable.dispose();
         }
     }, [props.api, props.panelId]);
-
-    const [panel, setPanel] = React.useState<IDockviewPanel | undefined>(
-        undefined
-    );
 
     React.useEffect(() => {
         const list = [
@@ -41,76 +52,108 @@ const PanelAction = (props: {
                 setVisible(event.isVisible);
             });
             setVisible(panel.api.isVisible);
-
             list.push(disposable);
         }
 
         setPanel(props.api.getPanel(props.panelId));
 
-        return () => {
-            list.forEach((l) => l.dispose());
-        };
+        return () => list.forEach((l) => l.dispose());
     }, [props.api, props.panelId]);
 
-    const [visible, setVisible] = React.useState<boolean>(true);
+    const isActive = props.activePanel === props.panelId;
 
     return (
-        <div className="button-action">
-            <div style={{ display: 'flex' }}>
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '3px 16px',
+                minHeight: 28,
+            }}
+        >
+            <button
+                onClick={onClick}
+                style={{
+                    flex: 1,
+                    padding: '3px 8px',
+                    fontSize: 11,
+                    border: '1px solid rgba(255,255,255,0.12)',
+                    borderRadius: 4,
+                    background: isActive
+                        ? 'rgba(72,100,220,0.25)'
+                        : 'rgba(255,255,255,0.04)',
+                    color: isActive ? 'white' : 'rgba(255,255,255,0.7)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                {props.panelId}
+            </button>
+            <div style={{ display: 'flex', gap: 2 }}>
                 <button
-                    className={
-                        props.activePanel === props.panelId
-                            ? 'demo-button selected'
-                            : 'demo-button'
-                    }
-                    onClick={onClick}
-                >
-                    {props.panelId}
-                </button>
-            </div>
-            <div style={{ display: 'flex' }}>
-                <button
-                    className="demo-icon-button"
+                    style={iconBtn}
                     onClick={() => {
-                        const panel = props.api.getPanel(props.panelId);
-                        if (panel) {
-                            props.api.addFloatingGroup(panel);
-                        }
+                        const p = props.api.getPanel(props.panelId);
+                        if (p) props.api.addFloatingGroup(p);
                     }}
+                    title="Float"
                 >
-                    <span className="material-symbols-outlined">ad_group</span>
+                    <span
+                        className="material-symbols-outlined"
+                        style={{ fontSize: 14 }}
+                    >
+                        ad_group
+                    </span>
                 </button>
                 <button
-                    className="demo-icon-button"
+                    style={iconBtn}
                     onClick={() => {
-                        const panel = props.api.getPanel(props.panelId);
-                        if (panel) {
-                            props.api.addPopoutGroup(panel);
-                        }
+                        const p = props.api.getPanel(props.panelId);
+                        if (p) props.api.addPopoutGroup(p);
                     }}
+                    title="Popout"
                 >
-                    <span className="material-symbols-outlined">
+                    <span
+                        className="material-symbols-outlined"
+                        style={{ fontSize: 14 }}
+                    >
                         open_in_new
                     </span>
                 </button>
                 <button
-                    className="demo-icon-button"
+                    style={iconBtn}
                     onClick={() => {
-                        const panel = props.api.getPanel(props.panelId);
-                        panel?.api.close();
+                        const p = props.api.getPanel(props.panelId);
+                        p?.api.close();
                     }}
+                    title="Close"
                 >
-                    <span className="material-symbols-outlined">close</span>
-                </button>
-                <button
-                    title="Panel visiblity cannot be edited manually."
-                    disabled={true}
-                    className="demo-icon-button"
-                >
-                    <span className="material-symbols-outlined">
-                        {visible ? 'visibility' : 'visibility_off'}
+                    <span
+                        className="material-symbols-outlined"
+                        style={{ fontSize: 14 }}
+                    >
+                        close
                     </span>
                 </button>
+                <span
+                    className="material-symbols-outlined"
+                    style={{
+                        fontSize: 14,
+                        color: visible
+                            ? 'rgba(255,255,255,0.4)'
+                            : 'rgba(255,255,255,0.2)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        padding: '0 2px',
+                    }}
+                    title="Visibility (read-only)"
+                >
+                    {visible ? 'visibility' : 'visibility_off'}
+                </span>
             </div>
         </div>
     );
@@ -122,10 +165,10 @@ export const PanelActions = (props: {
     activePanel?: string;
 }) => {
     return (
-        <div className="action-container">
-            {props.panels.map((id) => {
-                return <PanelAction key={id} {...props} panelId={id} />;
-            })}
+        <div style={{ padding: '2px 0' }}>
+            {props.panels.map((id) => (
+                <PanelAction key={id} {...props} panelId={id} />
+            ))}
         </div>
     );
 };

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/settingsModal.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/settingsModal.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { GridActions } from './gridActions';
 import { PanelActions } from './panelActions';
 import { GroupActions } from './groupActions';
-import { ToggleRow } from './toggleRow';
 
 const Section = (props: { title: string; children: React.ReactNode }) => (
     <div style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
@@ -23,9 +22,25 @@ const Section = (props: { title: string; children: React.ReactNode }) => (
     </div>
 );
 
-export const SettingsModal = (props: {
-    open: boolean;
-    onClose: () => void;
+const toggleBtn = (active: boolean): React.CSSProperties => ({
+    padding: '4px 10px',
+    fontSize: 11,
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 4,
+    background: active
+        ? 'rgba(72,100,220,0.25)'
+        : 'rgba(255,255,255,0.04)',
+    borderColor: active
+        ? 'rgba(72,100,220,0.5)'
+        : 'rgba(255,255,255,0.12)',
+    color: active ? 'white' : 'rgba(255,255,255,0.7)',
+    cursor: 'pointer',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 4,
+});
+
+export const ControlsContent = (props: {
     api?: DockviewApi;
     panels: string[];
     groups: string[];
@@ -38,156 +53,86 @@ export const SettingsModal = (props: {
     showLogs: boolean;
     onToggleShowLogs: () => void;
     onClearLogs: () => void;
-    tabAnimation: 'smooth' | 'default';
-    onToggleTabAnimation: (v: 'smooth' | 'default') => void;
 }) => {
-    if (!props.open) return null;
-
     return (
-        <div
-            style={{
-                position: 'absolute',
-                inset: 0,
-                zIndex: 9999,
-                backgroundColor: 'rgba(0,0,0,0.4)',
-            }}
-            onClick={props.onClose}
-        >
-            <div
-                style={{
-                    position: 'absolute',
-                    top: 0,
-                    right: 0,
-                    bottom: 0,
-                    width: '320px',
-                    backgroundColor: '#0d1117',
-                    borderLeft: '1px solid rgba(255,255,255,0.1)',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    overflowY: 'auto',
-                }}
-                onClick={(e) => e.stopPropagation()}
-            >
+        <>
+            <Section title="Grid">
+                <GridActions
+                    api={props.api}
+                    hasCustomWatermark={props.hasCustomWatermark}
+                    toggleCustomWatermark={props.toggleCustomWatermark}
+                />
+            </Section>
+
+            {props.api && props.activePanel && (
+                <Section title="Active Panel">
+                    <PanelActions
+                        api={props.api}
+                        panels={[props.activePanel]}
+                        activePanel={props.activePanel}
+                    />
+                </Section>
+            )}
+
+            {props.api && props.activeGroup && (
+                <Section title="Active Group">
+                    <GroupActions
+                        api={props.api}
+                        groups={[props.activeGroup]}
+                        activeGroup={props.activeGroup}
+                    />
+                </Section>
+            )}
+
+            <Section title="View">
                 <div
                     style={{
-                        padding: '12px 16px',
-                        borderBottom: '1px solid rgba(255,255,255,0.1)',
                         display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        flexShrink: 0,
+                        gap: 6,
+                        padding: '6px 16px 8px',
+                        flexWrap: 'wrap',
                     }}
                 >
-                    <span
-                        style={{
-                            color: 'white',
-                            fontWeight: 600,
-                            fontSize: '14px',
-                        }}
-                    >
-                        Controls
-                    </span>
                     <button
-                        onClick={props.onClose}
-                        style={{
-                            background: 'none',
-                            outline: 'none',
-                            border: 'none',
-                            color: 'rgba(255,255,255,0.6)',
-                            cursor: 'pointer',
-                            padding: '4px',
-                            display: 'flex',
-                            alignItems: 'center',
-                        }}
+                        onClick={props.onToggleDebug}
+                        style={toggleBtn(props.debug)}
                     >
                         <span
                             className="material-symbols-outlined"
-                            style={{ fontSize: '18px' }}
+                            style={{ fontSize: 14 }}
                         >
-                            close
+                            engineering
                         </span>
+                        <span>Debug</span>
                     </button>
-                </div>
-
-                <Section title="Grid">
-                    <GridActions
-                        api={props.api}
-                        hasCustomWatermark={props.hasCustomWatermark}
-                        toggleCustomWatermark={props.toggleCustomWatermark}
-                    />
-                </Section>
-
-                {props.api && props.activePanel && (
-                    <Section title="Active Panel">
-                        <PanelActions
-                            api={props.api}
-                            panels={[props.activePanel]}
-                            activePanel={props.activePanel}
-                        />
-                    </Section>
-                )}
-
-                {props.api && props.activeGroup && (
-                    <Section title="Active Group">
-                        <GroupActions
-                            api={props.api}
-                            groups={[props.activeGroup]}
-                            activeGroup={props.activeGroup}
-                        />
-                    </Section>
-                )}
-
-                <Section title="View">
-                    <div
-                        className="action-container"
-                        style={{ flexWrap: 'wrap', gap: '4px' }}
+                    <button
+                        onClick={props.onToggleShowLogs}
+                        style={toggleBtn(props.showLogs)}
                     >
-                        <button
-                            onClick={props.onToggleDebug}
-                            style={
-                                props.debug
-                                    ? { backgroundColor: '#4864dc' }
-                                    : {}
-                            }
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
                         >
-                            <span className="material-symbols-outlined">
-                                engineering
-                            </span>
-                        </button>
+                            terminal
+                        </span>
+                        <span>Events Log</span>
+                    </button>
+                    {props.showLogs && (
                         <button
-                            onClick={props.onToggleShowLogs}
-                            style={
-                                props.showLogs
-                                    ? { backgroundColor: '#4864dc' }
-                                    : {}
-                            }
+                            onClick={props.onClearLogs}
+                            style={toggleBtn(false)}
                         >
-                            <span style={{ paddingRight: '4px' }}>
-                                Events Log
+                            <span
+                                className="material-symbols-outlined"
+                                style={{ fontSize: 14 }}
+                            >
+                                undo
                             </span>
-                            <span className="material-symbols-outlined">
-                                terminal
-                            </span>
+                            <span>Clear</span>
                         </button>
-                        {props.showLogs && (
-                            <button onClick={props.onClearLogs}>
-                                <span className="material-symbols-outlined">
-                                    undo
-                                </span>
-                            </button>
-                        )}
-                    </div>
-                    <ToggleRow
-                        label="Tab Animation"
-                        value={props.tabAnimation}
-                        options={[
-                            { value: 'default', label: 'default' },
-                            { value: 'smooth', label: 'smooth' },
-                        ]}
-                        onChange={props.onToggleTabAnimation}
-                    />
-                </Section>
-            </div>
-        </div>
+                    )}
+                </div>
+            </Section>
+        </>
     );
 };

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilder.ts
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilder.ts
@@ -1,4 +1,5 @@
 import {
+    TabAnimation,
     DockviewTheme,
     themeAbyss,
     themeAbyssSpaced,
@@ -80,6 +81,7 @@ export interface ThemeBuilderState {
     dndTabIndicator: 'line' | 'fill';
     dndOverlayBorder: string;
     tabGroupIndicator: 'wrap' | 'none';
+    tabAnimation: TabAnimation;
     cssOverrides: ThemeCssOverrides;
 }
 
@@ -93,6 +95,7 @@ export function getInitialStateFromTheme(
         dndTabIndicator: theme.dndTabIndicator ?? 'fill',
         dndOverlayBorder: theme.dndOverlayBorder ?? '',
         tabGroupIndicator: theme.tabGroupIndicator ?? 'wrap',
+        tabAnimation: theme.tabAnimation ?? 'default',
         cssOverrides: {},
     };
 }
@@ -109,6 +112,7 @@ export function buildEffectiveTheme(
         dndTabIndicator: state.dndTabIndicator,
         dndOverlayBorder: state.dndOverlayBorder || undefined,
         tabGroupIndicator: state.tabGroupIndicator,
+        tabAnimation: state.tabAnimation,
     };
 }
 
@@ -151,6 +155,9 @@ export function generateCodeSnippet(
         themeFields.push(
             `  tabGroupIndicator: '${state.tabGroupIndicator}',`
         );
+    }
+    if (state.tabAnimation !== (baseTheme.tabAnimation ?? 'default')) {
+        themeFields.push(`  tabAnimation: '${state.tabAnimation}',`);
     }
 
     let out = `import { ${importName} } from 'dockview';\n\n`;

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilderModal.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilderModal.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { DockviewTheme } from 'dockview';
+import { DockviewApi, DockviewTheme } from 'dockview';
 import {
     ThemeBuilderState,
     ThemeCssOverrides,
     generateCodeSnippet,
 } from './themeBuilder';
 import { ToggleRow } from './toggleRow';
+import { ControlsContent } from './settingsModal';
 
 const Section = (props: { title: string; children: React.ReactNode }) => (
     <div style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
@@ -232,16 +233,77 @@ const ColorRow = (props: {
     );
 };
 
-export const ThemeBuilderModal = (props: {
+type SidebarTab = 'theme' | 'controls';
+
+const TabToggle = (props: {
+    active: SidebarTab;
+    onChange: (tab: SidebarTab) => void;
+}) => {
+    const tabStyle = (tab: SidebarTab): React.CSSProperties => ({
+        flex: 1,
+        padding: '6px 0',
+        fontSize: 11,
+        fontWeight: 600,
+        textTransform: 'uppercase',
+        letterSpacing: '0.05em',
+        cursor: 'pointer',
+        background: 'none',
+        border: 'none',
+        borderBottom:
+            props.active === tab
+                ? '2px solid rgba(255,255,255,0.8)'
+                : '2px solid transparent',
+        color:
+            props.active === tab
+                ? 'rgba(255,255,255,0.9)'
+                : 'rgba(255,255,255,0.4)',
+        outline: 'none',
+        transition: 'color 0.15s, border-color 0.15s',
+    });
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                borderBottom: '1px solid rgba(255,255,255,0.1)',
+            }}
+        >
+            <button style={tabStyle('theme')} onClick={() => props.onChange('theme')}>
+                Theme
+            </button>
+            <button style={tabStyle('controls')} onClick={() => props.onChange('controls')}>
+                Controls
+            </button>
+        </div>
+    );
+};
+
+export const Sidebar = (props: {
     open: boolean;
     onClose: () => void;
+    // Theme builder props
     state: ThemeBuilderState;
     onChange: (patch: Partial<ThemeBuilderState>) => void;
     onCssChange: (patch: Partial<ThemeCssOverrides>) => void;
     onReset: () => void;
     baseTheme: DockviewTheme;
     containerEl: HTMLElement | null;
+    // Controls props
+    api?: DockviewApi;
+    panels: string[];
+    groups: string[];
+    activePanel?: string;
+    activeGroup?: string;
+    hasCustomWatermark: boolean;
+    toggleCustomWatermark: () => void;
+    debug: boolean;
+    onToggleDebug: () => void;
+    showLogs: boolean;
+    onToggleShowLogs: () => void;
+    onClearLogs: () => void;
 }) => {
+    const [activeTab, setActiveTab] = React.useState<SidebarTab>('theme');
+
     const [themeDefaults, setThemeDefaults] = React.useState<
         Record<string, number>
     >({});
@@ -276,7 +338,6 @@ export const ThemeBuilderModal = (props: {
                 ),
             });
         };
-        // RAF ensures dockview's own effects (which swap the CSS class) have run first
         const id = requestAnimationFrame(read);
         return () => cancelAnimationFrame(id);
     }, [props.open, props.containerEl, props.baseTheme]);
@@ -335,40 +396,27 @@ export const ThemeBuilderModal = (props: {
     return (
         <div
             style={{
-                width: '300px',
+                width: '320px',
                 backgroundColor: '#0d1117',
                 borderLeft: '1px solid rgba(255,255,255,0.1)',
                 display: 'flex',
                 flexDirection: 'column',
-                overflowY: 'auto',
                 flexShrink: 0,
             }}
         >
             {/* Header */}
             <div
                 style={{
-                    padding: '12px 16px',
+                    padding: '8px 16px',
                     borderBottom: '1px solid rgba(255,255,255,0.1)',
                     display: 'flex',
-                    justifyContent: 'space-between',
+                    justifyContent: 'flex-end',
                     alignItems: 'center',
                     flexShrink: 0,
-                    position: 'sticky',
-                    top: 0,
                     backgroundColor: '#0d1117',
-                    zIndex: 1,
                 }}
             >
-                <span
-                    style={{
-                        color: 'white',
-                        fontWeight: 600,
-                        fontSize: '14px',
-                    }}
-                >
-                    Theme Builder
-                </span>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                {activeTab === 'theme' && (
                     <button
                         onClick={props.onReset}
                         style={{
@@ -380,395 +428,488 @@ export const ThemeBuilderModal = (props: {
                             cursor: 'pointer',
                             padding: '3px 8px',
                             fontSize: 11,
+                            marginRight: 'auto',
                         }}
                         title="Reset all overrides"
                     >
                         Reset
                     </button>
-                    <button
-                        onClick={props.onClose}
-                        style={{
-                            background: 'none',
-                            outline: 'none',
-                            border: 'none',
-                            color: 'rgba(255,255,255,0.6)',
-                            cursor: 'pointer',
-                            padding: '4px',
-                            display: 'flex',
-                            alignItems: 'center',
-                        }}
-                    >
-                        <span
-                            className="material-symbols-outlined"
-                            style={{ fontSize: '18px' }}
-                        >
-                            close
-                        </span>
-                    </button>
-                </div>
-            </div>
-
-            {/* Layout */}
-            <Section title="Layout">
-                <SliderRow
-                    label="Gap"
-                    value={props.state.gap}
-                    min={0}
-                    max={20}
-                    onChange={(v) => props.onChange({ gap: v })}
-                />
-                <SliderRow
-                    label="Spacing Padding"
-                    value={spacingPadding}
-                    min={0}
-                    max={30}
-                    unit="px"
-                    onChange={(v) => set({ '--dv-spacing-padding': `${v}px` })}
-                />
-                <SliderRow
-                    label="Tab Bar Height"
-                    value={tabH}
-                    min={20}
-                    max={60}
-                    unit="px"
-                    onChange={(v) =>
-                        set({
-                            '--dv-tabs-and-actions-container-height': `${v}px`,
-                        })
-                    }
-                />
-                <SliderRow
-                    label="Font Size"
-                    value={tabFs}
-                    min={10}
-                    max={18}
-                    unit="px"
-                    onChange={(v) =>
-                        set({
-                            '--dv-tabs-and-actions-container-font-size': `${v}px`,
-                        })
-                    }
-                />
-            </Section>
-
-            {/* Radius */}
-            <Section title="Radius">
-                <SliderRow
-                    label="Border Radius"
-                    value={borderRadius}
-                    min={0}
-                    max={20}
-                    unit="px"
-                    onChange={(v) => set({ '--dv-border-radius': `${v}px` })}
-                />
-                <SliderRow
-                    label="Tab Border Radius"
-                    value={tabBorderRadius}
-                    min={0}
-                    max={20}
-                    unit="px"
-                    onChange={(v) =>
-                        set({ '--dv-tab-border-radius': `${v}px` })
-                    }
-                />
-                <SliderRow
-                    label="Sash Border Radius"
-                    value={sashBorderRadius}
-                    min={0}
-                    max={20}
-                    unit="px"
-                    onChange={(v) =>
-                        set({ '--dv-sash-border-radius': `${v}px` })
-                    }
-                />
-            </Section>
-
-            {/* Floating Group */}
-            <Section title="Floating Group">
-                <TextRow
-                    label="Floating Group Border"
-                    varName="--dv-floating-group-border"
-                    value={css['--dv-floating-group-border'] ?? ''}
-                    containerEl={props.containerEl}
-                    themeKey={props.baseTheme.name}
-                    onChange={(v) =>
-                        set({ '--dv-floating-group-border': v || undefined })
-                    }
-                />
-            </Section>
-
-            {/* Tab Groups */}
-            <Section title="Tab Groups">
-                <ToggleRow
-                    label="Group Indicator"
-                    value={props.state.tabGroupIndicator}
-                    options={[
-                        { value: 'wrap', label: 'wrap' },
-                        { value: 'none', label: 'none' },
-                    ]}
-                    onChange={(v) =>
-                        props.onChange({
-                            tabGroupIndicator: v as 'wrap' | 'none',
-                        })
-                    }
-                />
-            </Section>
-
-            {/* DnD */}
-            <Section title="Drag & Drop">
-                <ToggleRow
-                    label="DnD Overlay"
-                    value={props.state.dndOverlayMounting}
-                    options={[
-                        { value: 'relative', label: 'relative' },
-                        { value: 'absolute', label: 'absolute' },
-                    ]}
-                    onChange={(v) =>
-                        props.onChange({
-                            dndOverlayMounting: v as 'relative' | 'absolute',
-                        })
-                    }
-                />
-                <ToggleRow
-                    label="DnD Panel Target"
-                    value={props.state.dndPanelOverlay}
-                    options={[
-                        { value: 'content', label: 'content' },
-                        { value: 'group', label: 'group' },
-                    ]}
-                    onChange={(v) =>
-                        props.onChange({
-                            dndPanelOverlay: v as 'content' | 'group',
-                        })
-                    }
-                />
-                <ToggleRow
-                    label="Tab Indicator"
-                    value={props.state.dndTabIndicator}
-                    options={[
-                        { value: 'fill', label: 'fill' },
-                        { value: 'line', label: 'line' },
-                    ]}
-                    onChange={(v) =>
-                        props.onChange({
-                            dndTabIndicator: v as 'fill' | 'line',
-                        })
-                    }
-                />
-                {colorRow('Drag-over bg', '--dv-drag-over-background-color')}
-                <TextRow
-                    label="Drag-over border"
-                    varName="--dv-drag-over-border"
-                    value={props.state.dndOverlayBorder}
-                    containerEl={props.containerEl}
-                    themeKey={props.baseTheme.name}
-                    onChange={(v) => props.onChange({ dndOverlayBorder: v })}
-                />
-            </Section>
-
-            {/* Backgrounds */}
-            <Section title="Backgrounds">
-                {colorRow(
-                    'Panel background',
-                    '--dv-group-view-background-color'
                 )}
-                {colorRow(
-                    'Tab bar background',
-                    '--dv-tabs-and-actions-container-background-color'
-                )}
-                {colorRow('Separator', '--dv-separator-border')}
-                {colorRow(
-                    'Pane header border',
-                    '--dv-paneview-header-border-color'
-                )}
-            </Section>
-
-            {/* Active Group Tabs */}
-            <Section title="Active Group Tabs">
-                {colorRow(
-                    'Visible tab bg',
-                    '--dv-activegroup-visiblepanel-tab-background-color'
-                )}
-                {colorRow(
-                    'Hidden tab bg',
-                    '--dv-activegroup-hiddenpanel-tab-background-color'
-                )}
-                {colorRow(
-                    'Visible tab text',
-                    '--dv-activegroup-visiblepanel-tab-color'
-                )}
-                {colorRow(
-                    'Hidden tab text',
-                    '--dv-activegroup-hiddenpanel-tab-color'
-                )}
-            </Section>
-
-            {/* Inactive Group Tabs */}
-            <Section title="Inactive Group Tabs">
-                {colorRow(
-                    'Visible tab bg',
-                    '--dv-inactivegroup-visiblepanel-tab-background-color'
-                )}
-                {colorRow(
-                    'Hidden tab bg',
-                    '--dv-inactivegroup-hiddenpanel-tab-background-color'
-                )}
-                {colorRow(
-                    'Visible tab text',
-                    '--dv-inactivegroup-visiblepanel-tab-color'
-                )}
-                {colorRow(
-                    'Hidden tab text',
-                    '--dv-inactivegroup-hiddenpanel-tab-color'
-                )}
-            </Section>
-
-            {/* Chrome */}
-            <Section title="Chrome">
-                {colorRow('Tab divider', '--dv-tab-divider-color')}
-                {colorRow('Icon hover bg', '--dv-icon-hover-background-color')}
-                {colorRow('Active sash', '--dv-active-sash-color')}
-                {colorRow('Sash', '--dv-sash-color')}
-                {colorRow('Scrollbar', '--dv-scrollbar-background-color')}
-            </Section>
-
-            {/* Floating */}
-            <Section title="Floating">
-                <div
+                <button
+                    onClick={props.onClose}
                     style={{
+                        background: 'none',
+                        outline: 'none',
+                        border: 'none',
+                        color: 'rgba(255,255,255,0.6)',
+                        cursor: 'pointer',
+                        padding: '4px',
                         display: 'flex',
                         alignItems: 'center',
-                        gap: 8,
-                        padding: '4px 16px',
-                        minHeight: 30,
+                        marginLeft: activeTab !== 'theme' ? 'auto' : undefined,
                     }}
                 >
                     <span
-                        style={{
-                            flex: 1,
-                            fontSize: 11,
-                            color: 'rgba(255,255,255,0.7)',
-                        }}
+                        className="material-symbols-outlined"
+                        style={{ fontSize: '18px' }}
                     >
-                        Dragging Opacity
+                        close
                     </span>
-                    <input
-                        type="range"
-                        min={0}
-                        max={1}
-                        step={0.05}
-                        value={draggingOpacity}
-                        onChange={(e) =>
-                            set({
-                                '--dv-floating-group-dragging-opacity':
-                                    e.target.value,
-                            })
-                        }
-                        style={{ width: 90 }}
-                    />
-                    <span
-                        style={{
-                            width: 36,
-                            textAlign: 'right',
-                            fontSize: 11,
-                            color: 'rgba(255,255,255,0.5)',
-                            fontFamily: 'monospace',
-                        }}
-                    >
-                        {draggingOpacity.toFixed(2)}
-                    </span>
-                </div>
-                <TextRow
-                    label="Box Shadow"
-                    varName="--dv-floating-box-shadow"
-                    value={css['--dv-floating-box-shadow'] ?? ''}
-                    containerEl={props.containerEl}
-                    themeKey={props.baseTheme.name}
-                    onChange={(v) =>
-                        set({
-                            '--dv-floating-box-shadow': v || undefined,
-                        })
-                    }
-                />
-                <TextRow
-                    label="Border"
-                    varName="--dv-floating-border"
-                    value={css['--dv-floating-border'] ?? ''}
-                    containerEl={props.containerEl}
-                    themeKey={props.baseTheme.name}
-                    onChange={(v) =>
-                        set({
-                            '--dv-floating-border': v || undefined,
-                        })
-                    }
-                />
-            </Section>
+                </button>
+            </div>
 
-            {/* Export */}
-            <Section title="Export">
-                <div style={{ padding: '0 16px 8px' }}>
-                    <button
-                        onClick={() => setShowExport((v) => !v)}
-                        style={{
-                            background: 'rgba(255,255,255,0.05)',
-                            border: '1px solid rgba(255,255,255,0.1)',
-                            borderRadius: 4,
-                            color: 'rgba(255,255,255,0.7)',
-                            cursor: 'pointer',
-                            padding: '4px 10px',
-                            fontSize: 11,
-                            marginBottom: showExport ? 8 : 0,
-                        }}
-                    >
-                        {showExport ? 'Hide' : 'Show'} code
-                    </button>
-                    {showExport && (
-                        <div>
-                            <pre
+            {/* Tab Toggle */}
+            <TabToggle active={activeTab} onChange={setActiveTab} />
+
+            {/* Scrollable content */}
+            <div style={{ flexGrow: 1, overflowY: 'auto' }}>
+                {activeTab === 'theme' ? (
+                    <>
+                        {/* Layout */}
+                        <Section title="Layout">
+                            <SliderRow
+                                label="Gap"
+                                value={props.state.gap}
+                                min={0}
+                                max={20}
+                                onChange={(v) => props.onChange({ gap: v })}
+                            />
+                            <SliderRow
+                                label="Spacing Padding"
+                                value={spacingPadding}
+                                min={0}
+                                max={30}
+                                unit="px"
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-spacing-padding': `${v}px`,
+                                    })
+                                }
+                            />
+                            <SliderRow
+                                label="Tab Bar Height"
+                                value={tabH}
+                                min={20}
+                                max={60}
+                                unit="px"
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-tabs-and-actions-container-height': `${v}px`,
+                                    })
+                                }
+                            />
+                            <SliderRow
+                                label="Font Size"
+                                value={tabFs}
+                                min={10}
+                                max={18}
+                                unit="px"
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-tabs-and-actions-container-font-size': `${v}px`,
+                                    })
+                                }
+                            />
+                        </Section>
+
+                        {/* Radius */}
+                        <Section title="Radius">
+                            <SliderRow
+                                label="Border Radius"
+                                value={borderRadius}
+                                min={0}
+                                max={20}
+                                unit="px"
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-border-radius': `${v}px`,
+                                    })
+                                }
+                            />
+                            <SliderRow
+                                label="Tab Border Radius"
+                                value={tabBorderRadius}
+                                min={0}
+                                max={20}
+                                unit="px"
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-tab-border-radius': `${v}px`,
+                                    })
+                                }
+                            />
+                            <SliderRow
+                                label="Sash Border Radius"
+                                value={sashBorderRadius}
+                                min={0}
+                                max={20}
+                                unit="px"
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-sash-border-radius': `${v}px`,
+                                    })
+                                }
+                            />
+                        </Section>
+
+                        {/* Floating Group */}
+                        <Section title="Floating Group">
+                            <TextRow
+                                label="Floating Group Border"
+                                varName="--dv-floating-group-border"
+                                value={css['--dv-floating-group-border'] ?? ''}
+                                containerEl={props.containerEl}
+                                themeKey={props.baseTheme.name}
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-floating-group-border':
+                                            v || undefined,
+                                    })
+                                }
+                            />
+                        </Section>
+
+                        {/* Tabs */}
+                        <Section title="Tabs">
+                            <ToggleRow
+                                label="Tab Animation"
+                                value={props.state.tabAnimation}
+                                options={[
+                                    { value: 'default', label: 'default' },
+                                    { value: 'smooth', label: 'smooth' },
+                                ]}
+                                onChange={(v) =>
+                                    props.onChange({
+                                        tabAnimation: v as
+                                            | 'smooth'
+                                            | 'default',
+                                    })
+                                }
+                            />
+                        </Section>
+
+                        {/* Tab Groups */}
+                        <Section title="Tab Groups">
+                            <ToggleRow
+                                label="Group Indicator"
+                                value={props.state.tabGroupIndicator}
+                                options={[
+                                    { value: 'wrap', label: 'wrap' },
+                                    { value: 'none', label: 'none' },
+                                ]}
+                                onChange={(v) =>
+                                    props.onChange({
+                                        tabGroupIndicator: v as
+                                            | 'wrap'
+                                            | 'none',
+                                    })
+                                }
+                            />
+                        </Section>
+
+                        {/* DnD */}
+                        <Section title="Drag & Drop">
+                            <ToggleRow
+                                label="DnD Overlay"
+                                value={props.state.dndOverlayMounting}
+                                options={[
+                                    {
+                                        value: 'relative',
+                                        label: 'relative',
+                                    },
+                                    {
+                                        value: 'absolute',
+                                        label: 'absolute',
+                                    },
+                                ]}
+                                onChange={(v) =>
+                                    props.onChange({
+                                        dndOverlayMounting: v as
+                                            | 'relative'
+                                            | 'absolute',
+                                    })
+                                }
+                            />
+                            <ToggleRow
+                                label="DnD Panel Target"
+                                value={props.state.dndPanelOverlay}
+                                options={[
+                                    { value: 'content', label: 'content' },
+                                    { value: 'group', label: 'group' },
+                                ]}
+                                onChange={(v) =>
+                                    props.onChange({
+                                        dndPanelOverlay: v as
+                                            | 'content'
+                                            | 'group',
+                                    })
+                                }
+                            />
+                            <ToggleRow
+                                label="Tab Indicator"
+                                value={props.state.dndTabIndicator}
+                                options={[
+                                    { value: 'fill', label: 'fill' },
+                                    { value: 'line', label: 'line' },
+                                ]}
+                                onChange={(v) =>
+                                    props.onChange({
+                                        dndTabIndicator: v as 'fill' | 'line',
+                                    })
+                                }
+                            />
+                            {colorRow(
+                                'Drag-over bg',
+                                '--dv-drag-over-background-color'
+                            )}
+                            <TextRow
+                                label="Drag-over border"
+                                varName="--dv-drag-over-border"
+                                value={props.state.dndOverlayBorder}
+                                containerEl={props.containerEl}
+                                themeKey={props.baseTheme.name}
+                                onChange={(v) =>
+                                    props.onChange({ dndOverlayBorder: v })
+                                }
+                            />
+                        </Section>
+
+                        {/* Backgrounds */}
+                        <Section title="Backgrounds">
+                            {colorRow(
+                                'Panel background',
+                                '--dv-group-view-background-color'
+                            )}
+                            {colorRow(
+                                'Tab bar background',
+                                '--dv-tabs-and-actions-container-background-color'
+                            )}
+                            {colorRow('Separator', '--dv-separator-border')}
+                            {colorRow(
+                                'Pane header border',
+                                '--dv-paneview-header-border-color'
+                            )}
+                        </Section>
+
+                        {/* Active Group Tabs */}
+                        <Section title="Active Group Tabs">
+                            {colorRow(
+                                'Visible tab bg',
+                                '--dv-activegroup-visiblepanel-tab-background-color'
+                            )}
+                            {colorRow(
+                                'Hidden tab bg',
+                                '--dv-activegroup-hiddenpanel-tab-background-color'
+                            )}
+                            {colorRow(
+                                'Visible tab text',
+                                '--dv-activegroup-visiblepanel-tab-color'
+                            )}
+                            {colorRow(
+                                'Hidden tab text',
+                                '--dv-activegroup-hiddenpanel-tab-color'
+                            )}
+                        </Section>
+
+                        {/* Inactive Group Tabs */}
+                        <Section title="Inactive Group Tabs">
+                            {colorRow(
+                                'Visible tab bg',
+                                '--dv-inactivegroup-visiblepanel-tab-background-color'
+                            )}
+                            {colorRow(
+                                'Hidden tab bg',
+                                '--dv-inactivegroup-hiddenpanel-tab-background-color'
+                            )}
+                            {colorRow(
+                                'Visible tab text',
+                                '--dv-inactivegroup-visiblepanel-tab-color'
+                            )}
+                            {colorRow(
+                                'Hidden tab text',
+                                '--dv-inactivegroup-hiddenpanel-tab-color'
+                            )}
+                        </Section>
+
+                        {/* Chrome */}
+                        <Section title="Chrome">
+                            {colorRow(
+                                'Tab divider',
+                                '--dv-tab-divider-color'
+                            )}
+                            {colorRow(
+                                'Icon hover bg',
+                                '--dv-icon-hover-background-color'
+                            )}
+                            {colorRow(
+                                'Active sash',
+                                '--dv-active-sash-color'
+                            )}
+                            {colorRow('Sash', '--dv-sash-color')}
+                            {colorRow(
+                                'Scrollbar',
+                                '--dv-scrollbar-background-color'
+                            )}
+                        </Section>
+
+                        {/* Floating */}
+                        <Section title="Floating">
+                            <div
                                 style={{
-                                    background: 'rgba(0,0,0,0.3)',
-                                    border: '1px solid rgba(255,255,255,0.1)',
-                                    borderRadius: 4,
-                                    padding: '8px 10px',
-                                    fontSize: 10.5,
-                                    color: 'rgba(255,255,255,0.7)',
-                                    overflow: 'auto',
-                                    fontFamily: 'monospace',
-                                    whiteSpace: 'pre',
-                                    margin: 0,
-                                    maxHeight: 240,
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 8,
+                                    padding: '4px 16px',
+                                    minHeight: 30,
                                 }}
                             >
-                                {code}
-                            </pre>
-                            <button
-                                onClick={handleCopy}
-                                style={{
-                                    marginTop: 6,
-                                    background: copied
-                                        ? 'rgba(74,222,128,0.15)'
-                                        : 'rgba(255,255,255,0.05)',
-                                    border: `1px solid ${
-                                        copied
-                                            ? 'rgba(74,222,128,0.3)'
-                                            : 'rgba(255,255,255,0.1)'
-                                    }`,
-                                    borderRadius: 4,
-                                    color: copied
-                                        ? '#4ade80'
-                                        : 'rgba(255,255,255,0.7)',
-                                    cursor: 'pointer',
-                                    padding: '4px 10px',
-                                    fontSize: 11,
-                                    width: '100%',
-                                }}
-                            >
-                                {copied ? 'Copied!' : 'Copy to clipboard'}
-                            </button>
-                        </div>
-                    )}
-                </div>
-            </Section>
+                                <span
+                                    style={{
+                                        flex: 1,
+                                        fontSize: 11,
+                                        color: 'rgba(255,255,255,0.7)',
+                                    }}
+                                >
+                                    Dragging Opacity
+                                </span>
+                                <input
+                                    type="range"
+                                    min={0}
+                                    max={1}
+                                    step={0.05}
+                                    value={draggingOpacity}
+                                    onChange={(e) =>
+                                        set({
+                                            '--dv-floating-group-dragging-opacity':
+                                                e.target.value,
+                                        })
+                                    }
+                                    style={{ width: 90 }}
+                                />
+                                <span
+                                    style={{
+                                        width: 36,
+                                        textAlign: 'right',
+                                        fontSize: 11,
+                                        color: 'rgba(255,255,255,0.5)',
+                                        fontFamily: 'monospace',
+                                    }}
+                                >
+                                    {draggingOpacity.toFixed(2)}
+                                </span>
+                            </div>
+                            <TextRow
+                                label="Box Shadow"
+                                varName="--dv-floating-box-shadow"
+                                value={css['--dv-floating-box-shadow'] ?? ''}
+                                containerEl={props.containerEl}
+                                themeKey={props.baseTheme.name}
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-floating-box-shadow':
+                                            v || undefined,
+                                    })
+                                }
+                            />
+                            <TextRow
+                                label="Border"
+                                varName="--dv-floating-border"
+                                value={css['--dv-floating-border'] ?? ''}
+                                containerEl={props.containerEl}
+                                themeKey={props.baseTheme.name}
+                                onChange={(v) =>
+                                    set({
+                                        '--dv-floating-border': v || undefined,
+                                    })
+                                }
+                            />
+                        </Section>
+
+                        {/* Export */}
+                        <Section title="Export">
+                            <div style={{ padding: '0 16px 8px' }}>
+                                <button
+                                    onClick={() => setShowExport((v) => !v)}
+                                    style={{
+                                        background: 'rgba(255,255,255,0.05)',
+                                        border: '1px solid rgba(255,255,255,0.1)',
+                                        borderRadius: 4,
+                                        color: 'rgba(255,255,255,0.7)',
+                                        cursor: 'pointer',
+                                        padding: '4px 10px',
+                                        fontSize: 11,
+                                        marginBottom: showExport ? 8 : 0,
+                                    }}
+                                >
+                                    {showExport ? 'Hide' : 'Show'} code
+                                </button>
+                                {showExport && (
+                                    <div>
+                                        <pre
+                                            style={{
+                                                background: 'rgba(0,0,0,0.3)',
+                                                border: '1px solid rgba(255,255,255,0.1)',
+                                                borderRadius: 4,
+                                                padding: '8px 10px',
+                                                fontSize: 10.5,
+                                                color: 'rgba(255,255,255,0.7)',
+                                                overflow: 'auto',
+                                                fontFamily: 'monospace',
+                                                whiteSpace: 'pre',
+                                                margin: 0,
+                                                maxHeight: 240,
+                                            }}
+                                        >
+                                            {code}
+                                        </pre>
+                                        <button
+                                            onClick={handleCopy}
+                                            style={{
+                                                marginTop: 6,
+                                                background: copied
+                                                    ? 'rgba(74,222,128,0.15)'
+                                                    : 'rgba(255,255,255,0.05)',
+                                                border: `1px solid ${
+                                                    copied
+                                                        ? 'rgba(74,222,128,0.3)'
+                                                        : 'rgba(255,255,255,0.1)'
+                                                }`,
+                                                borderRadius: 4,
+                                                color: copied
+                                                    ? '#4ade80'
+                                                    : 'rgba(255,255,255,0.7)',
+                                                cursor: 'pointer',
+                                                padding: '4px 10px',
+                                                fontSize: 11,
+                                                width: '100%',
+                                            }}
+                                        >
+                                            {copied
+                                                ? 'Copied!'
+                                                : 'Copy to clipboard'}
+                                        </button>
+                                    </div>
+                                )}
+                            </div>
+                        </Section>
+                    </>
+                ) : (
+                    <ControlsContent
+                        api={props.api}
+                        panels={props.panels}
+                        groups={props.groups}
+                        activePanel={props.activePanel}
+                        activeGroup={props.activeGroup}
+                        hasCustomWatermark={props.hasCustomWatermark}
+                        toggleCustomWatermark={props.toggleCustomWatermark}
+                        debug={props.debug}
+                        onToggleDebug={props.onToggleDebug}
+                        showLogs={props.showLogs}
+                        onToggleShowLogs={props.onToggleShowLogs}
+                        onClearLogs={props.onClearLogs}
+                    />
+                )}
+            </div>
         </div>
     );
 };

--- a/packages/docs/sandboxes/react/dockview/tabview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/tabview/src/app.tsx
@@ -2,7 +2,10 @@ import {
     DockviewApi,
     DockviewReact,
     DockviewReadyEvent,
+    DockviewTheme,
     IDockviewPanelProps,
+    themeAbyss,
+    TabAnimation,
 } from 'dockview';
 import * as React from 'react';
 
@@ -20,12 +23,15 @@ const components = {
 
 const Component = (props: { theme?: string }) => {
     const [api, setApi] = React.useState<DockviewApi>();
-    const [tabAnimation, setTabAnimation] = React.useState<'smooth' | 'default'>('default');
+    const [tabAnimation, setTabAnimation] = React.useState<TabAnimation>('default');
+
+    const theme: DockviewTheme = React.useMemo(
+        () => ({ ...themeAbyss, tabAnimation }),
+        [tabAnimation]
+    );
 
     const toggleMode = () => {
-        const next = tabAnimation === 'smooth' ? 'default' : 'smooth';
-        setTabAnimation(next);
-        api?.updateOptions({ tabAnimation: next });
+        setTabAnimation((prev) => (prev === 'smooth' ? 'default' : 'smooth'));
     };
 
     React.useEffect(() => {
@@ -101,7 +107,7 @@ const Component = (props: { theme?: string }) => {
                     className={`${props.theme || 'dockview-theme-abyss'}`}
                     onReady={onReady}
                     components={components}
-                    tabAnimation={tabAnimation}
+                    theme={theme}
                     disableFloatingGroups={true}
                 />
             </div>

--- a/packages/docs/src/pages/demo.tsx
+++ b/packages/docs/src/pages/demo.tsx
@@ -19,8 +19,7 @@ const updateTheme = (theme: DockviewTheme) => {
 
 const DemoPage: React.FC = () => {
     const [theme, setTheme] = React.useState<DockviewTheme>(themeAbyss);
-    const [showSettings, setShowSettings] = React.useState(false);
-    const [showThemeBuilder, setShowThemeBuilder] = React.useState(false);
+    const [showSidebar, setShowSidebar] = React.useState(false);
 
     React.useEffect(() => {
         const urlParams = new URLSearchParams(window.location.search);
@@ -89,54 +88,8 @@ const DemoPage: React.FC = () => {
                 <div className={styles.divider} />
                 <button
                     className={styles.iconButton}
-                    title="Theme Builder"
-                    onClick={() => setShowThemeBuilder(true)}
-                >
-                    <svg
-                        width="16"
-                        height="16"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                    >
-                        <circle
-                            cx="13.5"
-                            cy="6.5"
-                            r=".5"
-                            fill="currentColor"
-                            stroke="none"
-                        />
-                        <circle
-                            cx="17.5"
-                            cy="10.5"
-                            r=".5"
-                            fill="currentColor"
-                            stroke="none"
-                        />
-                        <circle
-                            cx="8.5"
-                            cy="7.5"
-                            r=".5"
-                            fill="currentColor"
-                            stroke="none"
-                        />
-                        <circle
-                            cx="6.5"
-                            cy="12.5"
-                            r=".5"
-                            fill="currentColor"
-                            stroke="none"
-                        />
-                        <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z" />
-                    </svg>
-                </button>
-                <button
-                    className={styles.iconButton}
-                    title="Controls"
-                    onClick={() => setShowSettings(true)}
+                    title={showSidebar ? 'Close sidebar' : 'Open sidebar'}
+                    onClick={() => setShowSidebar((v) => !v)}
                 >
                     <svg
                         width="16"
@@ -181,10 +134,8 @@ const DemoPage: React.FC = () => {
                 height="100%"
                 id="dockview/demo-dockview"
                 extraProps={{
-                    showSettings,
-                    onCloseSettings: () => setShowSettings(false),
-                    showThemeBuilder,
-                    onCloseThemeBuilder: () => setShowThemeBuilder(false),
+                    showSidebar,
+                    onCloseSidebar: () => setShowSidebar(false),
                     onChangeTheme: (t: DockviewTheme) => {
                         setTheme(t);
                         updateTheme(t);

--- a/packages/docs/templates/dockview/tab-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/tab-groups/react/src/app.tsx
@@ -5,6 +5,7 @@ import {
     DockviewApi,
     GetTabContextMenuItemsParams,
     GetTabGroupChipContextMenuItemsParams,
+    themeAbyss,
 } from 'dockview';
 import React from 'react';
 import {
@@ -158,7 +159,7 @@ export default () => {
                 className={'dockview-theme-abyss'}
                 onReady={onReady}
                 components={components}
-                tabAnimation={'smooth'}
+                theme={{ ...themeAbyss, tabAnimation: 'smooth' }}
                 disableFloatingGroups={true}
                 getTabContextMenuItems={getTabContextMenuItems}
                 getTabGroupChipContextMenuItems={

--- a/packages/docs/templates/dockview/tabview/react/src/app.tsx
+++ b/packages/docs/templates/dockview/tabview/react/src/app.tsx
@@ -2,7 +2,10 @@ import {
     DockviewApi,
     DockviewReact,
     DockviewReadyEvent,
+    DockviewTheme,
     IDockviewPanelProps,
+    themeAbyss,
+    TabAnimation,
 } from 'dockview';
 import React from 'react';
 
@@ -20,12 +23,15 @@ const components = {
 
 const Component = (props: { theme?: string }) => {
     const [api, setApi] = React.useState<DockviewApi>();
-    const [tabAnimation, setTabAnimation] = React.useState<'smooth' | 'default'>('default');
+    const [tabAnimation, setTabAnimation] = React.useState<TabAnimation>('default');
+
+    const theme: DockviewTheme = React.useMemo(
+        () => ({ ...themeAbyss, tabAnimation }),
+        [tabAnimation]
+    );
 
     const toggleMode = () => {
-        const next = tabAnimation === 'smooth' ? 'default' : 'smooth';
-        setTabAnimation(next);
-        api?.updateOptions({ tabAnimation: next });
+        setTabAnimation((prev) => (prev === 'smooth' ? 'default' : 'smooth'));
     };
 
     React.useEffect(() => {
@@ -94,7 +100,7 @@ const Component = (props: { theme?: string }) => {
                     className={`${props.theme || 'dockview-theme-abyss'}`}
                     onReady={onReady}
                     components={components}
-                    tabAnimation={tabAnimation}
+                    theme={theme}
                     disableFloatingGroups={true}
                 />
             </div>


### PR DESCRIPTION
Move tabAnimation from DockviewOptions to DockviewTheme so it sits alongside other visual/behavioral theme properties like dndTabIndicator and tabGroupIndicator. Merge the settings modal and theme builder into a single collapsible sidebar with a Theme/Controls tab toggle, and restyle the controls components to match the sidebar aesthetic.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
