### PR TITLE
fix(dockview-vue): scope typedoc tsconfig to avoid stray @types lib c…

### DIFF
--- a/packages/dockview-vue/tsconfig.typedoc.json
+++ b/packages/dockview-vue/tsconfig.typedoc.json
@@ -1,3 +1,8 @@
 {
+  "extends": "@vue/tsconfig/tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "types": []
+  },
   "include": ["src/dockview/types.ts"]
 }


### PR DESCRIPTION
…hecks

tsconfig.typedoc.json had no extends and no compilerOptions, so TypeScript fell back to defaults (target ES3, skipLibCheck off, types auto-included from all of node_modules/@types). After the react 19 upgrade pulled in newer eslint/mdx typings, typedoc started failing on unrelated d.ts files.

Extend @vue/tsconfig (matching tsconfig.app.json), enable skipLibCheck, and set types: [] so only the declared entry point is type-checked.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
