### PR TITLE
fix(dockview-core): allow tab group chip drop on own group's edge (#1…

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1281,6 +1281,60 @@ describe('dockviewComponent', () => {
         dockview.dispose();
     });
 
+    // Regression test for #1242: dropping a tab group at the edge of its
+    // own (and only) source group when the tab group contains all of the
+    // source group's panels must split the layout and leave no orphan
+    // empty group behind.
+    test('moveGroupOrPanel with tabGroupId to extremity of own group when tabgroup contains all panels removes empty source', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                return new PanelContentPartTest(options.id, options.name);
+            },
+        });
+
+        dockview.layout(1000, 1000);
+
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        dockview.addPanel({ id: 'panel2', component: 'default' });
+
+        const panel1 = dockview.getGroupPanel('panel1')!;
+        const panel2 = dockview.getGroupPanel('panel2')!;
+        const sourceGroup = panel1.group;
+
+        // Tab group spans every panel in the source group.
+        const tabGroup = sourceGroup.model.createTabGroup({
+            label: 'All',
+            color: 'red',
+        });
+        sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
+        sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel2');
+
+        dockview.moveGroupOrPanel({
+            from: {
+                groupId: sourceGroup.id,
+                tabGroupId: tabGroup.id,
+            },
+            to: { group: sourceGroup, position: 'right' },
+        });
+
+        // Source group should be removed (it became empty); only the new
+        // group at the right contains the panels.
+        expect(dockview.groups.length).toBe(1);
+        const newGroup = panel1.group;
+        expect(newGroup).not.toBe(sourceGroup);
+        expect(panel2.group).toBe(newGroup);
+        expect(newGroup.model.size).toBe(2);
+
+        const newTabGroups = newGroup.model.getTabGroups();
+        expect(newTabGroups.length).toBe(1);
+        expect(newTabGroups[0].label).toBe('All');
+        expect(newTabGroups[0].color).toBe('red');
+
+        dockview.dispose();
+    });
+
     test('remove group', () => {
         dockview.layout(500, 1000);
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
@@ -1140,6 +1140,207 @@ describe('dockviewGroupPanelModel', () => {
         ).toBe(1);
     });
 
+    // Regression test for #1242: dropping a tab-group chip on the edge of
+    // its own group must fire onMove (so the layout splits). Previously
+    // the handler short-circuited any panelId === null drop on self,
+    // which silently swallowed tab-group chip drops on the same group.
+    test('that tab group chip drop on self at edge fires onMove with tabGroupId', () => {
+        const accessor = fromPartial<DockviewComponent>({
+            id: 'testcomponentid',
+            options: {},
+            getPanel: jest.fn(),
+            doSetGroupActive: jest.fn(),
+            onDidAddPanel: jest.fn(),
+            onDidRemovePanel: jest.fn(),
+            overlayRenderContainer: new OverlayRenderContainer(
+                document.createElement('div'),
+                fromPartial<DockviewComponent>({})
+            ),
+            onDidOptionsChange: jest.fn(),
+        });
+
+        const groupviewMock = jest.fn<Partial<DockviewGroupPanelModel>, []>(
+            () => {
+                return {
+                    canDisplayOverlay: jest.fn(),
+                };
+            }
+        );
+
+        const groupView = new groupviewMock() as DockviewGroupPanelModel;
+
+        const groupPanelMock = jest.fn<Partial<DockviewGroupPanel>, []>(() => {
+            return {
+                id: 'testgroupid',
+                model: groupView,
+            };
+        });
+
+        const container = document.createElement('div');
+        const cut = new DockviewGroupPanelModel(
+            container,
+            accessor,
+            'groupviewid',
+            {},
+            new groupPanelMock() as DockviewGroupPanel
+        );
+
+        cut.openPanel(new TestPanel('panel1', panelApi));
+
+        const element = container
+            .getElementsByClassName('dv-content-container')
+            .item(0) as HTMLElement;
+
+        jest.spyOn(element, 'offsetHeight', 'get').mockImplementation(
+            () => 100
+        );
+        jest.spyOn(element, 'offsetWidth', 'get').mockImplementation(() => 100);
+
+        // Tab-group chip drag: panelId is null, tabGroupId identifies the
+        // moving subset, groupId matches the group we are dropping on.
+        LocalSelectionTransfer.getInstance().setData(
+            [new PanelTransfer('testcomponentid', 'groupviewid', null, 'tg-1')],
+            PanelTransfer.prototype
+        );
+
+        const moveEvents: Array<{
+            target: string;
+            tabGroupId?: string;
+            itemId?: string;
+        }> = [];
+        cut.onMove((e) => {
+            moveEvents.push({
+                target: e.target,
+                tabGroupId: e.tabGroupId,
+                itemId: e.itemId,
+            });
+        });
+
+        fireEvent.dragEnter(element);
+        // Position cursor near the right edge so the drop position
+        // resolves to 'right' (split).
+        fireEvent(
+            element,
+            createOffsetDragOverEvent({ clientX: 95, clientY: 50 })
+        );
+
+        const target = element.querySelector(
+            '.dv-drop-target-dropzone'
+        ) as HTMLElement;
+        expect(target).not.toBeNull();
+
+        jest.spyOn(target, 'clientHeight', 'get').mockImplementation(() => 100);
+        jest.spyOn(target, 'clientWidth', 'get').mockImplementation(() => 100);
+
+        // Re-fire with the dropzone target so the directional zone is
+        // computed against the dropzone's geometry.
+        fireEvent(
+            target,
+            createOffsetDragOverEvent({ clientX: 95, clientY: 50 })
+        );
+        fireEvent.drop(target);
+
+        expect(moveEvents.length).toBe(1);
+        expect(moveEvents[0].target).toBe('right');
+        expect(moveEvents[0].tabGroupId).toBe('tg-1');
+        expect(moveEvents[0].itemId).toBeUndefined();
+
+        LocalSelectionTransfer.getInstance().clearData(PanelTransfer.prototype);
+    });
+
+    // Companion regression test: full-group drag on self (no tabGroupId)
+    // must still be a no-op so we don't regress the original behavior.
+    test('that full group drop on self at edge does not fire onMove', () => {
+        const accessor = fromPartial<DockviewComponent>({
+            id: 'testcomponentid',
+            options: {},
+            getPanel: jest.fn(),
+            doSetGroupActive: jest.fn(),
+            onDidAddPanel: jest.fn(),
+            onDidRemovePanel: jest.fn(),
+            overlayRenderContainer: new OverlayRenderContainer(
+                document.createElement('div'),
+                fromPartial<DockviewComponent>({})
+            ),
+            onDidOptionsChange: jest.fn(),
+        });
+
+        const groupviewMock = jest.fn<Partial<DockviewGroupPanelModel>, []>(
+            () => {
+                return {
+                    canDisplayOverlay: jest.fn(),
+                };
+            }
+        );
+
+        const groupView = new groupviewMock() as DockviewGroupPanelModel;
+
+        const groupPanelMock = jest.fn<Partial<DockviewGroupPanel>, []>(() => {
+            return {
+                id: 'testgroupid',
+                model: groupView,
+            };
+        });
+
+        const container = document.createElement('div');
+        const cut = new DockviewGroupPanelModel(
+            container,
+            accessor,
+            'groupviewid',
+            {},
+            new groupPanelMock() as DockviewGroupPanel
+        );
+
+        cut.openPanel(new TestPanel('panel1', panelApi));
+
+        const element = container
+            .getElementsByClassName('dv-content-container')
+            .item(0) as HTMLElement;
+
+        jest.spyOn(element, 'offsetHeight', 'get').mockImplementation(
+            () => 100
+        );
+        jest.spyOn(element, 'offsetWidth', 'get').mockImplementation(() => 100);
+
+        // Full-group drag: panelId null AND tabGroupId undefined.
+        LocalSelectionTransfer.getInstance().setData(
+            [new PanelTransfer('testcomponentid', 'groupviewid', null)],
+            PanelTransfer.prototype
+        );
+
+        const moveEvents: unknown[] = [];
+        cut.onMove((e) => {
+            moveEvents.push(e);
+        });
+
+        fireEvent.dragEnter(element);
+        fireEvent(
+            element,
+            createOffsetDragOverEvent({ clientX: 95, clientY: 50 })
+        );
+
+        const target = element.querySelector(
+            '.dv-drop-target-dropzone'
+        ) as HTMLElement;
+        if (target) {
+            jest.spyOn(target, 'clientHeight', 'get').mockImplementation(
+                () => 100
+            );
+            jest.spyOn(target, 'clientWidth', 'get').mockImplementation(
+                () => 100
+            );
+            fireEvent(
+                target,
+                createOffsetDragOverEvent({ clientX: 95, clientY: 50 })
+            );
+            fireEvent.drop(target);
+        }
+
+        expect(moveEvents.length).toBe(0);
+
+        LocalSelectionTransfer.getInstance().clearData(PanelTransfer.prototype);
+    });
+
     test('that should not allow drop when not dropping for different component id', () => {
         const accessor = fromPartial<DockviewComponent>({
             id: 'testcomponentid',

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3013,6 +3013,14 @@ export class DockviewComponent
         const collapsed = tabGroup.collapsed;
         const panelIds = [...tabGroup.panelIds];
 
+        // Capture the destination's grid location BEFORE potentially
+        // removing the source group, in case source === destination and
+        // the source becomes empty after panel removal.
+        const referenceLocation =
+            destinationTarget && destinationTarget !== 'center'
+                ? getGridLocation(destinationGroup.element)
+                : undefined;
+
         // Remove panels from the source group
         const removedPanels = this.movingLock(() =>
             panelIds
@@ -3027,14 +3035,6 @@ export class DockviewComponent
 
         if (removedPanels.length === 0) {
             return;
-        }
-
-        if (
-            !options.keepEmptyGroups &&
-            sourceGroup.model.size === 0 &&
-            sourceGroup !== destinationGroup
-        ) {
-            this.doRemoveGroup(sourceGroup, { skipActive: true });
         }
 
         const addPanelsToGroup = (targetGroup: DockviewGroupPanel) => {
@@ -3070,18 +3070,36 @@ export class DockviewComponent
             }
         };
 
-        if (!destinationTarget || destinationTarget === 'center') {
-            addPanelsToGroup(destinationGroup);
+        let targetGroup: DockviewGroupPanel;
+        if (
+            !destinationTarget ||
+            destinationTarget === 'center' ||
+            !referenceLocation
+        ) {
+            targetGroup = destinationGroup;
         } else {
-            const referenceLocation = getGridLocation(destinationGroup.element);
             const dropLocation = getRelativeLocation(
                 this.gridview.orientation,
                 referenceLocation,
                 destinationTarget
             );
-            const newGroup = this.createGroupAtLocation(dropLocation);
-            addPanelsToGroup(newGroup);
+            targetGroup = this.createGroupAtLocation(dropLocation);
         }
+
+        // Remove the source group if it became empty. We compare against
+        // the actual targetGroup (which is a freshly-created group for
+        // edge drops) rather than the originally-passed destinationGroup,
+        // so a tab-group drag onto its own group's edge still cleans up
+        // the now-empty source.
+        if (
+            !options.keepEmptyGroups &&
+            sourceGroup.model.size === 0 &&
+            sourceGroup !== targetGroup
+        ) {
+            this.doRemoveGroup(sourceGroup, { skipActive: true });
+        }
+
+        addPanelsToGroup(targetGroup);
     }
 
     moveGroup(options: MoveGroupOptions): void {

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1702,8 +1702,10 @@ export class DockviewGroupPanelModel
                         return;
                     }
 
-                    if (data.panelId === null) {
-                        // don't allow group move to drop anywhere on self
+                    if (data.panelId === null && !data.tabGroupId) {
+                        // Full-group drops on self are a no-op.
+                        // Tab-group drags are partial moves: an edge drop
+                        // splits the layout and creates a new group.
                         return;
                     }
                 }
@@ -1711,7 +1713,7 @@ export class DockviewGroupPanelModel
 
             if (type === 'header') {
                 if (data.groupId === this.id) {
-                    if (data.panelId === null) {
+                    if (data.panelId === null && !data.tabGroupId) {
                         return;
                     }
                 }


### PR DESCRIPTION
…242)

The drop handler short-circuited any drop where panelId is null on the same group, which silently swallowed tab-group chip drops because they also have panelId === null (with tabGroupId set). Narrow the guard so only true full-group drags are blocked. Also fix moveTabGroupToGroup so an edge drop onto the source group cleans up the source when it becomes empty by comparing against the actual targetGroup (which may be a freshly created edge group) rather than the originally passed destinationGroup.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
