### PR TITLE
fix: hoist floating overlays into shell so they share a stacking cont…

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -4630,13 +4630,59 @@ describe('dockviewComponent', () => {
 
         panel1.api.setSize({ height: 123, width: 256 });
 
-        const items = dockview.element.querySelectorAll('.dv-resize-container');
+        const items = container.querySelectorAll('.dv-resize-container');
         expect(items.length).toBe(1);
 
         const el = items[0] as HTMLElement;
 
         expect(el.style.height).toBe('123px');
         expect(el.style.width).toBe('256px');
+    });
+
+    test('floating overlays share a stacking context with render overlays (issue: positions blocks other floating tabs)', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                switch (options.name) {
+                    case 'default':
+                        return new PanelContentPartTest(
+                            options.id,
+                            options.name
+                        );
+                    default:
+                        throw new Error(`unsupported`);
+                }
+            },
+        });
+
+        dockview.layout(1000, 500);
+
+        dockview.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            floating: true,
+        });
+
+        const overlay = container.querySelector(
+            '.dv-resize-container'
+        ) as HTMLElement;
+        expect(overlay).toBeTruthy();
+
+        const host = overlay.parentElement!;
+        expect(host.classList.contains('dv-floating-overlay-host')).toBe(true);
+
+        // Host must share a parent with the OverlayRenderContainer (the shell)
+        // so floating overlay z-indexes and `dv-render-overlay` z-indexes
+        // resolve in the same stacking context.
+        expect(host.parentElement).toBe(
+            dockview.overlayRenderContainer.element
+        );
+
+        // Host must NOT live inside `.dv-dockview` — that element has
+        // `contain: layout` which forms a stacking context that would trap
+        // floating z-indexes below shell-level render overlays.
+        expect(dockview.element.contains(overlay)).toBe(false);
     });
 
     test('that external dnd events do not trigger the top-level center dnd target unless empty', () => {
@@ -5007,7 +5053,7 @@ describe('dockviewComponent', () => {
         expect(dockview.groups.length).toBe(2);
         expect(dockview.panels.length).toBe(2);
 
-        el = dockview.element.querySelector('.dv-resize-container');
+        el = container.querySelector('.dv-resize-container');
         expect(el).toBeTruthy();
 
         el = dockview.element.querySelector('.dv-view-container');
@@ -5087,7 +5133,7 @@ describe('dockviewComponent', () => {
         expect(dockview.groups.length).toBe(0);
         expect(dockview.panels.length).toBe(0);
 
-        el = dockview.element.querySelector('.dv-resize-container');
+        el = container.querySelector('.dv-resize-container');
         expect(el).toBeFalsy();
 
         el = dockview.element.querySelector('.dv-view-container');

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -408,6 +408,7 @@ export class DockviewComponent
     readonly onDidMaximizedGroupChange = this._onDidMaximizedGroupChange.event;
 
     private _shellManager: ShellManager | undefined;
+    private _floatingOverlayHost: HTMLDivElement | undefined;
     private _inShellLayout = false;
     private readonly _edgeGroups = new Map<
         EdgeGroupPosition,
@@ -543,6 +544,13 @@ export class DockviewComponent
             this._shellManager.element,
             this
         );
+
+        // Hosted in the shell (not inside `.dv-dockview`) so floating overlays
+        // share a stacking context with `dv-render-overlay` panels; sized to
+        // mirror the gridview rect so saved positions remain valid.
+        this._floatingOverlayHost = document.createElement('div');
+        this._floatingOverlayHost.className = 'dv-floating-overlay-host';
+        this._shellManager.element.appendChild(this._floatingOverlayHost);
 
         this._rootDropTarget = new Droptarget(this.element, {
             className: 'dv-drop-target-edge',
@@ -1267,7 +1275,7 @@ export class DockviewComponent
         const anchoredBox = getAnchoredBox();
 
         const overlay = new Overlay({
-            container: this.gridview.element,
+            container: this._floatingOverlayHost ?? this.gridview.element,
             content: group.element,
             ...anchoredBox,
             minimumInViewportWidth:
@@ -1463,12 +1471,27 @@ export class DockviewComponent
             super.layout(width, height, forceResize);
         }
 
+        this._syncFloatingOverlayHost();
+
         if (this._floatingGroups) {
             for (const floating of this._floatingGroups) {
                 // ensure floting groups stay within visible boundaries
                 floating.overlay.setBounds();
             }
         }
+    }
+
+    private _syncFloatingOverlayHost(): void {
+        if (!this._floatingOverlayHost || !this._shellManager) {
+            return;
+        }
+        const shellRect = this._shellManager.element.getBoundingClientRect();
+        const gridRect = this.element.getBoundingClientRect();
+        const host = this._floatingOverlayHost;
+        host.style.left = `${gridRect.left - shellRect.left}px`;
+        host.style.top = `${gridRect.top - shellRect.top}px`;
+        host.style.width = `${gridRect.width}px`;
+        host.style.height = `${gridRect.height}px`;
     }
 
     private _layoutFromShell(width: number, height: number): void {

--- a/packages/dockview-core/src/overlay/overlay.scss
+++ b/packages/dockview-core/src/overlay/overlay.scss
@@ -25,6 +25,11 @@
     }
 }
 
+.dv-floating-overlay-host {
+    position: absolute;
+    pointer-events: none;
+}
+
 .dv-resize-container {
     --dv-overlay-z-index: var(--dv-overlay-z-index, 999);
 


### PR DESCRIPTION
…ext with render overlays

`.dv-dockview` has `contain: layout`, which forms a stacking context. That trapped floating overlay z-indexes inside `.dv-dockview` and prevented them from stacking against the OverlayRenderContainer's `.dv-render-overlay` panels (which live at the shell level). The visible symptom was that a floating panel using `renderer: 'always'` would always appear above other floating panels regardless of which group was active — the `AriaLevelTracker` ordering was correct, but the two layers were resolving in different stacking contexts.

Add a `.dv-floating-overlay-host` element in the shell, sized to mirror the gridview rect on each layout. Floating overlays now live inside this host alongside the render overlays, so all overlay z-indexes resolve in the same shell-level stacking context and the `AriaLevelTracker` is the single source of truth for layering.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
