### PR TITLE
Fix/tab group indicator none border bleed

### DIFF
--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -135,9 +135,6 @@ export class TabGroupManager {
             return;
         }
 
-        const groupPanelIds = new Set(tabGroup.panelIds);
-        const underlineEl = this._indicator?.getUnderline(tabGroup.id);
-
         const isVertical = this._ctx.getDirection() === 'vertical';
 
         // Clone the entire tabs list so cloned nodes inherit all
@@ -158,41 +155,16 @@ export class TabGroupManager {
         clone.style.overflow = 'visible';
         clone.style.pointerEvents = 'none';
 
-        // Remove elements not belonging to this group.
-        // Keep: chip, group tabs, group underline.
-        // Walk backwards so removals don't shift indices.
+        // Remove all elements except the chip so the drag ghost
+        // shows only the chip regardless of the group's expanded state.
         const children = Array.from(clone.children);
         const realChildren = Array.from(this._ctx.tabsList.children);
         for (let i = children.length - 1; i >= 0; i--) {
             const real = realChildren[i];
-            if (!real) {
-                children[i].remove();
-                continue;
-            }
-            if (real === chipEl || real === underlineEl) {
-                continue; // keep the chip and underline
-            }
-            if (real.classList.contains('dv-tab')) {
-                const tabEntry = this._ctx
-                    .getTabs()
-                    .find((t) => t.value.element === real);
-                if (tabEntry && groupPanelIds.has(tabEntry.value.panel.id)) {
-                    continue; // keep
-                }
+            if (real === chipEl) {
+                continue; // keep the chip only
             }
             children[i].remove();
-        }
-
-        // Re-position the underline clone as a simple bottom line for the drag ghost
-        const underlineClone = clone.querySelector('.dv-tab-group-underline');
-        if (underlineClone instanceof HTMLElement) {
-            underlineClone.innerHTML = '';
-            underlineClone.style.left = '0px';
-            underlineClone.style.width = '100%';
-            underlineClone.style.top = 'auto';
-            underlineClone.style.bottom = '0';
-            underlineClone.style.height = '2px';
-            underlineClone.style.backgroundColor = `var(--dv-tab-group-color-${tabGroup.color})`;
         }
 
         // Wrap the clone in a minimal ancestor chain so that CSS

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -154,7 +154,6 @@
     line-height: 1;
 
     &.dv-tab-group-chip--collapsed {
-        opacity: 0.7;
     }
 
     &.dv-tab-group-chip--shifting {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -310,13 +310,12 @@ export class Tabs extends CompositeDisposable {
                             if (data.tabGroupId) {
                                 // External group drag — look up the
                                 // source tab group to size the gap
-                                const sourceGroup =
-                                    this.accessor.getPanel(data.groupId);
+                                const sourceGroup = this.accessor.getPanel(
+                                    data.groupId
+                                );
                                 const sourceTg = sourceGroup?.model
                                     .getTabGroups()
-                                    .find(
-                                        (tg) => tg.id === data.tabGroupId
-                                    );
+                                    .find((tg) => tg.id === data.tabGroupId);
                                 const panelCount =
                                     sourceTg?.panelIds.length ?? 1;
                                 const groupGapWidth =
@@ -325,8 +324,7 @@ export class Tabs extends CompositeDisposable {
                                 this._animState = {
                                     sourceTabId: '',
                                     sourceIndex: -1,
-                                    tabPositions:
-                                        this.snapshotTabPositions(),
+                                    tabPositions: this.snapshotTabPositions(),
                                     chipPositions:
                                         this._tabGroupManager.snapshotChipWidths(),
                                     currentInsertionIndex: null,
@@ -336,8 +334,7 @@ export class Tabs extends CompositeDisposable {
                                         ? new Set(sourceTg.panelIds)
                                         : new Set<string>(),
                                     sourceChipWidth: avgWidth,
-                                    cursorOffsetFromDragLeft:
-                                        groupGapWidth / 2,
+                                    cursorOffsetFromDragLeft: groupGapWidth / 2,
                                     sourceGapWidth: groupGapWidth,
                                     containerLeft:
                                         this._tabsList.getBoundingClientRect()
@@ -347,8 +344,7 @@ export class Tabs extends CompositeDisposable {
                                 this._animState = {
                                     sourceTabId: data.panelId!,
                                     sourceIndex: -1,
-                                    tabPositions:
-                                        this.snapshotTabPositions(),
+                                    tabPositions: this.snapshotTabPositions(),
                                     chipPositions:
                                         this._tabGroupManager.snapshotChipWidths(),
                                     currentInsertionIndex: null,
@@ -356,8 +352,7 @@ export class Tabs extends CompositeDisposable {
                                     sourceTabGroupId: null,
                                     sourceGroupPanelIds: null,
                                     sourceChipWidth: 0,
-                                    cursorOffsetFromDragLeft:
-                                        avgWidth / 2,
+                                    cursorOffsetFromDragLeft: avgWidth / 2,
                                     sourceGapWidth: avgWidth,
                                     containerLeft:
                                         this._tabsList.getBoundingClientRect()

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -302,26 +302,68 @@ export class Tabs extends CompositeDisposable {
                         const data = getPanelData();
                         if (
                             data &&
-                            data.panelId &&
+                            (data.panelId || data.tabGroupId) &&
                             data.groupId !== this.group.id
                         ) {
                             const avgWidth = this.getAverageTabWidth();
-                            this._animState = {
-                                sourceTabId: data.panelId,
-                                sourceIndex: -1,
-                                tabPositions: this.snapshotTabPositions(),
-                                chipPositions:
-                                    this._tabGroupManager.snapshotChipWidths(),
-                                currentInsertionIndex: null,
-                                targetTabGroupId: null,
-                                sourceTabGroupId: null,
-                                sourceGroupPanelIds: null,
-                                sourceChipWidth: 0,
-                                cursorOffsetFromDragLeft: avgWidth / 2,
-                                sourceGapWidth: avgWidth,
-                                containerLeft:
-                                    this._tabsList.getBoundingClientRect().left,
-                            };
+
+                            if (data.tabGroupId) {
+                                // External group drag — look up the
+                                // source tab group to size the gap
+                                const sourceGroup =
+                                    this.accessor.getPanel(data.groupId);
+                                const sourceTg = sourceGroup?.model
+                                    .getTabGroups()
+                                    .find(
+                                        (tg) => tg.id === data.tabGroupId
+                                    );
+                                const panelCount =
+                                    sourceTg?.panelIds.length ?? 1;
+                                const groupGapWidth =
+                                    avgWidth * panelCount + avgWidth;
+
+                                this._animState = {
+                                    sourceTabId: '',
+                                    sourceIndex: -1,
+                                    tabPositions:
+                                        this.snapshotTabPositions(),
+                                    chipPositions:
+                                        this._tabGroupManager.snapshotChipWidths(),
+                                    currentInsertionIndex: null,
+                                    targetTabGroupId: null,
+                                    sourceTabGroupId: data.tabGroupId,
+                                    sourceGroupPanelIds: sourceTg
+                                        ? new Set(sourceTg.panelIds)
+                                        : new Set<string>(),
+                                    sourceChipWidth: avgWidth,
+                                    cursorOffsetFromDragLeft:
+                                        groupGapWidth / 2,
+                                    sourceGapWidth: groupGapWidth,
+                                    containerLeft:
+                                        this._tabsList.getBoundingClientRect()
+                                            .left,
+                                };
+                            } else {
+                                this._animState = {
+                                    sourceTabId: data.panelId!,
+                                    sourceIndex: -1,
+                                    tabPositions:
+                                        this.snapshotTabPositions(),
+                                    chipPositions:
+                                        this._tabGroupManager.snapshotChipWidths(),
+                                    currentInsertionIndex: null,
+                                    targetTabGroupId: null,
+                                    sourceTabGroupId: null,
+                                    sourceGroupPanelIds: null,
+                                    sourceChipWidth: 0,
+                                    cursorOffsetFromDragLeft:
+                                        avgWidth / 2,
+                                    sourceGapWidth: avgWidth,
+                                    containerLeft:
+                                        this._tabsList.getBoundingClientRect()
+                                            .left,
+                                };
+                            }
                         } else {
                             return;
                         }

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -1120,4 +1120,20 @@
     .dv-tab-group-chip {
         box-shadow: inset 0 -2px 0 var(--dv-tab-group-color);
     }
+
+    // Header-bottom: overline instead of underline
+    .dv-groupview-header-bottom {
+        .dv-tab.dv-tab--grouped,
+        .dv-tab-group-chip {
+            box-shadow: inset 0 2px 0 var(--dv-tab-group-color);
+        }
+    }
+
+    // Vertical tabs: sideline instead of underline
+    .dv-tabs-container-vertical {
+        .dv-tab.dv-tab--grouped,
+        .dv-tab-group-chip {
+            box-shadow: inset 2px 0 0 var(--dv-tab-group-color);
+        }
+    }
 }

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -1118,16 +1118,6 @@
     }
 
     .dv-tab-group-chip {
-        position: static !important;
-
-        &::after {
-            content: '';
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            height: 2px;
-            background-color: var(--dv-tab-group-color);
-        }
+        box-shadow: inset 0 -2px 0 var(--dv-tab-group-color);
     }
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
