### PR TITLE
fix: prevent tab group chip flicker on cross-group drop

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1154,9 +1154,8 @@ describe('dockviewComponent', () => {
         // Tabs of the moved group should land in the collapsed state instantly
         // (no animation). The animation path sets an inline width/height to
         // measure-then-collapse; the instant path leaves both unset.
-        const movedTabs = destGroup.element.querySelectorAll(
-            '.dv-tab--grouped'
-        );
+        const movedTabs =
+            destGroup.element.querySelectorAll('.dv-tab--grouped');
         expect(movedTabs.length).toBeGreaterThan(0);
         for (const tabEl of Array.from(movedTabs) as HTMLElement[]) {
             expect(tabEl.classList.contains('dv-tab--group-collapsed')).toBe(

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1147,6 +1147,25 @@ describe('dockviewComponent', () => {
         expect(destTabGroups.length).toBe(1);
         expect(destTabGroups[0].collapsed).toBe(true);
 
+        // Force synchronous chip rendering (updateTabGroups is normally
+        // batched via queueMicrotask).
+        (destGroup.model as any).tabsContainer.tabs.updateTabGroups();
+
+        // Tabs of the moved group should land in the collapsed state instantly
+        // (no animation). The animation path sets an inline width/height to
+        // measure-then-collapse; the instant path leaves both unset.
+        const movedTabs = destGroup.element.querySelectorAll(
+            '.dv-tab--grouped'
+        );
+        expect(movedTabs.length).toBeGreaterThan(0);
+        for (const tabEl of Array.from(movedTabs) as HTMLElement[]) {
+            expect(tabEl.classList.contains('dv-tab--group-collapsed')).toBe(
+                true
+            );
+            expect(tabEl.style.width).toBe('');
+            expect(tabEl.style.height).toBe('');
+        }
+
         dockview.dispose();
     });
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1091,6 +1091,65 @@ describe('dockviewComponent', () => {
         dockview.dispose();
     });
 
+    test('moveGroupOrPanel with collapsed tabGroupId does not transition through expanded state on destination', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                return new PanelContentPartTest(options.id, options.name);
+            },
+        });
+
+        dockview.layout(1000, 1000);
+
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        dockview.addPanel({ id: 'panel2', component: 'default' });
+
+        const panel1 = dockview.getGroupPanel('panel1')!;
+        const sourceGroup = panel1.group;
+
+        const tabGroup = sourceGroup.model.createTabGroup({
+            label: 'Born collapsed',
+            color: 'red',
+        });
+        sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
+        tabGroup.collapse();
+
+        // Split panel2 out to make a destination group
+        dockview.moveGroupOrPanel({
+            from: { groupId: sourceGroup.id, panelId: 'panel2' },
+            to: { group: sourceGroup, position: 'right' },
+        });
+        const panel2 = dockview.getGroupPanel('panel2')!;
+        const destGroup = panel2.group;
+
+        // Track collapse-change events fired on destination during the move
+        const destCollapseEvents: any[] = [];
+        destGroup.model.onDidTabGroupCollapsedChange((e) =>
+            destCollapseEvents.push(e)
+        );
+
+        dockview.moveGroupOrPanel({
+            from: {
+                groupId: sourceGroup.id,
+                tabGroupId: tabGroup.id,
+            },
+            to: { group: destGroup, position: 'center' },
+        });
+
+        // Regression: previously the destination group was created uncollapsed
+        // and then `.collapse()` was called, firing a transition event that
+        // animated the chip/tabs from expanded → collapsed. The new tab group
+        // should be born collapsed, so no transition event fires.
+        expect(destCollapseEvents).toHaveLength(0);
+
+        const destTabGroups = destGroup.model.getTabGroups();
+        expect(destTabGroups.length).toBe(1);
+        expect(destTabGroups[0].collapsed).toBe(true);
+
+        dockview.dispose();
+    });
+
     test('moveGroupOrPanel with tabGroupId to extremity creates new group', () => {
         const container = document.createElement('div');
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
@@ -1341,6 +1341,23 @@ describe('dockviewGroupPanelModel', () => {
             expect(groupview.model.getTabGroups()[0]).toBe(tabGroup);
         });
 
+        test('createTabGroup with collapsed option creates collapsed group without firing onDidTabGroupCollapsedChange', () => {
+            const collapseEvents: any[] = [];
+            groupview.model.onDidTabGroupCollapsedChange((e) =>
+                collapseEvents.push(e)
+            );
+
+            const tabGroup = groupview.model.createTabGroup({
+                label: 'Born collapsed',
+                color: 'red',
+                collapsed: true,
+            });
+
+            expect(tabGroup.collapsed).toBe(true);
+            // No transition occurred — chip / tabs render collapsed from the start.
+            expect(collapseEvents).toHaveLength(0);
+        });
+
         test('createTabGroup fires onDidCreateTabGroup', () => {
             const events: any[] = [];
             groupview.model.onDidCreateTabGroup((e) => events.push(e));

--- a/packages/dockview-core/src/__tests__/dockview/tabGroup.test.ts
+++ b/packages/dockview-core/src/__tests__/dockview/tabGroup.test.ts
@@ -24,6 +24,22 @@ describe('TabGroup', () => {
         group.dispose();
     });
 
+    test('should create with collapsed option', () => {
+        const group = new TabGroup('g-collapsed', { collapsed: true });
+        expect(group.collapsed).toBe(true);
+        group.dispose();
+    });
+
+    test('should not fire onDidCollapseChange when constructed collapsed', () => {
+        const group = new TabGroup('g-collapsed', { collapsed: true });
+        const events: boolean[] = [];
+        group.onDidCollapseChange((c) => events.push(c));
+        // collapse() on an already-collapsed group is a no-op
+        group.collapse();
+        expect(events).toEqual([]);
+        group.dispose();
+    });
+
     test('should default invalid color to grey', () => {
         const group = new TabGroup('g3', {
             color: 'invalid' as DockviewTabGroupColor,

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -320,6 +320,14 @@ export class TabGroupManager {
 
         const disposable = new CompositeDisposable(...disposables);
         this._chipRenderers.set(tabGroup.id, { chip, disposable });
+
+        // Group is born collapsed (cross-group drop, layout restore, etc.):
+        // its tabs are about to be added without the collapsed class. Skip
+        // the animation in the upcoming _updateTabGroupClasses call so they
+        // apply the class instantly instead of transitioning from expanded.
+        if (tabGroup.collapsed) {
+            this._skipNextCollapseAnimation = true;
+        }
     }
 
     private _positionChipForGroup(tabGroup: ITabGroup): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2954,12 +2954,10 @@ export class DockviewComponent
             const newTabGroup = targetGroup.model.createTabGroup({
                 label,
                 color,
+                collapsed,
             });
             for (const panel of removedPanels) {
                 targetGroup.model.addPanelToTabGroup(newTabGroup.id, panel.id);
-            }
-            if (collapsed) {
-                newTabGroup.collapse();
             }
 
             if (!options.skipSetActive) {

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -56,6 +56,7 @@ import {
     ITabGroup,
     DockviewTabGroupColor,
     SerializedTabGroup,
+    TabGroupOptions,
 } from './tabGroup';
 import { EdgeGroupPosition } from './dockviewShell';
 
@@ -92,6 +93,10 @@ export interface GroupPanelViewState extends CoreGroupOptions {
 
 export interface DockviewGroupChangeEvent {
     readonly panel: IDockviewPanel;
+}
+
+export interface CreateTabGroupOptions extends TabGroupOptions {
+    id?: string;
 }
 
 export class DockviewDidDropEvent extends DockviewEvent {
@@ -658,15 +663,12 @@ export class DockviewGroupPanelModel
         });
     }
 
-    createTabGroup(options?: {
-        label?: string;
-        color?: DockviewTabGroupColor;
-        id?: string;
-    }): ITabGroup {
+    createTabGroup(options?: CreateTabGroupOptions): ITabGroup {
         const id = options?.id ?? `tg-${this.id}-${this._tabGroupIdCounter++}`;
         const tabGroup = new TabGroup(id, {
             label: options?.label,
             color: options?.color,
+            collapsed: options?.collapsed,
         });
         this._tabGroups.push(tabGroup);
         this._tabGroupMap.set(id, tabGroup);

--- a/packages/dockview-core/src/dockview/tabGroup.ts
+++ b/packages/dockview-core/src/dockview/tabGroup.ts
@@ -142,7 +142,10 @@ export class TabGroup extends CompositeDisposable implements ITabGroup {
         return this._panelIds.length === 0;
     }
 
-    constructor(readonly id: string, options?: TabGroupOptions) {
+    constructor(
+        readonly id: string,
+        options?: TabGroupOptions
+    ) {
         super();
 
         this._label = options?.label ?? '';

--- a/packages/dockview-core/src/dockview/tabGroup.ts
+++ b/packages/dockview-core/src/dockview/tabGroup.ts
@@ -42,6 +42,12 @@ export interface SerializedTabGroup {
     panelIds: string[];
 }
 
+export interface TabGroupOptions {
+    label?: string;
+    color?: DockviewTabGroupColor;
+    collapsed?: boolean;
+}
+
 export interface ITabGroup {
     readonly id: string;
     readonly label: string;
@@ -136,16 +142,14 @@ export class TabGroup extends CompositeDisposable implements ITabGroup {
         return this._panelIds.length === 0;
     }
 
-    constructor(
-        readonly id: string,
-        options?: { label?: string; color?: DockviewTabGroupColor }
-    ) {
+    constructor(readonly id: string, options?: TabGroupOptions) {
         super();
 
         this._label = options?.label ?? '';
         this._color = isValidTabGroupColor(options?.color ?? '')
             ? (options!.color as DockviewTabGroupColor)
             : 'grey';
+        this._collapsed = options?.collapsed ?? false;
 
         this.addDisposables(
             this._onDidChange,


### PR DESCRIPTION
When a collapsed tab group chip was dropped into a new group, the destination group was created uncollapsed, panels were added (rendering chip+tabs in expanded state), and only then was `.collapse()` called — causing a visible expanded → collapsed transition.

Thread `collapsed` through `TabGroup` constructor and `createTabGroup` options so the new group is born collapsed. Add `TabGroupOptions` and `CreateTabGroupOptions` interfaces.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
