### PR TITLE
fix(docs): use pathname:// for sitemap footer link

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -298,7 +298,7 @@ const config = {
                         items: [
                             {
                                 label: 'Sitemap',
-                                to: '/sitemap.xml',
+                                href: 'pathname:///sitemap.xml',
                             },
                             {
                                 label: 'Contact us',


### PR DESCRIPTION
## Summary
- The "Deploy Docs" workflow has been failing because the Docusaurus build aborts on broken links. Every page is reported as linking to a broken `/sitemap.xml`.
- Root cause: commit 6155b1e69 added a footer entry `{ label: 'Sitemap', to: '/sitemap.xml' }`. Docusaurus's broken-link checker validates `to:` targets against routed pages, but `/sitemap.xml` is a static artifact emitted by `@docusaurus/plugin-sitemap`, not a route — so the checker flags it as broken on every page.
- Fix: switch to `href: 'pathname:///sitemap.xml'`. The `pathname://` prefix is the documented Docusaurus escape hatch that tells the link processor to treat the value as a literal URL path (bypassing the broken-link check).

Failing run for reference: https://github.com/mathuo/dockview/actions/runs/25828829653

## Test plan
- [ ] CI "Deploy Docs" workflow passes on this branch
- [ ] Verify the Sitemap footer link still navigates to `/sitemap.xml` on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)