### PR TITLE
Fix destructuring when tabToRemove is undefined

### DIFF
--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -858,11 +858,13 @@ export class Tabs extends CompositeDisposable {
         const tabToRemove = this._tabs.splice(index, 1)[0];
         this._tabMap.delete(id);
 
-        const { value, disposable } = tabToRemove;
+        if (tabToRemove) {
+            const { value, disposable } = tabToRemove;
 
-        disposable.dispose();
-        value.dispose();
-        value.element.remove();
+            disposable.dispose();
+            value.dispose();
+            value.element.remove();
+        }
 
         // If a non-source tab was removed during active drag, refresh positions
         if (this._animState) {


### PR DESCRIPTION
## Description

There was a bug when calling `fromJSON`, dockview will try to `clear` the different panels and destructure an undefined variable.

## Type of change

<!-- Check the one that applies -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

I had this bug when mounting/unmounting a React root (similar to this bug https://github.com/mathuo/dockview/pull/845)

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
