### PR TITLE
ci: add release workflow, CODEOWNERS, and explicit job permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS — required reviewers for security-sensitive paths.
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Enforcement is opt-in: enable "Require review from Code Owners" in the
+# branch ruleset protecting master for these rules to actually gate merges.
+
+# Anything under .github/ — workflows, Dependabot, actions config, this file.
+/.github/                @mathuo
+
+# Release plumbing.
+/nx.json                 @mathuo

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,10 @@ jobs:
     analyze:
         name: Analyze
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            actions: read
+            security-events: write
 
         strategy:
             fail-fast: false

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,8 @@ on:
 jobs:
     deploy-nightly-demo-app:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - name: Checkout 🛎️
               uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            specifier:
+                description: 'patch | minor | major | prerelease | explicit version (e.g. 6.1.0)'
+                required: true
+                type: string
+                default: patch
+            dry-run:
+                description: 'Dry run (compute version and commit locally, do not push)'
+                required: false
+                type: boolean
+                default: false
+
+concurrency:
+    group: release
+    cancel-in-progress: false
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: master
+                  fetch-depth: 0
+                  fetch-tags: true
+                  token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: '20.x'
+
+            - uses: actions/cache@v4
+              with:
+                  path: |
+                      node_modules
+                      ~/.npm
+                  key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-modules-
+
+            - run: yarn
+
+            - name: Configure git
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+            - name: Version
+              run: npx nx release version ${{ inputs.specifier }}
+
+            - name: Show release commit
+              run: git --no-pager log -1 --stat
+
+            - name: Push commit and tag
+              if: ${{ !inputs.dry-run }}
+              run: git push --follow-tags origin master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         steps:
             - name: Generate App token
               id: app-token
-              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              uses: actions/create-github-app-token@v3.1.1
               with:
                   app-id: ${{ secrets.RELEASE_APP_ID }}
                   private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,9 @@ jobs:
               id: app-user
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  SLUG: ${{ steps.app-token.outputs.app-slug }}
               run: |
-                  slug="${{ steps.app-token.outputs.app-slug }}"
-                  id=$(gh api "/users/${slug}[bot]" --jq .id)
+                  id=$(gh api "/users/${SLUG}[bot]" --jq .id)
                   echo "user-id=${id}" >> "$GITHUB_OUTPUT"
 
             - name: Configure git
@@ -72,7 +72,9 @@ jobs:
                   git config user.email "${UID}+${SLUG}[bot]@users.noreply.github.com"
 
             - name: Version
-              run: npx nx release version ${{ inputs.specifier }}
+              env:
+                  SPECIFIER: ${{ inputs.specifier }}
+              run: npx nx release version "$SPECIFIER"
 
             - name: Show release commit
               run: git --no-pager log -1 --stat

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,22 @@ jobs:
 
             - run: yarn
 
-            - name: Configure git
+            - name: Get App user id
+              id: app-user
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  slug="${{ steps.app-token.outputs.app-slug }}"
+                  id=$(gh api "/users/${slug}[bot]" --jq .id)
+                  echo "user-id=${id}" >> "$GITHUB_OUTPUT"
+
+            - name: Configure git
+              env:
+                  SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  UID: ${{ steps.app-user.outputs.user-id }}
+              run: |
+                  git config user.name  "${SLUG}[bot]"
+                  git config user.email "${UID}+${SLUG}[bot]@users.noreply.github.com"
 
             - name: Version
               run: npx nx release version ${{ inputs.specifier }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,15 +21,23 @@ concurrency:
 jobs:
     release:
         runs-on: ubuntu-latest
+        environment: release
         permissions:
-            contents: write
+            contents: read
         steps:
+            - name: Generate App token
+              id: app-token
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  app-id: ${{ secrets.RELEASE_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
             - uses: actions/checkout@v4
               with:
                   ref: master
                   fetch-depth: 0
                   fetch-tags: true
-                  token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+                  token: ${{ steps.app-token.outputs.token }}
 
             - uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
## Summary
- New `release.yml` (`workflow_dispatch`) runs `nx release version` non-interactively, commits + tags, and pushes to master with `--follow-tags`. Auth is via a GitHub App token (`actions/create-github-app-token`), scoped to a `release` environment. Manual GitHub Release creation remains the publish gate (existing `publish.yml` is unchanged).
- Add `.github/CODEOWNERS` for `/.github/` and `/nx.json` so changes to release plumbing and workflow security require maintainer review.
- Add explicit job-level `permissions:` blocks to `codeql-analysis.yml` (`security-events: write`) and `deploy-docs.yml` (`contents: write`) so they keep working once the repo default workflow permission is set to read-only.

## Required follow-up (manual, in repo Settings)
- Settings → Actions → General → **Workflow permissions** = "Read repository contents and packages permissions" (the change that makes the explicit blocks load-bearing).
- Master ruleset → enable **Require review from Code Owners** so CODEOWNERS actually gates merges instead of just auto-requesting review.
- For `release.yml` to push to a protected master, add the GitHub App to the ruleset bypass list. The `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` secrets must be set on the `release` environment.

## Test plan
- [ ] Trigger `release.yml` with `dry-run: true` from the Actions UI and confirm it computes the next version, makes the local commit, and skips the push step.
- [ ] Confirm the `JamesIves/github-pages-deploy-action` step in `deploy-docs.yml` still completes after the read-only default is enabled (the `contents: write` block should make it work).
- [ ] Confirm the next CodeQL scheduled run uploads SARIF results to the Security tab.
- [ ] Edit a workflow file in a throwaway PR and confirm the maintainer is auto-requested as reviewer via CODEOWNERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)