### PR TITLE
fix(docs): resolve dockview-react in template SystemJS imports

### DIFF
--- a/packages/docs/scripts/buildTemplates.mjs
+++ b/packages/docs/scripts/buildTemplates.mjs
@@ -31,10 +31,12 @@ const DOCKVIEW_CDN = {
         remote: {
             'dockview-core': `https://cdn.jsdelivr.net/npm/dockview-core@${DOCKVIEW_VERSION}`,
             dockview: `https://cdn.jsdelivr.net/npm/dockview@${DOCKVIEW_VERSION}`,
+            'dockview-react': `https://cdn.jsdelivr.net/npm/dockview-react@${DOCKVIEW_VERSION}`,
         },
         local: {
             'dockview-core': `${local}/dockview-core`,
             dockview: `${local}/dockview`,
+            'dockview-react': `${local}/dockview-react`,
         },
     },
     vue: {

--- a/packages/docs/static/example-runner/dockview-react-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-react-boilerplate/systemjs.config.js
@@ -56,6 +56,11 @@
                 format: 'cjs',
                 defaultExtension: 'js',
             },
+            'dockview-react': {
+                main: './dist/cjs/index.js',
+                format: 'cjs',
+                defaultExtension: 'js',
+            },
         },
     });
 })(window);


### PR DESCRIPTION
Templates import from `dockview-react`, but neither the buildTemplates import map nor the React boilerplate's SystemJS packages config knew about it, so the bare specifier fell back to a relative path (404 -> "Unexpected token '<'") or to jsdelivr's redirected rollup bundle (named exports unresolvable -> React error #130).

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
