### PR TITLE
fix(dockview-core): guard Tabs.delete when tabToRemove is undefined

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
@@ -547,6 +547,45 @@ describe('tabs', () => {
         });
     });
 
+    describe('delete', () => {
+        test('does not throw when id is not present on an empty tabs list', () => {
+            const cut = new Tabs(
+                fromPartial<DockviewGroupPanel>({}),
+                fromPartial<DockviewComponent>({
+                    options: {},
+                }),
+                {
+                    showTabsOverflowControl: false,
+                }
+            );
+
+            expect(() => cut.delete('does-not-exist')).not.toThrow();
+        });
+
+        test('does not throw when deleting an id after the tabs list has been emptied', () => {
+            const panel1 = createMockPanel('panel1');
+
+            const cut = new Tabs(
+                fromPartial<DockviewGroupPanel>({}),
+                fromPartial<DockviewComponent>({
+                    options: {},
+                    onDidOptionsChange: jest
+                        .fn()
+                        .mockReturnValue({ dispose: jest.fn() }),
+                }),
+                {
+                    showTabsOverflowControl: false,
+                }
+            );
+
+            cut.openPanel(panel1);
+            cut.delete('panel1');
+            expect(cut.tabs.length).toBe(0);
+
+            expect(() => cut.delete('panel1')).not.toThrow();
+        });
+    });
+
     describe('direction', () => {
         test('direction setter toggles CSS classes', () => {
             const cut = new Tabs(

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -858,11 +858,13 @@ export class Tabs extends CompositeDisposable {
         const tabToRemove = this._tabs.splice(index, 1)[0];
         this._tabMap.delete(id);
 
-        const { value, disposable } = tabToRemove;
+        if (tabToRemove) {
+            const { value, disposable } = tabToRemove;
 
-        disposable.dispose();
-        value.dispose();
-        value.element.remove();
+            disposable.dispose();
+            value.dispose();
+            value.element.remove();
+        }
 
         // If a non-source tab was removed during active drag, refresh positions
         if (this._animState) {


### PR DESCRIPTION
## Summary
- Picks up @arnaudchenyensu's fix from #1196 (preserves the original commit/authorship)
- Adds tests that exercise `Tabs.delete()` when the id is not present on the tabs list, locking in the guard

## Background
`Tabs.delete(id)` calls `indexOf(id)` (returns `-1` when missing) and then `_tabs.splice(index, 1)[0]`. When `_tabs` is empty, the splice returns `[]`, so `tabToRemove` is `undefined` and destructuring throws. The fix wraps the dispose block in `if (tabToRemove) { ... }`. Reproduces in flows like `fromJSON` after a React root unmount/remount (same shape as #845).

## Test plan
- [x] `yarn nx run dockview-core:test --testPathPattern=tabs.spec` — all 17 tests pass
- [x] Verified the new tests fail on master (without the fix) with `TypeError: Cannot read properties of undefined (reading 'value')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)