### PR TITLE
ci: harden workflows against cache-poisoning publish chain

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,11 +6,6 @@
 name: 'CodeQL'
 
 on:
-    # push:
-    #   branches: [master]
-    # pull_request:
-    #   # The branches below must be a subset of the branches above
-    #   branches: [master]
     schedule:
         - cron: '0 4 * * *'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
         branches: [master]
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     format:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     publish:
         if: github.event_name == 'release'
         runs-on: ubuntu-latest
+        environment: release
         permissions:
             contents: read
             id-token: write
@@ -25,13 +26,6 @@ jobs:
               with:
                   node-version: '24.x'
             - run: npm install -g npm@latest
-
-            - uses: actions/cache@v4
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-
 
             - run: yarn
             - run: npx nx run-many -t build --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular
@@ -44,6 +38,7 @@ jobs:
     publish-experimental:
         if: github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
+        environment: release
         permissions:
             contents: read
             id-token: write
@@ -55,13 +50,6 @@ jobs:
               with:
                   node-version: '24.x'
             - run: npm install -g npm@latest
-
-            - uses: actions/cache@v4
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-
 
             - run: yarn
             - run: npx nx run-many -t build --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     publish:
         if: github.event_name == 'release'
         runs-on: ubuntu-latest
-        environment: release
+        environment: publish
         permissions:
             contents: read
             id-token: write
@@ -38,7 +38,7 @@ jobs:
     publish-experimental:
         if: github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
-        environment: release
+        environment: publish
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ jobs:
                   path: |
                       node_modules
                       ~/.npm
-                  key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+                  key: release-${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
                   restore-keys: |
-                      ${{ runner.os }}-modules-
+                      release-${{ runner.os }}-modules-
 
             - run: yarn
 


### PR DESCRIPTION
Closes the actions/cache -> OIDC chain demonstrated by the TanStack npm supply-chain compromise (May 2026):

- publish.yml: gate publish + publish-experimental behind the release environment, and drop the unused ~/.npm cache step (workflow installs with yarn, so the cache was both dead weight and a poisoning surface in the job that holds id-token: write).
- release.yml: re-key the build cache with a release- prefix so CI's ${runner.os}-modules- scope can no longer be restored into the release runner (which holds the GitHub App signing token).
- main.yml: declare top-level permissions: contents: read as a least-privilege default for the GITHUB_TOKEN; the gen job's existing per-job override still grants pull-requests: write where needed.
- codeql-analysis.yml: remove the dead commented-out push/pull_request triggers. Intent is nightly-only; Sonar covers per-PR analysis.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
