### PR TITLE
ci: bump sonarqube-scan-action to v6 (CVE-2025-59844)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,7 +228,7 @@ jobs:
 
             - name: SonarCloud Scan
               if: env.SONAR_TOKEN != ''
-              uses: sonarsource/sonarqube-scan-action@v5
+              uses: sonarsource/sonarqube-scan-action@v6
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps `sonarsource/sonarqube-scan-action` from `@v5` to `@v6` in `main.yml`.
- Fixes [CVE-2025-59844 / GHSA-5xq9-5g24-4g6f](https://github.com/SonarSource/sonarqube-scan-action/security/advisories/GHSA-5xq9-5g24-4g6f) — argument injection in the action. Vulnerable range `>= 4.0.0, < 6.0.0`, fixed in `6.0.0` (Sep 2025).
- This is the only **runtime-scope** high-severity Dependabot alert against this repo.

## Exploitability against this workflow

Bounded but worth fixing on principle:

- The CVE specifically calls out **Windows runners** passing user-controlled input into the `args:` parameter; we run `ubuntu-latest` and don't set `args:`.
- Still, "clear runtime-scope high-severity alerts" is the right baseline policy.

## Breaking change check

`v6.0.0` rewrote the action from Bash to JS and changes how `args:` is parsed. **We don't set `args:`**, so no migration is required. All `env:` (`GITHUB_TOKEN`, `SONAR_TOKEN`) and `if:` behavior is unchanged.

## Test plan

- [ ] `sonar` job runs successfully on this PR.
- [ ] SonarCloud results appear on the PR as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)