### PR TITLE
chore(deps): tidy and bump docs package

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -30,22 +30,20 @@
         "@docusaurus/module-type-aliases": "^3.10.1",
         "@docusaurus/preset-classic": "^3.10.1",
         "@docusaurus/theme-search-algolia": "^3.10.1",
-        "@mdx-js/react": "^3.0.0",
-        "@minoru/react-dnd-treeview": "^3.4.4",
-        "@radix-ui/react-dropdown-menu": "^2.1.1",
-        "@radix-ui/react-icons": "^1.3.0",
-        "@radix-ui/react-popover": "^1.0.7",
+        "@mdx-js/react": "^3.1.1",
+        "@minoru/react-dnd-treeview": "^3.5.3",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "ag-grid-community": "^31.3.4",
         "ag-grid-react": "^31.3.4",
-        "clsx": "^2.1.0",
+        "clsx": "^2.1.1",
         "dockview-react": "^6.0.1",
         "dockview-core": "^6.0.1",
-        "prism-react-renderer": "^2.3.1",
+        "prism-react-renderer": "^2.4.1",
         "react-dnd": "^16.0.1",
         "source-map-loader": "^5.0.0"
     },
     "devDependencies": {
-        "@tsconfig/docusaurus": "^2.0.2",
-        "docusaurus-plugin-sass": "^0.2.5"
+        "@tsconfig/docusaurus": "^2.0.9",
+        "docusaurus-plugin-sass": "^0.2.6"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,14 +3232,14 @@
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
 
-"@mdx-js/react@^3.0.0":
+"@mdx-js/react@^3.0.0", "@mdx-js/react@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-3.1.1.tgz#24bda7fffceb2fe256f954482123cda1be5f5fef"
   integrity sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==
   dependencies:
     "@types/mdx" "^2.0.0"
 
-"@minoru/react-dnd-treeview@^3.4.4":
+"@minoru/react-dnd-treeview@^3.5.3":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/@minoru/react-dnd-treeview/-/react-dnd-treeview-3.5.3.tgz#0e34a6aa3df1f28b7bd30d95c2ad025563edaa63"
   integrity sha512-k9Hz99pLWR/0AMWYR4Hyda4jQjhfBz0dqqqLpk9apfbB7RthamjIJsKKobxgvA8d7ykbVRLCOlrWlRckP1uSkw==
@@ -3821,7 +3821,7 @@
     "@radix-ui/react-use-callback-ref" "1.1.1"
     "@radix-ui/react-use-escape-keydown" "1.1.1"
 
-"@radix-ui/react-dropdown-menu@^2.1.1":
+"@radix-ui/react-dropdown-menu@^2.1.16":
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz#5ee045c62bad8122347981c479d92b1ff24c7254"
   integrity sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==
@@ -3847,11 +3847,6 @@
     "@radix-ui/react-compose-refs" "1.1.2"
     "@radix-ui/react-primitive" "2.1.3"
     "@radix-ui/react-use-callback-ref" "1.1.1"
-
-"@radix-ui/react-icons@^1.3.0":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-icons/-/react-icons-1.3.2.tgz#09be63d178262181aeca5fb7f7bc944b10a7f441"
-  integrity sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==
 
 "@radix-ui/react-id@1.1.1":
   version "1.1.1"
@@ -3881,27 +3876,6 @@
     "@radix-ui/react-roving-focus" "1.1.11"
     "@radix-ui/react-slot" "1.2.3"
     "@radix-ui/react-use-callback-ref" "1.1.1"
-    aria-hidden "^1.2.4"
-    react-remove-scroll "^2.6.3"
-
-"@radix-ui/react-popover@^1.0.7":
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.15.tgz#9c852f93990a687ebdc949b2c3de1f37cdc4c5d5"
-  integrity sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==
-  dependencies:
-    "@radix-ui/primitive" "1.1.3"
-    "@radix-ui/react-compose-refs" "1.1.2"
-    "@radix-ui/react-context" "1.1.2"
-    "@radix-ui/react-dismissable-layer" "1.1.11"
-    "@radix-ui/react-focus-guards" "1.1.3"
-    "@radix-ui/react-focus-scope" "1.1.7"
-    "@radix-ui/react-id" "1.1.1"
-    "@radix-ui/react-popper" "1.2.8"
-    "@radix-ui/react-portal" "1.1.9"
-    "@radix-ui/react-presence" "1.1.5"
-    "@radix-ui/react-primitive" "2.1.3"
-    "@radix-ui/react-slot" "1.2.3"
-    "@radix-ui/react-use-controllable-state" "1.2.2"
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.6.3"
 
@@ -4466,7 +4440,7 @@
   resolved "https://registry.yarnpkg.com/@total-typescript/shoehorn/-/shoehorn-0.1.2.tgz#a0c095ce8cb9b4ae3556bcff42702ddb072e9d18"
   integrity sha512-p7nNZbOZIofpDNyP0u1BctFbjxD44Qc+oO5jufgQdFdGIXJLc33QRloJpq7k5T59CTgLWfQSUxsuqLcmeurYRw==
 
-"@tsconfig/docusaurus@^2.0.2":
+"@tsconfig/docusaurus@^2.0.9":
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/docusaurus/-/docusaurus-2.0.9.tgz#e530ae78bca4f88917af48fe25a944d6d6bdcdf5"
   integrity sha512-0jVxZCgy2v7TnJrW9kVNikNwJHeiWb68Zhiiw2vHw4tzBFSP5vS2zn3O5EY2oPEVz5dXZRkK7MnWG3Ay5q0mIg==
@@ -6547,7 +6521,7 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
-clsx@^2.0.0, clsx@^2.1.0:
+clsx@^2.0.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -7349,7 +7323,7 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docusaurus-plugin-sass@^0.2.5:
+docusaurus-plugin-sass@^0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/docusaurus-plugin-sass/-/docusaurus-plugin-sass-0.2.6.tgz#b4930a1fe1cc7bcead639bb1bee38bce0ffd073d"
   integrity sha512-2hKQQDkrufMong9upKoG/kSHJhuwd+FA3iAe/qzS/BmWpbIpe7XKmq5wlz4J5CJaOPu4x+iDJbgAxZqcoQf0kg==
@@ -13014,7 +12988,7 @@ pretty-time@^1.1.0:
   resolved "https://registry.yarnpkg.com/pretty-time/-/pretty-time-1.1.0.tgz#ffb7429afabb8535c346a34e41873adf3d74dd0e"
   integrity sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==
 
-prism-react-renderer@^2.3.0, prism-react-renderer@^2.3.1:
+prism-react-renderer@^2.3.0, prism-react-renderer@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz#ac63b7f78e56c8f2b5e76e823a976d5ede77e35f"
   integrity sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==


### PR DESCRIPTION
## Summary

- Drop two completely-unused Radix packages from `packages/docs/dependencies` (verified zero imports anywhere in `src/`, `docs/`, `blog/`, `templates/`, or config)
- Apply seven patch/minor bumps that are already on master's range

## Removed

| Package | Reason |
|---|---|
| `@radix-ui/react-icons` | Zero imports |
| `@radix-ui/react-popover` | Zero imports |

The third Radix package, `@radix-ui/react-dropdown-menu`, is kept — used in `src/components/frameworkSpecific.tsx` and `src/pages/demo.tsx`.

`@mdx-js/react` looks unused too but is a required peer dependency of `@docusaurus/core` ^3 (consumed internally by the MDX loader), so it stays.

## Bumped

- `@mdx-js/react` 3.0 → 3.1
- `@minoru/react-dnd-treeview` 3.4 → 3.5
- `@radix-ui/react-dropdown-menu` 2.1.1 → 2.1.16
- `prism-react-renderer` 2.3 → 2.4
- `clsx` 2.1.0 → 2.1.1
- `@tsconfig/docusaurus` 2.0.2 → 2.0.9
- `docusaurus-plugin-sass` 0.2.5 → 0.2.6

## Not touched (intentional)

- `ag-grid-community` / `ag-grid-react` — 4 majors behind (31 → 35). The only consumer is the `demo-dockview` sandbox; v32 introduced a required modules API and v33 redid theming, so a bump would need a non-trivial sandbox rewrite. AGENTS.md already flags those sandboxes as legacy — leaving the pins until the demo gets a refresh.
- `@docusaurus/*` 3.10.1 — already on the latest within ^3.x range.

## Test plan

- [ ] `yarn install` clean
- [ ] `yarn build` — all 5 publishable packages build
- [ ] `cd packages/docs && yarn build` — docs site builds (sandboxes intact)
- [ ] `yarn lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)