### PR TITLE
fix(docs): drop theme entries whose import resolved to undefined

### DIFF
--- a/packages/docs/src/config/theme.config.ts
+++ b/packages/docs/src/config/theme.config.ts
@@ -128,4 +128,4 @@ export const themeConfig = [
         key: '**[GitHub Light Spaced](/demo?theme=githubLightSpaced)**',
         text: '',
     },
-];
+].filter((entry) => entry.id != null);


### PR DESCRIPTION
The /demo page crashed on the deployed site with "Cannot read properties of undefined (reading 'name')" when the bundle was built against a `dockview-react` that lacked some of the new theme exports (Nord, Catppuccin, Monokai, Solarized, GitHub variants). Webpack left those imports as live namespace property accesses, which evaluated to undefined at runtime, and `themeConfig.map(t => t.id.name)` blew up.

Filter out config entries whose `id` is undefined so the theme picker just hides any missing themes instead of taking down the page.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
