### PR TITLE
fix(core): break resize loop from sub-pixel jitter (#1219)

### DIFF
--- a/packages/dockview-core/src/__tests__/resizable.spec.ts
+++ b/packages/dockview-core/src/__tests__/resizable.spec.ts
@@ -1,0 +1,149 @@
+import { Resizable } from '../resizable';
+
+class TestResizable extends Resizable {
+    public readonly layoutCalls: Array<{ width: number; height: number }> =
+        [];
+
+    layout(width: number, height: number): void {
+        this.layoutCalls.push({ width, height });
+    }
+}
+
+describe('Resizable', () => {
+    let observerCallbacks: Array<(entries: any[]) => void>;
+    let rAFCallbacks: FrameRequestCallback[];
+    let originalResizeObserver: typeof window.ResizeObserver;
+
+    beforeEach(() => {
+        observerCallbacks = [];
+        rAFCallbacks = [];
+
+        originalResizeObserver = window.ResizeObserver;
+        (window as any).ResizeObserver = class {
+            constructor(cb: (entries: any[]) => void) {
+                observerCallbacks.push(cb);
+            }
+            observe(): void {
+                /* noop */
+            }
+            unobserve(): void {
+                /* noop */
+            }
+            disconnect(): void {
+                /* noop */
+            }
+        };
+
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            rAFCallbacks.push(cb);
+            return rAFCallbacks.length;
+        });
+    });
+
+    afterEach(() => {
+        window.ResizeObserver = originalResizeObserver;
+        jest.restoreAllMocks();
+    });
+
+    function fireResize(width: number, height: number): void {
+        for (const cb of observerCallbacks) {
+            cb([{ contentRect: { width, height } }]);
+        }
+        const pending = [...rAFCallbacks];
+        rAFCallbacks = [];
+        for (const cb of pending) {
+            cb(performance.now());
+        }
+    }
+
+    function createElement(): HTMLElement {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        // jsdom does not compute offsetParent; force it truthy so the
+        // visibility guard in Resizable doesn't short-circuit.
+        Object.defineProperty(el, 'offsetParent', {
+            configurable: true,
+            get: () => document.body,
+        });
+        return el;
+    }
+
+    test('fires layout for the initial size', () => {
+        const r = new TestResizable(createElement());
+        fireResize(100, 200);
+        expect(r.layoutCalls).toEqual([{ width: 100, height: 200 }]);
+    });
+
+    test('rounds fractional contentRect dimensions', () => {
+        const r = new TestResizable(createElement());
+        fireResize(100.4, 200.6);
+        expect(r.layoutCalls).toEqual([{ width: 100, height: 201 }]);
+    });
+
+    test('skips layout when rounded size is unchanged', () => {
+        // Reproduces issue #1219: sub-pixel jitter from fractional
+        // devicePixelRatio (multi-monitor setups) produces contentRect
+        // values that round to the same integer. Without the early-return
+        // these would re-fire layout in a feedback loop.
+        const r = new TestResizable(createElement());
+
+        fireResize(100.1, 200.1);
+        fireResize(100.4, 200.4);
+        fireResize(99.9, 199.9);
+        fireResize(100, 200);
+
+        expect(r.layoutCalls).toEqual([{ width: 100, height: 200 }]);
+    });
+
+    test('fires layout again when rounded size changes', () => {
+        const r = new TestResizable(createElement());
+
+        fireResize(100, 200);
+        fireResize(100.4, 200.4); // still rounds to 100, 200
+        fireResize(101, 200); // width changes
+        fireResize(101, 205); // height changes
+
+        expect(r.layoutCalls).toEqual([
+            { width: 100, height: 200 },
+            { width: 101, height: 200 },
+            { width: 101, height: 205 },
+        ]);
+    });
+
+    test('does not fire layout when element is hidden', () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        Object.defineProperty(el, 'offsetParent', {
+            configurable: true,
+            get: () => null,
+        });
+
+        const r = new TestResizable(el);
+        fireResize(100, 200);
+        expect(r.layoutCalls).toEqual([]);
+    });
+
+    test('does not fire layout when disposed before rAF flushes', () => {
+        const r = new TestResizable(createElement());
+
+        // Schedule a resize but dispose before the rAF runs.
+        for (const cb of observerCallbacks) {
+            cb([{ contentRect: { width: 100, height: 200 } }]);
+        }
+        r.dispose();
+
+        const pending = [...rAFCallbacks];
+        rAFCallbacks = [];
+        for (const cb of pending) {
+            cb(performance.now());
+        }
+
+        expect(r.layoutCalls).toEqual([]);
+    });
+
+    test('does not fire layout when disableResizing is true', () => {
+        const r = new TestResizable(createElement(), true);
+        fireResize(100, 200);
+        expect(r.layoutCalls).toEqual([]);
+    });
+});

--- a/packages/dockview-core/src/__tests__/resizable.spec.ts
+++ b/packages/dockview-core/src/__tests__/resizable.spec.ts
@@ -1,8 +1,7 @@
 import { Resizable } from '../resizable';
 
 class TestResizable extends Resizable {
-    public readonly layoutCalls: Array<{ width: number; height: number }> =
-        [];
+    public readonly layoutCalls: Array<{ width: number; height: number }> = [];
 
     layout(width: number, height: number): void {
         this.layoutCalls.push({ width, height });

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1370,10 +1370,20 @@ export class DockviewComponent
                     overlay.bringToFront();
                 }
             }),
-            watchElementResize(group.element, (entry) => {
-                const { width, height } = entry.contentRect;
-                group.layout(width, height); // let the group know it's size is changing so it can fire events to the panel
-            })
+            (() => {
+                let lastWidth = -1;
+                let lastHeight = -1;
+                return watchElementResize(group.element, (entry) => {
+                    const width = Math.round(entry.contentRect.width);
+                    const height = Math.round(entry.contentRect.height);
+                    if (width === lastWidth && height === lastHeight) {
+                        return;
+                    }
+                    lastWidth = width;
+                    lastHeight = height;
+                    group.layout(width, height); // let the group know it's size is changing so it can fire events to the panel
+                });
+            })()
         );
 
         floatingGroupPanel.addDisposables(

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -438,7 +438,14 @@ export class ShellManager implements IDisposable {
 
         this._disposables.addDisposables(
             watchElementResize(this._shellElement, (entry) => {
-                const { width, height } = entry.contentRect;
+                const width = Math.round(entry.contentRect.width);
+                const height = Math.round(entry.contentRect.height);
+                if (
+                    width === this._currentWidth &&
+                    height === this._currentHeight
+                ) {
+                    return;
+                }
                 this._currentWidth = width;
                 this._currentHeight = height;
                 this.layout(width, height);

--- a/packages/dockview-core/src/resizable.ts
+++ b/packages/dockview-core/src/resizable.ts
@@ -4,6 +4,8 @@ import { CompositeDisposable } from './lifecycle';
 export abstract class Resizable extends CompositeDisposable {
     private readonly _element: HTMLElement;
     private _disableResizing: boolean;
+    private _lastWidth = -1;
+    private _lastHeight = -1;
 
     get element(): HTMLElement {
         return this._element;
@@ -63,7 +65,16 @@ export abstract class Resizable extends CompositeDisposable {
                     return;
                 }
 
-                const { width, height } = entry.contentRect;
+                // Round to integers to absorb sub-pixel jitter from
+                // fractional devicePixelRatio (e.g. multi-monitor setups),
+                // which would otherwise re-fire layout in a feedback loop.
+                const width = Math.round(entry.contentRect.width);
+                const height = Math.round(entry.contentRect.height);
+                if (width === this._lastWidth && height === this._lastHeight) {
+                    return;
+                }
+                this._lastWidth = width;
+                this._lastHeight = height;
                 this.layout(width, height);
             })
         );


### PR DESCRIPTION
## Summary
- Fixes #1219 — multi-minute height-recalculation loop during horizontal browser resize on multi-monitor setups with mismatched display heights.
- Root cause: `ResizeObserver` `entry.contentRect` returns fractional sub-pixel values that drift across firings when `devicePixelRatio` is non-integer (common when an external monitor uses different fractional scaling than the laptop). The cascading `layout(width, height)` call writes inline pixel sizes back to children, which re-fires the observer, which re-fires layout — a feedback loop that pegs CPU until the fractional values happen to converge.
- Fix: at all three `watchElementResize` call sites, round `contentRect.{width,height}` to integers and skip the `layout(...)` call when the rounded size matches the previous delivery. Two `Math.round` + two integer compares per firing — no DOM reads, no forced sync layout.

### Files changed
- `packages/dockview-core/src/resizable.ts` — added `_lastWidth`/`_lastHeight` cache on the base class.
- `packages/dockview-core/src/dockview/dockviewShell.ts` — reused existing `_currentWidth`/`_currentHeight` fields as the cache.
- `packages/dockview-core/src/dockview/dockviewComponent.ts` — closure-scoped cache for the floating-group watcher.
- `packages/dockview-core/src/__tests__/resizable.spec.ts` — new spec, 7 tests.

## Test plan
- [x] `yarn jest` in `packages/dockview-core` — 852/852 passing (845 previously + 7 new).
- [x] `yarn build:cjs` — no type errors.
- [ ] Manual repro on a multi-monitor setup with mismatched DPI: drag Chrome to the larger external display, fullscreen, open DevTools, observe dockview element height while resizing width — should no longer thrash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)