### PR TITLE
fix(core): drop `contain: layout` so inner sashes/separators win z-index

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.scss
+++ b/packages/dockview-core/src/dockview/dockviewComponent.scss
@@ -1,7 +1,9 @@
 .dv-dockview {
     position: relative;
     background-color: var(--dv-group-view-background-color);
-    contain: layout;
+    // Avoid `contain: layout` here: it creates a stacking context that traps
+    // inner sash z-index inside the dockview's SC, so render-overlays mounted
+    // at the shell level paint on top of the sashes (and separators).
 
     .dv-watermark-container {
         position: absolute;


### PR DESCRIPTION
`.dv-dockview { contain: layout }` was creating a stacking context that trapped the inner sash (z-index 99) and separator (z-index 5) z-indices inside the dockview's SC. The SC then sat at z-index auto in the page root, getting painted under render-overlays mounted at the shell level (z-index 1) — so panel content from `renderer: 'always'` covered the sashes (no resize cursor / no drag) and the separators (invisible).

Outer sashes/separators were unaffected because they live in the shell's outer splitview, outside the dockview's SC.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
