### PR TITLE
fix: restore pointer events on floating overlays

### DIFF
--- a/packages/dockview-core/src/overlay/overlay.scss
+++ b/packages/dockview-core/src/overlay/overlay.scss
@@ -28,6 +28,10 @@
 .dv-floating-overlay-host {
     position: absolute;
     pointer-events: none;
+
+    > .dv-resize-container {
+        pointer-events: auto;
+    }
 }
 
 .dv-resize-container {


### PR DESCRIPTION
The `.dv-floating-overlay-host` introduced in #1203 has `pointer-events: none` so it doesn't block clicks on the gridview underneath, but nothing re-enabled pointer events on the floating overlay inside it — so clicks and drags on a floating group passed straight through and the group became uninteractable.

Set `pointer-events: auto` on `.dv-floating-overlay-host > .dv-resize-container`.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
