### PR TITLE
fix(dockview-core): keep dv-render-overlay hidden when visibility fli…

### DIFF
--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -474,6 +474,81 @@ describe('overlayRenderContainer', () => {
         expect(container2.style.visibility).toBe('');
     });
 
+    test('resize rAF that fires after a panel was hidden mid-flight keeps visibility hidden', async () => {
+        // Regression test for a race where:
+        //   1. visibilityChanged(visible=true) schedules a resize rAF and clears pointerEvents
+        //   2. before the rAF fires, the panel becomes non-visible:
+        //      visibilityChanged(visible=false) sets visibility:hidden + pointerEvents:none
+        //   3. the rAF then ran `if (style.visibility === 'hidden') style.visibility = ''`,
+        //      leaving the overlay computed-visible with pointer-events:none at a stale
+        //      position. onDidDimensionsChange skips non-visible panels, so subsequent
+        //      sash drags never repositioned the overlay — its stale content leaked into
+        //      neighbouring panel areas.
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        jest.spyOn(
+            referenceContainer.element,
+            'getBoundingClientRect'
+        ).mockReturnValue(
+            fromPartial<DOMRect>({
+                left: 100,
+                top: 200,
+                width: 100,
+                height: 200,
+            })
+        );
+        jest.spyOn(parentContainer, 'getBoundingClientRect').mockReturnValue(
+            fromPartial<DOMRect>({ left: 0, top: 0, width: 1000, height: 1000 })
+        );
+
+        const container = cut.attach({ panel, referenceContainer });
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        // Baseline: panel is visible and positioned.
+        expect(container.style.visibility).toBe('');
+        expect(container.style.pointerEvents).toBe('');
+
+        // Flip the panel to non-visible so the queued post-resize rAF sees
+        // `panel.api.isVisible === false`.
+        (panel as Writable<IDockviewPanel>).api.isVisible = false;
+        onDidVisibilityChange.fire({});
+        expect(container.style.visibility).toBe('hidden');
+        expect(container.style.pointerEvents).toBe('none');
+
+        // Now simulate an in-flight resize completing AFTER the visibility flip.
+        // The rAF runs and must NOT clobber `visibility:hidden`.
+        (panel as Writable<IDockviewPanel>).api.isVisible = true;
+        onDidVisibilityChange.fire({}); // schedules a resize rAF
+        (panel as Writable<IDockviewPanel>).api.isVisible = false;
+        onDidVisibilityChange.fire({}); // hides again before rAF
+        await exhaustAnimationFrame();
+
+        expect(container.style.visibility).toBe('hidden');
+        expect(container.style.pointerEvents).toBe('none');
+    });
+
     test('updateAllPositions forces position recalculation for visible panels', async () => {
         const cut = new OverlayRenderContainer(
             parentContainer,

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -194,10 +194,19 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 focusContainer.style.top = `${top}px`;
                 focusContainer.style.width = `${width}px`;
                 focusContainer.style.height = `${height}px`;
-                // Reveal after the first position is applied (was hidden to
-                // prevent a flash at 0,0 before the initial layout fires).
-                if (focusContainer.style.visibility === 'hidden') {
+                // Sync visibility/pointer-events with the panel's current
+                // visibility at paint time. visibilityChanged() may have
+                // flipped to hidden between scheduling this rAF and now;
+                // unconditionally clearing `visibility:hidden` here would
+                // leave a hidden panel visually visible at a stale position,
+                // because onDidDimensionsChange skips non-visible panels and
+                // never recomputes their box on subsequent resizes.
+                if (panel.api.isVisible) {
                     focusContainer.style.visibility = '';
+                    focusContainer.style.pointerEvents = '';
+                } else {
+                    focusContainer.style.visibility = 'hidden';
+                    focusContainer.style.pointerEvents = 'none';
                 }
 
                 toggleClass(


### PR DESCRIPTION
…ps mid-rAF

`OverlayRenderContainer.resize()` queued a position update on `requestAnimationFrame` and, when the rAF fired, unconditionally cleared `focusContainer.style.visibility = ''` if it had been 'hidden'. That comment- matched a benign first-attach reveal case, but the same line runs every resize — so any sequence that goes

  visible → resize() rAF queued → hidden via visibilityChanged → rAF fires

ended up clearing the inline `visibility:hidden` that visibilityChanged() had just set, leaving the overlay computed-visible with `pointer-events:none` at the panel's last visible position.

`onDidDimensionsChange` short-circuits non-visible panels, so on subsequent sash drags those orphaned overlays never recomputed their box and their stale content bled into neighbouring panel areas — most visibly the non-visible tabs of a tab group whose parent group had been resized.

Sync visibility/pointer-events with `panel.api.isVisible` inside the rAF instead of conditionally clearing. The "hide until first paint" intent is preserved because a freshly attached panel is either visible (the rAF clears the initial `visibility:hidden`) or not visible (the rAF re-asserts it).

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
