### PR TITLE
ci: bump release workflow to Node 24.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: '20.x'
+                  node-version: '24.x'
 
             - uses: actions/cache@v4
               with:


### PR DESCRIPTION
## Summary
- Release workflow pinned Node 20.x while `package.json` `engines.node` requires `^22.13.0 || >=24.0.0`, so `yarn install` aborted at engine validation (run [25690474696](https://github.com/mathuo/dockview/actions/runs/25690474696/job/75425258486)).
- Bumped `node-version` in `.github/workflows/release.yml` to `24.x` to match `main.yml`, `publish.yml`, and `deploy-docs.yml`.

## Test plan
- [ ] Re-run the Release workflow (`workflow_dispatch`) with `dry-run: true` and confirm `yarn` step now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)