### PR TITLE
Fix: fix angular types path for v21

### DIFF
--- a/packages/dockview-angular/package.json
+++ b/packages/dockview-angular/package.json
@@ -46,7 +46,7 @@
         "README.md"
     ],
     "module": "./dist/fesm2022/dockview-angular.mjs",
-    "typings": "./dist/index.d.ts",
+    "typings": "./dist/types/dockview-angular.d.ts",
     "scripts": {
         "build:angular": "ng-packagr -c tsconfig.lib.json -p ng-package.json",
         "build:css": "node scripts/copy-css.js",
@@ -72,11 +72,5 @@
         "jest-preset-angular": "^16.0.0",
         "ng-packagr": "^21.0.0",
         "zone.js": "^0.15.1"
-    },
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "default": "./dist/fesm2022/dockview-angular.mjs"
-        }
     }
 }


### PR DESCRIPTION
## Description

ng-packagr v21 produce different types structure. update paths to reflect this

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [x] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [x] `dockview-angular`
- [ ] `docs`

## How to test

not sure if testable, the affected package.json is generated on publish, not build
