### PR TITLE
fix(docs): rename demo localStorage key to dv-demo-state-v6 and clear…

### DIFF
--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -436,7 +436,7 @@ const DockviewDemo = (props: {
         ];
 
         const loadLayout = () => {
-            const state = localStorage.getItem('dv-demo-state');
+            const state = localStorage.getItem('dv-demo-state-v6');
 
             if (state) {
                 try {
@@ -445,7 +445,7 @@ const DockviewDemo = (props: {
                     setLayoutReady(true);
                     return;
                 } catch {
-                    localStorage.removeItem('dv-demo-state');
+                    localStorage.removeItem('dv-demo-state-v6');
                 }
                 return;
             }

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
@@ -237,13 +237,13 @@ export const GridActions = (props: {
     };
 
     const onLoad = () => {
-        const state = localStorage.getItem('dv-demo-state');
+        const state = localStorage.getItem('dv-demo-state-v6');
         if (state) {
             try {
                 props.api?.fromJSON(JSON.parse(state));
             } catch (err) {
                 console.error('failed to load state', err);
-                localStorage.removeItem('dv-demo-state');
+                localStorage.removeItem('dv-demo-state-v6');
             }
         }
     };
@@ -252,20 +252,19 @@ export const GridActions = (props: {
         if (props.api) {
             const state = props.api.toJSON();
             console.log(state);
-            localStorage.setItem('dv-demo-state', JSON.stringify(state));
+            localStorage.setItem('dv-demo-state-v6', JSON.stringify(state));
         }
     };
 
     const onReset = () => {
         if (props.api) {
+            localStorage.removeItem('dv-demo-state-v6');
             try {
                 props.api.clear();
                 setupEdgeGroups(props.api);
                 defaultConfig(props.api);
                 populateEdgeGroups(props.api);
-            } catch (err) {
-                localStorage.removeItem('dv-demo-state');
-            }
+            } catch {}
         }
     };
 


### PR DESCRIPTION
… on reset

Reset previously only removed the saved state when the rebuild threw, so a normal Reset left the old state in localStorage and the next reload restored it instead of the default layout. Always clear on Reset.

Bumping the key to `dv-demo-state-v6` invalidates everyone's existing saved state in one go — useful since some users still have v5-format JSON pinned that doesn't round-trip through the v6 API.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
