### PR TITLE
feat: support strict CSP

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -19,6 +19,7 @@ ContextMenuItemConfig
 Contraints
 CreateComponentOptions
 CreateContextMenuItemComponentOptions
+CspNonce
 DefaultDockviewDeserialzier
 DefaultTab
 Direction

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -26,6 +26,7 @@ import {
     PROPERTY_KEYS_DOCKVIEW,
     DockviewFrameworkOptions,
     DockviewComponentOptions,
+    CspNonce,
     GetTabContextMenuItemsParams,
     GetTabGroupChipContextMenuItemsParams,
     BuiltInChipContextMenuItem,
@@ -93,6 +94,7 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Input() disableFloatingGroups?: boolean;
     @Input() floatingGroupBounds?: 'boundedWithinViewport';
     @Input() popoutUrl?: string;
+    @Input() nonce?: CspNonce;
     @Input() debug?: boolean;
     @Input() locked?: boolean;
     @Input() disableAutoResizing?: boolean;

--- a/packages/dockview-core/src/__tests__/dom.spec.ts
+++ b/packages/dockview-core/src/__tests__/dom.spec.ts
@@ -1,4 +1,5 @@
 import {
+    addStyles,
     disableIframePointEvents,
     isInDocument,
     quasiDefaultPrevented,
@@ -79,5 +80,148 @@ describe('dom', () => {
         expect(el2.style.pointerEvents).toBe('');
         expect(el3.style.pointerEvents).toBe('inherit');
         expect(el4.style.pointerEvents).toBe('');
+    });
+
+    describe('addStyles', () => {
+        function makeTargetDocument() {
+            return document.implementation.createHTMLDocument('target');
+        }
+
+        function makeStyleSheet(
+            rules: string[],
+            href?: string
+        ): CSSStyleSheet {
+            return {
+                href,
+                type: 'text/css',
+                cssRules: rules.map((cssText) => ({ cssText })),
+            } as unknown as CSSStyleSheet;
+        }
+
+        function makeStyleSheetList(sheets: CSSStyleSheet[]): StyleSheetList {
+            const list: any = {
+                length: sheets.length,
+                [Symbol.iterator]: function* () {
+                    for (const s of sheets) yield s;
+                },
+            };
+            sheets.forEach((s, i) => (list[i] = s));
+            return list as StyleSheetList;
+        }
+
+        test('applies nonce to every created <style> element', () => {
+            const targetDoc = makeTargetDocument();
+            const sheets = makeStyleSheetList([
+                makeStyleSheet(['.a { color: red; }', '.b { color: blue; }']),
+            ]);
+
+            addStyles(targetDoc, sheets, { nonce: 'abc123' });
+
+            const styles = targetDoc.head.querySelectorAll('style');
+            expect(styles.length).toBe(2);
+            expect(styles[0].getAttribute('nonce')).toBe('abc123');
+            expect(styles[1].getAttribute('nonce')).toBe('abc123');
+            expect(styles[0].textContent).toBe('.a { color: red; }');
+            expect(styles[1].textContent).toBe('.b { color: blue; }');
+        });
+
+        test('omits nonce attribute when no nonce is supplied', () => {
+            const targetDoc = makeTargetDocument();
+            const sheets = makeStyleSheetList([
+                makeStyleSheet(['.b { color: blue; }']),
+            ]);
+
+            addStyles(targetDoc, sheets);
+
+            const style = targetDoc.head.querySelector('style')!;
+            expect(style.hasAttribute('nonce')).toBe(false);
+        });
+
+        test('appends <link> for external stylesheet hrefs', () => {
+            const targetDoc = makeTargetDocument();
+            const sheets = makeStyleSheetList([
+                makeStyleSheet(
+                    ['.c { color: green; }'],
+                    'https://example.test/main.css'
+                ),
+            ]);
+
+            addStyles(targetDoc, sheets, { nonce: 'xyz' });
+
+            const link = targetDoc.head.querySelector('link');
+            expect(link).not.toBeNull();
+            expect(link?.getAttribute('rel')).toBe('stylesheet');
+            expect(link?.getAttribute('href')).toBe(
+                'https://example.test/main.css'
+            );
+        });
+
+        test('preserves source order across readable and unreadable sheets', () => {
+            // Simulate a CORS-restricted sheet whose cssRules throws on access.
+            const unreadable: any = {
+                href: 'https://cdn.test/blocked.css',
+                type: 'text/css',
+                get cssRules(): CSSRuleList {
+                    throw new DOMException(
+                        'SecurityError',
+                        'SecurityError'
+                    );
+                },
+            };
+
+            const targetDoc = makeTargetDocument();
+            const sheets = makeStyleSheetList([
+                makeStyleSheet(['.first { color: red; }']),
+                unreadable,
+                makeStyleSheet(['.third { color: green; }']),
+            ]);
+
+            const warn = jest
+                .spyOn(console, 'warn')
+                .mockImplementation(() => {});
+
+            addStyles(targetDoc, sheets, { nonce: 'n1' });
+
+            const appended = Array.from(targetDoc.head.children).filter(
+                (el) => el.tagName === 'STYLE' || el.tagName === 'LINK'
+            );
+            expect(appended.length).toBe(3);
+            expect(appended[0].tagName).toBe('STYLE');
+            expect(appended[0].textContent).toBe('.first { color: red; }');
+            expect(appended[1].tagName).toBe('LINK');
+            expect(
+                (appended[1] as HTMLLinkElement).getAttribute('href')
+            ).toBe('https://cdn.test/blocked.css');
+            expect(appended[2].tagName).toBe('STYLE');
+            expect(appended[2].textContent).toBe('.third { color: green; }');
+
+            warn.mockRestore();
+        });
+
+        test('nonce accepts a function that receives the target document', () => {
+            const targetDoc = makeTargetDocument();
+            const meta = targetDoc.createElement('meta');
+            meta.setAttribute('name', 'csp-nonce');
+            meta.setAttribute('content', 'from-popout');
+            targetDoc.head.appendChild(meta);
+
+            const sheets = makeStyleSheetList([
+                makeStyleSheet(['.x { color: red; }']),
+            ]);
+
+            const nonceFn = jest.fn(
+                (doc: Document) =>
+                    doc
+                        .querySelector<HTMLMetaElement>('meta[name="csp-nonce"]')
+                        ?.getAttribute('content') ?? undefined
+            );
+
+            addStyles(targetDoc, sheets, { nonce: nonceFn });
+
+            expect(nonceFn).toHaveBeenCalledTimes(1);
+            expect(nonceFn).toHaveBeenCalledWith(targetDoc);
+            const style = targetDoc.head.querySelector('style')!;
+            expect(style.getAttribute('nonce')).toBe('from-popout');
+        });
     });
 });

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
@@ -334,7 +334,7 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
         let svg = underline.firstElementChild as SVGSVGElement | null;
         let path: SVGPathElement;
         if (!svg || svg.tagName !== 'svg') {
-            underline.innerHTML = '';
+            underline.replaceChildren();
             svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
             svg.style.display = 'block';
             path = document.createElementNS(
@@ -483,7 +483,7 @@ export class NoneTabGroupIndicator extends BaseTabGroupIndicator {
 
         // Clear any SVG content left over from a mode switch
         if (underline.firstElementChild) {
-            underline.innerHTML = '';
+            underline.replaceChildren();
         }
 
         underline.style.backgroundColor = color;

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -846,6 +846,7 @@ export class DockviewComponent
                 height: box.height,
                 onDidOpen: options?.onDidOpen,
                 onWillClose: options?.onWillClose,
+                nonce: this.options?.nonce,
             }
         );
 

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -17,6 +17,8 @@ import { Contraints } from '../gridview/gridviewPanel';
 import { AcceptableEvent, IAcceptableEvent } from '../events';
 import { DockviewTheme } from './theme';
 import { ITabGroup } from './tabGroup';
+import { CspNonce } from '../dom';
+export { CspNonce } from '../dom';
 
 export interface IHeaderActionsRenderer extends IDisposable {
     readonly element: HTMLElement;
@@ -107,6 +109,7 @@ export interface DockviewOptions {
               minimumWidthWithinViewport?: number;
           };
     popoutUrl?: string;
+    nonce?: CspNonce;
     defaultRenderer?: DockviewPanelRenderer;
     defaultHeaderPosition?: DockviewHeaderPosition;
     debug?: boolean;
@@ -205,6 +208,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         disableFloatingGroups: undefined,
         floatingGroupBounds: undefined,
         popoutUrl: undefined,
+        nonce: undefined,
         defaultRenderer: undefined,
         defaultHeaderPosition: undefined,
         debug: undefined,

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -209,8 +209,23 @@ export function quasiDefaultPrevented(event: Event): boolean {
     return (event as any)[QUASI_PREVENT_DEFAULT_KEY];
 }
 
-export function addStyles(document: Document, styleSheetList: StyleSheetList) {
+export type CspNonce =
+    | string
+    | ((targetDocument: Document) => string | undefined);
+
+export interface AddStylesOptions {
+    nonce?: CspNonce;
+}
+
+export function addStyles(
+    document: Document,
+    styleSheetList: StyleSheetList,
+    options: AddStylesOptions = {}
+) {
     const styleSheets = Array.from(styleSheetList);
+    const { nonce } = options;
+    const resolvedNonce =
+        typeof nonce === 'function' ? nonce(document) : nonce;
 
     for (const styleSheet of styleSheets) {
         if (styleSheet.href) {
@@ -236,11 +251,16 @@ export function addStyles(document: Document, styleSheetList: StyleSheetList) {
             );
         }
 
+        const fragment = document.createDocumentFragment();
         for (const rule of cssTexts) {
             const style = document.createElement('style');
+            if (resolvedNonce) {
+                style.setAttribute('nonce', resolvedNonce);
+            }
             style.appendChild(document.createTextNode(rule));
-            document.head.appendChild(style);
+            fragment.appendChild(style);
         }
+        document.head.appendChild(fragment);
     }
 }
 

--- a/packages/dockview-core/src/popoutWindow.ts
+++ b/packages/dockview-core/src/popoutWindow.ts
@@ -1,4 +1,4 @@
-import { addStyles } from './dom';
+import { addStyles, CspNonce } from './dom';
 import { Emitter, addDisposableListener } from './events';
 import { CompositeDisposable, Disposable, IDisposable } from './lifecycle';
 import { Box } from './types';
@@ -7,6 +7,7 @@ export type PopoutWindowOptions = {
     url: string;
     onDidOpen?: (event: { id: string; window: Window }) => void;
     onWillClose?: (event: { id: string; window: Window }) => void;
+    nonce?: CspNonce;
 } & Box;
 
 export class PopoutWindow extends CompositeDisposable {
@@ -140,7 +141,9 @@ export class PopoutWindow extends CompositeDisposable {
 
                     externalDocument.body.appendChild(container);
 
-                    addStyles(externalDocument, window.document.styleSheets);
+                    addStyles(externalDocument, window.document.styleSheets, {
+                        nonce: this.options.nonce,
+                    });
 
                     /**
                      * beforeunload must be registered after load for reasons I could not determine

--- a/packages/docs/docs/advanced/csp.mdx
+++ b/packages/docs/docs/advanced/csp.mdx
@@ -1,0 +1,86 @@
+---
+title: Content Security Policy
+description: How to run Dockview under a strict Content Security Policy that forbids `style-src 'unsafe-inline'`.
+---
+
+# Content Security Policy
+
+Dockview is designed to work under a strict [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP). This page covers what Dockview does at runtime, what you need to allow, and how to configure Dockview so that a strict policy doesn't break popout windows.
+
+## What Dockview does at runtime
+
+For the main document Dockview only writes to `element.style` properties (e.g. positioning, sizing), manipulates `classList`, and attaches event listeners via `addEventListener`. None of those are restricted by `style-src` or `script-src`. Dockview does not use `eval`, the `Function` constructor, `setTimeout`/`setInterval` with string arguments, `document.write`, inline event handlers, or any CSS-in-JS runtime.
+
+The **one** place Dockview needs dynamic styling is when opening a **popout window**: Dockview reads the parent window's stylesheets and recreates them in the popout's `<head>` as `<style>` elements, preserving the original cascade order. This is the path that interacts with `style-src`.
+
+## Recommended CSP
+
+A policy like the following is enough to run Dockview with popouts:
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  style-src   'self' 'nonce-RANDOM_NONCE';
+  script-src  'self' 'nonce-RANDOM_NONCE';
+```
+
+Note that:
+
+- You do **not** need `'unsafe-inline'` in `style-src`.
+- `RANDOM_NONCE` must be regenerated per response. It should be the same nonce that your server-rendered HTML applies to its own `<script>` / `<style>` tags.
+- If your popout is same-origin (the default for `window.open(url)` where `url` is on your origin), the popout document inherits your CSP and nonce, so the same nonce works for both windows.
+
+## Passing the nonce to Dockview
+
+Dockview forwards a `nonce` option to every `<style>` element it creates. The nonce must be valid for the document the `<style>` lands in, which — for popout windows — is **not** the opener document. Because `popout.html` is a separate HTTP response with its own freshly-generated nonce, the parent page's nonce is never valid in the popout's CSP context.
+
+For this reason `nonce` accepts either a **string** (when the same nonce is known to cover both documents, e.g. during local development with a static policy) or a **function** that is called with the target `Document` so you can read the nonce directly off the popout page.
+
+The recommended setup is to have your `popout.html` emit a `<meta name="csp-nonce">` element with its request nonce, then read it through the function form:
+
+```tsx title="React"
+<DockviewReact
+    nonce={(doc) =>
+        doc
+            .querySelector<HTMLMetaElement>('meta[name="csp-nonce"]')
+            ?.content
+    }
+    onReady={onReady}
+    components={components}
+/>
+```
+
+```vue
+<!-- Vue -->
+<dockview-vue :nonce="readCspNonce" @ready="onReady" />
+```
+
+```ts title="Angular"
+<dockview-angular [nonce]="readCspNonce" (ready)="onReady($event)"></dockview-angular>
+```
+
+```ts title="Vanilla"
+import { createDockview } from 'dockview-core';
+
+const api = createDockview(element, {
+    nonce: (doc) =>
+        doc
+            .querySelector<HTMLMetaElement>('meta[name="csp-nonce"]')
+            ?.content,
+    createComponent: (options) => { /* ... */ },
+});
+```
+
+If your popout markup uses a different convention (for example a global like `window.__CSP_NONCE__`), return that from the function instead.
+
+## Trusted Types
+
+Dockview is also compatible with [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) (`require-trusted-types-for 'script'`). Dockview clears DOM subtrees with `Node.replaceChildren()` rather than `element.innerHTML = ''`, which Trusted Types treats as a sink.
+
+## Checklist
+
+- Add `'nonce-<value>'` to your `style-src` directive on **both** the main page and the popout page.
+- Generate a fresh nonce per response (on both pages).
+- In the popout HTML, expose the nonce in a known location (a `<meta name="csp-nonce">` tag is the most portable choice).
+- Provide the function form of `nonce` to Dockview so it reads the popout's own nonce at the moment styles are injected.
+- Serve the popout from the same origin as the host so it inherits your origin's CSP defaults.


### PR DESCRIPTION
Hey! Thanks for the great library — I'm running it on a project with strict CSP, and  saw a good opportunity to land first-class support for it.

Adds a `nonce` option to DockviewOptions (and the React, Vue and Angular wrappers) so Dockview works under a CSP that forbids `style-src 'unsafe-inline'`. The nonce is applied to the `<style>` elements created when the parent window's stylesheets are copied into a popout. It accepts a string or a `(targetDocument) => string | undefined` function — the function form is what you want in production, since the popout is a separate response with its own fresh nonce and usually exposes it via `<meta name="csp-nonce">`.

Also swaps two `innerHTML = ''` calls in tabGroupIndicator for `replaceChildren()` so the library is compatible with `require-trusted-types-for 'script'`. New "Content Security Policy" page under Advanced covers the header, nonce wiring, and Trusted Types note.

Let me know what you think!