### PR TITLE
fix(release): allow nx to rewrite internal dep ranges on experimental…

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -54,6 +54,7 @@
             "generatorOptions": {
                 "currentVersionSource": "git-tag"
             },
+            "preserveMatchingDependencyRanges": false,
             "git": {
                 "commit": true,
                 "commitMessage": "chore(release): publish {version}",


### PR DESCRIPTION
… publish

NX 20.8+ defaults `preserveMatchingDependencyRanges` to true, which causes `nx release version` to fail when bumping to an experimental `0.0.0-experimental-<sha>` version that falls outside the existing `^5.x.x` ranges in dockview, dockview-vue, and dockview-angular. Disable it so the experimental publish workflow can rewrite ranges in lockstep.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
