### PR TITLE
fix: avoid disposal-order crash in Angular renderer teardown (#1220)

### DIFF
--- a/packages/dockview-angular/src/__tests__/angular-renderer.spec.ts
+++ b/packages/dockview-angular/src/__tests__/angular-renderer.spec.ts
@@ -140,6 +140,40 @@ describe('AngularRenderer', () => {
 
         renderer.dispose();
 
+        // Element reference is intentionally retained after dispose so that
+        // dockview's overlay teardown can still detach the node from its
+        // parent without the getter throwing mid-cascade. See issue #1220.
+        expect(renderer.element).toBe(element);
+        expect(renderer.component).toBeNull();
+        expect(renderer.view).toBeNull();
+    });
+
+    it('should still expose its element after dispose (regression #1220)', () => {
+        // Reproduces the disposal-order bug from issue #1220: dockview-core's
+        // OverlayRenderContainer reads `panel.view.content.element` while
+        // tearing down its own disposables — by which point the renderer has
+        // already been disposed. Previously the getter threw "Angular
+        // renderer not initialized" here.
+        const renderer = new AngularRenderer<TestComponent>({
+            component: TestComponent,
+            injector,
+            environmentInjector,
+        });
+
+        renderer.init({ params: { title: 'Test Title' } });
+        renderer.dispose();
+
+        expect(() => renderer.element).not.toThrow();
+        expect(renderer.element).toBeInstanceOf(HTMLElement);
+    });
+
+    it('still throws from the element getter when accessed before init', () => {
+        const renderer = new AngularRenderer<TestComponent>({
+            component: TestComponent,
+            injector,
+            environmentInjector,
+        });
+
         expect(() => renderer.element).toThrow(
             'Angular renderer not initialized'
         );

--- a/packages/dockview-angular/src/lib/utils/angular-renderer.ts
+++ b/packages/dockview-angular/src/lib/utils/angular-renderer.ts
@@ -152,6 +152,10 @@ export class AngularRenderer<T = unknown>
             this.viewRef.destroy();
             this.viewRef = null;
         }
-        this._element = null;
+        // Intentionally retain `_element` after dispose. Dockview's overlay
+        // teardown reads `panel.view.content.element` while removing the node
+        // from its overlay parent — nulling here would make the getter throw
+        // mid-cascade. The HTMLElement reference is cheap and will be GC'd
+        // when the renderer itself is collected.
     }
 }

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -579,4 +579,109 @@ describe('overlayRenderContainer', () => {
         ).toHaveBeenCalled();
         expect(parentContainer.getBoundingClientRect).toHaveBeenCalled();
     });
+
+    test('disposes cleanly when the renderer element getter throws (#1220)', () => {
+        // Reproduces the disposal-order failure from #1220: framework
+        // adapters such as dockview-angular may tear down their renderer
+        // before OverlayRenderContainer's destroy disposable runs, after
+        // which their `element` getter throws. The container should hold
+        // a direct reference captured at attach time and not re-query.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        let rendererDisposed = false;
+
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const content = {
+            get element(): HTMLElement {
+                if (rendererDisposed) {
+                    throw new Error('Angular renderer not initialized');
+                }
+                return panelContentEl;
+            },
+        };
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content },
+            group: {
+                api: {
+                    location: { type: 'grid' },
+                },
+            },
+        });
+
+        cut.attach({ panel, referenceContainer });
+        expect(panelContentEl.parentElement?.parentElement).toBe(
+            parentContainer
+        );
+
+        // Simulate the framework adapter tearing down its renderer first.
+        rendererDisposed = true;
+
+        expect(() => cut.detatch(panel)).not.toThrow();
+        expect(panelContentEl.parentElement?.parentElement).toBeUndefined();
+    });
+
+    test('disposing the container while a renderer throws does not propagate (#1220)', () => {
+        // Same root cause as the test above, but exercised through the
+        // container's own dispose() — the failure path in the original bug
+        // report's stack trace.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        let rendererDisposed = false;
+
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const content = {
+            get element(): HTMLElement {
+                if (rendererDisposed) {
+                    throw new Error('Angular renderer not initialized');
+                }
+                return panelContentEl;
+            },
+        };
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content },
+            group: {
+                api: {
+                    location: { type: 'grid' },
+                },
+            },
+        });
+
+        cut.attach({ panel, referenceContainer });
+
+        rendererDisposed = true;
+
+        expect(() => cut.dispose()).not.toThrow();
+    });
 });

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -148,8 +148,15 @@ export class OverlayRenderContainer extends CompositeDisposable {
 
         const focusContainer = this.map[panel.api.id].element;
 
-        if (panel.view.content.element.parentElement !== focusContainer) {
-            focusContainer.appendChild(panel.view.content.element);
+        // Capture the content element now so the destroy disposable below
+        // does not re-query the renderer's `element` getter during teardown.
+        // Some framework adapters (e.g. dockview-angular) tear down their
+        // backing renderer before this disposable fires; reading through the
+        // getter at that point can throw.
+        const contentElement = panel.view.content.element;
+
+        if (contentElement.parentElement !== focusContainer) {
+            focusContainer.appendChild(contentElement);
         }
 
         if (focusContainer.parentElement !== this.element) {
@@ -302,8 +309,8 @@ export class OverlayRenderContainer extends CompositeDisposable {
         );
 
         this.map[panel.api.id].destroy = Disposable.from(() => {
-            if (panel.view.content.element.parentElement === focusContainer) {
-                focusContainer.removeChild(panel.view.content.element);
+            if (contentElement.parentElement === focusContainer) {
+                focusContainer.removeChild(contentElement);
             }
 
             focusContainer.parentElement?.removeChild(focusContainer);


### PR DESCRIPTION
## Summary
- Fixes #1220 — `Error: Angular renderer not initialized` thrown from `OverlayRenderContainer` during dockview destroy.
- Disposal-order bug: `OverlayRenderContainer`'s per-panel `destroy` disposable reads `panel.view.content.element` to detach the node from its overlay parent. The Angular renderer's `dispose()` was nulling `_element` *before* that destroy disposable ran, so the getter threw mid-cascade and aborted the rest of the teardown.

## Fixes

Two complementary changes:

1. **`AngularRenderer.dispose()` no longer nulls `_element`.**
   The underlying `HTMLElement` is a cheap reference to retain and the JS object is still valid after Angular has destroyed the component/view. Keeping it around lets external cleanup paths (dockview-core's overlay teardown) still see and detach the node from its overlay parent. The element will be GC'd when the renderer itself is collected.

2. **`OverlayRenderContainer.attach()` captures the content element at attach time.**
   The `destroy` disposable now uses that captured local instead of re-querying `panel.view.content.element`. This hardens the container against any framework adapter that nulls its element on dispose, not just the Angular case.

### Files changed
- `packages/dockview-angular/src/lib/utils/angular-renderer.ts` — drop `this._element = null` in `dispose()`.
- `packages/dockview-core/src/overlay/overlayRenderContainer.ts` — capture `contentElement` once in `attach()` and reuse in the `destroy` disposable.
- `packages/dockview-angular/src/__tests__/angular-renderer.spec.ts` — flipped the existing post-dispose test, added regression test for #1220 and a guard test that the getter still throws when accessed before `init()`.
- `packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts` — added two regression tests simulating a renderer whose `element` getter throws after disposal (covers both `detatch()` and full container `dispose()` paths).

## Test plan
- [x] `yarn jest` in `packages/dockview-core` — 847/847 (was 845, +2 new).
- [x] `yarn jest` in `packages/dockview-angular` — 122/122 (was 120, +2 new, 1 existing test flipped to match new contract).
- [x] `yarn build:cjs` in `packages/dockview-core` — no type errors.
- [ ] Manual repro in an Angular 21 host: mount dockview, then destroy the parent component — should no longer log `Angular renderer not initialized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)