### PR TITLE
fix(dockview-core): preserve tab groups when dragging a group via its…

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1281,6 +1281,135 @@ describe('dockviewComponent', () => {
         dockview.dispose();
     });
 
+    // Regression test for #1244: dragging a group via its header onto
+    // another group's center must preserve the source's tab groups
+    // (label, color, collapsed, componentParams, panelIds).
+    test('moveGroup to center preserves tab groups from the source', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                return new PanelContentPartTest(options.id, options.name);
+            },
+        });
+
+        dockview.layout(1000, 1000);
+
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        dockview.addPanel({ id: 'panel2', component: 'default' });
+
+        const panel1 = dockview.getGroupPanel('panel1')!;
+        const panel2 = dockview.getGroupPanel('panel2')!;
+        const sourceGroup = panel1.group;
+
+        // Create a tab group on the source spanning both panels.
+        const tabGroup = sourceGroup.model.createTabGroup({
+            label: 'Feature',
+            color: 'blue',
+            collapsed: true,
+            componentParams: { foo: 'bar' },
+        });
+        sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
+        sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel2');
+
+        // Spin off a destination group so the merge has somewhere to go.
+        dockview.addPanel({
+            id: 'panel3',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        const panel3 = dockview.getGroupPanel('panel3')!;
+        const destGroup = panel3.group;
+        expect(destGroup).not.toBe(sourceGroup);
+
+        // Drag the source group onto destGroup's center (this is what
+        // the void-container header drag fires).
+        dockview.moveGroupOrPanel({
+            from: { groupId: sourceGroup.id },
+            to: { group: destGroup, position: 'center' },
+        });
+
+        // All three panels should now live in destGroup.
+        expect(destGroup.model.size).toBe(3);
+        expect(panel1.group).toBe(destGroup);
+        expect(panel2.group).toBe(destGroup);
+
+        // Tab group should have come along with its panels and metadata.
+        const movedTabGroups = destGroup.model.getTabGroups();
+        expect(movedTabGroups.length).toBe(1);
+        const moved = movedTabGroups[0];
+        expect(moved.label).toBe('Feature');
+        expect(moved.color).toBe('blue');
+        expect(moved.collapsed).toBe(true);
+        expect(moved.componentParams).toEqual({ foo: 'bar' });
+        expect([...moved.panelIds]).toEqual(['panel1', 'panel2']);
+
+        dockview.dispose();
+    });
+
+    // Companion to the above: confirm the active panel stays correct
+    // when the source contains a collapsed tab group + an ungrouped
+    // panel that is the active one.
+    test('moveGroup to center preserves active panel across collapsed tab group merge', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                return new PanelContentPartTest(options.id, options.name);
+            },
+        });
+
+        dockview.layout(1000, 1000);
+
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        dockview.addPanel({ id: 'panel2', component: 'default' });
+        dockview.addPanel({ id: 'panel3', component: 'default' });
+
+        const panel3 = dockview.getGroupPanel('panel3')!;
+        const sourceGroup = panel3.group;
+
+        // Collapsed tab group on panel1 + panel2; panel3 is ungrouped
+        // and is the active panel (since the only other panels are
+        // inside a collapsed group).
+        const tabGroup = sourceGroup.model.createTabGroup({
+            label: 'Hidden',
+            color: 'red',
+        });
+        sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
+        sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel2');
+        tabGroup.collapse();
+
+        // panel3 is the active panel; collapsing the group above
+        // redirects active away from the collapsed-group panels.
+        expect(sourceGroup.model.activePanel?.id).toBe('panel3');
+
+        // Spin off destination group.
+        dockview.addPanel({
+            id: 'panel4',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        const panel4 = dockview.getGroupPanel('panel4')!;
+        const destGroup = panel4.group;
+
+        // Drag entire source onto destGroup's center.
+        dockview.moveGroupOrPanel({
+            from: { groupId: sourceGroup.id },
+            to: { group: destGroup, position: 'center' },
+        });
+
+        // Active panel should still be panel3.
+        expect(destGroup.model.activePanel?.id).toBe('panel3');
+
+        // Tab group recreated and still collapsed.
+        const tgs = destGroup.model.getTabGroups();
+        expect(tgs.length).toBe(1);
+        expect(tgs[0].collapsed).toBe(true);
+        expect([...tgs[0].panelIds]).toEqual(['panel1', 'panel2']);
+
+        dockview.dispose();
+    });
+
     test('remove group', () => {
         dockview.layout(500, 1000);
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3011,6 +3011,7 @@ export class DockviewComponent
         const label = tabGroup.label;
         const color = tabGroup.color;
         const collapsed = tabGroup.collapsed;
+        const componentParams = tabGroup.componentParams;
         const panelIds = [...tabGroup.panelIds];
 
         // Remove panels from the source group
@@ -3053,6 +3054,7 @@ export class DockviewComponent
                 label,
                 color,
                 collapsed,
+                componentParams,
             });
             for (const panel of removedPanels) {
                 targetGroup.model.addPanelToTabGroup(newTabGroup.id, panel.id);
@@ -3097,6 +3099,17 @@ export class DockviewComponent
         if (target === 'center') {
             const activePanel = from.activePanel;
 
+            // Snapshot tab group metadata before removing panels so we
+            // can recreate the tab groups in the destination after the
+            // panels are merged in.
+            const tabGroupSnapshots = from.model.getTabGroups().map((tg) => ({
+                label: tg.label,
+                color: tg.color,
+                collapsed: tg.collapsed,
+                componentParams: tg.componentParams,
+                panelIds: [...tg.panelIds],
+            }));
+
             const panels = this.movingLock(() =>
                 [...from.panels].map((p) =>
                     from.model.removePanel(p.id, {
@@ -3117,6 +3130,18 @@ export class DockviewComponent
                     });
                 }
             });
+
+            for (const snapshot of tabGroupSnapshots) {
+                const newTabGroup = to.model.createTabGroup({
+                    label: snapshot.label,
+                    color: snapshot.color,
+                    collapsed: snapshot.collapsed,
+                    componentParams: snapshot.componentParams,
+                });
+                for (const panelId of snapshot.panelIds) {
+                    to.model.addPanelToTabGroup(newTabGroup.id, panelId);
+                }
+            }
 
             // Ensure group becomes active after move
             if (options.skipSetActive !== true) {
@@ -3139,6 +3164,19 @@ export class DockviewComponent
                  * positions `source` like any other moved group.
                  */
                 const activePanel = from.activePanel;
+
+                // Snapshot tab group metadata so the new group inherits
+                // the tab grouping from the edge slot.
+                const tabGroupSnapshots = from.model
+                    .getTabGroups()
+                    .map((tg) => ({
+                        label: tg.label,
+                        color: tg.color,
+                        collapsed: tg.collapsed,
+                        componentParams: tg.componentParams,
+                        panelIds: [...tg.panelIds],
+                    }));
+
                 const movedPanels = this.movingLock(() =>
                     [...from.panels].map((p) =>
                         from.model.removePanel(p.id, { skipSetActive: true })
@@ -3153,6 +3191,21 @@ export class DockviewComponent
                         });
                     }
                 });
+
+                for (const snapshot of tabGroupSnapshots) {
+                    const newTabGroup = source.model.createTabGroup({
+                        label: snapshot.label,
+                        color: snapshot.color,
+                        collapsed: snapshot.collapsed,
+                        componentParams: snapshot.componentParams,
+                    });
+                    for (const panelId of snapshot.panelIds) {
+                        source.model.addPanelToTabGroup(
+                            newTabGroup.id,
+                            panelId
+                        );
+                    }
+                }
             } else {
                 switch (from.api.location.type) {
                     case 'grid':


### PR DESCRIPTION
… header (#1244)

moveGroup's center branch removes panels from the source group and re-adds them to the destination one by one, but the source's tab group metadata lives on its model and was never copied across — so any tab groups in the dragged group were silently dissolved on drop. The same shape exists in the edge-source branch (panels are moved into a fresh group). Fix both by snapshotting tab groups before removing panels and recreating them on the target after the panels are merged.

Also include componentParams in the snapshot/restore in moveTabGroupToGroup so chip drags don't drop the renderer state either.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
