### PR TITLE
fix(dockview-core): keep edge group anchored when moved (#1235)

### DIFF
--- a/packages/dockview-core/src/__tests__/dnd/groupDragHandler.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/groupDragHandler.spec.ts
@@ -80,6 +80,62 @@ describe('groupDragHandler', () => {
         cut.dispose();
     });
 
+    test('that the event is cancelled when the group is an empty edge group', () => {
+        const element = document.createElement('div');
+
+        const groupMock = jest.fn<DockviewGroupPanel, []>(() => {
+            const partial: Partial<DockviewGroupPanel> = {
+                api: {
+                    location: { type: 'edge', position: 'left' },
+                } as any,
+                size: 0,
+            };
+            return partial as DockviewGroupPanel;
+        });
+        const group = new groupMock();
+
+        const cut = new GroupDragHandler(
+            element,
+            { id: 'accessor_id' } as DockviewComponent,
+            group
+        );
+
+        const event = new KeyboardEvent('dragstart', { shiftKey: false });
+        const spy = jest.spyOn(event, 'preventDefault');
+        fireEvent(element, event);
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        cut.dispose();
+    });
+
+    test('that the event is not cancelled when the edge group has panels', () => {
+        const element = document.createElement('div');
+
+        const groupMock = jest.fn<DockviewGroupPanel, []>(() => {
+            const partial: Partial<DockviewGroupPanel> = {
+                api: {
+                    location: { type: 'edge', position: 'left' },
+                } as any,
+                size: 1,
+            };
+            return partial as DockviewGroupPanel;
+        });
+        const group = new groupMock();
+
+        const cut = new GroupDragHandler(
+            element,
+            { id: 'accessor_id' } as DockviewComponent,
+            group
+        );
+
+        const event = new KeyboardEvent('dragstart', { shiftKey: false });
+        const spy = jest.spyOn(event, 'preventDefault');
+        fireEvent(element, event);
+        expect(spy).toHaveBeenCalledTimes(0);
+
+        cut.dispose();
+    });
+
     test('that the event is never cancelled when the group is not floating', () => {
         const element = document.createElement('div');
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -10195,6 +10195,92 @@ describe('dockviewComponent', () => {
             dv.dispose();
         });
 
+        test('moveGroup from edge to grid leaves edge group empty and collapsed (#1235)', () => {
+            const c = document.createElement('div');
+            const dv = createFixedDockview(c, ['left']);
+            dv.layout(1000, 800);
+
+            const edgeGroup = dv.groups.find(
+                (g) => g.api.location.type === 'edge'
+            )!;
+
+            const target = dv.addPanel({ id: 'center', component: 'default' });
+            const edgeP1 = dv.addPanel({
+                id: 'edge-p1',
+                component: 'default',
+                position: { referenceGroup: edgeGroup.id },
+            });
+            dv.addPanel({
+                id: 'edge-p2',
+                component: 'default',
+                position: { referenceGroup: edgeGroup.id },
+            });
+            edgeP1.api.setActive();
+
+            expect(edgeGroup.panels.length).toBe(2);
+            expect(edgeGroup.activePanel?.id).toBe('edge-p1');
+
+            dv.moveGroup({
+                from: { group: edgeGroup },
+                to: { group: target.api.group, position: 'right' },
+            });
+
+            // Edge group still exists at its position, now empty
+            expect(dv.getEdgeGroup('left')).toBeDefined();
+            expect(edgeGroup.api.location.type).toBe('edge');
+            expect(edgeGroup.panels.length).toBe(0);
+            // ...and auto-collapsed via the addEdgeGroup listener
+            expect((dv as any)._shellManager.isEdgeGroupCollapsed('left')).toBe(
+                true
+            );
+
+            // Panels moved into a new grid group at the target
+            const movedPanel = dv.getGroupPanel('edge-p1')!;
+            expect(movedPanel.group.api.location.type).toBe('grid');
+            expect(movedPanel.group).not.toBe(edgeGroup);
+            expect(movedPanel.group.panels.map((p) => p.id).sort()).toEqual([
+                'edge-p1',
+                'edge-p2',
+            ]);
+
+            // The originally-active panel remains active in the new group
+            expect(movedPanel.group.activePanel?.id).toBe(edgeP1.id);
+
+            dv.dispose();
+        });
+
+        test('moveGroup from edge to grid does not destroy the edge group', () => {
+            const c = document.createElement('div');
+            const dv = createFixedDockview(c, ['right']);
+            dv.layout(1000, 800);
+
+            const edgeGroup = dv.groups.find(
+                (g) => g.api.location.type === 'edge'
+            )!;
+
+            const target = dv.addPanel({ id: 'center', component: 'default' });
+            dv.addPanel({
+                id: 'edge-p1',
+                component: 'default',
+                position: { referenceGroup: edgeGroup.id },
+            });
+
+            const removed: string[] = [];
+            dv.onDidRemoveGroup((g) => removed.push(g.id));
+
+            dv.moveGroup({
+                from: { group: edgeGroup },
+                to: { group: target.api.group, position: 'left' },
+            });
+
+            // The edge group must not be removed
+            expect(removed).not.toContain(edgeGroup.id);
+            expect(dv.getEdgeGroup('right')).toBeDefined();
+            expect(dv.groups).toContain(edgeGroup);
+
+            dv.dispose();
+        });
+
         test('fromJSON auto-creates edge groups from serialized state', () => {
             const c = document.createElement('div');
             // No addEdgeGroup called before fromJSON

--- a/packages/dockview-core/src/dnd/groupDragHandler.ts
+++ b/packages/dockview-core/src/dnd/groupDragHandler.ts
@@ -42,6 +42,12 @@ export class GroupDragHandler extends DragHandler {
         if (this.group.api.location.type === 'floating' && !_event.shiftKey) {
             return true;
         }
+        if (
+            this.group.api.location.type === 'edge' &&
+            this.group.size === 0
+        ) {
+            return true;
+        }
         return false;
     }
 

--- a/packages/dockview-core/src/dnd/groupDragHandler.ts
+++ b/packages/dockview-core/src/dnd/groupDragHandler.ts
@@ -42,10 +42,7 @@ export class GroupDragHandler extends DragHandler {
         if (this.group.api.location.type === 'floating' && !_event.shiftKey) {
             return true;
         }
-        if (
-            this.group.api.location.type === 'edge' &&
-            this.group.size === 0
-        ) {
+        if (this.group.api.location.type === 'edge' && this.group.size === 0) {
             return true;
         }
         return false;

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3079,6 +3079,11 @@ export class DockviewComponent
         const to = options.to.group;
         const target = options.to.position;
 
+        // The group whose panels end up at the target. For non-edge moves
+        // we relocate `from` itself; for edge moves we move panels into a
+        // freshly created group so the edge slot stays anchored.
+        let source: DockviewGroupPanel = from;
+
         if (target === 'center') {
             const activePanel = from.activePanel;
 
@@ -3116,11 +3121,12 @@ export class DockviewComponent
         } else {
             if (from.api.location.type === 'edge') {
                 /**
-                 * Edge groups are permanent structural elements and must stay
-                 * anchored in their edge slot. Move the panels into a new
-                 * group at the target location; the auto-collapse listener
-                 * registered in addEdgeGroup will collapse the now-empty
-                 * edge slot once the last panel leaves.
+                 * Edge groups are permanent structural elements and must
+                 * stay anchored in their edge slot. Move the panels into a
+                 * new group; the auto-collapse listener registered in
+                 * addEdgeGroup will collapse the now-empty edge slot once
+                 * the last panel leaves. The placement code below then
+                 * positions `source` like any other moved group.
                  */
                 const activePanel = from.activePanel;
                 const movedPanels = this.movingLock(() =>
@@ -3128,137 +3134,85 @@ export class DockviewComponent
                         from.model.removePanel(p.id, { skipSetActive: true })
                     )
                 );
-
-                let newGroup: DockviewGroupPanel;
-
-                if (to.api.location.type === 'grid') {
-                    const referenceLocation = getGridLocation(to.element);
-                    const dropLocation = getRelativeLocation(
-                        this.gridview.orientation,
-                        referenceLocation,
-                        target
-                    );
-                    newGroup = this.createGroupAtLocation(dropLocation);
-                } else if (to.api.location.type === 'floating') {
-                    newGroup = this.createGroup();
-                    const targetFloatingGroup = this._floatingGroups.find(
-                        (x) => x.group === to
-                    );
-                    if (targetFloatingGroup) {
-                        const box = targetFloatingGroup.overlay.toJSON();
-                        let left: number, top: number;
-                        if ('left' in box) {
-                            left = box.left + 50;
-                        } else if ('right' in box) {
-                            left = Math.max(0, box.right - box.width - 50);
-                        } else {
-                            left = 50;
-                        }
-                        if ('top' in box) {
-                            top = box.top + 50;
-                        } else if ('bottom' in box) {
-                            top = Math.max(0, box.bottom - box.height - 50);
-                        } else {
-                            top = 50;
-                        }
-                        this.addFloatingGroup(newGroup, {
-                            height: box.height,
-                            width: box.width,
-                            position: { left, top },
-                        });
-                    } else {
-                        this.addFloatingGroup(newGroup);
-                    }
-                } else {
-                    return;
-                }
-
+                source = this.createGroup();
                 this.movingLock(() => {
                     for (const panel of movedPanels) {
-                        newGroup.model.openPanel(panel, {
+                        source.model.openPanel(panel, {
                             skipSetActive: panel !== activePanel,
                             skipSetGroupActive: true,
                         });
                     }
                 });
-
-                for (const panel of movedPanels) {
-                    this._onDidMovePanel.fire({ panel, from });
-                }
-
-                this.debouncedUpdateAllPositions();
-
-                if (options.skipSetActive !== true) {
-                    this.doSetGroupAndPanelActive(newGroup);
-                }
-
-                return;
-            }
-
-            switch (from.api.location.type) {
-                case 'grid':
-                    this.gridview.removeView(getGridLocation(from.element));
-                    break;
-                case 'floating': {
-                    const selectedFloatingGroup = this._floatingGroups.find(
-                        (x) => x.group === from
-                    );
-                    if (!selectedFloatingGroup) {
-                        throw new Error(
-                            'dockview: failed to find floating group'
+            } else {
+                switch (from.api.location.type) {
+                    case 'grid':
+                        this.gridview.removeView(
+                            getGridLocation(from.element)
                         );
-                    }
-                    selectedFloatingGroup.dispose();
-                    break;
-                }
-                case 'popout': {
-                    const selectedPopoutGroup = this._popoutGroups.find(
-                        (x) => x.popoutGroup === from
-                    );
-                    if (!selectedPopoutGroup) {
-                        throw new Error(
-                            'dockview: failed to find popout group'
-                        );
-                    }
-
-                    // Remove from popout groups list to prevent automatic restoration
-                    const index =
-                        this._popoutGroups.indexOf(selectedPopoutGroup);
-                    if (index >= 0) {
-                        this._popoutGroups.splice(index, 1);
-                    }
-
-                    // Clean up the reference group (ghost) if it exists and is hidden
-                    if (selectedPopoutGroup.referenceGroup) {
-                        const referenceGroup = this.getPanel(
-                            selectedPopoutGroup.referenceGroup
-                        );
-                        if (referenceGroup && !referenceGroup.api.isVisible) {
-                            this.doRemoveGroup(referenceGroup, {
-                                skipActive: true,
-                            });
+                        break;
+                    case 'floating': {
+                        const selectedFloatingGroup =
+                            this._floatingGroups.find((x) => x.group === from);
+                        if (!selectedFloatingGroup) {
+                            throw new Error(
+                                'dockview: failed to find floating group'
+                            );
                         }
+                        selectedFloatingGroup.dispose();
+                        break;
                     }
+                    case 'popout': {
+                        const selectedPopoutGroup = this._popoutGroups.find(
+                            (x) => x.popoutGroup === from
+                        );
+                        if (!selectedPopoutGroup) {
+                            throw new Error(
+                                'dockview: failed to find popout group'
+                            );
+                        }
 
-                    // Manually dispose the window without triggering restoration
-                    selectedPopoutGroup.window.dispose();
+                        // Remove from popout groups list to prevent automatic restoration
+                        const index =
+                            this._popoutGroups.indexOf(selectedPopoutGroup);
+                        if (index >= 0) {
+                            this._popoutGroups.splice(index, 1);
+                        }
 
-                    // Update group's location and containers for target
-                    if (to.api.location.type === 'grid') {
-                        from.model.renderContainer =
-                            this.overlayRenderContainer;
-                        from.model.dropTargetContainer =
-                            this.rootDropTargetContainer;
-                        from.model.location = { type: 'grid' };
-                    } else if (to.api.location.type === 'floating') {
-                        from.model.renderContainer =
-                            this.overlayRenderContainer;
-                        from.model.dropTargetContainer =
-                            this.rootDropTargetContainer;
-                        from.model.location = { type: 'floating' };
+                        // Clean up the reference group (ghost) if it exists and is hidden
+                        if (selectedPopoutGroup.referenceGroup) {
+                            const referenceGroup = this.getPanel(
+                                selectedPopoutGroup.referenceGroup
+                            );
+                            if (
+                                referenceGroup &&
+                                !referenceGroup.api.isVisible
+                            ) {
+                                this.doRemoveGroup(referenceGroup, {
+                                    skipActive: true,
+                                });
+                            }
+                        }
+
+                        // Manually dispose the window without triggering restoration
+                        selectedPopoutGroup.window.dispose();
+
+                        // Update group's location and containers for target
+                        if (to.api.location.type === 'grid') {
+                            from.model.renderContainer =
+                                this.overlayRenderContainer;
+                            from.model.dropTargetContainer =
+                                this.rootDropTargetContainer;
+                            from.model.location = { type: 'grid' };
+                        } else if (to.api.location.type === 'floating') {
+                            from.model.renderContainer =
+                                this.overlayRenderContainer;
+                            from.model.dropTargetContainer =
+                                this.rootDropTargetContainer;
+                            from.model.location = { type: 'floating' };
+                        }
+
+                        break;
                     }
-
-                    break;
                 }
             }
 
@@ -3290,7 +3244,7 @@ export class DockviewComponent
                         break;
                 }
 
-                this.gridview.addView(from, size, dropLocation);
+                this.gridview.addView(source, size, dropLocation);
             } else if (to.api.location.type === 'floating') {
                 // For moves to floating locations, add as floating group
                 // Get the position/size from the target floating group
@@ -3318,7 +3272,7 @@ export class DockviewComponent
                         top = 50; // Default fallback
                     }
 
-                    this.addFloatingGroup(from, {
+                    this.addFloatingGroup(source, {
                         height: box.height,
                         width: box.width,
                         position: {
@@ -3330,7 +3284,7 @@ export class DockviewComponent
             }
         }
 
-        from.panels.forEach((panel) => {
+        source.panels.forEach((panel) => {
             this._onDidMovePanel.fire({ panel, from });
         });
 
@@ -3342,6 +3296,10 @@ export class DockviewComponent
             // Use 'to' group for non-center moves since 'from' may have been destroyed
             const targetGroup = to ?? from;
             this.doSetGroupAndPanelActive(targetGroup);
+        } else if (source !== from && options.skipSetActive !== true) {
+            // Edge group moves create a fresh `source` group; activate it
+            // by default so the moved panels receive focus.
+            this.doSetGroupAndPanelActive(source);
         }
     }
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3114,6 +3114,87 @@ export class DockviewComponent
                 this.doSetGroupAndPanelActive(to);
             }
         } else {
+            if (from.api.location.type === 'edge') {
+                /**
+                 * Edge groups are permanent structural elements and must stay
+                 * anchored in their edge slot. Move the panels into a new
+                 * group at the target location; the auto-collapse listener
+                 * registered in addEdgeGroup will collapse the now-empty
+                 * edge slot once the last panel leaves.
+                 */
+                const activePanel = from.activePanel;
+                const movedPanels = this.movingLock(() =>
+                    [...from.panels].map((p) =>
+                        from.model.removePanel(p.id, { skipSetActive: true })
+                    )
+                );
+
+                let newGroup: DockviewGroupPanel;
+
+                if (to.api.location.type === 'grid') {
+                    const referenceLocation = getGridLocation(to.element);
+                    const dropLocation = getRelativeLocation(
+                        this.gridview.orientation,
+                        referenceLocation,
+                        target
+                    );
+                    newGroup = this.createGroupAtLocation(dropLocation);
+                } else if (to.api.location.type === 'floating') {
+                    newGroup = this.createGroup();
+                    const targetFloatingGroup = this._floatingGroups.find(
+                        (x) => x.group === to
+                    );
+                    if (targetFloatingGroup) {
+                        const box = targetFloatingGroup.overlay.toJSON();
+                        let left: number, top: number;
+                        if ('left' in box) {
+                            left = box.left + 50;
+                        } else if ('right' in box) {
+                            left = Math.max(0, box.right - box.width - 50);
+                        } else {
+                            left = 50;
+                        }
+                        if ('top' in box) {
+                            top = box.top + 50;
+                        } else if ('bottom' in box) {
+                            top = Math.max(0, box.bottom - box.height - 50);
+                        } else {
+                            top = 50;
+                        }
+                        this.addFloatingGroup(newGroup, {
+                            height: box.height,
+                            width: box.width,
+                            position: { left, top },
+                        });
+                    } else {
+                        this.addFloatingGroup(newGroup);
+                    }
+                } else {
+                    return;
+                }
+
+                this.movingLock(() => {
+                    for (const panel of movedPanels) {
+                        newGroup.model.openPanel(panel, {
+                            skipSetActive: panel !== activePanel,
+                            skipSetGroupActive: true,
+                        });
+                    }
+                });
+
+                for (const panel of movedPanels) {
+                    this._onDidMovePanel.fire({ panel, from });
+                }
+
+                this.debouncedUpdateAllPositions();
+
+                if (options.skipSetActive !== true) {
+                    this.doSetGroupAndPanelActive(newGroup);
+                }
+
+                return;
+            }
+
             switch (from.api.location.type) {
                 case 'grid':
                     this.gridview.removeView(getGridLocation(from.element));

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3146,13 +3146,12 @@ export class DockviewComponent
             } else {
                 switch (from.api.location.type) {
                     case 'grid':
-                        this.gridview.removeView(
-                            getGridLocation(from.element)
-                        );
+                        this.gridview.removeView(getGridLocation(from.element));
                         break;
                     case 'floating': {
-                        const selectedFloatingGroup =
-                            this._floatingGroups.find((x) => x.group === from);
+                        const selectedFloatingGroup = this._floatingGroups.find(
+                            (x) => x.group === from
+                        );
                         if (!selectedFloatingGroup) {
                             throw new Error(
                                 'dockview: failed to find floating group'


### PR DESCRIPTION
## Summary
- `moveGroup` from an edge source no longer relocates the edge slot itself. Panels are extracted into a new grid (or floating) group at the target, and the edge slot stays in place and auto-collapses.
- Empty edge groups can no longer be dragged (cancelled in `GroupDragHandler.isCancelled`).
- Center-target moves already worked because `doRemoveGroup` is a no-op for edge groups and panels were removed individually.

Fixes #1235.

## Test plan
- [x] `yarn jest dockviewComponent.spec.ts` — 187 passing (incl. two new edge-move tests)
- [x] `yarn jest groupDragHandler.spec.ts` — 5 passing (incl. two new empty/non-empty edge cases)
- [ ] Manual: drag the whole edge group in `templates/edge-groups` and confirm the slot collapses to its `collapsedSize` rather than leaving an ~85px gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)