### PR TITLE
ci: grant gen job pull-requests:write so PR comment step succeeds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,10 @@ jobs:
     gen:
         runs-on: ubuntu-latest
 
+        permissions:
+            contents: read
+            pull-requests: write
+
         steps:
             - uses: actions/checkout@v4
             - name: Use Node.js


### PR DESCRIPTION
The "Comment diff on PR" step in the gen job calls gh pr comment, which hits the GraphQL addComment mutation and requires pull-requests:write. Without it the step fails with "Resource not accessible by integration" whenever generated files drift, masking the actionable diff comment.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
