### PR TITLE
fix: stop auto-injecting dockview.css from package cjs/esm bundles

### DIFF
--- a/packages/dockview-core/package.json
+++ b/packages/dockview-core/package.json
@@ -43,6 +43,10 @@
     "main": "./dist/package/main.cjs.js",
     "module": "./dist/package/main.esm.mjs",
     "types": "./dist/cjs/index.d.ts",
+    "sideEffects": [
+        "**/*.css",
+        "**/*.scss"
+    ],
     "files": [
         "dist",
         "README.md"

--- a/packages/dockview-core/rollup.config.js
+++ b/packages/dockview-core/rollup.config.js
@@ -95,9 +95,10 @@ module.exports = [
     createBundle('umd', { withStyles: true, isMinified: true }),
     createBundle('umd', { withStyles: false, isMinified: false }),
     createBundle('umd', { withStyles: false, isMinified: true }),
-    // Package bundles — dist/package/
-    createBundle('cjs', { withStyles: true, isMinified: false }),
-    createBundle('cjs', { withStyles: true, isMinified: true }),
-    createBundle('esm', { withStyles: true, isMinified: false }),
-    createBundle('esm', { withStyles: true, isMinified: true }),
+    // Package bundles — dist/package/ (no auto-injected CSS; consumers
+    // import 'dockview-core/dist/styles/dockview.css' explicitly)
+    createBundle('cjs', { withStyles: false, isMinified: false }),
+    createBundle('cjs', { withStyles: false, isMinified: true }),
+    createBundle('esm', { withStyles: false, isMinified: false }),
+    createBundle('esm', { withStyles: false, isMinified: true }),
 ];

--- a/packages/dockview-react/package.json
+++ b/packages/dockview-react/package.json
@@ -44,6 +44,10 @@
     "main": "./dist/package/main.cjs.js",
     "module": "./dist/package/main.esm.mjs",
     "types": "./dist/cjs/index.d.ts",
+    "sideEffects": [
+        "**/*.css",
+        "**/*.scss"
+    ],
     "files": [
         "dist",
         "README.md"

--- a/packages/dockview-react/rollup.config.js
+++ b/packages/dockview-react/rollup.config.js
@@ -104,9 +104,10 @@ module.exports = [
     // Browser bundles (UMD) — dist/
     createBundle('umd', { withStyles: true, isMinified: false }),
     createBundle('umd', { withStyles: true, isMinified: true }),
-    // Package bundles — dist/package/
-    createBundle('cjs', { withStyles: true, isMinified: false }),
-    createBundle('cjs', { withStyles: true, isMinified: true }),
-    createBundle('esm', { withStyles: true, isMinified: false }),
-    createBundle('esm', { withStyles: true, isMinified: true }),
+    // Package bundles — dist/package/ (no auto-injected CSS; consumers
+    // import 'dockview-react/dist/styles/dockview.css' explicitly)
+    createBundle('cjs', { withStyles: false, isMinified: false }),
+    createBundle('cjs', { withStyles: false, isMinified: true }),
+    createBundle('esm', { withStyles: false, isMinified: false }),
+    createBundle('esm', { withStyles: false, isMinified: true }),
 ];

--- a/packages/dockview/package.json
+++ b/packages/dockview/package.json
@@ -44,6 +44,10 @@
     "main": "./dist/package/main.cjs.js",
     "module": "./dist/package/main.esm.mjs",
     "types": "./dist/cjs/index.d.ts",
+    "sideEffects": [
+        "**/*.css",
+        "**/*.scss"
+    ],
     "files": [
         "dist",
         "README.md"

--- a/packages/dockview/rollup.config.js
+++ b/packages/dockview/rollup.config.js
@@ -104,9 +104,10 @@ module.exports = [
     // Browser bundles (UMD) — dist/
     createBundle('umd', { withStyles: true, isMinified: false }),
     createBundle('umd', { withStyles: true, isMinified: true }),
-    // Package bundles — dist/package/
-    createBundle('cjs', { withStyles: true, isMinified: false }),
-    createBundle('cjs', { withStyles: true, isMinified: true }),
-    createBundle('esm', { withStyles: true, isMinified: false }),
-    createBundle('esm', { withStyles: true, isMinified: true }),
+    // Package bundles — dist/package/ (no auto-injected CSS; consumers
+    // import 'dockview/dist/styles/dockview.css' explicitly)
+    createBundle('cjs', { withStyles: false, isMinified: false }),
+    createBundle('cjs', { withStyles: false, isMinified: true }),
+    createBundle('esm', { withStyles: false, isMinified: false }),
+    createBundle('esm', { withStyles: false, isMinified: true }),
 ];


### PR DESCRIPTION
## Summary

- The 5.0.0 rollup-bundle restructure (commit `6020e8c7c`) unintentionally piped the `cjs`/`esm` package bundles through `rollup-plugin-postcss` with default `inject: true`. Any consumer importing `dockview` / `dockview-core` / `dockview-react` via the package entry has been getting `dockview.css` appended to `<head>` at module-load time — contradicting the documented "Step 2: Import the Stylesheet" workflow and clobbering consumer CSS that loads earlier.
- Flipped the `cjs`/`esm` `createBundle` calls in all three `rollup.config.js` files from `withStyles: true` → `false`. The bundles now build from `src/index.ts` and skip `postcss()`. Output paths (`dist/package/main.{cjs.js,esm.mjs}`) are unchanged.
- UMD with-styles bundles (`dist/{name}.js`) are untouched — `<script>`/CDN users keep the auto-injection they expect.
- Added `"sideEffects": ["**/*.css", "**/*.scss"]` to each `package.json` so the manual `import 'dockview/dist/styles/dockview.css'` (per docs) survives tree-shaking, and the JS entry is honestly side-effect-free.

## Background

Reported by a user whose custom theme setup broke after upgrading: passing `theme={{ name: 'xxx', className: 'dv-theme' }}` was racing against an automatically-injected `dockview.css` in `<head>`, which their own stylesheet couldn't reliably override. Docs (`packages/docs/docs/overview/quickstart.mdx:37`) still tell users to import the stylesheet manually, so the auto-injection was a regression in published behaviour, not an intentional API.

## Verification

Built each package with `yarn workspace <pkg> build:bundle` and grep'd the outputs:

| Bundle | `styleInject + abyss` hits | Behaviour |
|---|---|---|
| `dist/{name}.js` (UMD with-styles) | 5 | Auto-injects on load — `<script>` users unchanged |
| `dist/{name}.noStyle.js` (UMD no-styles) | 2 | No injection (only `addStyles` fn refs for popouts) |
| `dist/package/main.{cjs.js,esm.mjs}` (package) | 2 | **Now matches `noStyle` — no auto-injection** |

The remaining 2 hits in package bundles are references to the `addStyles` function (`packages/dockview-core/src/dom.ts:212`), invoked only by `popoutWindow.ts:143` when a popout window is opened — never on module load.

## Test plan

- [ ] CI green
- [ ] Smoke-test the docs site against the rebuilt packages — ensure the explicit `import 'dockview/dist/styles/dockview.css'` (and the equivalents in the example boilerplates) still produce a styled layout
- [ ] Verify in the original reporter's reproduction (Next.js + custom theme) that `<head>` no longer contains an injected `dockview.css` after `import { DockviewReact } from 'dockview'`
- [ ] Confirm UMD CDN consumers still work via `dist/dockview.js` (auto-injected styles preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)