### PR TITLE
fix: remember active panel when collapsing and re-expanding a tab group

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
@@ -1669,7 +1669,7 @@ describe('dockviewGroupPanelModel', () => {
             expect(groupview.model.hasWatermark).toBe(true);
         });
 
-        test('expanding a tab group removes watermark and activates panel', () => {
+        test('expanding a tab group removes watermark and restores previously active panel', () => {
             const panel1 = new TestPanel('panel1', panelApi);
             const panel2 = new TestPanel('panel2', panelApi);
             groupview.model.openPanel(panel1);
@@ -1679,13 +1679,57 @@ describe('dockviewGroupPanelModel', () => {
             groupview.model.addPanelToTabGroup(tg.id, 'panel1');
             groupview.model.addPanelToTabGroup(tg.id, 'panel2');
 
+            // panel2 was the active panel before collapse — expand should restore it
             tg.collapse();
             expect(groupview.model.hasWatermark).toBe(true);
 
             tg.expand();
             expect(groupview.model.hasWatermark).toBe(false);
             expect(groupview.model.activePanel).toBeDefined();
-            expect(groupview.model.activePanel!.id).toBe('panel1');
+            expect(groupview.model.activePanel!.id).toBe('panel2');
+        });
+
+        test('expanding restores the most recently activated tab, not the first one', () => {
+            const panel1 = new TestPanel('panel1', panelApi);
+            const panel2 = new TestPanel('panel2', panelApi);
+            const panel3 = new TestPanel('panel3', panelApi);
+            groupview.model.openPanel(panel1);
+            groupview.model.openPanel(panel2);
+            groupview.model.openPanel(panel3);
+
+            const tg = groupview.model.createTabGroup({ label: 'All' });
+            groupview.model.addPanelToTabGroup(tg.id, 'panel1');
+            groupview.model.addPanelToTabGroup(tg.id, 'panel2');
+            groupview.model.addPanelToTabGroup(tg.id, 'panel3');
+
+            // Simulate the user clicking the middle tab
+            groupview.model.openPanel(panel2);
+            expect(groupview.model.activePanel?.id).toBe('panel2');
+
+            tg.collapse();
+            expect(groupview.model.hasWatermark).toBe(true);
+
+            tg.expand();
+            expect(groupview.model.activePanel?.id).toBe('panel2');
+        });
+
+        test('expanding falls back to first panel when last-active panel was removed', () => {
+            const panel1 = new TestPanel('panel1', panelApi);
+            const panel2 = new TestPanel('panel2', panelApi);
+            groupview.model.openPanel(panel1);
+            groupview.model.openPanel(panel2);
+
+            const tg = groupview.model.createTabGroup({ label: 'All' });
+            groupview.model.addPanelToTabGroup(tg.id, 'panel1');
+            groupview.model.addPanelToTabGroup(tg.id, 'panel2');
+
+            // panel2 is last-active; collapsing then removing it should make
+            // expand fall back to the only remaining panel
+            tg.collapse();
+            tg.removePanel('panel2');
+
+            tg.expand();
+            expect(groupview.model.activePanel?.id).toBe('panel1');
         });
 
         test('collapsing group with active panel activates panel in another group', () => {
@@ -1838,6 +1882,32 @@ describe('dockviewGroupPanelModel', () => {
             expect(restored[1].color).toBe('cyan');
             expect(restored[1].collapsed).toBe(true);
             expect(restored[1].panelIds).toEqual(['panel2']);
+        });
+
+        test('toJSON/restoreTabGroups round-trip preserves last-active panel', () => {
+            const panel1 = new TestPanel('panel1', panelApi);
+            const panel2 = new TestPanel('panel2', panelApi);
+            const panel3 = new TestPanel('panel3', panelApi);
+            groupview.model.openPanel(panel1);
+            groupview.model.openPanel(panel2);
+            groupview.model.openPanel(panel3);
+
+            const tg = groupview.model.createTabGroup({ label: 'G' });
+            groupview.model.addPanelToTabGroup(tg.id, 'panel1');
+            groupview.model.addPanelToTabGroup(tg.id, 'panel2');
+            groupview.model.addPanelToTabGroup(tg.id, 'panel3');
+
+            // panel2 is active when we serialize
+            groupview.model.openPanel(panel2);
+            expect(tg.lastActivePanelId).toBe('panel2');
+
+            const json = groupview.model.toJSON();
+            expect(json.tabGroups![0].lastActivePanelId).toBe('panel2');
+
+            groupview.model.dissolveTabGroup(tg.id);
+            groupview.model.restoreTabGroups(json.tabGroups!);
+            const restored = groupview.model.getTabGroups();
+            expect(restored[0].lastActivePanelId).toBe('panel2');
         });
     });
 });

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -747,6 +747,12 @@ export class DockviewGroupPanelModel
         // to the correct global position matching its group-local index
         this._enforceContiguity(tabGroup, panelId);
 
+        // If we just added the currently-active panel, record it so a
+        // collapse/expand cycle restores the right tab.
+        if (this._activePanel?.id === panelId) {
+            tabGroup.setLastActivePanelId(panelId);
+        }
+
         this._onDidAddPanelToTabGroup.fire({ tabGroup, panelId });
     }
 
@@ -1046,13 +1052,21 @@ export class DockviewGroupPanelModel
         }
 
         // Watermark is showing because all groups were collapsed.
-        // Activate the first panel in the newly expanded group.
-        const firstPanelId = tabGroup.panelIds[0];
-        if (firstPanelId) {
-            const panel = this._panels.find((p) => p.id === firstPanelId);
+        // Restore the panel that was last active in this tab group, falling
+        // back to the first available panel if that record is gone.
+        const candidateIds = [
+            tabGroup.lastActivePanelId,
+            ...tabGroup.panelIds,
+        ];
+        for (const panelId of candidateIds) {
+            if (!panelId) {
+                continue;
+            }
+            const panel = this._panels.find((p) => p.id === panelId);
             if (panel) {
                 this.doSetActivePanel(panel);
                 this.updateContainer();
+                return;
             }
         }
     }
@@ -1085,6 +1099,10 @@ export class DockviewGroupPanelModel
                     this._panelToTabGroup.set(panelId, concreteGroup);
                     this._enforceContiguity(concreteGroup, panelId);
                 }
+            }
+
+            if (data.lastActivePanelId) {
+                tabGroup.setLastActivePanelId(data.lastActivePanelId);
             }
 
             if (data.collapsed) {
@@ -1575,6 +1593,11 @@ export class DockviewGroupPanelModel
         this._activePanel = panel;
 
         if (panel) {
+            const tabGroup = this._findTabGroupForPanel(panel.id);
+            if (tabGroup) {
+                tabGroup.setLastActivePanelId(panel.id);
+            }
+
             this.tabsContainer.setActivePanel(panel);
 
             this.contentContainer.openPanel(panel);

--- a/packages/dockview-core/src/dockview/tabGroup.ts
+++ b/packages/dockview-core/src/dockview/tabGroup.ts
@@ -40,6 +40,7 @@ export interface SerializedTabGroup {
     color: DockviewTabGroupColor;
     collapsed: boolean;
     panelIds: string[];
+    lastActivePanelId?: string;
 }
 
 export interface TabGroupOptions {
@@ -63,12 +64,14 @@ export interface ITabGroup {
     }>;
     readonly onDidCollapseChange: Event<boolean>;
     readonly onDidDestroy: Event<void>;
+    readonly lastActivePanelId: string | undefined;
     addPanel(panelId: string, index?: number): void;
     removePanel(panelId: string): boolean;
     indexOfPanel(panelId: string): number;
     containsPanel(panelId: string): boolean;
     setLabel(value: string): void;
     setColor(value: DockviewTabGroupColor): void;
+    setLastActivePanelId(panelId: string | undefined): void;
     collapse(): void;
     expand(): void;
     toggle(): void;
@@ -80,6 +83,7 @@ export class TabGroup extends CompositeDisposable implements ITabGroup {
     private _label: string;
     private _color: DockviewTabGroupColor;
     private _collapsed = false;
+    private _lastActivePanelId: string | undefined;
     private readonly _panelIds: string[] = [];
 
     private readonly _onDidChange = new Emitter<void>();
@@ -142,6 +146,23 @@ export class TabGroup extends CompositeDisposable implements ITabGroup {
         return this._panelIds.length === 0;
     }
 
+    get lastActivePanelId(): string | undefined {
+        return this._lastActivePanelId;
+    }
+
+    setLastActivePanelId(panelId: string | undefined): void {
+        if (this.isDisposed) {
+            return;
+        }
+        if (panelId === undefined) {
+            this._lastActivePanelId = undefined;
+            return;
+        }
+        if (this._panelIds.includes(panelId)) {
+            this._lastActivePanelId = panelId;
+        }
+    }
+
     constructor(
         readonly id: string,
         options?: TabGroupOptions
@@ -188,6 +209,9 @@ export class TabGroup extends CompositeDisposable implements ITabGroup {
             return false;
         }
         this._panelIds.splice(index, 1);
+        if (this._lastActivePanelId === panelId) {
+            this._lastActivePanelId = undefined;
+        }
         this._onDidPanelChange.fire({ panelId, type: 'remove' });
         return true;
     }
@@ -233,6 +257,9 @@ export class TabGroup extends CompositeDisposable implements ITabGroup {
         };
         if (this._label) {
             result.label = this._label;
+        }
+        if (this._lastActivePanelId) {
+            result.lastActivePanelId = this._lastActivePanelId;
         }
         return result;
     }


### PR DESCRIPTION
TabGroup now tracks its last-active panel id, so re-expanding a collapsed tab group restores the panel the user was working in rather than always falling back to the first tab. The id is serialized through toJSON / restoreTabGroups so the behaviour also survives layout reload.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
