### PR TITLE
docs: refresh footer links and add contact page

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -281,8 +281,12 @@ const config = {
                 style: 'dark',
                 links: [
                     {
-                        title: 'Learn',
+                        title: 'Documentation',
                         items: [
+                            {
+                                label: 'Get Started',
+                                to: '/docs/overview/introduction',
+                            },
                             {
                                 label: 'Demo',
                                 to: '/demo',
@@ -290,28 +294,28 @@ const config = {
                         ],
                     },
                     {
-                        title: 'Community',
+                        title: 'Dockview',
                         items: [
                             {
-                                label: 'Stack Overflow',
-                                href: 'https://stackoverflow.com/questions/tagged/dockview',
+                                label: 'Sitemap',
+                                to: '/sitemap.xml',
+                            },
+                            {
+                                label: 'Contact us',
+                                to: '/contact-us',
                             },
                         ],
                     },
                     {
-                        title: 'More',
+                        title: 'Follow',
                         items: [
-                            // {
-                            //     label: 'Blog',
-                            //     to: '/blog',
-                            // },
                             {
                                 label: 'GitHub',
                                 href: 'https://github.com/mathuo/dockview',
                             },
                             {
-                                label: 'Contributing',
-                                href: 'https://github.com/mathuo/dockview/blob/master/CONTRIBUTING.md',
+                                label: 'LinkedIn',
+                                href: 'https://www.linkedin.com/company/dockviewjs',
                             },
                         ],
                     },

--- a/packages/docs/src/pages/contact-us.tsx
+++ b/packages/docs/src/pages/contact-us.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+
+export default function ContactUs(): JSX.Element {
+    return (
+        <Layout
+            title="Contact us"
+            description="Get in touch with the Dockview team."
+        >
+            <main>
+                <div
+                    style={{
+                        maxWidth: 600,
+                        margin: '80px auto',
+                        padding: '0 24px',
+                        minHeight: '60vh',
+                    }}
+                >
+                    <h1>Contact us</h1>
+                    <p style={{ color: 'var(--ifm-color-content-secondary)' }}>
+                        For enquiries, please email us at{' '}
+                        <a href="mailto:contact@dockview.dev">
+                            contact@dockview.dev
+                        </a>
+                        .
+                    </p>
+                </div>
+            </main>
+        </Layout>
+    );
+}


### PR DESCRIPTION
Rename "Learn" → "Documentation", add Get Started link, replace Community/More columns with Dockview (Sitemap, Contact us) and Follow (GitHub, LinkedIn), and add the contact-us page.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
