### PR TITLE
ci: pass GraphQL variables via request body, not -F flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
                       deletions=$(jq -c --argjson e "$entry" '. + [$e]' <<<"$deletions")
                   done < <(git diff --name-only --diff-filter=D -z HEAD)
 
-                  input=$(jq -nc \
+                  body=$(jq -nc \
                       --arg repo "${GITHUB_REPOSITORY}" \
                       --arg branch "master" \
                       --arg headline "chore(release): publish v${VERSION}" \
@@ -109,15 +109,23 @@ jobs:
                       --argjson additions "${additions}" \
                       --argjson deletions "${deletions}" \
                       '{
-                          branch: {repositoryNameWithOwner: $repo, branchName: $branch},
-                          message: {headline: $headline},
-                          expectedHeadOid: $oid,
-                          fileChanges: {additions: $additions, deletions: $deletions}
+                          query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+                          variables: {
+                              input: {
+                                  branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                                  message: {headline: $headline},
+                                  expectedHeadOid: $oid,
+                                  fileChanges: {additions: $additions, deletions: $deletions}
+                              }
+                          }
                       }')
 
-                  resp=$(gh api graphql \
-                      -f query='mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }' \
-                      -F input="${input}")
+                  resp=$(printf '%s' "$body" | gh api graphql --input -)
+                  if [ "$(jq 'has("errors")' <<<"$resp")" = "true" ]; then
+                      echo "GraphQL errors:" >&2
+                      jq '.errors' <<<"$resp" >&2
+                      exit 1
+                  fi
 
                   new_sha=$(jq -r '.data.createCommitOnBranch.commit.oid' <<<"$resp")
                   new_url=$(jq -r '.data.createCommitOnBranch.commit.url' <<<"$resp")


### PR DESCRIPTION
gh api graphql -F input=<json> sends the value as a string, since -F only does magic conversion for booleans/numbers/null. CreateCommitOnBranchInput then rejects it. Build the full request body (query + variables) with jq and pipe it through --input -, and surface GraphQL-level errors explicitly.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
