### PR TITLE
fix: prevent edge groups from being floated or popped out

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
@@ -536,6 +536,55 @@ describe('tabsContainer', () => {
         expect(eventPreventDefaultSpy2).toHaveBeenCalledTimes(0);
     });
 
+    test('that an edge group cannot be floated via shift+click', () => {
+        const accessor = fromPartial<DockviewComponent>({
+            options: {},
+            onDidAddPanel: jest.fn(),
+            onDidRemovePanel: jest.fn(),
+            element: document.createElement('div'),
+            addFloatingGroup: jest.fn(),
+            doSetGroupActive: jest.fn(),
+            onDidOptionsChange: jest
+                .fn()
+                .mockReturnValue({ dispose: jest.fn() }),
+        });
+
+        const groupPanelMock = jest.fn<DockviewGroupPanel, []>(() => {
+            return (<Partial<DockviewGroupPanel>>{
+                api: {
+                    location: { type: 'edge', position: 'left' },
+                } as any,
+            }) as DockviewGroupPanel;
+        });
+
+        const groupPanel = new groupPanelMock();
+
+        const cut = new TabsContainer(accessor, groupPanel);
+
+        const container = cut.element.querySelector('.dv-void-container')!;
+        expect(container).toBeTruthy();
+
+        jest.spyOn(cut.element, 'getBoundingClientRect').mockImplementation(
+            () => {
+                return { top: 50, left: 100, width: 0, height: 0 } as any;
+            }
+        );
+        jest.spyOn(
+            accessor.element,
+            'getBoundingClientRect'
+        ).mockImplementation(() => {
+            return { top: 10, left: 20, width: 0, height: 0 } as any;
+        });
+
+        const event = new KeyboardEvent('pointerdown', { shiftKey: true });
+        const eventPreventDefaultSpy = jest.spyOn(event, 'preventDefault');
+        fireEvent(container, event);
+
+        expect(accessor.doSetGroupActive).toHaveBeenCalledWith(groupPanel);
+        expect(accessor.addFloatingGroup).toHaveBeenCalledTimes(0);
+        expect(eventPreventDefaultSpy).toHaveBeenCalledTimes(0);
+    });
+
     test('that a tab that is already floating cannot be floated again', () => {
         const accessor = fromPartial<DockviewComponent>({
             options: {},

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -9680,6 +9680,43 @@ describe('dockviewComponent', () => {
             dv.dispose();
         });
 
+        test('edge group cannot be floated via addFloatingGroup', () => {
+            const c = document.createElement('div');
+            const dv = createFixedDockview(c, ['left']);
+
+            const edgeGroupApi = dv.getEdgeGroup('left')!;
+            const edgeGroup = dv.groups.find((g) => g.id === 'left-group')!;
+
+            expect(edgeGroupApi.location.type).toBe('edge');
+
+            // attempt to float the edge group — should be a no-op
+            dv.addFloatingGroup(edgeGroup);
+
+            // group should still be an edge group, not floating
+            expect(edgeGroupApi.location.type).toBe('edge');
+            expect(dv.groups.length).toBeGreaterThanOrEqual(1);
+
+            dv.dispose();
+        });
+
+        test('edge group cannot be popped out via addPopoutGroup', async () => {
+            const c = document.createElement('div');
+            const dv = createFixedDockview(c, ['left']);
+
+            const edgeGroupApi = dv.getEdgeGroup('left')!;
+            const edgeGroup = dv.groups.find((g) => g.id === 'left-group')!;
+
+            expect(edgeGroupApi.location.type).toBe('edge');
+
+            // attempt to popout the edge group — should return false
+            const result = await dv.addPopoutGroup(edgeGroup);
+
+            expect(result).toBe(false);
+            expect(edgeGroupApi.location.type).toBe('edge');
+
+            dv.dispose();
+        });
+
         test('fromJSON auto-creates edge groups from serialized state', () => {
             const c = document.createElement('div');
             // No addEdgeGroup called before fromJSON

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -274,7 +274,8 @@ export class TabsContainer
                     if (
                         isFloatingGroupsEnabled &&
                         event.shiftKey &&
-                        this.group.api.location.type !== 'floating'
+                        this.group.api.location.type !== 'floating' &&
+                        this.group.api.location.type !== 'edge'
                     ) {
                         event.preventDefault();
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -795,6 +795,14 @@ export class DockviewComponent
         options?: DockviewPopoutGroupOptions
     ): Promise<boolean> {
         if (
+            itemToPopout instanceof DockviewGroupPanel &&
+            itemToPopout.model.location.type === 'edge'
+        ) {
+            // edge groups are permanent structural elements and cannot be popped out
+            return Promise.resolve(false);
+        }
+
+        if (
             itemToPopout instanceof DockviewPanel &&
             itemToPopout.group.size === 1
         ) {
@@ -1140,6 +1148,14 @@ export class DockviewComponent
         item: DockviewPanel | DockviewGroupPanel,
         options?: FloatingGroupOptionsInternal
     ): void {
+        if (
+            item instanceof DockviewGroupPanel &&
+            item.model.location.type === 'edge'
+        ) {
+            // edge groups are permanent structural elements and cannot be floated
+            return;
+        }
+
         let group: DockviewGroupPanel;
 
         if (item instanceof DockviewPanel) {


### PR DESCRIPTION
Edge groups are permanent structural elements. Floating or popping them out caused broken state because doRemoveGroup silently skips edge groups, leaving them in both the grid and the floating/popout overlay.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
