### PR TITLE
fix(core): apply theme class only to the shell element

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -141,13 +141,13 @@ describe('dockviewComponent', () => {
             className: 'test-a test-b',
         });
         expect(dockview.element.className).toBe(
-            'test-a test-b dockview-theme-abyss dv-tab-group-indicator-none'
+            'test-a test-b dv-tab-group-indicator-none'
         );
 
         dockview.updateOptions({ className: 'test-b test-c' });
 
         expect(dockview.element.className).toBe(
-            'dockview-theme-abyss dv-tab-group-indicator-none test-b test-c'
+            'dv-tab-group-indicator-none test-b test-c'
         );
     });
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -329,7 +329,6 @@ export class DockviewComponent
     private _options: Exclude<DockviewComponentOptions, 'orientation'>;
     private _tabGroupColorPalette: TabGroupColorPalette;
     private _watermark: IWatermarkRenderer | null = null;
-    private readonly _themeClassnames: Classnames;
     private _shellThemeClassnames: Classnames | undefined;
 
     readonly overlayRenderContainer: OverlayRenderContainer;
@@ -535,7 +534,6 @@ export class DockviewComponent
 
         this.popupService = new PopupService(this.element);
         this.contextMenuController = new ContextMenuController(this);
-        this._themeClassnames = new Classnames(this.element);
         this._api = new DockviewApi(this);
 
         // The shell always wraps the dockview element so edge groups can be
@@ -3522,11 +3520,10 @@ export class DockviewComponent
 
     private updateTheme(): void {
         const theme = this._options.theme ?? themeAbyss;
-        this._themeClassnames.setClassNames(theme.className);
-        // When shell mode is active, edge group groups are siblings of
-        // .dv-dockview so they don't inherit theme CSS from it. Apply the
-        // same theme class to the shell element so all edge groups and the
-        // main grid share the same CSS custom properties and theme rules.
+        // Apply the theme class only to the shell so edge groups and the
+        // main grid both inherit its CSS custom properties via the cascade.
+        // Re-declaring it on `.dv-dockview` would block consumer overrides
+        // set on the shell from reaching the dockview subtree.
         this._shellThemeClassnames?.setClassNames(theme.className);
 
         this.gridview.margin = theme.gap ?? 0;

--- a/packages/dockview/src/react.ts
+++ b/packages/dockview/src/react.ts
@@ -32,7 +32,7 @@ const ReactComponentBridge: React.ForwardRefRenderFunction<
     IPanelWrapperRef,
     IPanelWrapperProps
 > = (props, ref) => {
-    const [_, triggerRender] = React.useState<number>();
+    const [, triggerRender] = React.useState<number>(0);
     const _props = React.useRef<object>(props.componentProps);
 
     React.useImperativeHandle(
@@ -45,8 +45,12 @@ const ReactComponentBridge: React.ForwardRefRenderFunction<
                  * trigger a re-render.
                  * we use this rather than updating through a prop since we can
                  * pass a ref into the vanilla-js world.
+                 *
+                 * Use a monotonic counter rather than `Date.now()` so two
+                 * updates within the same millisecond still produce distinct
+                 * state values and avoid React's bailout.
                  */
-                triggerRender(Date.now());
+                triggerRender((n) => n + 1);
             },
         }),
         []


### PR DESCRIPTION
Both `.dv-shell` and the inner `.dv-dockview` wrapper were getting the theme class. The class re-declares CSS custom properties (e.g. `--dv-separator-border`, `--dv-sash-color`), so a consumer setting an override on the shell would have it cascade as far as the inner wrapper, where the duplicate declaration blocked it from reaching the dockview subtree. Edge groups (siblings of the wrapper) saw the override; inner sashes/separators did not.

Drop the inner application — the shell is an ancestor of `.dv-dockview`, so the cascade carries the theme variables to the same elements without the redeclaration.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
