### PR TITLE
fix(dockview-vue): forward didDrop and willDrop events (#1195)

### DIFF
--- a/packages/dockview-angular/package.json
+++ b/packages/dockview-angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-angular",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "description": "Angular docking layout manager — tabs, groups, grids, splitviews, drag and drop, floating panels",
     "keywords": [
         "splitview",
@@ -61,7 +61,7 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'"
     },
     "dependencies": {
-        "dockview-core": "^6.0.2"
+        "dockview-core": "^6.0.3"
     },
     "peerDependencies": {
         "@angular/common": ">=21.0.6",

--- a/packages/dockview-core/package.json
+++ b/packages/dockview-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-core",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "description": "Zero dependency layout manager supporting tabs, groups, grids and splitviews for vanilla TypeScript",
     "keywords": [
         "splitview",

--- a/packages/dockview-react/package.json
+++ b/packages/dockview-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-react",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "description": "React docking layout manager — tabs, groups, grids, splitviews, drag and drop, floating panels",
     "keywords": [
         "splitview",
@@ -68,6 +68,6 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'"
     },
     "dependencies": {
-        "dockview": "^6.0.2"
+        "dockview": "^6.0.3"
     }
 }

--- a/packages/dockview-vue/package.json
+++ b/packages/dockview-vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-vue",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "description": "Vue 3 docking layout manager — tabs, groups, grids, splitviews, drag and drop, floating panels",
     "keywords": [
         "splitview",
@@ -67,7 +67,7 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx,vue}'"
     },
     "dependencies": {
-        "dockview-core": "^6.0.2"
+        "dockview-core": "^6.0.3"
     },
     "peerDependencies": {
         "vue": "^3.4.0"

--- a/packages/dockview-vue/src/__tests__/dockview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/dockview.spec.ts
@@ -249,4 +249,32 @@ describe('DockviewVue Component', () => {
 
         expect(disposeSpy).toHaveBeenCalled();
     });
+
+    test('should forward didDrop events from the api', async () => {
+        wrapper = mountDockview();
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+        const fakeEvent = { id: 'fake-did-drop' } as any;
+
+        (api as any).component._onDidDrop.fire(fakeEvent);
+
+        const emitted = wrapper.emitted('didDrop');
+        expect(emitted).toBeTruthy();
+        expect(emitted![0][0]).toBe(fakeEvent);
+    });
+
+    test('should forward willDrop events from the api', async () => {
+        wrapper = mountDockview();
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+        const fakeEvent = { id: 'fake-will-drop' } as any;
+
+        (api as any).component._onWillDrop.fire(fakeEvent);
+
+        const emitted = wrapper.emitted('willDrop');
+        expect(emitted).toBeTruthy();
+        expect(emitted![0][0]).toBe(fakeEvent);
+    });
 });

--- a/packages/dockview-vue/src/__tests__/paneview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/paneview.spec.ts
@@ -1,7 +1,31 @@
-import { describe, test, expect } from 'vitest';
-import { createPaneview, PROPERTY_KEYS_PANEVIEW } from 'dockview-core';
+import { describe, test, expect, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import {
+    createPaneview,
+    PaneviewApi,
+    PROPERTY_KEYS_PANEVIEW,
+} from 'dockview-core';
+import PaneviewVue from '../paneview/paneview.vue';
 import { VuePaneviewPanelView } from '../paneview/view';
 import * as paneviewTypes from '../paneview/types';
+
+const MockPaneComponent = defineComponent({
+    name: 'MockPaneComponent',
+    props: ['params', 'api', 'containerApi', 'title'],
+    template: '<div class="mock-pane">Pane</div>',
+});
+
+function mountPaneview(props: Record<string, any> = {}) {
+    return mount(PaneviewVue, {
+        props: {
+            components: { MockPaneComponent: 'MockPaneComponent' },
+            ...props,
+        },
+        attachTo: document.body,
+        global: { components: { MockPaneComponent } },
+    });
+}
 
 describe('PaneviewVue Component', () => {
     test('should export component types', () => {
@@ -128,5 +152,36 @@ describe('VuePaneviewPanelView', () => {
             panelView.update({ params: { data: 'test' } })
         ).not.toThrow();
         expect(() => panelView.dispose()).not.toThrow();
+    });
+});
+
+describe('PaneviewVue events', () => {
+    let wrapper: ReturnType<typeof mountPaneview>;
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    test('should emit ready with api', async () => {
+        wrapper = mountPaneview();
+        await flushPromises();
+
+        expect(wrapper.emitted('ready')).toBeTruthy();
+        const readyEvent = wrapper.emitted('ready')![0][0] as any;
+        expect(readyEvent.api).toBeInstanceOf(PaneviewApi);
+    });
+
+    test('should forward didDrop events from the api', async () => {
+        wrapper = mountPaneview();
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as PaneviewApi;
+        const fakeEvent = { id: 'fake-paneview-drop' } as any;
+
+        (api as any).component._onDidDrop.fire(fakeEvent);
+
+        const emitted = wrapper.emitted('didDrop');
+        expect(emitted).toBeTruthy();
+        expect(emitted![0][0]).toBe(fakeEvent);
     });
 });

--- a/packages/dockview-vue/src/composables/useViewComponent.ts
+++ b/packages/dockview-vue/src/composables/useViewComponent.ts
@@ -7,6 +7,7 @@ import {
     getCurrentInstance,
     type ComponentInternalInstance,
 } from 'vue';
+import type { DockviewIDisposable } from 'dockview-core';
 import { findComponent } from '../utils';
 
 export interface ViewComponentConfig<
@@ -30,6 +31,7 @@ export interface ViewComponentConfig<
         instance: ComponentInternalInstance
     ) => TView;
     extractCoreOptions: (props: TProps) => TOptions;
+    onApiCreated?: (api: TApi) => DockviewIDisposable[];
 }
 
 export function useViewComponent<
@@ -57,6 +59,7 @@ export function useViewComponent<
 ) {
     const el = ref<HTMLElement | null>(null);
     const instance = ref<TApi | null>(null);
+    const eventDisposables: DockviewIDisposable[] = [];
 
     config.propertyKeys.forEach((coreOptionKey) => {
         watch(
@@ -135,10 +138,16 @@ export function useViewComponent<
 
         instance.value = markRaw(api) as any;
 
+        if (config.onApiCreated) {
+            eventDisposables.push(...config.onApiCreated(api));
+        }
+
         emit('ready', { api });
     });
 
     onBeforeUnmount(() => {
+        eventDisposables.forEach((d) => d.dispose());
+        eventDisposables.length = 0;
         if (instance.value) {
             instance.value.dispose();
         }

--- a/packages/dockview-vue/src/dockview/dockview.vue
+++ b/packages/dockview-vue/src/dockview/dockview.vue
@@ -4,6 +4,7 @@ import {
     type DockviewOptions,
     PROPERTY_KEYS_DOCKVIEW,
     type DockviewFrameworkOptions,
+    type DockviewIDisposable,
     createDockview,
 } from 'dockview-core';
 import {
@@ -43,6 +44,7 @@ const props = defineProps<IDockviewVueProps>();
 
 const el = ref<HTMLElement | null>(null);
 const instance = ref<DockviewApi | null>(null);
+const eventDisposables: DockviewIDisposable[] = [];
 
 PROPERTY_KEYS_DOCKVIEW.forEach((coreOptionKey) => {
     watch(
@@ -281,10 +283,17 @@ onMounted(() => {
      */
     instance.value = markRaw(api);
 
+    eventDisposables.push(
+        api.onDidDrop((event) => emit('didDrop', event)),
+        api.onWillDrop((event) => emit('willDrop', event))
+    );
+
     emit('ready', { api });
 });
 
 onBeforeUnmount(() => {
+    eventDisposables.forEach((d) => d.dispose());
+    eventDisposables.length = 0;
     if (instance.value) {
         instance.value.dispose();
     }

--- a/packages/dockview-vue/src/dockview/types.ts
+++ b/packages/dockview-vue/src/dockview/types.ts
@@ -1,4 +1,9 @@
-import { type DockviewOptions, type DockviewReadyEvent } from 'dockview-core';
+import {
+    type DockviewDidDropEvent,
+    type DockviewOptions,
+    type DockviewReadyEvent,
+    type DockviewWillDropEvent,
+} from 'dockview-core';
 
 export interface VueProps {
     watermarkComponent?: string;
@@ -11,6 +16,8 @@ export interface VueProps {
 
 export type VueEvents = {
     ready: [event: DockviewReadyEvent];
+    didDrop: [event: DockviewDidDropEvent];
+    willDrop: [event: DockviewWillDropEvent];
 };
 
 export type IDockviewVueProps = DockviewOptions & VueProps;

--- a/packages/dockview-vue/src/paneview/paneview.vue
+++ b/packages/dockview-vue/src/paneview/paneview.vue
@@ -33,6 +33,9 @@ const { el } = useViewComponent(
         createView: (id, name, component, instance) =>
             new VuePaneviewPanelView(id, component, instance),
         extractCoreOptions,
+        onApiCreated: (api) => [
+            api.onDidDrop((event) => emit('didDrop', event)),
+        ],
     },
     props,
     emit

--- a/packages/dockview-vue/src/paneview/types.ts
+++ b/packages/dockview-vue/src/paneview/types.ts
@@ -1,5 +1,6 @@
 import type {
     PaneviewApi,
+    PaneviewDropEvent,
     PaneviewOptions,
     PaneviewPanelApi,
 } from 'dockview-core';
@@ -21,4 +22,5 @@ export interface IPaneviewVueProps extends PaneviewOptions {
 
 export type PaneviewVueEvents = {
     ready: [event: PaneviewReadyEvent];
+    didDrop: [event: PaneviewDropEvent];
 };

--- a/packages/dockview/package.json
+++ b/packages/dockview/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview",
-    "version": "6.0.2",
+    "version": "6.0.3",
     "description": "React docking layout manager — tabs, groups, grids, splitviews, drag and drop, floating panels",
     "keywords": [
         "splitview",
@@ -68,7 +68,7 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'"
     },
     "dependencies": {
-        "dockview-core": "^6.0.2"
+        "dockview-core": "^6.0.3"
     },
     "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/packages/docs/templates/dockview/dnd-external/vue/src/index.ts
+++ b/packages/docs/templates/dockview/dnd-external/vue/src/index.ts
@@ -167,6 +167,7 @@ const App = defineComponent({
                 <draggable-element />
                 <div
                     style="padding: 0px 4px; background-color: black; border-radius: 2px; color: white;"
+                    @dragover.prevent
                     @drop="onDrop">
                     Drop a tab or group here to inspect the attached metadata
                 </div>


### PR DESCRIPTION
## Summary

- The Vue `Dockview` wrapper only emitted `ready`, so `@didDrop` / `@willDrop` listeners were silently ignored. The Vue `Paneview` wrapper had the same gap for `didDrop`. This is what broke the docs external-DnD Vue example referenced in #1195.
- Subscribe to the underlying api events on mount and re-emit them as Vue events; explicit disposal on unmount via the existing composable.
- Also fixes the `dnd-external` Vue template's inspect drop target (missing `@dragover.prevent` meant `@drop` never fired).

## Parity audit (React vs Vue)

| Wrapper | React events | Before | After |
|---|---|---|---|
| Dockview | `ready`, `onDidDrop`, `onWillDrop` | `ready` | `ready`, `didDrop`, `willDrop` |
| Paneview | `ready`, `onDidDrop` | `ready` | `ready`, `didDrop` |
| Gridview | `ready` | `ready` | `ready` |
| Splitview | `ready` | `ready` | `ready` |

## Test plan

- [x] `yarn test` in `packages/dockview-vue` — 77 passed (was 73)
- [x] New tests verify `didDrop` and `willDrop` are emitted when the underlying api fires the event
- [ ] Manually verify `https://dockview.dev/docs/core/dnd/external/?framework=vue` after the templates are republished

Closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)