### PR TITLE
fix(core): fire onDidLayoutChange for edge group and tab group changes

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -7516,6 +7516,87 @@ describe('dockviewComponent', () => {
 
             disposeDidLayoutChangeHandler();
         });
+
+        test('when edge groups are added or removed (including empty)', () => {
+            const didLayoutChangeHandler = jest.fn();
+            dockview.onDidLayoutChange(didLayoutChangeHandler);
+
+            // add edge group
+            dockview.addEdgeGroup('left', { id: 'edge-left' });
+            jest.runAllTimers();
+            expect(didLayoutChangeHandler).toHaveBeenCalledTimes(1);
+
+            // remove an empty edge group — fires only _onDidRemoveGroup (no
+            // panel events). Without _onDidRemoveGroup in the composition
+            // this would not fire.
+            dockview.removeEdgeGroup('left');
+            jest.runAllTimers();
+            expect(didLayoutChangeHandler).toHaveBeenCalledTimes(2);
+        });
+
+        test('when tab groups are created, mutated, collapsed, or destroyed', () => {
+            const panel1 = dockview.addPanel({
+                id: 'panel_1',
+                component: 'default',
+            });
+            const panel2 = dockview.addPanel({
+                id: 'panel_2',
+                component: 'default',
+                position: { referenceGroup: panel1.group },
+            });
+            jest.runAllTimers();
+
+            const didLayoutChangeHandler = jest.fn();
+            dockview.onDidLayoutChange(didLayoutChangeHandler);
+
+            // create tab group
+            const tg = dockview.api.createTabGroup({
+                groupId: panel1.group.id,
+                label: 'My Group',
+                color: 'red',
+            });
+            jest.runAllTimers();
+            expect(didLayoutChangeHandler).toHaveBeenCalledTimes(1);
+
+            // add panels to tab group
+            dockview.api.addPanelToTabGroup({
+                groupId: panel1.group.id,
+                tabGroupId: tg.id,
+                panelId: panel1.id,
+            });
+            jest.runAllTimers();
+            expect(didLayoutChangeHandler).toHaveBeenCalledTimes(2);
+
+            dockview.api.addPanelToTabGroup({
+                groupId: panel1.group.id,
+                tabGroupId: tg.id,
+                panelId: panel2.id,
+            });
+            jest.runAllTimers();
+            expect(didLayoutChangeHandler).toHaveBeenCalledTimes(3);
+
+            // collapse tab group
+            tg.collapse();
+            jest.runAllTimers();
+            expect(didLayoutChangeHandler).toHaveBeenCalledTimes(4);
+
+            // remove a panel from the tab group (group still has panel2 so
+            // it is not auto-destroyed)
+            dockview.api.removePanelFromTabGroup({
+                groupId: panel1.group.id,
+                panelId: panel1.id,
+            });
+            jest.runAllTimers();
+            expect(didLayoutChangeHandler).toHaveBeenCalledTimes(5);
+
+            // explicitly dissolve the tab group
+            dockview.api.dissolveTabGroup({
+                groupId: panel1.group.id,
+                tabGroupId: tg.id,
+            });
+            jest.runAllTimers();
+            expect(didLayoutChangeHandler).toHaveBeenCalledTimes(6);
+        });
     });
 
     describe('panel visibility', () => {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -702,10 +702,17 @@ export class DockviewComponent
                 this.onDidRemovePanel,
                 this.onDidAddGroup,
                 this.onDidRemove,
+                this.onDidRemoveGroup,
                 this.onDidMovePanel,
                 this.onDidActivePanelChange,
                 this.onDidPopoutGroupPositionChange,
-                this.onDidPopoutGroupSizeChange
+                this.onDidPopoutGroupSizeChange,
+                this.onDidCreateTabGroup,
+                this.onDidDestroyTabGroup,
+                this.onDidAddPanelToTabGroup,
+                this.onDidRemovePanelFromTabGroup,
+                this.onDidTabGroupChange,
+                this.onDidTabGroupCollapsedChange
             )(() => {
                 this._bufferOnDidLayoutChange.fire();
             }),


### PR DESCRIPTION
onDidLayoutChange was composed only from gridview-tree events plus onDidAddGroup, so it missed:
- removeEdgeGroup on an empty edge group (fired only _onDidRemoveGroup, which was not in the composition)
- tab group create/destroy/mutate/collapse and panel-to-tab-group add/remove (none of which were in the composition)

All of these mutate state captured by toJSON, so consumers that persist layout on layout change were getting stale snapshots. Add the missing events to the composition and cover with tests.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
