### PR TITLE
feat: show tab groups in the tab overflow context menu

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
@@ -955,7 +955,9 @@ describe('tabsContainer', () => {
 
             const groupPanel = fromPartial<DockviewGroupPanel>({
                 id: 'testgroupid',
-                model: fromPartial<DockviewGroupPanelModel>({}),
+                model: fromPartial<DockviewGroupPanelModel>({
+                    getTabGroups: () => [],
+                }),
             });
 
             const cut = new TabsContainer(accessor, groupPanel);
@@ -1063,14 +1065,20 @@ describe('tabsContainer', () => {
             const groupPanel = fromPartial<DockviewGroupPanel>({
                 id: 'testgroupid',
                 panels: [mockPanel],
-                model: fromPartial<DockviewGroupPanelModel>({}),
+                model: fromPartial<DockviewGroupPanelModel>({
+                    getTabGroups: () => [],
+                }),
             });
 
             const cut = new TabsContainer(accessor, groupPanel);
             (cut as any).tabs = mockTabs;
 
             // Simulate overflow tabs
-            (cut as any).toggleDropdown({ tabs: ['test-panel'], reset: false });
+            (cut as any).toggleDropdown({
+                tabs: ['test-panel'],
+                tabGroups: [],
+                reset: false,
+            });
 
             // Find the dropdown trigger and click it
             const dropdownTrigger = cut.element.querySelector(
@@ -1197,14 +1205,20 @@ describe('tabsContainer', () => {
             const groupPanel = fromPartial<DockviewGroupPanel>({
                 id: 'testgroupid',
                 panels: [mockPanel],
-                model: fromPartial<DockviewGroupPanelModel>({}),
+                model: fromPartial<DockviewGroupPanelModel>({
+                    getTabGroups: () => [],
+                }),
             });
 
             const cut = new TabsContainer(accessor, groupPanel);
             (cut as any).tabs = mockTabs;
 
             // Simulate overflow tabs
-            (cut as any).toggleDropdown({ tabs: ['test-panel'], reset: false });
+            (cut as any).toggleDropdown({
+                tabs: ['test-panel'],
+                tabGroups: [],
+                reset: false,
+            });
 
             // Find the dropdown trigger and click it
             const dropdownTrigger = cut.element.querySelector(
@@ -1321,14 +1335,20 @@ describe('tabsContainer', () => {
             const groupPanel = fromPartial<DockviewGroupPanel>({
                 id: 'testgroupid',
                 panels: [mockPanel],
-                model: fromPartial<DockviewGroupPanelModel>({}),
+                model: fromPartial<DockviewGroupPanelModel>({
+                    getTabGroups: () => [],
+                }),
             });
 
             const cut = new TabsContainer(accessor, groupPanel);
             (cut as any).tabs = mockTabs;
 
             // Simulate overflow tabs
-            (cut as any).toggleDropdown({ tabs: ['test-panel'], reset: false });
+            (cut as any).toggleDropdown({
+                tabs: ['test-panel'],
+                tabGroups: [],
+                reset: false,
+            });
 
             // Find the dropdown trigger and click it
             const dropdownTrigger = cut.element.querySelector(

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -315,4 +315,49 @@
         );
         color: var(--dv-activegroup-hiddenpanel-tab-color);
     }
+
+    .dv-tabs-overflow-group-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 8px;
+        font-size: 0.8em;
+        font-weight: 600;
+        color: var(--dv-activegroup-hiddenpanel-tab-color);
+        cursor: pointer;
+        border-bottom: 1px solid var(--dv-tab-divider-color);
+
+        &:hover {
+            background-color: var(--dv-icon-hover-background-color);
+        }
+    }
+
+    .dv-tabs-overflow-group-color {
+        display: inline-block;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+        background-color: var(--dv-tab-group-color);
+    }
+
+    .dv-tabs-overflow-group-label {
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .dv-tabs-overflow-group-collapsed-badge {
+        font-size: 0.75em;
+        font-weight: 400;
+        opacity: 0.7;
+        padding: 1px 4px;
+        border-radius: 3px;
+        background-color: var(--dv-tab-divider-color);
+    }
+
+    .dv-tab.dv-tab--grouped {
+        padding-left: 16px;
+    }
 }

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -92,6 +92,7 @@ export class Tabs extends CompositeDisposable {
 
     private readonly _onOverflowTabsChange = new Emitter<{
         tabs: string[];
+        tabGroups: string[];
         reset: boolean;
     }>();
     readonly onOverflowTabsChange = this._onOverflowTabsChange.event;
@@ -900,19 +901,63 @@ export class Tabs extends CompositeDisposable {
     }
 
     private toggleDropdown(options: { reset: boolean }): void {
-        const tabs = options.reset
-            ? []
-            : this._tabs
-                  .filter(
-                      (tab) =>
-                          !isChildEntirelyVisibleWithinParent(
-                              tab.value.element,
-                              this._tabsList
-                          )
-                  )
-                  .map((x) => x.value.panel.id);
+        if (options.reset) {
+            this._onOverflowTabsChange.fire({
+                tabs: [],
+                tabGroups: [],
+                reset: true,
+            });
+            return;
+        }
 
-        this._onOverflowTabsChange.fire({ tabs, reset: options.reset });
+        const tabs = this._tabs
+            .filter(
+                (tab) =>
+                    !isChildEntirelyVisibleWithinParent(
+                        tab.value.element,
+                        this._tabsList
+                    )
+            )
+            .map((x) => x.value.panel.id);
+
+        // Detect tab groups whose chip is clipped or whose tabs are all
+        // in the overflow set (e.g. collapsed groups scrolled out of view).
+        const overflowTabSet = new Set(tabs);
+        const tabGroups: string[] = [];
+
+        for (const tg of this.group.model.getTabGroups()) {
+            const chipEntry = this._tabGroupManager.chipRenderers.get(tg.id);
+            const chipClipped =
+                chipEntry &&
+                !isChildEntirelyVisibleWithinParent(
+                    chipEntry.chip.element,
+                    this._tabsList
+                );
+
+            // A group is in overflow if its chip is clipped OR all its
+            // visible tabs are in the overflow set.
+            const allTabsOverflow =
+                tg.panelIds.length > 0 &&
+                tg.panelIds.every((pid) => overflowTabSet.has(pid));
+
+            if (chipClipped || allTabsOverflow) {
+                tabGroups.push(tg.id);
+
+                // For collapsed groups whose chip is clipped, ensure all
+                // member tabs are included in the overflow list so they
+                // appear in the dropdown.
+                if (tg.collapsed) {
+                    for (const pid of tg.panelIds) {
+                        if (!overflowTabSet.has(pid)) {
+                            overflowTabSet.add(pid);
+                            tabs.push(pid);
+                        }
+                    }
+                }
+            }
+        }
+
+        this._onOverflowTabsChange.fire({ tabs, tabGroups, reset: false });
     }
 
     updateDragAndDropState(): void {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -87,6 +87,7 @@ export class TabsContainer
 
     private dropdownPart: DropdownElement | null = null;
     private _overflowTabs: string[] = [];
+    private _overflowTabGroups: string[] = [];
     private readonly _dropdownDisposable = new MutableDisposable();
 
     private readonly _onDrop = new Emitter<TabDropIndexEvent>();
@@ -381,16 +382,24 @@ export class TabsContainer
         toggleClass(this._element, 'dv-single-tab', this.size === 1);
     }
 
-    private toggleDropdown(options: { tabs: string[]; reset: boolean }): void {
+    private toggleDropdown(options: {
+        tabs: string[];
+        tabGroups: string[];
+        reset: boolean;
+    }): void {
         const tabs = options.reset ? [] : options.tabs;
+        const tabGroups = options.reset ? [] : options.tabGroups;
         this._overflowTabs = tabs;
+        this._overflowTabGroups = tabGroups;
 
-        if (this._overflowTabs.length > 0 && this.dropdownPart) {
-            this.dropdownPart.update({ tabs: tabs.length });
+        const totalCount = this._overflowTabs.length;
+
+        if (totalCount > 0 && this.dropdownPart) {
+            this.dropdownPart.update({ tabs: totalCount });
             return;
         }
 
-        if (this._overflowTabs.length === 0) {
+        if (totalCount === 0) {
             this._dropdownDisposable.dispose();
             return;
         }
@@ -399,7 +408,7 @@ export class TabsContainer
         root.className = 'dv-tabs-overflow-dropdown-root';
 
         const part = createDropdownElementHandle();
-        part.update({ tabs: tabs.length });
+        part.update({ tabs: totalCount });
 
         this.dropdownPart = part;
 
@@ -425,9 +434,76 @@ export class TabsContainer
                 el.style.overflow = 'auto';
                 el.className = 'dv-tabs-overflow-container';
 
+                // Build lookup: panelId → tabGroup for overflow groups
+                const overflowGroupSet = new Set(this._overflowTabGroups);
+                const allTabGroups = this.group.model.getTabGroups();
+                const panelToGroup = new Map<
+                    string,
+                    (typeof allTabGroups)[0]
+                >();
+                for (const tg of allTabGroups) {
+                    if (overflowGroupSet.has(tg.id)) {
+                        for (const pid of tg.panelIds) {
+                            panelToGroup.set(pid, tg);
+                        }
+                    }
+                }
+
+                // Track which groups have already been rendered
+                const renderedGroups = new Set<string>();
+
                 for (const tab of this.tabs.tabs.filter((tab) =>
                     this._overflowTabs.includes(tab.panel.id)
                 )) {
+                    const tg = panelToGroup.get(tab.panel.id);
+
+                    // If this tab belongs to an overflow group, render the
+                    // group header before its first member tab.
+                    if (tg && !renderedGroups.has(tg.id)) {
+                        renderedGroups.add(tg.id);
+
+                        const groupHeader = document.createElement('div');
+                        groupHeader.className = 'dv-tabs-overflow-group-header';
+
+                        const colorDot = document.createElement('span');
+                        colorDot.className = 'dv-tabs-overflow-group-color';
+                        colorDot.style.setProperty(
+                            '--dv-tab-group-color',
+                            `var(--dv-tab-group-color-${tg.color})`
+                        );
+                        groupHeader.appendChild(colorDot);
+
+                        const labelSpan = document.createElement('span');
+                        labelSpan.className = 'dv-tabs-overflow-group-label';
+                        labelSpan.textContent = tg.label || tg.id;
+                        groupHeader.appendChild(labelSpan);
+
+                        if (tg.collapsed) {
+                            const badge = document.createElement('span');
+                            badge.className =
+                                'dv-tabs-overflow-group-collapsed-badge';
+                            badge.textContent = `${tg.panelIds.length}`;
+                            groupHeader.appendChild(badge);
+                        }
+
+                        groupHeader.addEventListener('click', () => {
+                            this.accessor.popupService.close();
+                            if (tg.collapsed) {
+                                tg.expand();
+                            }
+                            // Activate the first panel in the group
+                            const firstPanelId = tg.panelIds[0];
+                            if (firstPanelId) {
+                                const panel = this.group.panels.find(
+                                    (p) => p.id === firstPanelId
+                                );
+                                panel?.api.setActive();
+                            }
+                        });
+
+                        el.appendChild(groupHeader);
+                    }
+
                     const panelObject = this.group.panels.find(
                         (panel) => panel === tab.panel
                     )!;
@@ -449,6 +525,9 @@ export class TabsContainer
                         'dv-inactive-tab',
                         !panelObject.api.isActive
                     );
+                    if (tg) {
+                        toggleClass(wrapper, 'dv-tab--grouped', true);
+                    }
 
                     wrapper.addEventListener('click', (event) => {
                         this.accessor.popupService.close();
@@ -457,6 +536,9 @@ export class TabsContainer
                             return;
                         }
 
+                        if (tg?.collapsed) {
+                            tg.expand();
+                        }
                         tab.element.scrollIntoView();
                         tab.panel.api.setActive();
                     });

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/defaultLayout.ts
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/defaultLayout.ts
@@ -130,11 +130,42 @@ export function defaultConfig(api: DockviewApi) {
         tabGroupId: shipping.id,
         panelId: 'vesselfinder',
     });
-    shipping.collapse();
+    // Create a collapsed tab group in the eventlog group for "Logs"
+    const eventlogGroupId = eventlog.api.group.id;
 
-    // Set active panels (skip orders group — all its panels are collapsed)
+    // Add a standalone tab before the Logs tab group
+    api.addPanel({
+        id: 'console',
+        component: 'default',
+        title: 'Console',
+        position: { referencePanel: eventlog },
+    });
+
+    const logs = api.createTabGroup({
+        groupId: eventlogGroupId,
+        label: 'Logs',
+        color: 'orange',
+    });
+    api.addPanelToTabGroup({
+        groupId: eventlogGroupId,
+        tabGroupId: logs.id,
+        panelId: 'eventlog',
+    });
+    api.addPanelToTabGroup({
+        groupId: eventlogGroupId,
+        tabGroupId: logs.id,
+        panelId: 'layoutinspector',
+    });
+    api.addPanelToTabGroup({
+        groupId: eventlogGroupId,
+        tabGroupId: logs.id,
+        panelId: 'debuginfo',
+    });
+    logs.collapse();
+
+    // Set active panels
     watchlist.api.setActive();
     orderbook.api.setActive();
+    orders.api.setActive();
     positionsummary.api.setActive();
-    eventlog.api.setActive();
 }


### PR DESCRIPTION
When tabs overflow the visible area, the dropdown menu now renders tab group headers (color dot, label, collapsed badge) alongside their member tabs. Collapsed groups whose chip is clipped are included with all their panels so users can access them from the overflow menu.

Also updates the sandbox demo to show the Shipping group expanded and adds a collapsed Logs group with a standalone Console tab.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
