### PR TITLE
fix(docs): import useDoc from plugin-content-docs/client

### DIFF
--- a/packages/docs/src/theme/DocItem/Content/index.js
+++ b/packages/docs/src/theme/DocItem/Content/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import { ThemeClassNames } from '@docusaurus/theme-common';
-import { useDoc } from '@docusaurus/theme-common/internal';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import Heading from '@theme/Heading';
 import MDXContent from '@theme/MDXContent';
 import { FrameworkSelector } from '@site/src/components/frameworkSpecific';

--- a/packages/docs/src/theme/DocItem/Layout/index.js
+++ b/packages/docs/src/theme/DocItem/Layout/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import { useWindowSize } from '@docusaurus/theme-common';
-import { useDoc } from '@docusaurus/theme-common/internal';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import DocItemPaginator from '@theme/DocItem/Paginator';
 import DocVersionBanner from '@theme/DocVersionBanner';
 import DocVersionBadge from '@theme/DocVersionBadge';


### PR DESCRIPTION
## Summary
- Fixes runtime error `(0, useDoc) is not a function` in the docs site.
- Docusaurus 3.10 moved `useDoc` out of `@docusaurus/theme-common/internal` into `@docusaurus/plugin-content-docs/client`. The two swizzled `DocItem` components (`Content/index.js`, `Layout/index.js`) were still importing from the old path.

## Test plan
- [ ] `yarn workspace docs start` and confirm doc pages render without the `useDoc` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)