### PR TITLE
fix: edge group collapse/expand button stuck after two clicks (#1241)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -9845,6 +9845,76 @@ describe('dockviewComponent', () => {
             dv.dispose();
         });
 
+        test('onDidCollapsedChange fires once per actual state change, not on redundant calls (#1241)', () => {
+            const c = document.createElement('div');
+            const dv = createFixedDockview(c, ['right']);
+            dv.layout(1000, 800);
+
+            const rightApi = dv.getEdgeGroup('right')!;
+            const events: boolean[] = [];
+            rightApi.onDidCollapsedChange((e) => events.push(e.isCollapsed));
+
+            rightApi.collapse();
+            rightApi.collapse(); // redundant
+            rightApi.expand();
+            rightApi.expand(); // redundant
+
+            expect(events).toEqual([true, false]);
+
+            dv.dispose();
+        });
+
+        test('repeated expand() does not drift the expanded size (#1241)', () => {
+            const c = document.createElement('div');
+            const dv = new DockviewComponent(c, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+                // Non-zero gap is what surfaces splitview rounding drift
+                theme: { name: 'test', className: 'test', gap: 10 },
+            });
+            dv.addEdgeGroup('right', {
+                id: 'right-group',
+                initialSize: 220,
+                minimumSize: 100,
+            });
+            dv.layout(1000, 800);
+            dv.addPanel({
+                id: 'right-p1',
+                component: 'default',
+                position: { referenceGroup: 'right-group' },
+            });
+
+            const initialSize = (
+                dv as any
+            )._shellManager._outerSplitview.getViewSize(
+                (dv as any)._shellManager._rightIndex
+            );
+
+            const rightApi = dv.getEdgeGroup('right')!;
+            for (let i = 0; i < 10; i++) {
+                rightApi.expand();
+            }
+
+            const finalSize = (
+                dv as any
+            )._shellManager._outerSplitview.getViewSize(
+                (dv as any)._shellManager._rightIndex
+            );
+
+            expect(finalSize).toBe(initialSize);
+
+            dv.dispose();
+        });
+
         test('toJSON includes edgeGroups field for configured positions', () => {
             const c = document.createElement('div');
             const dv = createFixedDockview(c, ['left', 'top']);

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1602,7 +1602,7 @@ export class DockviewComponent
         // Collapse when the group becomes empty
         const autoCollapseDisposable = group.model.onDidRemovePanel(() => {
             if (group.model.isEmpty) {
-                this._shellManager!.setEdgeGroupCollapsed(position, true);
+                this.setEdgeGroupCollapsed(group, true);
             }
         });
         this._edgeGroupDisposables.set(position, autoCollapseDisposable);
@@ -1663,6 +1663,15 @@ export class DockviewComponent
     setEdgeGroupCollapsed(group: DockviewGroupPanel, collapsed: boolean): void {
         for (const [position, edgeGroup] of this._edgeGroups) {
             if (edgeGroup === group) {
+                if (
+                    this._shellManager!.isEdgeGroupCollapsed(position) ===
+                    collapsed
+                ) {
+                    // Skip the splitview resize on a no-op: with non-zero
+                    // theme gap, redundant resizeView calls accumulate
+                    // rounding drift that gradually shrinks the group.
+                    return;
+                }
                 this._shellManager!.setEdgeGroupCollapsed(position, collapsed);
                 edgeGroup.api._onDidCollapsedChange.fire({
                     isCollapsed: collapsed,

--- a/packages/docs/templates/dockview/edge-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/edge-groups/react/src/app.tsx
@@ -26,8 +26,8 @@ const RightActions = (props: IDockviewHeaderActionsProps) => {
     const [collapsed, setCollapsed] = React.useState(props.api.isCollapsed());
 
     React.useEffect(() => {
-        const disposable = props.api.onDidCollapsedChange((isCollapsed) => {
-            setCollapsed(isCollapsed);
+        const disposable = props.api.onDidCollapsedChange((event) => {
+            setCollapsed(event.isCollapsed);
         });
         return () => disposable.dispose();
     }, [props.api]);


### PR DESCRIPTION
- demo: read event.isCollapsed in onDidCollapsedChange handler instead of treating the event object as a boolean (kept React state truthy forever).
- core: route auto-collapse-when-empty through setEdgeGroupCollapsed so onDidCollapsedChange fires for listeners.
- core: skip the splitview resize on no-op state changes so spaced themes don't accumulate gap rounding drift on repeated expand() calls.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
