### PR TITLE
fix(docs): demo edge group reset + sync, swizzled DocItem Layout shadow

### DIFF
--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -15,7 +15,11 @@ import {
 import * as React from 'react';
 import * as ReactDOM from 'react-dom/client';
 import './app.scss';
-import { defaultConfig } from './defaultLayout';
+import {
+    defaultConfig,
+    populateEdgeGroups,
+    setupEdgeGroups,
+} from './defaultLayout';
 import { LeftControls, PrefixHeaderControls, RightControls } from './controls';
 import { Table, usePanelApiMetadata } from './debugPanel';
 import { OrdersPanel } from './ordersPanel';
@@ -431,41 +435,13 @@ const DockviewDemo = (props: {
             }),
         ];
 
-        const edgeGroupDefs: {
-            pos: 'bottom' | 'left' | 'right';
-            id: string;
-            title: string;
-        }[] = [
-            { pos: 'left', id: 'left-1', title: 'Explorer' },
-            { pos: 'right', id: 'right-1', title: 'Outline' },
-            { pos: 'right', id: 'right-2', title: 'Properties' },
-            { pos: 'bottom', id: 'bottom-1', title: 'Terminal' },
-            { pos: 'bottom', id: 'bottom-2', title: 'Output' },
-            { pos: 'bottom', id: 'bottom-3', title: 'Problems' },
-        ];
-
-        const populateEdgeGroups = () => {
-            for (const { pos, id, title } of edgeGroupDefs) {
-                const groupApi = api.getEdgeGroup(pos);
-                if (groupApi && !api.panels.find((p) => p.id === id)) {
-                    api.addPanel({
-                        id,
-                        component: 'fixedPlaceholder',
-                        title,
-                        position: { referenceGroup: groupApi.id },
-                        params: { label: title, position: pos },
-                    });
-                }
-            }
-        };
-
         const loadLayout = () => {
             const state = localStorage.getItem('dv-demo-state');
 
             if (state) {
                 try {
                     api.fromJSON(JSON.parse(state));
-                    populateEdgeGroups();
+                    populateEdgeGroups(api);
                     setLayoutReady(true);
                     return;
                 } catch {
@@ -475,27 +451,7 @@ const DockviewDemo = (props: {
             }
 
             defaultConfig(api);
-            populateEdgeGroups();
-
-            // Create a tab group in the bottom edge group
-            const bottomEdge = api.getEdgeGroup('bottom');
-            if (bottomEdge) {
-                const logs = api.createTabGroup({
-                    groupId: bottomEdge.id,
-                    label: 'Logs',
-                    color: 'purple',
-                });
-                api.addPanelToTabGroup({
-                    groupId: bottomEdge.id,
-                    tabGroupId: logs.id,
-                    panelId: 'bottom-1',
-                });
-                api.addPanelToTabGroup({
-                    groupId: bottomEdge.id,
-                    tabGroupId: logs.id,
-                    panelId: 'bottom-2',
-                });
-            }
+            populateEdgeGroups(api);
 
             setLayoutReady(true);
         };
@@ -508,26 +464,7 @@ const DockviewDemo = (props: {
     }, [api]);
 
     const onReady = (event: DockviewReadyEvent) => {
-        if (useEdgeGroups) {
-            event.api.addEdgeGroup('bottom', {
-                id: 'bottom',
-                initialSize: 200,
-                minimumSize: 100,
-                collapsed: true,
-            });
-            event.api.addEdgeGroup('left', {
-                id: 'left',
-                initialSize: 220,
-                minimumSize: 150,
-                collapsed: true,
-            });
-            event.api.addEdgeGroup('right', {
-                id: 'right',
-                initialSize: 220,
-                minimumSize: 150,
-                collapsed: true,
-            });
-        }
+        setupEdgeGroups(event.api);
         setApi(event.api);
     };
 
@@ -719,7 +656,6 @@ const DockviewDemo = (props: {
 
     const [showLogs, setShowLogs] = React.useState<boolean>(false);
     const [debug, setDebug] = React.useState<boolean>(false);
-    const [useEdgeGroups, setUseEdgeGroups] = React.useState<boolean>(true);
     return (
         <div
             className="dockview-demo"
@@ -758,11 +694,6 @@ const DockviewDemo = (props: {
                                         value={effectiveTheme}
                                     >
                                         <DockviewReact
-                                            key={
-                                                useEdgeGroups
-                                                    ? 'shell'
-                                                    : 'no-shell'
-                                            }
                                             components={components}
                                             defaultTabComponent={
                                                 headerComponents.default

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/defaultLayout.ts
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/defaultLayout.ts
@@ -1,4 +1,4 @@
-import { DockviewApi } from 'dockview-react';
+import { DockviewApi, EdgeGroupPosition } from 'dockview-react';
 
 export const nextId = (() => {
     let counter = 0;
@@ -168,4 +168,86 @@ export function defaultConfig(api: DockviewApi) {
     orderbook.api.setActive();
     orders.api.setActive();
     positionsummary.api.setActive();
+}
+
+const EDGE_GROUP_DEFS: {
+    pos: 'bottom' | 'left' | 'right';
+    options: { id: string; initialSize: number; minimumSize: number };
+}[] = [
+    {
+        pos: 'bottom',
+        options: { id: 'bottom', initialSize: 200, minimumSize: 100 },
+    },
+    {
+        pos: 'left',
+        options: { id: 'left', initialSize: 220, minimumSize: 150 },
+    },
+    {
+        pos: 'right',
+        options: { id: 'right', initialSize: 220, minimumSize: 150 },
+    },
+];
+
+const EDGE_GROUP_PANELS: {
+    pos: 'bottom' | 'left' | 'right';
+    id: string;
+    title: string;
+}[] = [
+    { pos: 'left', id: 'left-1', title: 'Explorer' },
+    { pos: 'right', id: 'right-1', title: 'Outline' },
+    { pos: 'right', id: 'right-2', title: 'Properties' },
+    { pos: 'bottom', id: 'bottom-1', title: 'Terminal' },
+    { pos: 'bottom', id: 'bottom-2', title: 'Output' },
+    { pos: 'bottom', id: 'bottom-3', title: 'Problems' },
+];
+
+export function setupEdgeGroups(api: DockviewApi) {
+    for (const position of [
+        'top',
+        'bottom',
+        'left',
+        'right',
+    ] as EdgeGroupPosition[]) {
+        if (api.getEdgeGroup(position)) {
+            api.removeEdgeGroup(position);
+        }
+    }
+
+    for (const { pos, options } of EDGE_GROUP_DEFS) {
+        api.addEdgeGroup(pos, { ...options, collapsed: true });
+    }
+}
+
+export function populateEdgeGroups(api: DockviewApi) {
+    for (const { pos, id, title } of EDGE_GROUP_PANELS) {
+        const groupApi = api.getEdgeGroup(pos);
+        if (groupApi && !api.panels.find((p) => p.id === id)) {
+            api.addPanel({
+                id,
+                component: 'fixedPlaceholder',
+                title,
+                position: { referenceGroup: groupApi.id },
+                params: { label: title, position: pos },
+            });
+        }
+    }
+
+    const bottomEdge = api.getEdgeGroup('bottom');
+    if (bottomEdge) {
+        const logs = api.createTabGroup({
+            groupId: bottomEdge.id,
+            label: 'Logs',
+            color: 'purple',
+        });
+        api.addPanelToTabGroup({
+            groupId: bottomEdge.id,
+            tabGroupId: logs.id,
+            panelId: 'bottom-1',
+        });
+        api.addPanelToTabGroup({
+            groupId: bottomEdge.id,
+            tabGroupId: logs.id,
+            panelId: 'bottom-2',
+        });
+    }
 }

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
@@ -79,12 +79,8 @@ const EdgeGroupToggles = (props: { api: DockviewApi }) => {
     React.useEffect(() => {
         const sync = () => setActive(readEdgeState(props.api));
         sync();
-        const disposables = [
-            props.api.onDidLayoutChange(sync),
-            props.api.onDidAddGroup(sync),
-            props.api.onDidRemoveGroup(sync),
-        ];
-        return () => disposables.forEach((d) => d.dispose());
+        const disposable = props.api.onDidLayoutChange(sync);
+        return () => disposable.dispose();
     }, [props.api]);
 
     const toggle = (position: EdgeGroupPosition) => {

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
@@ -77,11 +77,14 @@ const EdgeGroupToggles = (props: { api: DockviewApi }) => {
     >(() => readEdgeState(props.api));
 
     React.useEffect(() => {
-        setActive(readEdgeState(props.api));
-        const disposable = props.api.onDidLayoutChange(() => {
-            setActive(readEdgeState(props.api));
-        });
-        return () => disposable.dispose();
+        const sync = () => setActive(readEdgeState(props.api));
+        sync();
+        const disposables = [
+            props.api.onDidLayoutChange(sync),
+            props.api.onDidAddGroup(sync),
+            props.api.onDidRemoveGroup(sync),
+        ];
+        return () => disposables.forEach((d) => d.dispose());
     }, [props.api]);
 
     const toggle = (position: EdgeGroupPosition) => {

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
@@ -1,6 +1,11 @@
 import { DockviewApi, EdgeGroupPosition } from 'dockview-react';
 import * as React from 'react';
-import { defaultConfig, nextId } from './defaultLayout';
+import {
+    defaultConfig,
+    nextId,
+    populateEdgeGroups,
+    setupEdgeGroups,
+} from './defaultLayout';
 
 const btnStyle: React.CSSProperties = {
     padding: '4px 10px',
@@ -59,22 +64,29 @@ const Row = (props: {
 
 const EDGE_POSITIONS: EdgeGroupPosition[] = ['top', 'bottom', 'left', 'right'];
 
+const readEdgeState = (
+    api: DockviewApi
+): Partial<Record<EdgeGroupPosition, boolean>> =>
+    Object.fromEntries(
+        EDGE_POSITIONS.map((pos) => [pos, api.getEdgeGroup(pos) !== undefined])
+    );
+
 const EdgeGroupToggles = (props: { api: DockviewApi }) => {
     const [active, setActive] = React.useState<
         Partial<Record<EdgeGroupPosition, boolean>>
-    >(() =>
-        Object.fromEntries(
-            EDGE_POSITIONS.map((pos) => [
-                pos,
-                props.api.getEdgeGroup(pos) !== undefined,
-            ])
-        )
-    );
+    >(() => readEdgeState(props.api));
+
+    React.useEffect(() => {
+        setActive(readEdgeState(props.api));
+        const disposable = props.api.onDidLayoutChange(() => {
+            setActive(readEdgeState(props.api));
+        });
+        return () => disposable.dispose();
+    }, [props.api]);
 
     const toggle = (position: EdgeGroupPosition) => {
         if (active[position]) {
             props.api.removeEdgeGroup(position);
-            setActive((s) => ({ ...s, [position]: false }));
         } else {
             const groupApi = props.api.addEdgeGroup(position, {
                 id: `edge-${position}`,
@@ -88,7 +100,6 @@ const EdgeGroupToggles = (props: { api: DockviewApi }) => {
                 position: { referenceGroup: groupApi.id },
                 params: { label: position, position },
             });
-            setActive((s) => ({ ...s, [position]: true }));
         }
     };
 
@@ -250,7 +261,9 @@ export const GridActions = (props: {
         if (props.api) {
             try {
                 props.api.clear();
+                setupEdgeGroups(props.api);
                 defaultConfig(props.api);
+                populateEdgeGroups(props.api);
             } catch (err) {
                 localStorage.removeItem('dv-demo-state');
             }

--- a/packages/docs/src/theme/DocItem/Layout/index.js
+++ b/packages/docs/src/theme/DocItem/Layout/index.js
@@ -10,7 +10,7 @@ import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
 import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
 import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
-import Unlisted from '@theme/Unlisted';
+import ContentVisibility from '@theme/ContentVisibility';
 import styles from './styles.module.css';
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
@@ -33,13 +33,11 @@ function useDocTOC() {
 }
 export default function DocItemLayout({ children }) {
     const docTOC = useDocTOC();
-    const {
-        metadata: { unlisted },
-    } = useDoc();
+    const { metadata } = useDoc();
     return (
         <div className="row">
             <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
-                {unlisted && <Unlisted />}
+                <ContentVisibility metadata={metadata} />
                 <DocVersionBanner />
                 <div className={styles.docItemContainer}>
                     <article>


### PR DESCRIPTION
- demo: edge group toggle row now subscribes to onDidLayoutChange so the buttons stay in sync after fromJSON / load
- demo: extract setupEdgeGroups/populateEdgeGroups so Reset fully restores edge groups (clear preserves them but empties their panels, leaving the demo in a broken state without re-setup)
- demo: drop unused useEdgeGroups flag (no UI exposed it; always-on)
- docs theme: replace removed @theme/Unlisted with @theme/ContentVisibility to match Docusaurus 3.x

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
