### PR TITLE
docs: add Edge Groups and Tab Groups to feature lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,8 @@ NX handles build ordering automatically via `dependsOn: ["^build"]`. The depende
 
 -   Drag and drop with customizable drop zones
 -   Floating groups and popout windows
+-   Edge groups (pinned to layout edges with collapse/expand)
+-   Tab groups (colored chip-based visual tab organization)
 -   Serialization/deserialization for state persistence
 -   Theming system with CSS custom properties
 -   Comprehensive API for programmatic control

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,6 +9,8 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 - Zero runtime dependencies
 - Drag and drop with customizable drop zones
 - Floating/overlay groups
+- Edge groups (panels pinned to layout edges with collapse/expand)
+- Tab groups (visual tab organization with colored chips)
 - Popout windows (extracting panels to separate browser windows)
 - Full serialization and deserialization for state persistence
 - Theming system with CSS custom properties
@@ -224,6 +226,8 @@ The `DockviewApi` (available via the `onReady` event) provides:
 - `getGroup(id)` — Get group by ID
 - `moveToNext()` / `moveToPrevious()` — Navigate between panels
 - `addFloatingGroup(panel, options)` — Create a floating group
+- `addEdgeGroup(options)` — Pin a group to a layout edge
+- `createTabGroup(options)` — Create a tab group for visual organization
 - `addPopoutGroup(panel, options)` — Popout a panel to a new window
 - `toJSON()` — Serialize the layout
 - `fromJSON(data)` — Deserialize/restore a layout

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,8 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 - Zero runtime dependencies
 - Drag and drop with customizable drop zones
 - Floating/overlay groups
+- Edge groups (panels pinned to layout edges with collapse/expand)
+- Tab groups (visual tab organization with colored chips)
 - Popout windows (extracting panels to separate browser windows)
 - Full serialization and deserialization for state persistence
 - Theming system with CSS custom properties

--- a/packages/dockview-angular/README.md
+++ b/packages/dockview-angular/README.md
@@ -28,6 +28,8 @@ Please see the website: https://dockview.dev
 -   Tab and Group docking / Drag n' Drop
 -   Popout Windows
 -   Floating Groups
+-   Edge Groups
+-   Tab Groups
 -   Extensive API
 -   Supports Shadow DOMs
 -   High test coverage

--- a/packages/dockview-core/README.md
+++ b/packages/dockview-core/README.md
@@ -28,6 +28,8 @@ Please see the website: https://dockview.dev
 -   Tab and Group docking / Drag n' Drop
 -   Popout Windows
 -   Floating Groups
+-   Edge Groups
+-   Tab Groups
 -   Extensive API
 -   Supports Shadow DOMs
 -   High test coverage

--- a/packages/dockview-react/README.md
+++ b/packages/dockview-react/README.md
@@ -28,6 +28,8 @@ Please see the website: https://dockview.dev
 -   Tab and Group docking / Drag n' Drop
 -   Popout Windows
 -   Floating Groups
+-   Edge Groups
+-   Tab Groups
 -   Extensive API
 -   Supports Shadow DOMs
 -   High test coverage

--- a/packages/dockview-vue/README.md
+++ b/packages/dockview-vue/README.md
@@ -28,6 +28,8 @@ Please see the website: https://dockview.dev
 -   Tab and Group docking / Drag n' Drop
 -   Popout Windows
 -   Floating Groups
+-   Edge Groups
+-   Tab Groups
 -   Extensive API
 -   Supports Shadow DOMs
 -   High test coverage

--- a/packages/dockview/README.md
+++ b/packages/dockview/README.md
@@ -28,6 +28,8 @@ Please see the website: https://dockview.dev
 -   Tab and Group docking / Drag n' Drop
 -   Popout Windows
 -   Floating Groups
+-   Edge Groups
+-   Tab Groups
 -   Extensive API
 -   Supports Shadow DOMs
 -   High test coverage


### PR DESCRIPTION
These features have been shipped since v5.2.0 but were not reflected in READMEs, llms.txt, llms-full.txt, or AGENTS.md.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
