### PR TITLE
feat(dockview-core): allow overriding the group drag ghost (#1167)

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -112,6 +112,7 @@ IGridPanelView
 IGridView
 IGridviewComponent
 IGridviewPanel
+IGroupDragGhostRenderer
 IGroupHeaderProps
 IGroupPanelBaseProps
 IGroupPanelInitParameters

--- a/packages/dockview-angular/src/__tests__/angular-group-drag-ghost-renderer.spec.ts
+++ b/packages/dockview-angular/src/__tests__/angular-group-drag-ghost-renderer.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import {
+    ApplicationRef,
+    Component,
+    EnvironmentInjector,
+    Injector,
+} from '@angular/core';
+import { fromPartial } from '@total-typescript/shoehorn';
+import { DockviewApi, IDockviewGroupPanel } from 'dockview-core';
+import { AngularGroupDragGhostRenderer } from '../lib/dockview/angular-group-drag-ghost-renderer';
+
+@Component({
+    standalone: false,
+    selector: 'test-ghost',
+    template: '<span class="test-ghost">{{ group?.id }}</span>',
+})
+class TestGhostComponent {
+    group: IDockviewGroupPanel | undefined;
+    api: DockviewApi | undefined;
+}
+
+describe('AngularGroupDragGhostRenderer', () => {
+    let injector: Injector;
+    let environmentInjector: EnvironmentInjector;
+    let application: ApplicationRef;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [TestGhostComponent],
+        }).compileComponents();
+
+        injector = TestBed.inject(Injector);
+        environmentInjector = TestBed.inject(EnvironmentInjector);
+        application = TestBed.inject(ApplicationRef);
+    });
+
+    afterEach(() => {
+        TestBed.resetTestingModule();
+    });
+
+    test('element has correct class and display style', () => {
+        const renderer = new AngularGroupDragGhostRenderer(
+            TestGhostComponent,
+            injector,
+            environmentInjector
+        );
+
+        expect(renderer.element.className).toBe('dv-angular-part');
+        expect(renderer.element.style.display).toBe('inline-flex');
+    });
+
+    test('init renders the component with group and api', () => {
+        const renderer = new AngularGroupDragGhostRenderer(
+            TestGhostComponent,
+            injector,
+            environmentInjector
+        );
+
+        const group = fromPartial<IDockviewGroupPanel>({ id: 'group-1' });
+
+        renderer.init({
+            group,
+            api: fromPartial<DockviewApi>({}),
+        });
+        application.tick();
+
+        expect(renderer.element.innerHTML).toContain('group-1');
+    });
+
+    test('dispose destroys the component', () => {
+        const renderer = new AngularGroupDragGhostRenderer(
+            TestGhostComponent,
+            injector,
+            environmentInjector
+        );
+
+        renderer.init({
+            group: fromPartial<IDockviewGroupPanel>({ id: 'g' }),
+            api: fromPartial<DockviewApi>({}),
+        });
+
+        expect(() => renderer.dispose()).not.toThrow();
+    });
+
+    test('dispose before init does not throw', () => {
+        const renderer = new AngularGroupDragGhostRenderer(
+            TestGhostComponent,
+            injector,
+            environmentInjector
+        );
+
+        expect(() => renderer.dispose()).not.toThrow();
+    });
+});

--- a/packages/dockview-angular/src/lib/dockview/angular-group-drag-ghost-renderer.ts
+++ b/packages/dockview-angular/src/lib/dockview/angular-group-drag-ghost-renderer.ts
@@ -1,0 +1,68 @@
+import {
+    Type,
+    Injector,
+    EnvironmentInjector,
+    ApplicationRef,
+    ComponentRef,
+    EmbeddedViewRef,
+    createComponent,
+} from '@angular/core';
+import {
+    IGroupDragGhostRenderer,
+    IDockviewGroupPanel,
+    DockviewApi,
+} from 'dockview-core';
+
+export interface IDockviewAngularGroupDragGhostProps {
+    group: IDockviewGroupPanel;
+    api: DockviewApi;
+}
+
+export class AngularGroupDragGhostRenderer implements IGroupDragGhostRenderer {
+    private readonly _element: HTMLElement;
+    private componentRef: ComponentRef<any> | null = null;
+    private readonly appRef: ApplicationRef;
+
+    get element(): HTMLElement {
+        return this._element;
+    }
+
+    constructor(
+        private readonly component: Type<any>,
+        private readonly injector: Injector,
+        private readonly environmentInjector?: EnvironmentInjector
+    ) {
+        this._element = document.createElement('div');
+        this._element.className = 'dv-angular-part';
+        this._element.style.display = 'inline-flex';
+        this.appRef = injector.get(ApplicationRef);
+    }
+
+    init(params: { group: IDockviewGroupPanel; api: DockviewApi }): void {
+        this.componentRef = createComponent(this.component, {
+            environmentInjector:
+                this.environmentInjector ||
+                (this.injector as EnvironmentInjector),
+            elementInjector: this.injector,
+        });
+
+        const instance = this.componentRef.instance as Record<string, unknown>;
+        instance['group'] = params.group;
+        instance['api'] = params.api;
+
+        const hostView = this.componentRef.hostView as EmbeddedViewRef<any>;
+        const rootNode = hostView.rootNodes[0] as HTMLElement;
+        this._element.appendChild(rootNode);
+
+        this.appRef.attachView(hostView);
+        this.componentRef.changeDetectorRef.markForCheck();
+    }
+
+    dispose(): void {
+        if (this.componentRef) {
+            this.appRef.detachView(this.componentRef.hostView);
+            this.componentRef.destroy();
+            this.componentRef = null;
+        }
+    }
+}

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -38,6 +38,7 @@ import { AngularFrameworkComponentFactory } from '../utils/component-factory';
 import { AngularRenderer } from '../utils/angular-renderer';
 import { AngularLifecycleManager } from '../utils/lifecycle-utils';
 import { AngularTabGroupChipRenderer } from './angular-tab-group-chip-renderer';
+import { AngularGroupDragGhostRenderer } from './angular-group-drag-ghost-renderer';
 
 export interface DockviewAngularOptions extends DockviewOptions {
     components: Record<string, Type<any>>;
@@ -84,6 +85,7 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Input() rightHeaderActionsComponent?: Type<any> | TemplateRef<any>;
     @Input() prefixHeaderActionsComponent?: Type<any> | TemplateRef<any>;
     @Input() tabGroupChipComponent?: Type<any>;
+    @Input() groupDragGhostComponent?: Type<any>;
 
     // Core dockview options as inputs
     @Input() className?: string;
@@ -164,6 +166,24 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
                 hasChanges = true;
             }
 
+            // Handle groupDragGhostComponent → createGroupDragGhostComponent mapping
+            if (
+                changes['groupDragGhostComponent'] &&
+                !changes['groupDragGhostComponent'].isFirstChange()
+            ) {
+                const ghostComponent =
+                    changes['groupDragGhostComponent'].currentValue;
+                coreChanges.createGroupDragGhostComponent = ghostComponent
+                    ? () =>
+                          new AngularGroupDragGhostRenderer(
+                              ghostComponent,
+                              this.injector,
+                              this.environmentInjector
+                          )
+                    : undefined;
+                hasChanges = true;
+            }
+
             if (hasChanges) {
                 this.dockviewApi.updateOptions(coreChanges);
             }
@@ -211,6 +231,17 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             coreOptions.createTabGroupChipComponent = () => {
                 return new AngularTabGroupChipRenderer(
                     chipComponent,
+                    this.injector,
+                    this.environmentInjector
+                );
+            };
+        }
+
+        if (this.groupDragGhostComponent) {
+            const ghostComponent = this.groupDragGhostComponent;
+            coreOptions.createGroupDragGhostComponent = () => {
+                return new AngularGroupDragGhostRenderer(
+                    ghostComponent,
                     this.injector,
                     this.environmentInjector
                 );

--- a/packages/dockview-angular/src/public-api.ts
+++ b/packages/dockview-angular/src/public-api.ts
@@ -25,6 +25,7 @@ export {
     DockviewAngularComponentOptions,
 } from './lib/dockview/types';
 export { IDockviewAngularTabGroupChipProps } from './lib/dockview/angular-tab-group-chip-renderer';
+export { IDockviewAngularGroupDragGhostProps } from './lib/dockview/angular-group-drag-ghost-renderer';
 export {
     GridviewAngularOptions,
     GridviewAngularEvents,

--- a/packages/dockview-core/src/__tests__/dnd/groupDragHandler.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/groupDragHandler.spec.ts
@@ -3,6 +3,7 @@ import { GroupDragHandler } from '../../dnd/groupDragHandler';
 import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
 import { LocalSelectionTransfer, PanelTransfer } from '../../dnd/dataTransfer';
 import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { IGroupDragGhostRenderer } from '../../dockview/framework';
 
 describe('groupDragHandler', () => {
     test('that the dnd transfer object is setup and torndown', () => {
@@ -134,6 +135,112 @@ describe('groupDragHandler', () => {
         expect(spy).toHaveBeenCalledTimes(0);
 
         cut.dispose();
+    });
+
+    test('that a custom createGroupDragGhostComponent factory is invoked and disposed', () => {
+        jest.useFakeTimers();
+
+        const element = document.createElement('div');
+
+        const groupMock = jest.fn<DockviewGroupPanel, []>(() => {
+            const partial: Partial<DockviewGroupPanel> = {
+                id: 'g1',
+                api: { location: { type: 'grid' } } as any,
+                size: 3,
+            };
+            return partial as DockviewGroupPanel;
+        });
+        const group = new groupMock();
+
+        const ghostElement = document.createElement('div');
+        ghostElement.textContent = 'custom-ghost';
+
+        const init = jest.fn();
+        const dispose = jest.fn();
+        const renderer: IGroupDragGhostRenderer = {
+            element: ghostElement,
+            init,
+            dispose,
+        };
+        const factory = jest.fn(() => renderer);
+
+        const fakeApi = { id: 'api-id' };
+        const accessor = {
+            id: 'accessor_id',
+            api: fakeApi,
+            options: { createGroupDragGhostComponent: factory },
+        } as unknown as DockviewComponent;
+
+        const cut = new GroupDragHandler(element, accessor, group);
+
+        const dataTransfer = {
+            setDragImage: jest.fn(),
+        } as unknown as DataTransfer;
+        const dragEvent = {
+            dataTransfer,
+        } as unknown as DragEvent;
+
+        const disposable = cut.getData(dragEvent);
+
+        expect(factory).toHaveBeenCalledWith(group);
+        expect(init).toHaveBeenCalledWith({ group, api: fakeApi });
+        expect(dataTransfer.setDragImage).toHaveBeenCalledWith(
+            ghostElement,
+            30,
+            -10
+        );
+        expect(dispose).not.toHaveBeenCalled();
+
+        jest.runAllTimers();
+        expect(dispose).toHaveBeenCalledTimes(1);
+
+        disposable.dispose();
+        cut.dispose();
+        jest.useRealTimers();
+    });
+
+    test('that the default ghost is used when no factory is provided', () => {
+        jest.useFakeTimers();
+
+        const element = document.createElement('div');
+
+        const groupMock = jest.fn<DockviewGroupPanel, []>(() => {
+            const partial: Partial<DockviewGroupPanel> = {
+                id: 'g1',
+                api: { location: { type: 'grid' } } as any,
+                size: 4,
+            };
+            return partial as DockviewGroupPanel;
+        });
+        const group = new groupMock();
+
+        const accessor = {
+            id: 'accessor_id',
+            api: {},
+            options: {},
+        } as unknown as DockviewComponent;
+
+        const cut = new GroupDragHandler(element, accessor, group);
+
+        const dataTransfer = {
+            setDragImage: jest.fn(),
+        } as unknown as DataTransfer;
+        const dragEvent = {
+            dataTransfer,
+        } as unknown as DragEvent;
+
+        const disposable = cut.getData(dragEvent);
+
+        expect(dataTransfer.setDragImage).toHaveBeenCalledTimes(1);
+        const ghost = (dataTransfer.setDragImage as jest.Mock).mock
+            .calls[0][0] as HTMLElement;
+        expect(ghost.textContent).toBe('Multiple Panels (4)');
+
+        jest.runAllTimers();
+
+        disposable.dispose();
+        cut.dispose();
+        jest.useRealTimers();
     });
 
     test('that the event is never cancelled when the group is not floating', () => {

--- a/packages/dockview-core/src/dnd/groupDragHandler.ts
+++ b/packages/dockview-core/src/dnd/groupDragHandler.ts
@@ -1,5 +1,6 @@
 import { DockviewComponent } from '../dockview/dockviewComponent';
 import { DockviewGroupPanel } from '../dockview/dockviewGroupPanel';
+import { IGroupDragGhostRenderer } from '../dockview/framework';
 import { quasiPreventDefault } from '../dom';
 import { addDisposableListener } from '../events';
 import { IDisposable } from '../lifecycle';
@@ -66,21 +67,46 @@ export class GroupDragHandler extends DragHandler {
         );
 
         if (dataTransfer) {
-            const ghostElement = document.createElement('div');
+            const createGhost =
+                this.accessor.options.createGroupDragGhostComponent;
 
-            ghostElement.style.backgroundColor = bgColor;
-            ghostElement.style.color = color;
-            ghostElement.style.padding = '2px 8px';
-            ghostElement.style.height = '24px';
-            ghostElement.style.fontSize = '11px';
-            ghostElement.style.lineHeight = '20px';
-            ghostElement.style.borderRadius = '12px';
-            ghostElement.style.position = 'absolute';
-            ghostElement.style.pointerEvents = 'none';
-            ghostElement.style.top = '-9999px';
-            ghostElement.textContent = `Multiple Panels (${this.group.size})`;
+            let ghostElement: HTMLElement;
+            let customRenderer: IGroupDragGhostRenderer | undefined;
+
+            if (createGhost) {
+                customRenderer = createGhost(this.group);
+                customRenderer.init({
+                    group: this.group,
+                    api: this.accessor.api,
+                });
+                ghostElement = customRenderer.element;
+                ghostElement.style.position = 'absolute';
+                ghostElement.style.pointerEvents = 'none';
+                ghostElement.style.top = '-9999px';
+            } else {
+                ghostElement = document.createElement('div');
+
+                ghostElement.style.backgroundColor = bgColor;
+                ghostElement.style.color = color;
+                ghostElement.style.padding = '2px 8px';
+                ghostElement.style.height = '24px';
+                ghostElement.style.fontSize = '11px';
+                ghostElement.style.lineHeight = '20px';
+                ghostElement.style.borderRadius = '12px';
+                ghostElement.style.position = 'absolute';
+                ghostElement.style.pointerEvents = 'none';
+                ghostElement.style.top = '-9999px';
+                ghostElement.textContent = `Multiple Panels (${this.group.size})`;
+            }
 
             addGhostImage(dataTransfer, ghostElement, { y: -10, x: 30 });
+
+            if (customRenderer?.dispose) {
+                // addGhostImage removes the element from the DOM on the next
+                // tick; dispose the framework renderer on the same schedule.
+                const renderer = customRenderer;
+                setTimeout(() => renderer.dispose?.(), 0);
+            }
         }
 
         return {

--- a/packages/dockview-core/src/dockview/framework.ts
+++ b/packages/dockview-core/src/dockview/framework.ts
@@ -56,3 +56,9 @@ export interface ITabGroupChipRenderer {
     update?(params: { tabGroup: ITabGroup }): void;
     dispose(): void;
 }
+
+export interface IGroupDragGhostRenderer {
+    readonly element: HTMLElement;
+    init(params: { group: IDockviewGroupPanel; api: DockviewApi }): void;
+    dispose?(): void;
+}

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -11,7 +11,11 @@ import { GroupOptions } from './dockviewGroupPanelModel';
 import { DockviewGroupDropLocation } from './events';
 import { IDockviewPanel } from './dockviewPanel';
 import { DockviewPanelRenderer } from '../overlay/overlayRenderContainer';
-import { IGroupHeaderProps, ITabGroupChipRenderer } from './framework';
+import {
+    IGroupDragGhostRenderer,
+    IGroupHeaderProps,
+    ITabGroupChipRenderer,
+} from './framework';
 import { FloatingGroupOptions } from './dockviewComponent';
 import { Contraints } from '../gridview/gridviewPanel';
 import { AcceptableEvent, IAcceptableEvent } from '../events';
@@ -171,6 +175,17 @@ export interface DockviewOptions {
         tabGroup: ITabGroup
     ) => ITabGroupChipRenderer;
     /**
+     * Factory to create the custom ghost element shown while dragging a
+     * group of panels (the small floating chip that follows the cursor).
+     *
+     * If not provided, a default ghost rendering `"Multiple Panels (N)"`
+     * is used. Supplying a factory replaces the entire default ghost,
+     * enabling i18n / custom visuals.
+     */
+    createGroupDragGhostComponent?: (
+        group: DockviewGroupPanel
+    ) => IGroupDragGhostRenderer;
+    /**
      * Replace the built-in tab group color palette with a user-defined list.
      *
      * Each entry has an `id` (stored on `tabGroup.color` and serialized),
@@ -247,6 +262,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         getTabContextMenuItems: undefined,
         getTabGroupChipContextMenuItems: undefined,
         createTabGroupChipComponent: undefined,
+        createGroupDragGhostComponent: undefined,
         tabGroupColors: undefined,
         tabGroupAccent: undefined,
     };

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -74,6 +74,7 @@ export {
     IWatermarkPanelProps,
     DockviewReadyEvent,
     ITabGroupChipRenderer,
+    IGroupDragGhostRenderer,
 } from './dockview/framework';
 
 export * from './dockview/options';

--- a/packages/dockview-vue/src/__tests__/dockview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/dockview.spec.ts
@@ -216,6 +216,25 @@ describe('DockviewVue Component', () => {
         );
     });
 
+    test('should update groupDragGhostComponent when prop changes', async () => {
+        wrapper = mountDockview();
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+        const updateSpy = vi.spyOn(api, 'updateOptions');
+
+        await wrapper.setProps({
+            groupDragGhostComponent: 'MockHeaderAction',
+        });
+        await nextTick();
+
+        expect(updateSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                createGroupDragGhostComponent: expect.any(Function),
+            })
+        );
+    });
+
     test('should update tabGroupColors and tabGroupAccent when props change', async () => {
         wrapper = mountDockview();
         await flushPromises();

--- a/packages/dockview-vue/src/dockview/dockview.vue
+++ b/packages/dockview-vue/src/dockview/dockview.vue
@@ -16,6 +16,7 @@ import {
     getCurrentInstance,
 } from 'vue';
 import {
+    VueGroupDragGhostRenderer,
     VueHeaderActionsRenderer,
     VueContextMenuItemRenderer,
     VueTabGroupChipRenderer,
@@ -66,6 +67,25 @@ watch(
                     ? () => {
                           const component = findComponent(inst, newValue);
                           return new VueTabGroupChipRenderer(component!, inst);
+                      }
+                    : undefined,
+            });
+        }
+    }
+);
+
+watch(
+    () => props.groupDragGhostComponent,
+    (newValue) => {
+        if (instance.value) {
+            instance.value.updateOptions({
+                createGroupDragGhostComponent: newValue
+                    ? () => {
+                          const component = findComponent(inst, newValue);
+                          return new VueGroupDragGhostRenderer(
+                              component!,
+                              inst
+                          );
                       }
                     : undefined,
             });
@@ -255,6 +275,14 @@ onMounted(() => {
         coreOptions.createTabGroupChipComponent = () => {
             const component = findComponent(inst, chipComponentName);
             return new VueTabGroupChipRenderer(component!, inst);
+        };
+    }
+
+    if (props.groupDragGhostComponent) {
+        const ghostComponentName = props.groupDragGhostComponent;
+        coreOptions.createGroupDragGhostComponent = () => {
+            const component = findComponent(inst, ghostComponentName);
+            return new VueGroupDragGhostRenderer(component!, inst);
         };
     }
 

--- a/packages/dockview-vue/src/dockview/types.ts
+++ b/packages/dockview-vue/src/dockview/types.ts
@@ -12,6 +12,7 @@ export interface VueProps {
     leftHeaderActionsComponent?: string;
     prefixHeaderActionsComponent?: string;
     tabGroupChipComponent?: string;
+    groupDragGhostComponent?: string;
 }
 
 export type VueEvents = {

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -4,8 +4,10 @@ import type {
     DockviewGroupPanel,
     DockviewPanelApi,
     IContentRenderer,
+    IDockviewGroupPanel,
     IDockviewHeaderActionsProps,
     IDockviewPanelHeaderProps,
+    IGroupDragGhostRenderer,
     IGroupHeaderProps,
     IHeaderActionsRenderer,
     ITabGroupChipRenderer,
@@ -346,6 +348,41 @@ export class VueTabGroupChipRenderer
         this._renderDisposable?.update({
             params: { tabGroup: params.tabGroup },
         });
+    }
+
+    dispose(): void {
+        this._renderDisposable?.dispose();
+    }
+}
+
+export class VueGroupDragGhostRenderer
+    extends AbstractVueRenderer
+    implements IGroupDragGhostRenderer
+{
+    private _renderDisposable:
+        | { update: (props: any) => void; dispose: () => void }
+        | undefined;
+
+    constructor(component: VueComponent, parent: ComponentInternalInstance) {
+        super(component, parent);
+        this.element.style.height = '';
+        this.element.style.width = '';
+        this.element.style.display = 'inline-flex';
+    }
+
+    init(params: { group: IDockviewGroupPanel; api: DockviewApi }): void {
+        this._renderDisposable?.dispose();
+        this._renderDisposable = mountVueComponent(
+            this.component,
+            this.parent,
+            {
+                params: {
+                    group: params.group,
+                    api: params.api,
+                },
+            },
+            this.element
+        );
     }
 
     dispose(): void {

--- a/packages/dockview/src/__tests__/dockview/reactGroupDragGhostPart.spec.ts
+++ b/packages/dockview/src/__tests__/dockview/reactGroupDragGhostPart.spec.ts
@@ -1,0 +1,72 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import { DockviewApi, IDockviewGroupPanel } from 'dockview-core';
+import { ReactGroupDragGhostPart } from '../../dockview/reactGroupDragGhostPart';
+
+describe('ReactGroupDragGhostPart', () => {
+    test('element has class dv-react-part with inline-flex display', () => {
+        const cut = new ReactGroupDragGhostPart(jest.fn(), {
+            addPortal: jest.fn(),
+        });
+
+        expect(cut.element.className).toBe('dv-react-part');
+        expect(cut.element.style.display).toBe('inline-flex');
+    });
+
+    test('part is undefined before init', () => {
+        const cut = new ReactGroupDragGhostPart(jest.fn(), {
+            addPortal: jest.fn(),
+        });
+
+        expect((cut as any).part).toBeUndefined();
+    });
+
+    test('init creates a ReactPart and registers a portal', () => {
+        const addPortal = jest.fn().mockReturnValue({ dispose: jest.fn() });
+        const cut = new ReactGroupDragGhostPart(jest.fn(), { addPortal });
+
+        cut.init({
+            group: fromPartial<IDockviewGroupPanel>({ id: 'g-1' }),
+            api: fromPartial<DockviewApi>({}),
+        });
+
+        expect((cut as any).part).toBeDefined();
+        expect(addPortal).toHaveBeenCalled();
+    });
+
+    test('init passes group and api to ReactPart', () => {
+        const addPortal = jest.fn().mockReturnValue({ dispose: jest.fn() });
+        const cut = new ReactGroupDragGhostPart(jest.fn(), { addPortal });
+
+        const group = fromPartial<IDockviewGroupPanel>({ id: 'g-1' });
+        const api = fromPartial<DockviewApi>({});
+
+        cut.init({ group, api });
+
+        const params = (cut as any).part.parameters;
+        expect(params.group).toBe(group);
+        expect(params.api).toBe(api);
+    });
+
+    test('dispose cleans up the part', () => {
+        const addPortal = jest.fn().mockReturnValue({ dispose: jest.fn() });
+        const cut = new ReactGroupDragGhostPart(jest.fn(), { addPortal });
+
+        cut.init({
+            group: fromPartial<IDockviewGroupPanel>({ id: 'g-1' }),
+            api: fromPartial<DockviewApi>({}),
+        });
+
+        const disposeSpy = jest.spyOn((cut as any).part, 'dispose');
+        cut.dispose();
+
+        expect(disposeSpy).toHaveBeenCalled();
+    });
+
+    test('dispose before init does not throw', () => {
+        const cut = new ReactGroupDragGhostPart(jest.fn(), {
+            addPortal: jest.fn(),
+        });
+
+        expect(() => cut.dispose()).not.toThrow();
+    });
+});

--- a/packages/dockview/src/dockview/dockview.tsx
+++ b/packages/dockview/src/dockview/dockview.tsx
@@ -32,6 +32,10 @@ import {
     IDockviewTabGroupChipProps,
     ReactTabGroupChipPart,
 } from './reactTabGroupChipPart';
+import {
+    IDockviewGroupDragGhostProps,
+    ReactGroupDragGhostPart,
+} from './reactGroupDragGhostPart';
 
 function createGroupControlElement(
     component: React.FunctionComponent<IDockviewHeaderActionsProps> | undefined,
@@ -75,6 +79,16 @@ export interface IDockviewReactProps extends DockviewOptions {
         params: GetTabGroupChipContextMenuItemsParams
     ) => (BuiltInChipContextMenuItem | ReactContextMenuItemConfig)[];
     tabGroupChipComponent?: React.FunctionComponent<IDockviewTabGroupChipProps>;
+    /**
+     * Component rendered as the drag ghost (the small floating chip) while
+     * a group of panels is being dragged. If omitted, the default
+     * `"Multiple Panels (N)"` ghost is used.
+     *
+     * Note: the ghost is captured by the browser at drag start, so the
+     * component must render fast / synchronously enough to be visible
+     * before the browser snapshots it.
+     */
+    groupDragGhostComponent?: React.FunctionComponent<IDockviewGroupDragGhostProps>;
     //
     onReady: (event: DockviewReadyEvent) => void;
     onDidDrop?: (event: DockviewDidDropEvent) => void;
@@ -206,6 +220,15 @@ export const DockviewReact = React.forwardRef(
                 };
             }
 
+            if (props.groupDragGhostComponent) {
+                const ghostComponent = props.groupDragGhostComponent;
+                coreOptions.createGroupDragGhostComponent = () => {
+                    return new ReactGroupDragGhostPart(ghostComponent, {
+                        addPortal,
+                    });
+                };
+            }
+
             const api = createDockview(domRef.current, {
                 ...coreOptions,
                 ...frameworkOptions,
@@ -280,6 +303,25 @@ export const DockviewReact = React.forwardRef(
                     : undefined,
             });
         }, [props.tabGroupChipComponent]);
+
+        React.useEffect(() => {
+            if (!dockviewRef.current) {
+                return;
+            }
+
+            dockviewRef.current.updateOptions({
+                createGroupDragGhostComponent: props.groupDragGhostComponent
+                    ? () => {
+                          return new ReactGroupDragGhostPart(
+                              props.groupDragGhostComponent!,
+                              {
+                                  addPortal,
+                              }
+                          );
+                      }
+                    : undefined,
+            });
+        }, [props.groupDragGhostComponent]);
 
         React.useEffect(() => {
             if (!dockviewRef.current) {

--- a/packages/dockview/src/dockview/reactGroupDragGhostPart.ts
+++ b/packages/dockview/src/dockview/reactGroupDragGhostPart.ts
@@ -1,0 +1,46 @@
+import React from 'react';
+import { ReactPart, ReactPortalStore } from '../react';
+import {
+    IDockviewGroupPanel,
+    IGroupDragGhostRenderer,
+    DockviewApi,
+} from 'dockview-core';
+
+export interface IDockviewGroupDragGhostProps {
+    group: IDockviewGroupPanel;
+    api: DockviewApi;
+}
+
+export class ReactGroupDragGhostPart implements IGroupDragGhostRenderer {
+    private readonly _element: HTMLElement;
+    private part?: ReactPart<IDockviewGroupDragGhostProps>;
+
+    get element(): HTMLElement {
+        return this._element;
+    }
+
+    constructor(
+        private readonly component: React.FunctionComponent<IDockviewGroupDragGhostProps>,
+        private readonly reactPortalStore: ReactPortalStore
+    ) {
+        this._element = document.createElement('div');
+        this._element.className = 'dv-react-part';
+        this._element.style.display = 'inline-flex';
+    }
+
+    init(params: { group: IDockviewGroupPanel; api: DockviewApi }): void {
+        this.part = new ReactPart(
+            this._element,
+            this.reactPortalStore,
+            this.component,
+            {
+                group: params.group,
+                api: params.api,
+            }
+        );
+    }
+
+    dispose(): void {
+        this.part?.dispose();
+    }
+}

--- a/packages/dockview/src/index.ts
+++ b/packages/dockview/src/index.ts
@@ -3,6 +3,7 @@ export * from 'dockview-core';
 export * from './dockview/dockview';
 export * from './dockview/defaultTab';
 export { IDockviewTabGroupChipProps } from './dockview/reactTabGroupChipPart';
+export { IDockviewGroupDragGhostProps } from './dockview/reactGroupDragGhostPart';
 export * from './splitview/splitview';
 export * from './gridview/gridview';
 export * from './paneview/paneview';

--- a/packages/docs/docs/core/dnd/dragAndDrop.mdx
+++ b/packages/docs/docs/core/dnd/dragAndDrop.mdx
@@ -141,6 +141,92 @@ parentElement.addEventListener('drop', (e) => onDidDrop(e));
 ```
 </FrameworkSpecific>
 
+## Customizing the group drag ghost
+
+When the user drags a whole group of panels by its empty header area, dockview shows a small floating ghost that follows the cursor. By default it renders the text `Multiple Panels (N)` — to localize the label or replace the visual entirely, supply a `createGroupDragGhostComponent` factory. It receives the `DockviewGroupPanel` being dragged and must return an `IGroupDragGhostRenderer`.
+
+<FrameworkSpecific framework="React">
+  <DocRef declaration="IDockviewReactProps" methods={['groupDragGhostComponent']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Vue">
+  <DocRef declaration="IDockviewVueProps" methods={['groupDragGhostComponent']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Angular">
+  <DocRef declaration="IDockviewAngularProps" methods={['groupDragGhostComponent']} />
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="JavaScript">
+  <DocRef declaration="DockviewComponentOptions" methods={['createGroupDragGhostComponent']} />
+</FrameworkSpecific>
+
+The renderer must implement:
+
+```ts
+interface IGroupDragGhostRenderer {
+    readonly element: HTMLElement;   // the ghost DOM element
+    init(params: { group: IDockviewGroupPanel; api: DockviewApi }): void;
+    dispose?(): void;
+}
+```
+
+The ghost is captured by the browser at drag start and removed shortly after, so the component is short-lived — render synchronously enough to be painted before the browser snapshots the element.
+
+<FrameworkSpecific framework="React">
+```tsx
+const GroupDragGhost = (props: IDockviewGroupDragGhostProps) => (
+    <div className="my-drag-ghost">
+        {props.group.activePanel?.title} +{props.group.panels.length - 1} more
+    </div>
+);
+
+return (
+    <DockviewReact
+        components={components}
+        onReady={onReady}
+        groupDragGhostComponent={GroupDragGhost}
+    />
+);
+```
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Vue">
+```html
+<dockview-vue :components="components" group-drag-ghost-component="MyDragGhost" @ready="onReady" />
+```
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="Angular">
+```html
+<dv-dockview
+    [components]="components"
+    [groupDragGhostComponent]="MyDragGhostComponent"
+    (ready)="onReady($event)">
+</dv-dockview>
+```
+</FrameworkSpecific>
+
+<FrameworkSpecific framework="JavaScript">
+```ts
+class MyGroupDragGhost {
+    readonly element = document.createElement('div');
+
+    init({ group }) {
+        this.element.className = 'my-drag-ghost';
+        this.element.textContent = `${group.activePanel?.title} +${group.panels.length - 1} more`;
+    }
+
+    dispose() {}
+}
+
+const api = createDockview(parentElement, {
+    createComponent: (options) => new MyPanel(options),
+    createGroupDragGhostComponent: (group) => new MyGroupDragGhost(),
+});
+```
+</FrameworkSpecific>
+
 ## Third Party Dnd Libraries
 
 This shows a simple example of a third-party library used inside a panel that relies on drag

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -672,6 +672,7 @@ const DockviewDemo = (props: {
     );
 
     const [watermark, setWatermark] = React.useState<boolean>(false);
+    const [customGhost, setCustomGhost] = React.useState<boolean>(false);
 
     const [gapCheck, setGapCheck] = React.useState<boolean>(false);
 
@@ -745,7 +746,9 @@ const DockviewDemo = (props: {
                                                     : undefined
                                             }
                                             groupDragGhostComponent={
-                                                GroupDragGhost
+                                                customGhost
+                                                    ? GroupDragGhost
+                                                    : undefined
                                             }
                                             onReady={onReady}
                                             theme={effectiveTheme}
@@ -861,6 +864,8 @@ const DockviewDemo = (props: {
                     activeGroup={activeGroup}
                     hasCustomWatermark={watermark}
                     toggleCustomWatermark={() => setWatermark(!watermark)}
+                    hasCustomGhost={customGhost}
+                    toggleCustomGhost={() => setCustomGhost(!customGhost)}
                     debug={debug}
                     onToggleDebug={() => setDebug(!debug)}
                     showLogs={showLogs}

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -2,6 +2,7 @@ import {
     DockviewDefaultTab,
     DockviewReact,
     DockviewReadyEvent,
+    IDockviewGroupDragGhostProps,
     IDockviewPanelHeaderProps,
     IDockviewPanelProps,
     DockviewApi,
@@ -322,6 +323,37 @@ let count = 0;
 
 const WatermarkComponent = () => {
     return <div>custom watermark</div>;
+};
+
+const GroupDragGhost = (props: IDockviewGroupDragGhostProps) => {
+    const count = props.group.panels.length;
+    const title = props.group.activePanel?.title ?? 'Group';
+    return (
+        <div
+            style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '4px 10px',
+                borderRadius: 999,
+                background: 'rgba(33, 150, 243, 0.92)',
+                color: 'white',
+                font: '11px/1 system-ui, sans-serif',
+                boxShadow: '0 2px 6px rgba(0,0,0,0.25)',
+            }}
+        >
+            <span style={{ fontWeight: 600 }}>{title}</span>
+            <span
+                style={{
+                    padding: '1px 6px',
+                    borderRadius: 999,
+                    background: 'rgba(255,255,255,0.25)',
+                }}
+            >
+                +{Math.max(0, count - 1)} more
+            </span>
+        </div>
+    );
 };
 
 const ThemeContext = React.createContext<DockviewTheme | undefined>(undefined);
@@ -711,6 +743,9 @@ const DockviewDemo = (props: {
                                                 watermark
                                                     ? WatermarkComponent
                                                     : undefined
+                                            }
+                                            groupDragGhostComponent={
+                                                GroupDragGhost
                                             }
                                             onReady={onReady}
                                             theme={effectiveTheme}

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/settingsModal.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/settingsModal.tsx
@@ -48,6 +48,8 @@ export const ControlsContent = (props: {
     activeGroup?: string;
     hasCustomWatermark: boolean;
     toggleCustomWatermark: () => void;
+    hasCustomGhost: boolean;
+    toggleCustomGhost: () => void;
     debug: boolean;
     onToggleDebug: () => void;
     showLogs: boolean;
@@ -116,6 +118,19 @@ export const ControlsContent = (props: {
                             terminal
                         </span>
                         <span>Events Log</span>
+                    </button>
+                    <button
+                        onClick={props.toggleCustomGhost}
+                        style={toggleBtn(props.hasCustomGhost)}
+                        title="Replace the default 'Multiple Panels (N)' group drag ghost with a custom component"
+                    >
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
+                        >
+                            drag_indicator
+                        </span>
+                        <span>Custom Drag Ghost</span>
                     </button>
                     {props.showLogs && (
                         <button

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilderModal.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/themeBuilderModal.tsx
@@ -296,6 +296,8 @@ export const Sidebar = (props: {
     activeGroup?: string;
     hasCustomWatermark: boolean;
     toggleCustomWatermark: () => void;
+    hasCustomGhost: boolean;
+    toggleCustomGhost: () => void;
     debug: boolean;
     onToggleDebug: () => void;
     showLogs: boolean;
@@ -902,6 +904,8 @@ export const Sidebar = (props: {
                         activeGroup={props.activeGroup}
                         hasCustomWatermark={props.hasCustomWatermark}
                         toggleCustomWatermark={props.toggleCustomWatermark}
+                        hasCustomGhost={props.hasCustomGhost}
+                        toggleCustomGhost={props.toggleCustomGhost}
                         debug={props.debug}
                         onToggleDebug={props.onToggleDebug}
                         showLogs={props.showLogs}

--- a/packages/docs/src/generated/api.output.json
+++ b/packages/docs/src/generated/api.output.json
@@ -57,6 +57,22 @@
     },
     "DockviewEvent": {
         "name": "DockviewEvent",
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "Events, Emitters and Disposables are very common concepts that many codebases will contain, however we need\nto export them for dockview framework packages to use.\nTo be a good citizen these are exported with a "
+                },
+                {
+                    "kind": "code",
+                    "text": "`Dockview`"
+                },
+                {
+                    "kind": "text",
+                    "text": " prefix to prevent accidental use by others."
+                }
+            ]
+        },
         "code": "",
         "kind": "interface"
     },
@@ -163,20 +179,20 @@
             },
             {
                 "name": "_activeGroup",
-                "code": "BaseGrid.T | undefined",
+                "code": "undefined | BaseGrid.T",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "T",
                             "source": "dockview-core",
                             "refersToTypeParameter": true
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -247,7 +263,7 @@
             },
             {
                 "name": "onDidActiveChange",
-                "code": "Event<BaseGrid.T | undefined>",
+                "code": "Event<undefined | BaseGrid.T>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -258,14 +274,14 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "T",
                                     "source": "dockview-core",
                                     "refersToTypeParameter": true
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -385,24 +401,24 @@
             },
             {
                 "name": "activeGroup",
-                "code": "BaseGrid.T | undefined",
+                "code": "undefined | BaseGrid.T",
                 "kind": "accessor",
                 "value": {
                     "name": "activeGroup",
-                    "code": "BaseGrid.T | undefined",
+                    "code": "undefined | BaseGrid.T",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "T",
                                 "source": "dockview-core",
                                 "refersToTypeParameter": true
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -788,7 +804,7 @@
             },
             {
                 "name": "doSetGroupActive",
-                "code": "(group: BaseGrid.T | undefined): void",
+                "code": "(group: undefined | BaseGrid.T): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -797,19 +813,19 @@
                         "parameters": [
                             {
                                 "name": "group",
-                                "code": "group: BaseGrid.T | undefined",
+                                "code": "group: undefined | BaseGrid.T",
                                 "type": {
                                     "type": "or",
                                     "values": [
+                                        {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
                                         {
                                             "type": "reference",
                                             "value": "T",
                                             "source": "dockview-core",
                                             "refersToTypeParameter": true
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
@@ -820,7 +836,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(group: BaseGrid.T | undefined): void",
+                        "code": "(group: undefined | BaseGrid.T): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -891,7 +907,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): BaseGrid.T | undefined",
+                "code": "(id: string): undefined | BaseGrid.T",
                 "kind": "method",
                 "signature": [
                     {
@@ -912,18 +928,18 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "T",
                                     "source": "dockview-core",
                                     "refersToTypeParameter": true
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): BaseGrid.T | undefined",
+                        "code": "(id: string): undefined | BaseGrid.T",
                         "kind": "callSignature"
                     }
                 ]
@@ -1892,7 +1908,7 @@
             },
             {
                 "name": "activeGroup",
-                "code": "DockviewGroupPanel | undefined",
+                "code": "undefined | DockviewGroupPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "activeGroup",
@@ -1904,19 +1920,19 @@
                             }
                         ]
                     },
-                    "code": "DockviewGroupPanel | undefined",
+                    "code": "undefined | DockviewGroupPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "DockviewGroupPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -1932,7 +1948,7 @@
             },
             {
                 "name": "activePanel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "activePanel",
@@ -1944,19 +1960,19 @@
                             }
                         ]
                     },
-                    "code": "IDockviewPanel | undefined",
+                    "code": "undefined | IDockviewPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "IDockviewPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -2186,7 +2202,7 @@
             },
             {
                 "name": "onDidActiveGroupChange",
-                "code": "Event<DockviewGroupPanel | undefined>",
+                "code": "Event<undefined | DockviewGroupPanel>",
                 "kind": "accessor",
                 "value": {
                     "name": "onDidActiveGroupChange",
@@ -2198,7 +2214,7 @@
                             }
                         ]
                     },
-                    "code": "Event<DockviewGroupPanel | undefined>",
+                    "code": "Event<undefined | DockviewGroupPanel>",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "reference",
@@ -2209,13 +2225,13 @@
                                 "type": "or",
                                 "values": [
                                     {
+                                        "type": "intrinsic",
+                                        "value": "undefined"
+                                    },
+                                    {
                                         "type": "reference",
                                         "value": "DockviewGroupPanel",
                                         "source": "dockview-core"
-                                    },
-                                    {
-                                        "type": "intrinsic",
-                                        "value": "undefined"
                                     }
                                 ]
                             }
@@ -2233,7 +2249,7 @@
             },
             {
                 "name": "onDidActivePanelChange",
-                "code": "Event<IDockviewPanel | undefined>",
+                "code": "Event<undefined | IDockviewPanel>",
                 "kind": "accessor",
                 "value": {
                     "name": "onDidActivePanelChange",
@@ -2245,7 +2261,7 @@
                             }
                         ]
                     },
-                    "code": "Event<IDockviewPanel | undefined>",
+                    "code": "Event<undefined | IDockviewPanel>",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "reference",
@@ -2256,13 +2272,13 @@
                                 "type": "or",
                                 "values": [
                                     {
+                                        "type": "intrinsic",
+                                        "value": "undefined"
+                                    },
+                                    {
                                         "type": "reference",
                                         "value": "IDockviewPanel",
                                         "source": "dockview-core"
-                                    },
-                                    {
-                                        "type": "intrinsic",
-                                        "value": "undefined"
                                     }
                                 ]
                             }
@@ -3480,7 +3496,7 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddPanelOptions<T>): IDockviewPanel",
+                "code": "(options: AddPanelOptions<T>): IDockviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -3493,16 +3509,7 @@
                                 }
                             ]
                         },
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -3528,7 +3535,7 @@
                             "value": "IDockviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddPanelOptions<T>): IDockviewPanel",
+                        "code": "(options: AddPanelOptions<T>): IDockviewPanel",
                         "kind": "callSignature"
                     }
                 ],
@@ -4223,7 +4230,7 @@
             },
             {
                 "name": "getEdgeGroup",
-                "code": "(position: EdgeGroupPosition): DockviewGroupPanelApi | undefined",
+                "code": "(position: EdgeGroupPosition): undefined | DockviewGroupPanelApi",
                 "kind": "method",
                 "signature": [
                     {
@@ -4261,17 +4268,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewGroupPanelApi",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(position: EdgeGroupPosition): DockviewGroupPanelApi | undefined",
+                        "code": "(position: EdgeGroupPosition): undefined | DockviewGroupPanelApi",
                         "kind": "callSignature"
                     }
                 ],
@@ -4294,7 +4301,7 @@
             },
             {
                 "name": "getGroup",
-                "code": "(id: string): IDockviewGroupPanel | undefined",
+                "code": "(id: string): undefined | IDockviewGroupPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -4331,17 +4338,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IDockviewGroupPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): IDockviewGroupPanel | undefined",
+                        "code": "(id: string): undefined | IDockviewGroupPanel",
                         "kind": "callSignature"
                     }
                 ],
@@ -4364,7 +4371,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): IDockviewPanel | undefined",
+                "code": "(id: string): undefined | IDockviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -4409,17 +4416,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IDockviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): IDockviewPanel | undefined",
+                        "code": "(id: string): undefined | IDockviewPanel",
                         "kind": "callSignature"
                     }
                 ],
@@ -4450,7 +4457,7 @@
             },
             {
                 "name": "getTabGroupForPanel",
-                "code": "(options: { groupId: string, panelId: string }): ITabGroup | undefined",
+                "code": "(options: { groupId: string, panelId: string }): undefined | ITabGroup",
                 "kind": "method",
                 "signature": [
                     {
@@ -4497,17 +4504,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "ITabGroup",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(options: { groupId: string, panelId: string }): ITabGroup | undefined",
+                        "code": "(options: { groupId: string, panelId: string }): undefined | ITabGroup",
                         "kind": "callSignature"
                     }
                 ]
@@ -5185,24 +5192,25 @@
             },
             {
                 "name": "_activeGroup",
-                "code": "DockviewGroupPanel | undefined",
+                "code": "undefined | DockviewGroupPanel",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "DockviewGroupPanel",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isProtected": true
+                    "isProtected": true,
+                    "isInherited": true
                 }
             },
             {
@@ -5216,7 +5224,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -5248,7 +5257,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -5296,12 +5306,13 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidActiveChange",
-                "code": "Event<DockviewGroupPanel | undefined>",
+                "code": "Event<undefined | DockviewGroupPanel>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -5312,25 +5323,26 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewGroupPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidActiveGroupChange",
-                "code": "Event<DockviewGroupPanel | undefined>",
+                "code": "Event<undefined | DockviewGroupPanel>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -5341,13 +5353,13 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewGroupPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -5359,7 +5371,7 @@
             },
             {
                 "name": "onDidActivePanelChange",
-                "code": "Event<IDockviewPanel | undefined>",
+                "code": "Event<undefined | IDockviewPanel>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -5370,13 +5382,13 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IDockviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -5403,7 +5415,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -5542,7 +5555,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -5588,7 +5602,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -5726,7 +5741,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -5845,7 +5861,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -5989,24 +6006,24 @@
             },
             {
                 "name": "activeGroup",
-                "code": "BaseGrid.T | undefined",
+                "code": "undefined | BaseGrid.T",
                 "kind": "accessor",
                 "value": {
                     "name": "activeGroup",
-                    "code": "BaseGrid.T | undefined",
+                    "code": "undefined | BaseGrid.T",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "T",
                                 "source": "dockview-core",
                                 "refersToTypeParameter": true
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -6014,23 +6031,23 @@
             },
             {
                 "name": "activePanel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "activePanel",
-                    "code": "IDockviewPanel | undefined",
+                    "code": "undefined | IDockviewPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "IDockviewPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -6554,21 +6571,12 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddPanelOptions<T>): DockviewPanel",
+                "code": "(options: AddPanelOptions<T>): DockviewPanel",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "addPanel",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -6594,7 +6602,7 @@
                             "value": "DockviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddPanelOptions<T>): DockviewPanel",
+                        "code": "(options: AddPanelOptions<T>): DockviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -6903,7 +6911,7 @@
             },
             {
                 "name": "doSetGroupActive",
-                "code": "(group: DockviewGroupPanel | undefined): void",
+                "code": "(group: undefined | DockviewGroupPanel): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -6912,18 +6920,18 @@
                         "parameters": [
                             {
                                 "name": "group",
-                                "code": "group: DockviewGroupPanel | undefined",
+                                "code": "group: undefined | DockviewGroupPanel",
                                 "type": {
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "DockviewGroupPanel",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
@@ -6934,14 +6942,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(group: DockviewGroupPanel | undefined): void",
+                        "code": "(group: undefined | DockviewGroupPanel): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "doSetGroupAndPanelActive",
-                "code": "(group: DockviewGroupPanel | undefined): void",
+                "code": "(group: undefined | DockviewGroupPanel): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -6950,18 +6958,18 @@
                         "parameters": [
                             {
                                 "name": "group",
-                                "code": "group: DockviewGroupPanel | undefined",
+                                "code": "group: undefined | DockviewGroupPanel",
                                 "type": {
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "DockviewGroupPanel",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
@@ -6972,7 +6980,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(group: DockviewGroupPanel | undefined): void",
+                        "code": "(group: undefined | DockviewGroupPanel): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -7087,7 +7095,7 @@
             },
             {
                 "name": "getEdgeGroup",
-                "code": "(position: EdgeGroupPosition): DockviewGroupPanelApi | undefined",
+                "code": "(position: EdgeGroupPosition): undefined | DockviewGroupPanelApi",
                 "kind": "method",
                 "signature": [
                     {
@@ -7109,24 +7117,24 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewGroupPanelApi",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(position: EdgeGroupPosition): DockviewGroupPanelApi | undefined",
+                        "code": "(position: EdgeGroupPosition): undefined | DockviewGroupPanelApi",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "getGroupPanel",
-                "code": "(id: string): IDockviewPanel | undefined",
+                "code": "(id: string): undefined | IDockviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -7147,24 +7155,24 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IDockviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): IDockviewPanel | undefined",
+                        "code": "(id: string): undefined | IDockviewPanel",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): DockviewGroupPanel | undefined",
+                "code": "(id: string): undefined | DockviewGroupPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -7185,17 +7193,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewGroupPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): DockviewGroupPanel | undefined",
+                        "code": "(id: string): undefined | DockviewGroupPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -7218,10 +7226,10 @@
                                     "tag": "@link",
                                     "text": "PopupService",
                                     "target": {
-                                        "sourceFileName": "packages/dockview-core/src/dockview/components/popupService.ts",
+                                        "packageName": "dockview-core",
+                                        "packagePath": "src/dockview/components/popupService.ts",
                                         "qualifiedName": "PopupService"
-                                    },
-                                    "tsLinkText": ""
+                                    }
                                 },
                                 {
                                     "kind": "text",
@@ -7262,10 +7270,10 @@
                             "tag": "@link",
                             "text": "PopupService",
                             "target": {
-                                "sourceFileName": "packages/dockview-core/src/dockview/components/popupService.ts",
+                                "packageName": "dockview-core",
+                                "packagePath": "src/dockview/components/popupService.ts",
                                 "qualifiedName": "PopupService"
-                            },
-                            "tsLinkText": ""
+                            }
                         },
                         {
                             "kind": "text",
@@ -7601,16 +7609,12 @@
             },
             {
                 "name": "movingLock",
-                "code": "<T>(func: (): T): T",
+                "code": "(func: (): T): T",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "movingLock",
-                        "typeParameters": [
-                            {
-                                "name": "T"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "func",
@@ -7647,7 +7651,7 @@
                             "source": "dockview-core",
                             "refersToTypeParameter": true
                         },
-                        "code": "<T>(func: (): T): T",
+                        "code": "(func: (): T): T",
                         "kind": "callSignature"
                     }
                 ]
@@ -8266,23 +8270,23 @@
             },
             {
                 "name": "group",
-                "code": "DockviewGroupPanel | undefined",
+                "code": "undefined | DockviewGroupPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "group",
-                    "code": "DockviewGroupPanel | undefined",
+                    "code": "undefined | DockviewGroupPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "DockviewGroupPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -8305,23 +8309,23 @@
             },
             {
                 "name": "panel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "panel",
-                    "code": "IDockviewPanel | undefined",
+                    "code": "undefined | IDockviewPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "IDockviewPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -8344,7 +8348,7 @@
             },
             {
                 "name": "getData",
-                "code": "(): PanelTransfer | undefined",
+                "code": "(): undefined | PanelTransfer",
                 "kind": "method",
                 "signature": [
                     {
@@ -8355,17 +8359,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "PanelTransfer",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(): PanelTransfer | undefined",
+                        "code": "(): undefined | PanelTransfer",
                         "kind": "callSignature"
                     }
                 ]
@@ -8453,24 +8457,24 @@
             },
             {
                 "name": "value",
-                "code": "Emitter.T | undefined",
+                "code": "undefined | Emitter.T",
                 "kind": "accessor",
                 "value": {
                     "name": "value",
-                    "code": "Emitter.T | undefined",
+                    "code": "undefined | Emitter.T",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "T",
                                 "source": "dockview-core",
                                 "refersToTypeParameter": true
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -8520,6 +8524,25 @@
                             "value": "void"
                         },
                         "code": "(e: Emitter.T): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "pause",
+                "code": "(): IDisposable",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "pause",
+                        "typeParameters": [],
+                        "parameters": [],
+                        "returnType": {
+                            "type": "reference",
+                            "value": "IDisposable",
+                            "source": "dockview-core"
+                        },
+                        "code": "(): IDisposable",
                         "kind": "callSignature"
                     }
                 ]
@@ -8575,7 +8598,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -8589,7 +8613,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -8602,7 +8627,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -8615,12 +8641,13 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidChange",
-                "code": "Event<IViewSize | undefined>",
+                "code": "Event<undefined | IViewSize>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -8631,20 +8658,21 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IViewSize",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -8658,28 +8686,29 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "activePanel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "activePanel",
-                    "code": "IDockviewPanel | undefined",
+                    "code": "undefined | IDockviewPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "IDockviewPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -8877,23 +8906,23 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "accessor",
                 "value": {
                     "name": "params",
-                    "code": "Parameters | undefined",
+                    "code": "undefined | Parameters",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "Parameters",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -8901,23 +8930,23 @@
             },
             {
                 "name": "priority",
-                "code": "LayoutPriority | undefined",
+                "code": "undefined | LayoutPriority",
                 "kind": "accessor",
                 "value": {
                     "name": "priority",
-                    "code": "LayoutPriority | undefined",
+                    "code": "undefined | LayoutPriority",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "LayoutPriority",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -9313,7 +9342,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -9322,18 +9351,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -9342,7 +9364,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -9461,7 +9483,7 @@
             },
             {
                 "name": "onDidChange",
-                "code": "Event<IViewSize | undefined>",
+                "code": "Event<undefined | IViewSize>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -9472,13 +9494,13 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IViewSize",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -9880,23 +9902,23 @@
             },
             {
                 "name": "activePanel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "activePanel",
-                    "code": "IDockviewPanel | undefined",
+                    "code": "undefined | IDockviewPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "IDockviewPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -9904,23 +9926,23 @@
             },
             {
                 "name": "dropTargetContainer",
-                "code": "DropTargetAnchorContainer | 'null'",
+                "code": "'null' | DropTargetAnchorContainer",
                 "kind": "accessor",
                 "value": {
                     "name": "dropTargetContainer",
-                    "code": "DropTargetAnchorContainer | 'null'",
+                    "code": "'null' | DropTargetAnchorContainer",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "literal",
+                                "value": null
+                            },
+                            {
                                 "type": "reference",
                                 "value": "DropTargetAnchorContainer",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "literal",
-                                "value": null
                             }
                         ]
                     }
@@ -10457,7 +10479,7 @@
             },
             {
                 "name": "getTabGroupForPanel",
-                "code": "(panelId: string): ITabGroup | undefined",
+                "code": "(panelId: string): undefined | ITabGroup",
                 "kind": "method",
                 "signature": [
                     {
@@ -10478,17 +10500,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "ITabGroup",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(panelId: string): ITabGroup | undefined",
+                        "code": "(panelId: string): undefined | ITabGroup",
                         "kind": "callSignature"
                     }
                 ]
@@ -11324,7 +11346,7 @@
             },
             {
                 "name": "update",
-                "code": "(_params: PanelUpdateEvent<Parameters>): void",
+                "code": "(_params: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -11333,18 +11355,11 @@
                         "parameters": [
                             {
                                 "name": "_params",
-                                "code": "_params: PanelUpdateEvent<Parameters>",
+                                "code": "_params: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -11353,14 +11368,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(_params: PanelUpdateEvent<Parameters>): void",
+                        "code": "(_params: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "updateActions",
-                "code": "(element: HTMLElement | undefined): void",
+                "code": "(element: undefined | HTMLElement): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -11369,18 +11384,18 @@
                         "parameters": [
                             {
                                 "name": "element",
-                                "code": "element: HTMLElement | undefined",
+                                "code": "element: undefined | HTMLElement",
                                 "type": {
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "HTMLElement",
                                             "source": "typescript"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
@@ -11391,7 +11406,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(element: HTMLElement | undefined): void",
+                        "code": "(element: undefined | HTMLElement): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -11564,22 +11579,22 @@
             },
             {
                 "name": "maximumHeight",
-                "code": "number | undefined",
+                "code": "undefined | number",
                 "kind": "accessor",
                 "value": {
                     "name": "maximumHeight",
-                    "code": "number | undefined",
+                    "code": "undefined | number",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
                                 "type": "intrinsic",
-                                "value": "number"
+                                "value": "undefined"
                             },
                             {
                                 "type": "intrinsic",
-                                "value": "undefined"
+                                "value": "number"
                             }
                         ]
                     }
@@ -11587,22 +11602,22 @@
             },
             {
                 "name": "maximumWidth",
-                "code": "number | undefined",
+                "code": "undefined | number",
                 "kind": "accessor",
                 "value": {
                     "name": "maximumWidth",
-                    "code": "number | undefined",
+                    "code": "undefined | number",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
                                 "type": "intrinsic",
-                                "value": "number"
+                                "value": "undefined"
                             },
                             {
                                 "type": "intrinsic",
-                                "value": "undefined"
+                                "value": "number"
                             }
                         ]
                     }
@@ -11610,22 +11625,22 @@
             },
             {
                 "name": "minimumHeight",
-                "code": "number | undefined",
+                "code": "undefined | number",
                 "kind": "accessor",
                 "value": {
                     "name": "minimumHeight",
-                    "code": "number | undefined",
+                    "code": "undefined | number",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
                                 "type": "intrinsic",
-                                "value": "number"
+                                "value": "undefined"
                             },
                             {
                                 "type": "intrinsic",
-                                "value": "undefined"
+                                "value": "number"
                             }
                         ]
                     }
@@ -11633,22 +11648,22 @@
             },
             {
                 "name": "minimumWidth",
-                "code": "number | undefined",
+                "code": "undefined | number",
                 "kind": "accessor",
                 "value": {
                     "name": "minimumWidth",
-                    "code": "number | undefined",
+                    "code": "undefined | number",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
                                 "type": "intrinsic",
-                                "value": "number"
+                                "value": "undefined"
                             },
                             {
                                 "type": "intrinsic",
-                                "value": "undefined"
+                                "value": "number"
                             }
                         ]
                     }
@@ -11656,23 +11671,23 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "accessor",
                 "value": {
                     "name": "params",
-                    "code": "Parameters | undefined",
+                    "code": "undefined | Parameters",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "Parameters",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -11695,22 +11710,22 @@
             },
             {
                 "name": "title",
-                "code": "string | undefined",
+                "code": "undefined | string",
                 "kind": "accessor",
                 "value": {
                     "name": "title",
-                    "code": "string | undefined",
+                    "code": "undefined | string",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
                                 "type": "intrinsic",
-                                "value": "string"
+                                "value": "undefined"
                             },
                             {
                                 "type": "intrinsic",
-                                "value": "undefined"
+                                "value": "string"
                             }
                         ]
                     }
@@ -11975,7 +11990,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -11984,18 +11999,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -12004,7 +12012,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -12110,13 +12118,13 @@
             },
             {
                 "name": "getData",
-                "code": "(): PanelTransfer | undefined",
+                "code": "(): undefined | PanelTransfer",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(): PanelTransfer | undefined",
+                        "code": "(): undefined | PanelTransfer",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -12127,17 +12135,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "PanelTransfer",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(): PanelTransfer | undefined",
+                                "code": "(): undefined | PanelTransfer",
                                 "kind": "callSignature"
                             }
                         ]
@@ -12277,23 +12285,23 @@
             },
             {
                 "name": "group",
-                "code": "DockviewGroupPanel | undefined",
+                "code": "undefined | DockviewGroupPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "group",
-                    "code": "DockviewGroupPanel | undefined",
+                    "code": "undefined | DockviewGroupPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "DockviewGroupPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -12331,23 +12339,23 @@
             },
             {
                 "name": "panel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "panel",
-                    "code": "IDockviewPanel | undefined",
+                    "code": "undefined | IDockviewPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "IDockviewPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -12370,7 +12378,7 @@
             },
             {
                 "name": "getData",
-                "code": "(): PanelTransfer | undefined",
+                "code": "(): undefined | PanelTransfer",
                 "kind": "method",
                 "signature": [
                     {
@@ -12381,17 +12389,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "PanelTransfer",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(): PanelTransfer | undefined",
+                        "code": "(): undefined | PanelTransfer",
                         "kind": "callSignature"
                     }
                 ]
@@ -12472,23 +12480,23 @@
             },
             {
                 "name": "group",
-                "code": "DockviewGroupPanel | undefined",
+                "code": "undefined | DockviewGroupPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "group",
-                    "code": "DockviewGroupPanel | undefined",
+                    "code": "undefined | DockviewGroupPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "DockviewGroupPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -12526,23 +12534,23 @@
             },
             {
                 "name": "panel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "accessor",
                 "value": {
                     "name": "panel",
-                    "code": "IDockviewPanel | undefined",
+                    "code": "undefined | IDockviewPanel",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "IDockviewPanel",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -12565,7 +12573,7 @@
             },
             {
                 "name": "getData",
-                "code": "(): PanelTransfer | undefined",
+                "code": "(): undefined | PanelTransfer",
                 "kind": "method",
                 "signature": [
                     {
@@ -12576,17 +12584,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "PanelTransfer",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(): PanelTransfer | undefined",
+                        "code": "(): undefined | PanelTransfer",
                         "kind": "callSignature"
                     }
                 ]
@@ -12632,7 +12640,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -12659,7 +12668,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -12673,7 +12683,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -12686,7 +12697,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -12700,28 +12712,30 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "headerComponent",
-                "code": "string | undefined",
+                "code": "undefined | string",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
                             "type": "intrinsic",
-                            "value": "string"
+                            "value": "undefined"
                         },
                         {
                             "type": "intrinsic",
-                            "value": "undefined"
+                            "value": "string"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -12733,7 +12747,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -12746,7 +12761,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -12795,7 +12811,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -12813,7 +12830,9 @@
                         }
                     ]
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "onDidDrop",
@@ -12866,7 +12885,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -13013,23 +13033,23 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "accessor",
                 "value": {
                     "name": "params",
-                    "code": "Parameters | undefined",
+                    "code": "undefined | Parameters",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "Parameters",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -13406,7 +13426,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -13415,18 +13435,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -13435,7 +13448,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -13569,19 +13582,19 @@
             },
             {
                 "name": "styles",
-                "code": "ISplitviewStyles | undefined",
+                "code": "undefined | ISplitviewStyles",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "ISplitviewStyles",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -13810,16 +13823,12 @@
             },
             {
                 "name": "deserialize",
-                "code": "<T>(json: SerializedGridview<T>, deserializer: IViewDeserializer): void",
+                "code": "(json: SerializedGridview<T>, deserializer: IViewDeserializer): void",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "deserialize",
-                        "typeParameters": [
-                            {
-                                "name": "T"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "json",
@@ -13854,7 +13863,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "<T>(json: SerializedGridview<T>, deserializer: IViewDeserializer): void",
+                        "code": "(json: SerializedGridview<T>, deserializer: IViewDeserializer): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -14074,6 +14083,34 @@
                 ]
             },
             {
+                "name": "maximizedView",
+                "code": "(): undefined | IGridView",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "maximizedView",
+                        "typeParameters": [],
+                        "parameters": [],
+                        "returnType": {
+                            "type": "or",
+                            "values": [
+                                {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
+                                    "type": "reference",
+                                    "value": "IGridView",
+                                    "source": "dockview-core"
+                                }
+                            ]
+                        },
+                        "code": "(): undefined | IGridView",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
                 "name": "maximizeView",
                 "code": "(view: IGridView): void",
                 "kind": "method",
@@ -14098,34 +14135,6 @@
                             "value": "void"
                         },
                         "code": "(view: IGridView): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "maximizedView",
-                "code": "(): IGridView | undefined",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "maximizedView",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "or",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "IGridView",
-                                    "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
-                                }
-                            ]
-                        },
-                        "code": "(): IGridView | undefined",
                         "kind": "callSignature"
                     }
                 ]
@@ -14572,7 +14581,7 @@
             },
             {
                 "name": "onDidActivePanelChange",
-                "code": "Event<IGridviewPanel<GridviewPanelApi> | undefined>",
+                "code": "Event<undefined | IGridviewPanel<GridviewPanelApi>>",
                 "kind": "accessor",
                 "value": {
                     "name": "onDidActivePanelChange",
@@ -14584,7 +14593,7 @@
                             }
                         ]
                     },
-                    "code": "Event<IGridviewPanel<GridviewPanelApi> | undefined>",
+                    "code": "Event<undefined | IGridviewPanel<GridviewPanelApi>>",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "reference",
@@ -14594,6 +14603,10 @@
                             {
                                 "type": "or",
                                 "values": [
+                                    {
+                                        "type": "intrinsic",
+                                        "value": "undefined"
+                                    },
                                     {
                                         "type": "reference",
                                         "value": "IGridviewPanel",
@@ -14605,10 +14618,6 @@
                                                 "source": "dockview-core"
                                             }
                                         ]
-                                    },
-                                    {
-                                        "type": "intrinsic",
-                                        "value": "undefined"
                                     }
                                 ]
                             }
@@ -14908,7 +14917,7 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddComponentOptions<T>): IGridviewPanel<GridviewPanelApi>",
+                "code": "(options: AddComponentOptions<T>): IGridviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -14921,16 +14930,7 @@
                                 }
                             ]
                         },
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -14954,16 +14954,9 @@
                         "returnType": {
                             "type": "reference",
                             "value": "IGridviewPanel",
-                            "source": "dockview-core",
-                            "typeArguments": [
-                                {
-                                    "type": "reference",
-                                    "value": "GridviewPanelApi",
-                                    "source": "dockview-core"
-                                }
-                            ]
+                            "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddComponentOptions<T>): IGridviewPanel<GridviewPanelApi>",
+                        "code": "(options: AddComponentOptions<T>): IGridviewPanel",
                         "kind": "callSignature"
                     }
                 ],
@@ -15125,7 +15118,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): IGridviewPanel<GridviewPanelApi> | undefined",
+                "code": "(id: string): undefined | IGridviewPanel<GridviewPanelApi>",
                 "kind": "method",
                 "signature": [
                     {
@@ -15170,6 +15163,10 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IGridviewPanel",
                                     "source": "dockview-core",
@@ -15180,14 +15177,10 @@
                                             "source": "dockview-core"
                                         }
                                     ]
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): IGridviewPanel<GridviewPanelApi> | undefined",
+                        "code": "(id: string): undefined | IGridviewPanel<GridviewPanelApi>",
                         "kind": "callSignature"
                     }
                 ],
@@ -15280,7 +15273,7 @@
             },
             {
                 "name": "movePanel",
-                "code": "(panel: IGridviewPanel<GridviewPanelApi>, options: { direction: Direction, reference: string, size?: number }): void",
+                "code": "(panel: IGridviewPanel, options: { direction: Direction, reference: string, size?: number }): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -15297,18 +15290,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: IGridviewPanel<GridviewPanelApi>",
+                                "code": "panel: IGridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "IGridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApi",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -15365,7 +15351,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: IGridviewPanel<GridviewPanelApi>, options: { direction: Direction, reference: string, size?: number }): void",
+                        "code": "(panel: IGridviewPanel, options: { direction: Direction, reference: string, size?: number }): void",
                         "kind": "callSignature"
                     }
                 ],
@@ -15380,7 +15366,7 @@
             },
             {
                 "name": "removePanel",
-                "code": "(panel: IGridviewPanel<GridviewPanelApi>, sizing?: Sizing): void",
+                "code": "(panel: IGridviewPanel, sizing?: Sizing): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -15397,18 +15383,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: IGridviewPanel<GridviewPanelApi>",
+                                "code": "panel: IGridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "IGridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApi",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -15427,7 +15406,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: IGridviewPanel<GridviewPanelApi>, sizing?: Sizing): void",
+                        "code": "(panel: IGridviewPanel, sizing?: Sizing): void",
                         "kind": "callSignature"
                     }
                 ],
@@ -15525,11 +15504,15 @@
             },
             {
                 "name": "_activeGroup",
-                "code": "GridviewPanel<GridviewPanelApiImpl> | undefined",
+                "code": "undefined | GridviewPanel<GridviewPanelApiImpl>",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
+                        {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
                         {
                             "type": "reference",
                             "value": "GridviewPanel",
@@ -15541,15 +15524,12 @@
                                     "source": "dockview-core"
                                 }
                             ]
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isProtected": true
+                    "isProtected": true,
+                    "isInherited": true
                 }
             },
             {
@@ -15563,7 +15543,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -15602,7 +15583,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -15644,12 +15626,13 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidActiveChange",
-                "code": "Event<GridviewPanel<GridviewPanelApiImpl> | undefined>",
+                "code": "Event<undefined | GridviewPanel<GridviewPanelApiImpl>>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -15659,6 +15642,10 @@
                         {
                             "type": "or",
                             "values": [
+                                {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
                                 {
                                     "type": "reference",
                                     "value": "GridviewPanel",
@@ -15670,22 +15657,19 @@
                                             "source": "dockview-core"
                                         }
                                     ]
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidActiveGroupChange",
-                "code": "Event<GridviewPanel<GridviewPanelApiImpl> | undefined>",
+                "code": "Event<undefined | GridviewPanel<GridviewPanelApiImpl>>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -15695,6 +15679,10 @@
                         {
                             "type": "or",
                             "values": [
+                                {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
                                 {
                                     "type": "reference",
                                     "value": "GridviewPanel",
@@ -15706,10 +15694,6 @@
                                             "source": "dockview-core"
                                         }
                                     ]
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -15743,7 +15727,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -15789,7 +15774,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -15842,7 +15828,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -15869,7 +15856,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -15915,29 +15903,30 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "activeGroup",
-                "code": "BaseGrid.T | undefined",
+                "code": "undefined | BaseGrid.T",
                 "kind": "accessor",
                 "value": {
                     "name": "activeGroup",
-                    "code": "BaseGrid.T | undefined",
+                    "code": "undefined | BaseGrid.T",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "T",
                                 "source": "dockview-core",
                                 "refersToTypeParameter": true
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -15945,23 +15934,23 @@
             },
             {
                 "name": "deserializer",
-                "code": "IPanelDeserializer | undefined",
+                "code": "undefined | IPanelDeserializer",
                 "kind": "accessor",
                 "value": {
                     "name": "deserializer",
-                    "code": "IPanelDeserializer | undefined",
+                    "code": "undefined | IPanelDeserializer",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "IPanelDeserializer",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -16219,21 +16208,12 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddComponentOptions<T>): IGridviewPanel<GridviewPanelApi>",
+                "code": "(options: AddComponentOptions<T>): IGridviewPanel",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "addPanel",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -16257,16 +16237,9 @@
                         "returnType": {
                             "type": "reference",
                             "value": "IGridviewPanel",
-                            "source": "dockview-core",
-                            "typeArguments": [
-                                {
-                                    "type": "reference",
-                                    "value": "GridviewPanelApi",
-                                    "source": "dockview-core"
-                                }
-                            ]
+                            "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddComponentOptions<T>): IGridviewPanel<GridviewPanelApi>",
+                        "code": "(options: AddComponentOptions<T>): IGridviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -16309,7 +16282,7 @@
             },
             {
                 "name": "doAddGroup",
-                "code": "(group: GridviewPanel<GridviewPanelApiImpl>, location: number[], size?: number): void",
+                "code": "(group: GridviewPanel, location: number[], size?: number): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -16318,18 +16291,11 @@
                         "parameters": [
                             {
                                 "name": "group",
-                                "code": "group: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "group: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -16359,14 +16325,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(group: GridviewPanel<GridviewPanelApiImpl>, location: number[], size?: number): void",
+                        "code": "(group: GridviewPanel, location: number[], size?: number): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "doRemoveGroup",
-                "code": "(group: GridviewPanel<GridviewPanelApiImpl>, options?: { skipActive?: boolean, skipDispose?: boolean }): GridviewPanel<GridviewPanelApiImpl>",
+                "code": "(group: GridviewPanel, options?: { skipActive?: boolean, skipDispose?: boolean }): GridviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -16375,18 +16341,11 @@
                         "parameters": [
                             {
                                 "name": "group",
-                                "code": "group: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "group: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -16433,23 +16392,16 @@
                         "returnType": {
                             "type": "reference",
                             "value": "GridviewPanel",
-                            "source": "dockview-core",
-                            "typeArguments": [
-                                {
-                                    "type": "reference",
-                                    "value": "GridviewPanelApiImpl",
-                                    "source": "dockview-core"
-                                }
-                            ]
+                            "source": "dockview-core"
                         },
-                        "code": "(group: GridviewPanel<GridviewPanelApiImpl>, options?: { skipActive?: boolean, skipDispose?: boolean }): GridviewPanel<GridviewPanelApiImpl>",
+                        "code": "(group: GridviewPanel, options?: { skipActive?: boolean, skipDispose?: boolean }): GridviewPanel",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "doSetGroupActive",
-                "code": "(group: GridviewPanel<GridviewPanelApiImpl> | undefined): void",
+                "code": "(group: undefined | GridviewPanel<GridviewPanelApiImpl>): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -16458,10 +16410,14 @@
                         "parameters": [
                             {
                                 "name": "group",
-                                "code": "group: GridviewPanel<GridviewPanelApiImpl> | undefined",
+                                "code": "group: undefined | GridviewPanel<GridviewPanelApiImpl>",
                                 "type": {
                                     "type": "or",
                                     "values": [
+                                        {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
                                         {
                                             "type": "reference",
                                             "value": "GridviewPanel",
@@ -16473,10 +16429,6 @@
                                                     "source": "dockview-core"
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
@@ -16487,7 +16439,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(group: GridviewPanel<GridviewPanelApiImpl> | undefined): void",
+                        "code": "(group: undefined | GridviewPanel<GridviewPanelApiImpl>): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -16577,7 +16529,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): GridviewPanel<GridviewPanelApiImpl> | undefined",
+                "code": "(id: string): undefined | GridviewPanel<GridviewPanelApiImpl>",
                 "kind": "method",
                 "signature": [
                     {
@@ -16598,6 +16550,10 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "GridviewPanel",
                                     "source": "dockview-core",
@@ -16608,14 +16564,10 @@
                                             "source": "dockview-core"
                                         }
                                     ]
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): GridviewPanel<GridviewPanelApiImpl> | undefined",
+                        "code": "(id: string): undefined | GridviewPanel<GridviewPanelApiImpl>",
                         "kind": "callSignature"
                     }
                 ]
@@ -16640,7 +16592,7 @@
             },
             {
                 "name": "isMaximizedGroup",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): boolean",
+                "code": "(panel: GridviewPanel): boolean",
                 "kind": "method",
                 "signature": [
                     {
@@ -16649,18 +16601,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -16669,14 +16614,14 @@
                             "type": "intrinsic",
                             "value": "boolean"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): boolean",
+                        "code": "(panel: GridviewPanel): boolean",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "isVisible",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): boolean",
+                "code": "(panel: GridviewPanel): boolean",
                 "kind": "method",
                 "signature": [
                     {
@@ -16685,18 +16630,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -16705,7 +16643,7 @@
                             "type": "intrinsic",
                             "value": "boolean"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): boolean",
+                        "code": "(panel: GridviewPanel): boolean",
                         "kind": "callSignature"
                     }
                 ]
@@ -16758,7 +16696,7 @@
             },
             {
                 "name": "maximizeGroup",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): void",
+                "code": "(panel: GridviewPanel): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -16767,18 +16705,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -16787,7 +16718,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): void",
+                        "code": "(panel: GridviewPanel): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -16842,7 +16773,7 @@
             },
             {
                 "name": "movePanel",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>, options: { direction: Direction, reference: string, size?: number }): void",
+                "code": "(panel: GridviewPanel, options: { direction: Direction, reference: string, size?: number }): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -16851,18 +16782,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -16919,7 +16843,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>, options: { direction: Direction, reference: string, size?: number }): void",
+                        "code": "(panel: GridviewPanel, options: { direction: Direction, reference: string, size?: number }): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -17013,7 +16937,7 @@
             },
             {
                 "name": "removeGroup",
-                "code": "(group: GridviewPanel<GridviewPanelApiImpl>): void",
+                "code": "(group: GridviewPanel): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -17022,18 +16946,11 @@
                         "parameters": [
                             {
                                 "name": "group",
-                                "code": "group: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "group: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -17042,14 +16959,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(group: GridviewPanel<GridviewPanelApiImpl>): void",
+                        "code": "(group: GridviewPanel): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "removePanel",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): void",
+                "code": "(panel: GridviewPanel): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -17058,18 +16975,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -17078,14 +16988,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): void",
+                        "code": "(panel: GridviewPanel): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "setActive",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): void",
+                "code": "(panel: GridviewPanel): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -17094,18 +17004,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -17114,14 +17017,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): void",
+                        "code": "(panel: GridviewPanel): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "setVisible",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>, visible: boolean): void",
+                "code": "(panel: GridviewPanel, visible: boolean): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -17130,18 +17033,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -17159,7 +17055,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>, visible: boolean): void",
+                        "code": "(panel: GridviewPanel, visible: boolean): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -17282,7 +17178,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -17297,7 +17194,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -17310,7 +17208,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -17323,12 +17222,13 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidChange",
-                "code": "Event<IViewSize | undefined>",
+                "code": "Event<undefined | IViewSize>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -17339,13 +17239,13 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IViewSize",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -17366,7 +17266,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -17498,23 +17399,23 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "accessor",
                 "value": {
                     "name": "params",
-                    "code": "Parameters | undefined",
+                    "code": "undefined | Parameters",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "Parameters",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -17522,23 +17423,23 @@
             },
             {
                 "name": "priority",
-                "code": "LayoutPriority | undefined",
+                "code": "undefined | LayoutPriority",
                 "kind": "accessor",
                 "value": {
                     "name": "priority",
-                    "code": "LayoutPriority | undefined",
+                    "code": "undefined | LayoutPriority",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "LayoutPriority",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -17903,7 +17804,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -17912,18 +17813,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -17932,7 +17826,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -17962,7 +17856,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -17975,7 +17870,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -17989,7 +17885,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18003,7 +17900,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18016,7 +17914,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18030,28 +17929,30 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "headerComponent",
-                "code": "string | undefined",
+                "code": "undefined | string",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
                             "type": "intrinsic",
-                            "value": "string"
+                            "value": "undefined"
                         },
                         {
                             "type": "intrinsic",
-                            "value": "undefined"
+                            "value": "string"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18063,7 +17964,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18076,7 +17978,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18125,7 +18028,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18143,7 +18047,9 @@
                         }
                     ]
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "onDidDrop",
@@ -18162,7 +18068,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18182,7 +18089,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18196,7 +18104,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -18343,23 +18252,23 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "accessor",
                 "value": {
                     "name": "params",
-                    "code": "Parameters | undefined",
+                    "code": "undefined | Parameters",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "Parameters",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -18736,7 +18645,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -18745,18 +18654,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -18765,7 +18667,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -18773,46 +18675,6 @@
         ],
         "extends": [
             "DraggablePaneviewPanel"
-        ]
-    },
-    "PaneTransfer": {
-        "kind": "class",
-        "name": "PaneTransfer",
-        "children": [
-            {
-                "name": "constructor",
-                "kind": "constructor",
-                "code": ""
-            },
-            {
-                "name": "paneId",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isPublic": true,
-                    "isReadonly": true
-                }
-            },
-            {
-                "name": "viewId",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isPublic": true,
-                    "isReadonly": true
-                }
-            }
-        ],
-        "extends": [
-            "TransferObject"
         ]
     },
     "PanelTransfer": {
@@ -18839,18 +18701,18 @@
             },
             {
                 "name": "panelId",
-                "code": "string | 'null'",
+                "code": "'null' | string",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
-                            "type": "intrinsic",
-                            "value": "string"
-                        },
-                        {
                             "type": "literal",
                             "value": null
+                        },
+                        {
+                            "type": "intrinsic",
+                            "value": "string"
                         }
                     ]
                 },
@@ -18870,6 +18732,46 @@
                 "flags": {
                     "isPublic": true,
                     "isOptional": true,
+                    "isReadonly": true
+                }
+            },
+            {
+                "name": "viewId",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {
+                    "isPublic": true,
+                    "isReadonly": true
+                }
+            }
+        ],
+        "extends": [
+            "TransferObject"
+        ]
+    },
+    "PaneTransfer": {
+        "kind": "class",
+        "name": "PaneTransfer",
+        "children": [
+            {
+                "name": "constructor",
+                "kind": "constructor",
+                "code": ""
+            },
+            {
+                "name": "paneId",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {
+                    "isPublic": true,
                     "isReadonly": true
                 }
             },
@@ -19804,7 +19706,7 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
+                "code": "(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -19817,16 +19719,7 @@
                                 }
                             ]
                         },
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -19852,7 +19745,7 @@
                             "value": "IPaneviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
+                        "code": "(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
                         "kind": "callSignature"
                     }
                 ],
@@ -20014,7 +19907,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): IPaneviewPanel | undefined",
+                "code": "(id: string): undefined | IPaneviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -20059,17 +19952,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IPaneviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): IPaneviewPanel | undefined",
+                        "code": "(id: string): undefined | IPaneviewPanel",
                         "kind": "callSignature"
                     }
                 ],
@@ -20661,21 +20554,12 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
+                "code": "(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "addPanel",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -20701,7 +20585,7 @@
                             "value": "IPaneviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
+                        "code": "(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -20791,7 +20675,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): PaneviewPanel | undefined",
+                "code": "(id: string): undefined | PaneviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -20812,17 +20696,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "PaneviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): PaneviewPanel | undefined",
+                        "code": "(id: string): undefined | PaneviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -21077,7 +20961,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -21091,7 +20976,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -21118,7 +21004,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -21137,18 +21024,18 @@
             },
             {
                 "name": "headerComponent",
-                "code": "string | undefined",
+                "code": "undefined | string",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
                             "type": "intrinsic",
-                            "value": "string"
+                            "value": "undefined"
                         },
                         {
                             "type": "intrinsic",
-                            "value": "undefined"
+                            "value": "string"
                         }
                     ]
                 },
@@ -21178,7 +21065,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -21258,7 +21146,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -21405,23 +21294,23 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "accessor",
                 "value": {
                     "name": "params",
-                    "code": "Parameters | undefined",
+                    "code": "undefined | Parameters",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "Parameters",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -21798,7 +21687,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -21807,18 +21696,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -21827,7 +21709,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -21848,13 +21730,13 @@
             },
             {
                 "name": "getData",
-                "code": "(): PaneTransfer | undefined",
+                "code": "(): undefined | PaneTransfer",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(): PaneTransfer | undefined",
+                        "code": "(): undefined | PaneTransfer",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -21865,17 +21747,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "PaneTransfer",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(): PaneTransfer | undefined",
+                                "code": "(): undefined | PaneTransfer",
                                 "kind": "callSignature"
                             }
                         ]
@@ -22158,15 +22040,19 @@
             },
             {
                 "name": "proportions",
-                "code": "number | undefined[] | undefined",
+                "code": "undefined | undefined | number[]",
                 "kind": "accessor",
                 "value": {
                     "name": "proportions",
-                    "code": "number | undefined[] | undefined",
+                    "code": "undefined | undefined | number[]",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
+                            {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
                             {
                                 "type": "array",
                                 "value": {
@@ -22174,18 +22060,14 @@
                                     "values": [
                                         {
                                             "type": "intrinsic",
-                                            "value": "number"
+                                            "value": "undefined"
                                         },
                                         {
                                             "type": "intrinsic",
-                                            "value": "undefined"
+                                            "value": "number"
                                         }
                                     ]
                                 }
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -22323,7 +22205,7 @@
             },
             {
                 "name": "getViewCachedVisibleSize",
-                "code": "(index: number): number | undefined",
+                "code": "(index: number): undefined | number",
                 "kind": "method",
                 "signature": [
                     {
@@ -22345,15 +22227,38 @@
                             "values": [
                                 {
                                     "type": "intrinsic",
-                                    "value": "number"
+                                    "value": "undefined"
                                 },
                                 {
                                     "type": "intrinsic",
-                                    "value": "undefined"
+                                    "value": "number"
                                 }
                             ]
                         },
-                        "code": "(index: number): number | undefined",
+                        "code": "(index: number): undefined | number",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "getViews",
+                "code": "(): T[]",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "getViews",
+                        "typeParameters": [],
+                        "parameters": [],
+                        "returnType": {
+                            "type": "array",
+                            "value": {
+                                "type": "reference",
+                                "value": "T",
+                                "source": "dockview-core",
+                                "refersToTypeParameter": true
+                            }
+                        },
+                        "code": "(): T[]",
                         "kind": "callSignature"
                     }
                 ]
@@ -22382,38 +22287,6 @@
                             "value": "number"
                         },
                         "code": "(index: number): number",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "getViews",
-                "code": "<T extends IView>(): T[]",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "getViews",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "reference",
-                                    "value": "IView",
-                                    "source": "dockview-core"
-                                }
-                            }
-                        ],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "array",
-                            "value": {
-                                "type": "reference",
-                                "value": "T",
-                                "source": "dockview-core",
-                                "refersToTypeParameter": true
-                            }
-                        },
-                        "code": "<T extends IView>(): T[]",
                         "kind": "callSignature"
                     }
                 ]
@@ -23066,7 +22939,7 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddSplitviewComponentOptions<T>): ISplitviewPanel",
+                "code": "(options: AddSplitviewComponentOptions<T>): ISplitviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -23079,16 +22952,7 @@
                                 }
                             ]
                         },
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -23114,7 +22978,7 @@
                             "value": "ISplitviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddSplitviewComponentOptions<T>): ISplitviewPanel",
+                        "code": "(options: AddSplitviewComponentOptions<T>): ISplitviewPanel",
                         "kind": "callSignature"
                     }
                 ],
@@ -23276,7 +23140,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): ISplitviewPanel | undefined",
+                "code": "(id: string): undefined | ISplitviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -23313,17 +23177,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "ISplitviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): ISplitviewPanel | undefined",
+                        "code": "(id: string): undefined | ISplitviewPanel",
                         "kind": "callSignature"
                     }
                 ],
@@ -23908,21 +23772,12 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddSplitviewComponentOptions<T>): SplitviewPanel",
+                "code": "(options: AddSplitviewComponentOptions<T>): SplitviewPanel",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "addPanel",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -23948,7 +23803,7 @@
                             "value": "SplitviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddSplitviewComponentOptions<T>): SplitviewPanel",
+                        "code": "(options: AddSplitviewComponentOptions<T>): SplitviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -24038,7 +23893,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): SplitviewPanel | undefined",
+                "code": "(id: string): undefined | SplitviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -24059,17 +23914,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "SplitviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): SplitviewPanel | undefined",
+                        "code": "(id: string): undefined | SplitviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -24372,7 +24227,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -24386,7 +24242,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -24399,7 +24256,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -24412,7 +24270,8 @@
                 },
                 "flags": {
                     "isPublic": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -24475,7 +24334,8 @@
                 },
                 "flags": {
                     "isProtected": true,
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -24566,23 +24426,23 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "accessor",
                 "value": {
                     "name": "params",
-                    "code": "Parameters | undefined",
+                    "code": "undefined | Parameters",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "Parameters",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -24590,23 +24450,23 @@
             },
             {
                 "name": "priority",
-                "code": "LayoutPriority | undefined",
+                "code": "undefined | LayoutPriority",
                 "kind": "accessor",
                 "value": {
                     "name": "priority",
-                    "code": "LayoutPriority | undefined",
+                    "code": "undefined | LayoutPriority",
                     "kind": "getSignature",
                     "returnType": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "LayoutPriority",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     }
@@ -24880,7 +24740,7 @@
             },
             {
                 "name": "toJSON",
-                "code": "(): { component: string, id: string, maximumSize: number | undefined, minimumSize: number | undefined, params?: Parameters }",
+                "code": "(): { component: string, id: string, maximumSize: undefined | number, minimumSize: undefined | number, params?: Parameters }",
                 "kind": "method",
                 "signature": [
                     {
@@ -24891,7 +24751,7 @@
                             "type": "reflection",
                             "value": {
                                 "name": "__type",
-                                "code": "{ component: string, id: string, maximumSize: number | undefined, minimumSize: number | undefined, params?: Parameters }",
+                                "code": "{ component: string, id: string, maximumSize: undefined | number, minimumSize: undefined | number, params?: Parameters }",
                                 "kind": "typeLiteral",
                                 "properties": [
                                     {
@@ -24920,18 +24780,18 @@
                                     },
                                     {
                                         "name": "maximumSize",
-                                        "code": "number | undefined",
+                                        "code": "undefined | number",
                                         "kind": "property",
                                         "type": {
                                             "type": "or",
                                             "values": [
                                                 {
                                                     "type": "intrinsic",
-                                                    "value": "number"
+                                                    "value": "undefined"
                                                 },
                                                 {
                                                     "type": "intrinsic",
-                                                    "value": "undefined"
+                                                    "value": "number"
                                                 }
                                             ]
                                         },
@@ -24939,18 +24799,18 @@
                                     },
                                     {
                                         "name": "minimumSize",
-                                        "code": "number | undefined",
+                                        "code": "undefined | number",
                                         "kind": "property",
                                         "type": {
                                             "type": "or",
                                             "values": [
                                                 {
                                                     "type": "intrinsic",
-                                                    "value": "number"
+                                                    "value": "undefined"
                                                 },
                                                 {
                                                     "type": "intrinsic",
-                                                    "value": "undefined"
+                                                    "value": "number"
                                                 }
                                             ]
                                         },
@@ -24973,14 +24833,14 @@
                                 ]
                             }
                         },
-                        "code": "(): { component: string, id: string, maximumSize: number | undefined, minimumSize: number | undefined, params?: Parameters }",
+                        "code": "(): { component: string, id: string, maximumSize: undefined | number, minimumSize: undefined | number, params?: Parameters }",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -24989,18 +24849,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -25009,7 +24862,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -25404,7 +25257,7 @@
             },
             {
                 "name": "defaultId",
-                "code": "(): string | undefined",
+                "code": "(): undefined | string",
                 "kind": "method",
                 "signature": [
                     {
@@ -25424,15 +25277,15 @@
                             "values": [
                                 {
                                     "type": "intrinsic",
-                                    "value": "string"
+                                    "value": "undefined"
                                 },
                                 {
                                     "type": "intrinsic",
-                                    "value": "undefined"
+                                    "value": "string"
                                 }
                             ]
                         },
-                        "code": "(): string | undefined",
+                        "code": "(): undefined | string",
                         "kind": "callSignature"
                     }
                 ],
@@ -25473,7 +25326,7 @@
             },
             {
                 "name": "get",
-                "code": "(id: string): DockviewTabGroupColorEntry | undefined",
+                "code": "(id: string): undefined | DockviewTabGroupColorEntry",
                 "kind": "method",
                 "signature": [
                     {
@@ -25494,17 +25347,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewTabGroupColorEntry",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): DockviewTabGroupColorEntry | undefined",
+                        "code": "(id: string): undefined | DockviewTabGroupColorEntry",
                         "kind": "callSignature"
                     }
                 ]
@@ -25539,7 +25392,7 @@
             },
             {
                 "name": "resolveValue",
-                "code": "(color: string | undefined): string | undefined",
+                "code": "(color: undefined | string): undefined | string",
                 "kind": "method",
                 "signature": [
                     {
@@ -25556,17 +25409,17 @@
                         "parameters": [
                             {
                                 "name": "color",
-                                "code": "color: string | undefined",
+                                "code": "color: undefined | string",
                                 "type": {
                                     "type": "or",
                                     "values": [
                                         {
                                             "type": "intrinsic",
-                                            "value": "string"
+                                            "value": "undefined"
                                         },
                                         {
                                             "type": "intrinsic",
-                                            "value": "undefined"
+                                            "value": "string"
                                         }
                                     ]
                                 },
@@ -25578,15 +25431,15 @@
                             "values": [
                                 {
                                     "type": "intrinsic",
-                                    "value": "string"
+                                    "value": "undefined"
                                 },
                                 {
                                     "type": "intrinsic",
-                                    "value": "undefined"
+                                    "value": "string"
                                 }
                             ]
                         },
-                        "code": "(color: string | undefined): string | undefined",
+                        "code": "(color: undefined | string): undefined | string",
                         "kind": "callSignature"
                     }
                 ],
@@ -25701,7 +25554,9 @@
                     "type": "intrinsic",
                     "value": "string"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "id",
@@ -25711,7 +25566,9 @@
                     "type": "intrinsic",
                     "value": "string"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "location",
@@ -25787,7 +25644,8 @@
                     "refersToTypeParameter": true
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -25839,7 +25697,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -25851,7 +25710,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -25863,7 +25723,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             }
         ],
@@ -26018,7 +25879,9 @@
                     "type": "intrinsic",
                     "value": "string"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "id",
@@ -26028,7 +25891,9 @@
                     "type": "intrinsic",
                     "value": "string"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "index",
@@ -26077,7 +25942,8 @@
                     "refersToTypeParameter": true
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -26090,7 +25956,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -26102,7 +25969,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -26114,7 +25982,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             }
         ],
@@ -26752,13 +26621,13 @@
         "children": [
             {
                 "name": "getData",
-                "code": "(): PanelTransfer | undefined",
+                "code": "(): undefined | PanelTransfer",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(): PanelTransfer | undefined",
+                        "code": "(): undefined | PanelTransfer",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -26769,17 +26638,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "PanelTransfer",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(): PanelTransfer | undefined",
+                                "code": "(): undefined | PanelTransfer",
                                 "kind": "callSignature"
                             }
                         ]
@@ -26809,7 +26678,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -26913,13 +26783,13 @@
             },
             {
                 "name": "createContextMenuItemComponent",
-                "code": "(options: CreateContextMenuItemComponentOptions): IContextMenuItemRenderer | undefined",
+                "code": "(options: CreateContextMenuItemComponentOptions): undefined | IContextMenuItemRenderer",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(options: CreateContextMenuItemComponentOptions): IContextMenuItemRenderer | undefined",
+                        "code": "(options: CreateContextMenuItemComponentOptions): undefined | IContextMenuItemRenderer",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -26941,17 +26811,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "IContextMenuItemRenderer",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(options: CreateContextMenuItemComponentOptions): IContextMenuItemRenderer | undefined",
+                                "code": "(options: CreateContextMenuItemComponentOptions): undefined | IContextMenuItemRenderer",
                                 "kind": "callSignature"
                             }
                         ]
@@ -27086,13 +26956,13 @@
             },
             {
                 "name": "createTabComponent",
-                "code": "(options: CreateComponentOptions): ITabRenderer | undefined",
+                "code": "(options: CreateComponentOptions): undefined | ITabRenderer",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(options: CreateComponentOptions): ITabRenderer | undefined",
+                        "code": "(options: CreateComponentOptions): undefined | ITabRenderer",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -27114,17 +26984,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "ITabRenderer",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(options: CreateComponentOptions): ITabRenderer | undefined",
+                                "code": "(options: CreateComponentOptions): undefined | ITabRenderer",
                                 "kind": "callSignature"
                             }
                         ]
@@ -27302,7 +27172,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -27322,7 +27193,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -27342,7 +27214,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -27362,7 +27235,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -27382,7 +27256,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -27402,7 +27277,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -27443,7 +27319,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -27511,7 +27388,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -27531,7 +27409,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -27551,7 +27430,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -27591,7 +27471,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -27611,7 +27492,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -27631,7 +27513,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -27643,7 +27526,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -27779,22 +27663,12 @@
             },
             {
                 "name": "getParameters",
-                "code": "<T extends Parameters = Parameters>(): T",
+                "code": "(): T",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "getParameters",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "reference",
-                                    "value": "Parameters",
-                                    "source": "dockview-core"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [],
                         "returnType": {
                             "type": "reference",
@@ -27802,7 +27676,7 @@
                             "source": "dockview-core",
                             "refersToTypeParameter": true
                         },
-                        "code": "<T extends Parameters = Parameters>(): T",
+                        "code": "(): T",
                         "kind": "callSignature"
                     }
                 ]
@@ -28214,6 +28088,63 @@
                 },
                 "flags": {
                     "isOptional": true
+                }
+            },
+            {
+                "name": "createGroupDragGhostComponent",
+                "code": "(group: DockviewGroupPanel): IGroupDragGhostRenderer",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(group: DockviewGroupPanel): IGroupDragGhostRenderer",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [
+                                    {
+                                        "name": "group",
+                                        "code": "group: DockviewGroupPanel",
+                                        "type": {
+                                            "type": "reference",
+                                            "value": "DockviewGroupPanel",
+                                            "source": "dockview-core"
+                                        },
+                                        "kind": "parameter"
+                                    }
+                                ],
+                                "returnType": {
+                                    "type": "reference",
+                                    "value": "IGroupDragGhostRenderer",
+                                    "source": "dockview-core"
+                                },
+                                "code": "(group: DockviewGroupPanel): IGroupDragGhostRenderer",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true
+                },
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Factory to create the custom ghost element shown while dragging a\ngroup of panels (the small floating chip that follows the cursor).\n\nIf not provided, a default ghost rendering "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"Multiple Panels (N)\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": "\nis used. Supplying a factory replaces the entire default ghost,\nenabling i18n / custom visuals."
+                        }
+                    ]
                 }
             },
             {
@@ -28675,6 +28606,19 @@
                 }
             },
             {
+                "name": "nonce",
+                "code": "CspNonceProvider",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "CspNonceProvider",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
                 "name": "noPanelsOverlay",
                 "code": "'watermark' | 'emptyGroup'",
                 "kind": "property",
@@ -28994,7 +28938,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -29027,7 +28972,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -29047,7 +28993,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -29067,7 +29014,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -29087,7 +29035,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -29119,7 +29068,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -29160,7 +29110,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -29200,7 +29151,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -29220,7 +29172,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -29280,7 +29233,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -29340,7 +29294,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -29360,7 +29315,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -29378,18 +29334,18 @@
             },
             {
                 "name": "tabComponent",
-                "code": "string | undefined",
+                "code": "undefined | string",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
                             "type": "intrinsic",
-                            "value": "string"
+                            "value": "undefined"
                         },
                         {
                             "type": "intrinsic",
-                            "value": "undefined"
+                            "value": "string"
                         }
                     ]
                 },
@@ -29407,18 +29363,18 @@
             },
             {
                 "name": "title",
-                "code": "string | undefined",
+                "code": "undefined | string",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
                             "type": "intrinsic",
-                            "value": "string"
+                            "value": "undefined"
                         },
                         {
                             "type": "intrinsic",
-                            "value": "undefined"
+                            "value": "string"
                         }
                     ]
                 },
@@ -29435,7 +29391,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -29484,22 +29441,12 @@
             },
             {
                 "name": "getParameters",
-                "code": "<T extends Parameters = Parameters>(): T",
+                "code": "(): T",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "getParameters",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "reference",
-                                    "value": "Parameters",
-                                    "source": "dockview-core"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [],
                         "returnType": {
                             "type": "reference",
@@ -29507,7 +29454,7 @@
                             "source": "dockview-core",
                             "refersToTypeParameter": true
                         },
-                        "code": "<T extends Parameters = Parameters>(): T",
+                        "code": "(): T",
                         "kind": "callSignature"
                     }
                 ]
@@ -30930,18 +30877,18 @@
             },
             {
                 "name": "cachedVisibleSize",
-                "code": "number | undefined",
+                "code": "undefined | number",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
                             "type": "intrinsic",
-                            "value": "number"
+                            "value": "undefined"
                         },
                         {
                             "type": "intrinsic",
-                            "value": "undefined"
+                            "value": "number"
                         }
                     ]
                 },
@@ -30979,7 +30926,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -30991,7 +30939,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -31053,7 +31002,8 @@
                 },
                 "flags": {
                     "isOptional": true,
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -31092,13 +31042,13 @@
         "children": [
             {
                 "name": "createComponent",
-                "code": "(options: CreateComponentOptions): GridviewPanel<GridviewPanelApiImpl>",
+                "code": "(options: CreateComponentOptions): GridviewPanel",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(options: CreateComponentOptions): GridviewPanel<GridviewPanelApiImpl>",
+                        "code": "(options: CreateComponentOptions): GridviewPanel",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -31119,16 +31069,9 @@
                                 "returnType": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
-                                "code": "(options: CreateComponentOptions): GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "(options: CreateComponentOptions): GridviewPanel",
                                 "kind": "callSignature"
                             }
                         ]
@@ -31230,7 +31173,9 @@
                     "value": "Parameters",
                     "source": "dockview-core"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "priority",
@@ -31341,7 +31286,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -31361,7 +31307,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -31381,7 +31328,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -31401,7 +31349,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -31421,7 +31370,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -31441,7 +31391,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -31469,7 +31420,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -31509,7 +31461,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -31529,7 +31482,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -31549,7 +31503,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -31569,7 +31524,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -31589,7 +31545,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -31601,7 +31558,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -31614,22 +31572,12 @@
             },
             {
                 "name": "getParameters",
-                "code": "<T extends Parameters = Parameters>(): T",
+                "code": "(): T",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "getParameters",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "reference",
-                                    "value": "Parameters",
-                                    "source": "dockview-core"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [],
                         "returnType": {
                             "type": "reference",
@@ -31637,7 +31585,7 @@
                             "source": "dockview-core",
                             "refersToTypeParameter": true
                         },
-                        "code": "<T extends Parameters = Parameters>(): T",
+                        "code": "(): T",
                         "kind": "callSignature"
                     }
                 ]
@@ -31848,7 +31796,9 @@
                     "value": "Parameters",
                     "source": "dockview-core"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "title",
@@ -31858,7 +31808,9 @@
                     "type": "intrinsic",
                     "value": "string"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             }
         ],
         "extends": [
@@ -32019,20 +31971,20 @@
         "children": [
             {
                 "name": "activeGroup",
-                "code": "IBaseGrid.T | undefined",
+                "code": "undefined | IBaseGrid.T",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "T",
                             "source": "dockview-core",
                             "refersToTypeParameter": true
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -32297,7 +32249,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): IBaseGrid.T | undefined",
+                "code": "(id: string): undefined | IBaseGrid.T",
                 "kind": "method",
                 "signature": [
                     {
@@ -32318,18 +32270,18 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "T",
                                     "source": "dockview-core",
                                     "refersToTypeParameter": true
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): IBaseGrid.T | undefined",
+                        "code": "(id: string): undefined | IBaseGrid.T",
                         "kind": "callSignature"
                     }
                 ]
@@ -32922,6 +32874,36 @@
         "name": "IContentRenderer",
         "children": [
             {
+                "name": "dispose",
+                "code": "(): void",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(): void",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(): void",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
                 "name": "element",
                 "code": "HTMLElement",
                 "kind": "property",
@@ -32935,40 +32917,161 @@
                 }
             },
             {
-                "name": "dispose",
-                "code": "(): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "dispose",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
                 "name": "focus",
                 "code": "(): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "focus",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
                         "code": "(): void",
-                        "kind": "callSignature"
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(): void",
+                                "kind": "callSignature"
+                            }
+                        ]
                     }
-                ]
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "layout",
+                "code": "(width: number, height: number): void",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(width: number, height: number): void",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [
+                                    {
+                                        "name": "width",
+                                        "code": "width: number",
+                                        "type": {
+                                            "type": "intrinsic",
+                                            "value": "number"
+                                        },
+                                        "kind": "parameter"
+                                    },
+                                    {
+                                        "name": "height",
+                                        "code": "height: number",
+                                        "type": {
+                                            "type": "intrinsic",
+                                            "value": "number"
+                                        },
+                                        "kind": "parameter"
+                                    }
+                                ],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(width: number, height: number): void",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "toJSON",
+                "code": "(): object",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(): object",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "object"
+                                },
+                                "code": "(): object",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "update",
+                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [
+                                    {
+                                        "name": "event",
+                                        "code": "event: PanelUpdateEvent<Parameters>",
+                                        "type": {
+                                            "type": "reference",
+                                            "value": "PanelUpdateEvent",
+                                            "source": "dockview-core",
+                                            "typeArguments": [
+                                                {
+                                                    "type": "reference",
+                                                    "value": "Parameters",
+                                                    "source": "dockview-core"
+                                                }
+                                            ]
+                                        },
+                                        "kind": "parameter"
+                                    }
+                                ],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
             },
             {
                 "name": "init",
@@ -32995,43 +33098,6 @@
                             "value": "void"
                         },
                         "code": "(parameters: GroupPanelPartInitParameters): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "layout",
-                "code": "(width: number, height: number): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "layout",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "width",
-                                "code": "width: number",
-                                "type": {
-                                    "type": "intrinsic",
-                                    "value": "number"
-                                },
-                                "kind": "parameter"
-                            },
-                            {
-                                "name": "height",
-                                "code": "height: number",
-                                "type": {
-                                    "type": "intrinsic",
-                                    "value": "number"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(width: number, height: number): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -33068,60 +33134,6 @@
                             "value": "void"
                         },
                         "code": "(): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "toJSON",
-                "code": "(): object",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "toJSON",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "object"
-                        },
-                        "code": "(): object",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "update",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -33293,41 +33305,42 @@
         "children": [
             {
                 "name": "activeGroup",
-                "code": "DockviewGroupPanel | undefined",
+                "code": "undefined | DockviewGroupPanel",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
+                        {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
                         {
                             "type": "reference",
                             "value": "DockviewGroupPanel",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "activePanel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "IDockviewPanel",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -33392,18 +33405,19 @@
                     "source": "typescript"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "getGroupPanel",
-                "code": "(id: string): IDockviewPanel | undefined",
+                "code": "(id: string): undefined | IDockviewPanel",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(id: string): IDockviewPanel | undefined",
+                        "code": "(id: string): undefined | IDockviewPanel",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -33424,17 +33438,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "IDockviewPanel",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(id: string): IDockviewPanel | undefined",
+                                "code": "(id: string): undefined | IDockviewPanel",
                                 "kind": "callSignature"
                             }
                         ]
@@ -33455,7 +33469,8 @@
                     }
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -33467,7 +33482,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -33479,7 +33495,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -33491,7 +33508,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -33503,7 +33521,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -33515,7 +33534,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -33527,12 +33547,13 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidActiveGroupChange",
-                "code": "Event<DockviewGroupPanel | undefined>",
+                "code": "Event<undefined | DockviewGroupPanel>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -33543,13 +33564,13 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewGroupPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -33561,7 +33582,7 @@
             },
             {
                 "name": "onDidActivePanelChange",
-                "code": "Event<IDockviewPanel | undefined>",
+                "code": "Event<undefined | IDockviewPanel>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -33572,13 +33593,13 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IDockviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -33724,7 +33745,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -33770,7 +33792,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -34161,7 +34184,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -34198,7 +34222,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -34322,21 +34347,12 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddPanelOptions<T>): IDockviewPanel",
+                "code": "(options: AddPanelOptions<T>): IDockviewPanel",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "addPanel",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -34362,7 +34378,7 @@
                             "value": "IDockviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddPanelOptions<T>): IDockviewPanel",
+                        "code": "(options: AddPanelOptions<T>): IDockviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -34771,7 +34787,7 @@
             },
             {
                 "name": "getEdgeGroup",
-                "code": "(position: EdgeGroupPosition): DockviewGroupPanelApi | undefined",
+                "code": "(position: EdgeGroupPosition): undefined | DockviewGroupPanelApi",
                 "kind": "method",
                 "signature": [
                     {
@@ -34793,24 +34809,24 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewGroupPanelApi",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(position: EdgeGroupPosition): DockviewGroupPanelApi | undefined",
+                        "code": "(position: EdgeGroupPosition): undefined | DockviewGroupPanelApi",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): DockviewGroupPanel | undefined",
+                "code": "(id: string): undefined | DockviewGroupPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -34831,17 +34847,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "DockviewGroupPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): DockviewGroupPanel | undefined",
+                        "code": "(id: string): undefined | DockviewGroupPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -35364,19 +35380,19 @@
         "children": [
             {
                 "name": "activePanel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "IDockviewPanel",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -35394,7 +35410,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35406,7 +35423,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35418,7 +35436,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35441,7 +35460,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35453,7 +35473,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35465,7 +35486,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35477,7 +35499,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35509,46 +35532,48 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
+                        {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
                         {
                             "type": "reference",
                             "value": "Parameters",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "priority",
-                "code": "LayoutPriority | undefined",
+                "code": "undefined | LayoutPriority",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "LayoutPriority",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35572,7 +35597,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35584,7 +35610,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35625,7 +35652,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -35634,18 +35661,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -35654,7 +35674,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -35670,19 +35690,19 @@
         "children": [
             {
                 "name": "activePanel",
-                "code": "IDockviewPanel | undefined",
+                "code": "undefined | IDockviewPanel",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "IDockviewPanel",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -35811,7 +35831,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -35868,19 +35889,19 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "Parameters",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -35890,18 +35911,18 @@
             },
             {
                 "name": "title",
-                "code": "string | undefined",
+                "code": "undefined | string",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
                             "type": "intrinsic",
-                            "value": "string"
+                            "value": "undefined"
                         },
                         {
                             "type": "intrinsic",
-                            "value": "undefined"
+                            "value": "string"
                         }
                     ]
                 },
@@ -36091,7 +36112,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -36100,18 +36121,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -36120,7 +36134,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -36286,7 +36300,8 @@
                     "source": "typescript"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36298,7 +36313,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36348,7 +36364,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36360,7 +36377,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36372,7 +36390,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36384,7 +36403,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36396,7 +36416,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36408,12 +36429,13 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidChange",
-                "code": "Event<IViewSize | undefined>",
+                "code": "Event<undefined | IViewSize>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -36424,20 +36446,21 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IViewSize",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36450,7 +36473,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36462,7 +36486,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36695,7 +36720,8 @@
                     "source": "typescript"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36707,7 +36733,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36731,7 +36758,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36743,7 +36771,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36755,7 +36784,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36767,7 +36797,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36779,12 +36810,13 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidChange",
-                "code": "Event<IViewSize | undefined>",
+                "code": "Event<undefined | IViewSize>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -36795,20 +36827,21 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IViewSize",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36821,7 +36854,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -36833,7 +36867,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37161,7 +37196,7 @@
             },
             {
                 "name": "onDidChange",
-                "code": "Event<IViewSize | undefined>",
+                "code": "Event<undefined | IViewSize>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -37172,13 +37207,13 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IViewSize",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -37333,11 +37368,15 @@
         "children": [
             {
                 "name": "activeGroup",
-                "code": "GridviewPanel<GridviewPanelApiImpl> | undefined",
+                "code": "undefined | GridviewPanel<GridviewPanelApiImpl>",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
+                        {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
                         {
                             "type": "reference",
                             "value": "GridviewPanel",
@@ -37349,15 +37388,12 @@
                                     "source": "dockview-core"
                                 }
                             ]
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37370,7 +37406,8 @@
                     "source": "typescript"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37393,7 +37430,8 @@
                     }
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37405,7 +37443,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37417,7 +37456,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37429,7 +37469,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37441,7 +37482,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37453,7 +37495,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37465,12 +37508,13 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "onDidActiveGroupChange",
-                "code": "Event<GridviewPanel<GridviewPanelApiImpl> | undefined>",
+                "code": "Event<undefined | GridviewPanel<GridviewPanelApiImpl>>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -37480,6 +37524,10 @@
                         {
                             "type": "or",
                             "values": [
+                                {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
                                 {
                                     "type": "reference",
                                     "value": "GridviewPanel",
@@ -37491,10 +37539,6 @@
                                             "source": "dockview-core"
                                         }
                                     ]
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         }
@@ -37547,7 +37591,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37600,7 +37645,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37652,7 +37698,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -37664,26 +37711,18 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddComponentOptions<T>): IGridviewPanel<GridviewPanelApi>",
+                "code": "(options: AddComponentOptions<T>): IGridviewPanel",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "addPanel",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -37707,16 +37746,9 @@
                         "returnType": {
                             "type": "reference",
                             "value": "IGridviewPanel",
-                            "source": "dockview-core",
-                            "typeArguments": [
-                                {
-                                    "type": "reference",
-                                    "value": "GridviewPanelApi",
-                                    "source": "dockview-core"
-                                }
-                            ]
+                            "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddComponentOptions<T>): IGridviewPanel<GridviewPanelApi>",
+                        "code": "(options: AddComponentOptions<T>): IGridviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -37824,7 +37856,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): GridviewPanel<GridviewPanelApiImpl> | undefined",
+                "code": "(id: string): undefined | GridviewPanel<GridviewPanelApiImpl>",
                 "kind": "method",
                 "signature": [
                     {
@@ -37845,6 +37877,10 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "GridviewPanel",
                                     "source": "dockview-core",
@@ -37855,14 +37891,10 @@
                                             "source": "dockview-core"
                                         }
                                     ]
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): GridviewPanel<GridviewPanelApiImpl> | undefined",
+                        "code": "(id: string): undefined | GridviewPanel<GridviewPanelApiImpl>",
                         "kind": "callSignature"
                     }
                 ]
@@ -37887,7 +37919,7 @@
             },
             {
                 "name": "isMaximizedGroup",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): boolean",
+                "code": "(panel: GridviewPanel): boolean",
                 "kind": "method",
                 "signature": [
                     {
@@ -37896,18 +37928,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -37916,14 +37941,14 @@
                             "type": "intrinsic",
                             "value": "boolean"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): boolean",
+                        "code": "(panel: GridviewPanel): boolean",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "isVisible",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): boolean",
+                "code": "(panel: GridviewPanel): boolean",
                 "kind": "method",
                 "signature": [
                     {
@@ -37932,18 +37957,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -37952,7 +37970,7 @@
                             "type": "intrinsic",
                             "value": "boolean"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): boolean",
+                        "code": "(panel: GridviewPanel): boolean",
                         "kind": "callSignature"
                     }
                 ]
@@ -38005,7 +38023,7 @@
             },
             {
                 "name": "maximizeGroup",
-                "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): void",
+                "code": "(panel: GridviewPanel): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -38014,18 +38032,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: GridviewPanel<GridviewPanelApiImpl>",
+                                "code": "panel: GridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "GridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApiImpl",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -38034,14 +38045,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: GridviewPanel<GridviewPanelApiImpl>): void",
+                        "code": "(panel: GridviewPanel): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "movePanel",
-                "code": "(panel: IGridviewPanel<GridviewPanelApi>, options: { direction: Direction, reference: string, size?: number }): void",
+                "code": "(panel: IGridviewPanel, options: { direction: Direction, reference: string, size?: number }): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -38050,18 +38061,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: IGridviewPanel<GridviewPanelApi>",
+                                "code": "panel: IGridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "IGridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApi",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -38118,14 +38122,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: IGridviewPanel<GridviewPanelApi>, options: { direction: Direction, reference: string, size?: number }): void",
+                        "code": "(panel: IGridviewPanel, options: { direction: Direction, reference: string, size?: number }): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "removePanel",
-                "code": "(panel: IGridviewPanel<GridviewPanelApi>, sizing?: Sizing): void",
+                "code": "(panel: IGridviewPanel, sizing?: Sizing): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -38134,18 +38138,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: IGridviewPanel<GridviewPanelApi>",
+                                "code": "panel: IGridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "IGridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApi",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -38164,14 +38161,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: IGridviewPanel<GridviewPanelApi>, sizing?: Sizing): void",
+                        "code": "(panel: IGridviewPanel, sizing?: Sizing): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "setActive",
-                "code": "(panel: IGridviewPanel<GridviewPanelApi>): void",
+                "code": "(panel: IGridviewPanel): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -38180,18 +38177,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: IGridviewPanel<GridviewPanelApi>",
+                                "code": "panel: IGridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "IGridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApi",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -38200,14 +38190,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: IGridviewPanel<GridviewPanelApi>): void",
+                        "code": "(panel: IGridviewPanel): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "setVisible",
-                "code": "(panel: IGridviewPanel<GridviewPanelApi>, visible: boolean): void",
+                "code": "(panel: IGridviewPanel, visible: boolean): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -38216,18 +38206,11 @@
                         "parameters": [
                             {
                                 "name": "panel",
-                                "code": "panel: IGridviewPanel<GridviewPanelApi>",
+                                "code": "panel: IGridviewPanel",
                                 "type": {
                                     "type": "reference",
                                     "value": "IGridviewPanel",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "GridviewPanelApi",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             },
@@ -38245,7 +38228,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: IGridviewPanel<GridviewPanelApi>, visible: boolean): void",
+                        "code": "(panel: IGridviewPanel, visible: boolean): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -38325,7 +38308,8 @@
                     "refersToTypeParameter": true
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -38337,7 +38321,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -38349,7 +38334,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -38402,41 +38388,42 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
+                        {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
                         {
                             "type": "reference",
                             "value": "Parameters",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "priority",
-                "code": "LayoutPriority | undefined",
+                "code": "undefined | LayoutPriority",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "LayoutPriority",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -38465,7 +38452,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -38506,7 +38494,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -38515,18 +38503,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -38535,7 +38516,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -38544,6 +38525,100 @@
         "extends": [
             "BasePanelViewExported"
         ]
+    },
+    "IGroupDragGhostRenderer": {
+        "kind": "interface",
+        "name": "IGroupDragGhostRenderer",
+        "children": [
+            {
+                "name": "element",
+                "code": "HTMLElement",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "HTMLElement",
+                    "source": "typescript"
+                },
+                "flags": {
+                    "isReadonly": true
+                }
+            },
+            {
+                "name": "dispose",
+                "code": "(): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "dispose",
+                        "typeParameters": [],
+                        "parameters": [],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "init",
+                "code": "(params: { api: DockviewApi, group: IDockviewGroupPanel }): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "init",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "params",
+                                "code": "params: { api: DockviewApi, group: IDockviewGroupPanel }",
+                                "type": {
+                                    "type": "reflection",
+                                    "value": {
+                                        "name": "__type",
+                                        "code": "{ api: DockviewApi, group: IDockviewGroupPanel }",
+                                        "kind": "typeLiteral",
+                                        "properties": [
+                                            {
+                                                "name": "api",
+                                                "code": "DockviewApi",
+                                                "kind": "property",
+                                                "type": {
+                                                    "type": "reference",
+                                                    "value": "DockviewApi",
+                                                    "source": "dockview-core"
+                                                },
+                                                "flags": {}
+                                            },
+                                            {
+                                                "name": "group",
+                                                "code": "IDockviewGroupPanel",
+                                                "kind": "property",
+                                                "type": {
+                                                    "type": "reference",
+                                                    "value": "IDockviewGroupPanel",
+                                                    "source": "dockview-core"
+                                                },
+                                                "flags": {}
+                                            }
+                                        ]
+                                    }
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(params: { api: DockviewApi, group: IDockviewGroupPanel }): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            }
+        ],
+        "extends": []
     },
     "IGroupHeaderProps": {
         "kind": "interface",
@@ -38621,7 +38696,9 @@
                     "source": "dockview-core",
                     "refersToTypeParameter": true
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             }
         ],
         "extends": [
@@ -38641,7 +38718,9 @@
                     "value": "Parameters",
                     "source": "dockview-core"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "title",
@@ -38651,7 +38730,9 @@
                     "type": "intrinsic",
                     "value": "string"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             }
         ],
         "extends": [
@@ -38757,111 +38838,6 @@
             }
         ],
         "extends": []
-    },
-    "IPanePart": {
-        "kind": "interface",
-        "name": "IPanePart",
-        "children": [
-            {
-                "name": "element",
-                "code": "HTMLElement",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "HTMLElement",
-                    "source": "typescript"
-                },
-                "flags": {
-                    "isReadonly": true
-                }
-            },
-            {
-                "name": "dispose",
-                "code": "(): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "dispose",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "init",
-                "code": "(parameters: PanePanelComponentInitParameter): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "init",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "parameters",
-                                "code": "parameters: PanePanelComponentInitParameter",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "PanePanelComponentInitParameter",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(parameters: PanePanelComponentInitParameter): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "update",
-                "code": "(params: PanelUpdateEvent<Parameters>): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "update",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "params",
-                                "code": "params: PanelUpdateEvent<Parameters>",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(params: PanelUpdateEvent<Parameters>): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            }
-        ],
-        "extends": [
-            "IDisposable"
-        ]
     },
     "IPanel": {
         "kind": "interface",
@@ -39087,6 +39063,104 @@
         ],
         "extends": []
     },
+    "IPanePart": {
+        "kind": "interface",
+        "name": "IPanePart",
+        "children": [
+            {
+                "name": "element",
+                "code": "HTMLElement",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "HTMLElement",
+                    "source": "typescript"
+                },
+                "flags": {
+                    "isReadonly": true
+                }
+            },
+            {
+                "name": "dispose",
+                "code": "(): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "dispose",
+                        "typeParameters": [],
+                        "parameters": [],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "init",
+                "code": "(parameters: PanePanelComponentInitParameter): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "init",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "parameters",
+                                "code": "parameters: PanePanelComponentInitParameter",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "PanePanelComponentInitParameter",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(parameters: PanePanelComponentInitParameter): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "update",
+                "code": "(params: PanelUpdateEvent): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "update",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "params",
+                                "code": "params: PanelUpdateEvent",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "PanelUpdateEvent",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(params: PanelUpdateEvent): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            }
+        ],
+        "extends": [
+            "IDisposable"
+        ]
+    },
     "IPaneview": {
         "kind": "interface",
         "name": "IPaneview",
@@ -39111,7 +39185,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -39122,7 +39197,9 @@
                     "type": "intrinsic",
                     "value": "number"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "minimumSize",
@@ -39132,7 +39209,9 @@
                     "type": "intrinsic",
                     "value": "number"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "onDidChange",
@@ -39180,7 +39259,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -39210,7 +39290,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -39222,7 +39303,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -39526,21 +39608,12 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
+                "code": "(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "addPanel",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -39566,7 +39639,7 @@
                             "value": "IPaneviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
+                        "code": "(options: AddPaneviewComponentOptions<T>): IPaneviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -39656,7 +39729,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): IPaneviewPanel | undefined",
+                "code": "(id: string): undefined | IPaneviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -39677,17 +39750,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "IPaneviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): IPaneviewPanel | undefined",
+                        "code": "(id: string): undefined | IPaneviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -39907,7 +39980,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -39929,7 +40003,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -39941,7 +40016,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -39994,24 +40070,25 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "Parameters",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -40023,7 +40100,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -40110,7 +40188,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -40119,18 +40197,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -40139,7 +40210,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -40237,75 +40308,6 @@
                 "flags": {
                     "isOptional": true
                 }
-            }
-        ],
-        "extends": []
-    },
-    "ISplitViewDescriptor": {
-        "kind": "interface",
-        "name": "ISplitViewDescriptor",
-        "children": [
-            {
-                "name": "size",
-                "code": "number",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "number"
-                },
-                "flags": {}
-            },
-            {
-                "name": "views",
-                "code": "{ size: number, view: IView, visible?: boolean }[]",
-                "kind": "property",
-                "type": {
-                    "type": "array",
-                    "value": {
-                        "type": "reflection",
-                        "value": {
-                            "name": "__type",
-                            "code": "{ size: number, view: IView, visible?: boolean }",
-                            "kind": "typeLiteral",
-                            "properties": [
-                                {
-                                    "name": "size",
-                                    "code": "number",
-                                    "kind": "property",
-                                    "type": {
-                                        "type": "intrinsic",
-                                        "value": "number"
-                                    },
-                                    "flags": {}
-                                },
-                                {
-                                    "name": "view",
-                                    "code": "IView",
-                                    "kind": "property",
-                                    "type": {
-                                        "type": "reference",
-                                        "value": "IView",
-                                        "source": "dockview-core"
-                                    },
-                                    "flags": {}
-                                },
-                                {
-                                    "name": "visible",
-                                    "code": "boolean",
-                                    "kind": "property",
-                                    "type": {
-                                        "type": "intrinsic",
-                                        "value": "boolean"
-                                    },
-                                    "flags": {
-                                        "isOptional": true
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                },
-                "flags": {}
             }
         ],
         "extends": []
@@ -40481,21 +40483,12 @@
             },
             {
                 "name": "addPanel",
-                "code": "<T extends object = Parameters>(options: AddSplitviewComponentOptions<T>): ISplitviewPanel",
+                "code": "(options: AddSplitviewComponentOptions<T>): ISplitviewPanel",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "addPanel",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "intrinsic",
-                                    "value": "object"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [
                             {
                                 "name": "options",
@@ -40521,7 +40514,7 @@
                             "value": "ISplitviewPanel",
                             "source": "dockview-core"
                         },
-                        "code": "<T extends object = Parameters>(options: AddSplitviewComponentOptions<T>): ISplitviewPanel",
+                        "code": "(options: AddSplitviewComponentOptions<T>): ISplitviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -40611,7 +40604,7 @@
             },
             {
                 "name": "getPanel",
-                "code": "(id: string): ISplitviewPanel | undefined",
+                "code": "(id: string): undefined | ISplitviewPanel",
                 "kind": "method",
                 "signature": [
                     {
@@ -40632,17 +40625,17 @@
                             "type": "or",
                             "values": [
                                 {
+                                    "type": "intrinsic",
+                                    "value": "undefined"
+                                },
+                                {
                                     "type": "reference",
                                     "value": "ISplitviewPanel",
                                     "source": "dockview-core"
-                                },
-                                {
-                                    "type": "intrinsic",
-                                    "value": "undefined"
                                 }
                             ]
                         },
-                        "code": "(id: string): ISplitviewPanel | undefined",
+                        "code": "(id: string): undefined | ISplitviewPanel",
                         "kind": "callSignature"
                     }
                 ]
@@ -40858,6 +40851,75 @@
             "IDisposable"
         ]
     },
+    "ISplitViewDescriptor": {
+        "kind": "interface",
+        "name": "ISplitViewDescriptor",
+        "children": [
+            {
+                "name": "size",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {}
+            },
+            {
+                "name": "views",
+                "code": "{ size: number, view: IView, visible?: boolean }[]",
+                "kind": "property",
+                "type": {
+                    "type": "array",
+                    "value": {
+                        "type": "reflection",
+                        "value": {
+                            "name": "__type",
+                            "code": "{ size: number, view: IView, visible?: boolean }",
+                            "kind": "typeLiteral",
+                            "properties": [
+                                {
+                                    "name": "size",
+                                    "code": "number",
+                                    "kind": "property",
+                                    "type": {
+                                        "type": "intrinsic",
+                                        "value": "number"
+                                    },
+                                    "flags": {}
+                                },
+                                {
+                                    "name": "view",
+                                    "code": "IView",
+                                    "kind": "property",
+                                    "type": {
+                                        "type": "reference",
+                                        "value": "IView",
+                                        "source": "dockview-core"
+                                    },
+                                    "flags": {}
+                                },
+                                {
+                                    "name": "visible",
+                                    "code": "boolean",
+                                    "kind": "property",
+                                    "type": {
+                                        "type": "intrinsic",
+                                        "value": "boolean"
+                                    },
+                                    "flags": {
+                                        "isOptional": true
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "flags": {}
+            }
+        ],
+        "extends": []
+    },
     "ISplitviewPanel": {
         "kind": "interface",
         "name": "ISplitviewPanel",
@@ -40872,7 +40934,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -40884,7 +40947,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -40896,7 +40960,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -40938,41 +41003,42 @@
             },
             {
                 "name": "params",
-                "code": "Parameters | undefined",
+                "code": "undefined | Parameters",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
+                        {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
                         {
                             "type": "reference",
                             "value": "Parameters",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
                 "name": "priority",
-                "code": "LayoutPriority | undefined",
+                "code": "undefined | LayoutPriority",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
+                        {
                             "type": "reference",
                             "value": "LayoutPriority",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -41001,7 +41067,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -41042,7 +41109,7 @@
             },
             {
                 "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "code": "(event: PanelUpdateEvent): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -41051,18 +41118,11 @@
                         "parameters": [
                             {
                                 "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
+                                "code": "event: PanelUpdateEvent",
                                 "type": {
                                     "type": "reference",
                                     "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
+                                    "source": "dockview-core"
                                 },
                                 "kind": "parameter"
                             }
@@ -41071,7 +41131,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "code": "(event: PanelUpdateEvent): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -41116,18 +41176,18 @@
             },
             {
                 "name": "color",
-                "code": "string | undefined",
+                "code": "undefined | string",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
                             "type": "intrinsic",
-                            "value": "string"
+                            "value": "undefined"
                         },
                         {
                             "type": "intrinsic",
-                            "value": "undefined"
+                            "value": "string"
                         }
                     ]
                 },
@@ -41137,11 +41197,15 @@
             },
             {
                 "name": "componentParams",
-                "code": "Record<string, unknown> | undefined",
+                "code": "undefined | Record<string, unknown>",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
+                        {
+                            "type": "intrinsic",
+                            "value": "undefined"
+                        },
                         {
                             "type": "reference",
                             "value": "Record",
@@ -41156,10 +41220,6 @@
                                     "value": "unknown"
                                 }
                             ]
-                        },
-                        {
-                            "type": "intrinsic",
-                            "value": "undefined"
                         }
                     ]
                 },
@@ -41522,7 +41582,7 @@
             },
             {
                 "name": "setColor",
-                "code": "(value: string | undefined): void",
+                "code": "(value: undefined | string): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -41531,17 +41591,17 @@
                         "parameters": [
                             {
                                 "name": "value",
-                                "code": "value: string | undefined",
+                                "code": "value: undefined | string",
                                 "type": {
                                     "type": "or",
                                     "values": [
                                         {
                                             "type": "intrinsic",
-                                            "value": "string"
+                                            "value": "undefined"
                                         },
                                         {
                                             "type": "intrinsic",
-                                            "value": "undefined"
+                                            "value": "string"
                                         }
                                     ]
                                 },
@@ -41552,14 +41612,14 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(value: string | undefined): void",
+                        "code": "(value: undefined | string): void",
                         "kind": "callSignature"
                     }
                 ]
             },
             {
                 "name": "setComponentParams",
-                "code": "(value: Record<string, unknown> | undefined): void",
+                "code": "(value: undefined | Record<string, unknown>): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -41568,10 +41628,14 @@
                         "parameters": [
                             {
                                 "name": "value",
-                                "code": "value: Record<string, unknown> | undefined",
+                                "code": "value: undefined | Record<string, unknown>",
                                 "type": {
                                     "type": "or",
                                     "values": [
+                                        {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
                                         {
                                             "type": "reference",
                                             "value": "Record",
@@ -41586,10 +41650,6 @@
                                                     "value": "unknown"
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
@@ -41600,7 +41660,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(value: Record<string, unknown> | undefined): void",
+                        "code": "(value: undefined | Record<string, unknown>): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -41634,6 +41694,24 @@
                 ]
             },
             {
+                "name": "toggle",
+                "code": "(): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "toggle",
+                        "typeParameters": [],
+                        "parameters": [],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
                 "name": "toJSON",
                 "code": "(): SerializedTabGroup",
                 "kind": "method",
@@ -41648,24 +41726,6 @@
                             "source": "dockview-core"
                         },
                         "code": "(): SerializedTabGroup",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "toggle",
-                "code": "(): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "toggle",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -41817,6 +41877,36 @@
         "name": "ITabRenderer",
         "children": [
             {
+                "name": "dispose",
+                "code": "(): void",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(): void",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(): void",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
                 "name": "element",
                 "code": "HTMLElement",
                 "kind": "property",
@@ -41830,40 +41920,161 @@
                 }
             },
             {
-                "name": "dispose",
-                "code": "(): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "dispose",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
                 "name": "focus",
                 "code": "(): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "focus",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
                         "code": "(): void",
-                        "kind": "callSignature"
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(): void",
+                                "kind": "callSignature"
+                            }
+                        ]
                     }
-                ]
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "layout",
+                "code": "(width: number, height: number): void",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(width: number, height: number): void",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [
+                                    {
+                                        "name": "width",
+                                        "code": "width: number",
+                                        "type": {
+                                            "type": "intrinsic",
+                                            "value": "number"
+                                        },
+                                        "kind": "parameter"
+                                    },
+                                    {
+                                        "name": "height",
+                                        "code": "height: number",
+                                        "type": {
+                                            "type": "intrinsic",
+                                            "value": "number"
+                                        },
+                                        "kind": "parameter"
+                                    }
+                                ],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(width: number, height: number): void",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "toJSON",
+                "code": "(): object",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(): object",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "object"
+                                },
+                                "code": "(): object",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "update",
+                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(event: PanelUpdateEvent<Parameters>): void",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [
+                                    {
+                                        "name": "event",
+                                        "code": "event: PanelUpdateEvent<Parameters>",
+                                        "type": {
+                                            "type": "reference",
+                                            "value": "PanelUpdateEvent",
+                                            "source": "dockview-core",
+                                            "typeArguments": [
+                                                {
+                                                    "type": "reference",
+                                                    "value": "Parameters",
+                                                    "source": "dockview-core"
+                                                }
+                                            ]
+                                        },
+                                        "kind": "parameter"
+                                    }
+                                ],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
             },
             {
                 "name": "init",
@@ -41890,97 +42101,6 @@
                             "value": "void"
                         },
                         "code": "(parameters: TabPartInitParameters): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "layout",
-                "code": "(width: number, height: number): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "layout",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "width",
-                                "code": "width: number",
-                                "type": {
-                                    "type": "intrinsic",
-                                    "value": "number"
-                                },
-                                "kind": "parameter"
-                            },
-                            {
-                                "name": "height",
-                                "code": "height: number",
-                                "type": {
-                                    "type": "intrinsic",
-                                    "value": "number"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(width: number, height: number): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "toJSON",
-                "code": "(): object",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "toJSON",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "object"
-                        },
-                        "code": "(): object",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "update",
-                "code": "(event: PanelUpdateEvent<Parameters>): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "update",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(event: PanelUpdateEvent<Parameters>): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -42025,7 +42145,9 @@
                     "type": "intrinsic",
                     "value": "number"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "minimumSize",
@@ -42035,7 +42157,9 @@
                     "type": "intrinsic",
                     "value": "number"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "onDidChange",
@@ -42096,7 +42220,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -42108,7 +42233,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -42205,13 +42331,13 @@
         "children": [
             {
                 "name": "fromJSON",
-                "code": "(data: ISerializedLeafNode<any>): IGridView",
+                "code": "(data: ISerializedLeafNode): IGridView",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(data: ISerializedLeafNode<any>): IGridView",
+                        "code": "(data: ISerializedLeafNode): IGridView",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -42220,17 +42346,11 @@
                                 "parameters": [
                                     {
                                         "name": "data",
-                                        "code": "data: ISerializedLeafNode<any>",
+                                        "code": "data: ISerializedLeafNode",
                                         "type": {
                                             "type": "reference",
                                             "value": "ISerializedLeafNode",
-                                            "source": "dockview-core",
-                                            "typeArguments": [
-                                                {
-                                                    "type": "intrinsic",
-                                                    "value": "any"
-                                                }
-                                            ]
+                                            "source": "dockview-core"
                                         },
                                         "kind": "parameter"
                                     }
@@ -42240,7 +42360,7 @@
                                     "value": "IGridView",
                                     "source": "dockview-core"
                                 },
-                                "code": "(data: ISerializedLeafNode<any>): IGridView",
+                                "code": "(data: ISerializedLeafNode): IGridView",
                                 "kind": "callSignature"
                             }
                         ]
@@ -42318,6 +42438,36 @@
         "name": "IWatermarkRenderer",
         "children": [
             {
+                "name": "dispose",
+                "code": "(): void",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(): void",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(): void",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
                 "name": "element",
                 "code": "HTMLElement",
                 "kind": "property",
@@ -42328,6 +42478,36 @@
                 },
                 "flags": {
                     "isReadonly": true
+                }
+            },
+            {
+                "name": "focus",
+                "code": "(): void",
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(): void",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(): void",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -42369,131 +42549,131 @@
                 "flags": {}
             },
             {
-                "name": "dispose",
-                "code": "(): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "dispose",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "focus",
-                "code": "(): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "focus",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
                 "name": "layout",
                 "code": "(width: number, height: number): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "layout",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "width",
-                                "code": "width: number",
-                                "type": {
-                                    "type": "intrinsic",
-                                    "value": "number"
-                                },
-                                "kind": "parameter"
-                            },
-                            {
-                                "name": "height",
-                                "code": "height: number",
-                                "type": {
-                                    "type": "intrinsic",
-                                    "value": "number"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
                         "code": "(width: number, height: number): void",
-                        "kind": "callSignature"
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [
+                                    {
+                                        "name": "width",
+                                        "code": "width: number",
+                                        "type": {
+                                            "type": "intrinsic",
+                                            "value": "number"
+                                        },
+                                        "kind": "parameter"
+                                    },
+                                    {
+                                        "name": "height",
+                                        "code": "height: number",
+                                        "type": {
+                                            "type": "intrinsic",
+                                            "value": "number"
+                                        },
+                                        "kind": "parameter"
+                                    }
+                                ],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(width: number, height: number): void",
+                                "kind": "callSignature"
+                            }
+                        ]
                     }
-                ]
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
             },
             {
                 "name": "toJSON",
                 "code": "(): object",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "toJSON",
-                        "typeParameters": [],
-                        "parameters": [],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "object"
-                        },
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
                         "code": "(): object",
-                        "kind": "callSignature"
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "object"
+                                },
+                                "code": "(): object",
+                                "kind": "callSignature"
+                            }
+                        ]
                     }
-                ]
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
             },
             {
                 "name": "update",
                 "code": "(event: PanelUpdateEvent<Parameters>): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "update",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "event",
-                                "code": "event: PanelUpdateEvent<Parameters>",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "PanelUpdateEvent",
-                                    "source": "dockview-core",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "Parameters",
-                                            "source": "dockview-core"
-                                        }
-                                    ]
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
+                "kind": "property",
+                "type": {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
                         "code": "(event: PanelUpdateEvent<Parameters>): void",
-                        "kind": "callSignature"
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [
+                                    {
+                                        "name": "event",
+                                        "code": "event: PanelUpdateEvent<Parameters>",
+                                        "type": {
+                                            "type": "reference",
+                                            "value": "PanelUpdateEvent",
+                                            "source": "dockview-core",
+                                            "typeArguments": [
+                                                {
+                                                    "type": "reference",
+                                                    "value": "Parameters",
+                                                    "source": "dockview-core"
+                                                }
+                                            ]
+                                        },
+                                        "kind": "parameter"
+                                    }
+                                ],
+                                "returnType": {
+                                    "type": "intrinsic",
+                                    "value": "void"
+                                },
+                                "code": "(event: PanelUpdateEvent<Parameters>): void",
+                                "kind": "callSignature"
+                            }
+                        ]
                     }
-                ]
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
             }
         ],
         "extends": [
@@ -42557,35 +42737,6 @@
         ],
         "extends": []
     },
-    "MovePanelEvent": {
-        "kind": "interface",
-        "name": "MovePanelEvent",
-        "children": [
-            {
-                "name": "from",
-                "code": "DockviewGroupPanel",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "DockviewGroupPanel",
-                    "source": "dockview-core"
-                },
-                "flags": {}
-            },
-            {
-                "name": "panel",
-                "code": "IDockviewPanel",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "IDockviewPanel",
-                    "source": "dockview-core"
-                },
-                "flags": {}
-            }
-        ],
-        "extends": []
-    },
     "MovementOptions": {
         "kind": "interface",
         "name": "MovementOptions",
@@ -42640,261 +42791,34 @@
         ],
         "extends": []
     },
-    "PanePanelComponentInitParameter": {
+    "MovePanelEvent": {
         "kind": "interface",
-        "name": "PanePanelComponentInitParameter",
+        "name": "MovePanelEvent",
         "children": [
             {
-                "name": "accessor",
-                "code": "PaneviewComponent",
+                "name": "from",
+                "code": "DockviewGroupPanel",
                 "kind": "property",
                 "type": {
                     "type": "reference",
-                    "value": "PaneviewComponent",
+                    "value": "DockviewGroupPanel",
                     "source": "dockview-core"
                 },
                 "flags": {}
             },
             {
-                "name": "api",
-                "code": "PaneviewPanelApiImpl",
+                "name": "panel",
+                "code": "IDockviewPanel",
                 "kind": "property",
                 "type": {
                     "type": "reference",
-                    "value": "PaneviewPanelApiImpl",
+                    "value": "IDockviewPanel",
                     "source": "dockview-core"
-                },
-                "flags": {}
-            },
-            {
-                "name": "containerApi",
-                "code": "PaneviewApi",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "PaneviewApi",
-                    "source": "dockview-core"
-                },
-                "flags": {}
-            },
-            {
-                "name": "isExpanded",
-                "code": "boolean",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "boolean"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "maximumBodySize",
-                "code": "number",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "number"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "minimumBodySize",
-                "code": "number",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "number"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "params",
-                "code": "Parameters",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Parameters",
-                    "source": "dockview-core"
-                },
-                "flags": {}
-            },
-            {
-                "name": "title",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
                 },
                 "flags": {}
             }
         ],
-        "extends": [
-            "PanePanelInitParameter"
-        ]
-    },
-    "PanePanelInitParameter": {
-        "kind": "interface",
-        "name": "PanePanelInitParameter",
-        "children": [
-            {
-                "name": "accessor",
-                "code": "PaneviewComponent",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "PaneviewComponent",
-                    "source": "dockview-core"
-                },
-                "flags": {}
-            },
-            {
-                "name": "containerApi",
-                "code": "PaneviewApi",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "PaneviewApi",
-                    "source": "dockview-core"
-                },
-                "flags": {}
-            },
-            {
-                "name": "isExpanded",
-                "code": "boolean",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "boolean"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "maximumBodySize",
-                "code": "number",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "number"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "minimumBodySize",
-                "code": "number",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "number"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "params",
-                "code": "Parameters",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Parameters",
-                    "source": "dockview-core"
-                },
-                "flags": {}
-            },
-            {
-                "name": "title",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {}
-            }
-        ],
-        "extends": [
-            "PanelInitParameters"
-        ]
-    },
-    "PanePanelViewState": {
-        "kind": "interface",
-        "name": "PanePanelViewState",
-        "children": [
-            {
-                "name": "component",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isReadonly": true
-                }
-            },
-            {
-                "name": "headerComponent",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "id",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isReadonly": true
-                }
-            },
-            {
-                "name": "params",
-                "code": "Parameters",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Parameters",
-                    "source": "dockview-core"
-                },
-                "flags": {
-                    "isOptional": true,
-                    "isReadonly": true
-                }
-            },
-            {
-                "name": "title",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {}
-            }
-        ],
-        "extends": [
-            "BasePanelViewState"
-        ]
+        "extends": []
     },
     "PanelApi": {
         "kind": "interface",
@@ -43162,22 +43086,12 @@
             },
             {
                 "name": "getParameters",
-                "code": "<T extends Parameters = Parameters>(): T",
+                "code": "(): T",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "getParameters",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "reference",
-                                    "value": "Parameters",
-                                    "source": "dockview-core"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [],
                         "returnType": {
                             "type": "reference",
@@ -43185,7 +43099,7 @@
                             "source": "dockview-core",
                             "refersToTypeParameter": true
                         },
-                        "code": "<T extends Parameters = Parameters>(): T",
+                        "code": "(): T",
                         "kind": "callSignature"
                     }
                 ]
@@ -43599,7 +43513,9 @@
                     "value": "Parameters",
                     "source": "dockview-core"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "priority",
@@ -43631,19 +43547,291 @@
             "PanelInitParameters"
         ]
     },
+    "PanePanelComponentInitParameter": {
+        "kind": "interface",
+        "name": "PanePanelComponentInitParameter",
+        "children": [
+            {
+                "name": "accessor",
+                "code": "PaneviewComponent",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "PaneviewComponent",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "api",
+                "code": "PaneviewPanelApiImpl",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "PaneviewPanelApiImpl",
+                    "source": "dockview-core"
+                },
+                "flags": {}
+            },
+            {
+                "name": "containerApi",
+                "code": "PaneviewApi",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "PaneviewApi",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "isExpanded",
+                "code": "boolean",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "boolean"
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "maximumBodySize",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "minimumBodySize",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "params",
+                "code": "Parameters",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "Parameters",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "title",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {
+                    "isInherited": true
+                }
+            }
+        ],
+        "extends": [
+            "PanePanelInitParameter"
+        ]
+    },
+    "PanePanelInitParameter": {
+        "kind": "interface",
+        "name": "PanePanelInitParameter",
+        "children": [
+            {
+                "name": "accessor",
+                "code": "PaneviewComponent",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "PaneviewComponent",
+                    "source": "dockview-core"
+                },
+                "flags": {}
+            },
+            {
+                "name": "containerApi",
+                "code": "PaneviewApi",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "PaneviewApi",
+                    "source": "dockview-core"
+                },
+                "flags": {}
+            },
+            {
+                "name": "isExpanded",
+                "code": "boolean",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "boolean"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
+                "name": "maximumBodySize",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
+                "name": "minimumBodySize",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
+                "name": "params",
+                "code": "Parameters",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "Parameters",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "title",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {}
+            }
+        ],
+        "extends": [
+            "PanelInitParameters"
+        ]
+    },
+    "PanePanelViewState": {
+        "kind": "interface",
+        "name": "PanePanelViewState",
+        "children": [
+            {
+                "name": "component",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {
+                    "isReadonly": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "headerComponent",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
+                "name": "id",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {
+                    "isReadonly": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "params",
+                "code": "Parameters",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "Parameters",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isReadonly": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "title",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {}
+            }
+        ],
+        "extends": [
+            "BasePanelViewState"
+        ]
+    },
     "PaneviewDndOverlayEvent": {
         "kind": "interface",
         "name": "PaneviewDndOverlayEvent",
         "children": [
             {
                 "name": "getData",
-                "code": "(): PaneTransfer | undefined",
+                "code": "(): undefined | PaneTransfer",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(): PaneTransfer | undefined",
+                        "code": "(): undefined | PaneTransfer",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -43654,17 +43842,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "PaneTransfer",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(): PaneTransfer | undefined",
+                                "code": "(): undefined | PaneTransfer",
                                 "kind": "callSignature"
                             }
                         ]
@@ -43681,7 +43869,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -43757,13 +43946,13 @@
             },
             {
                 "name": "getData",
-                "code": "(): PaneTransfer | undefined",
+                "code": "(): undefined | PaneTransfer",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(): PaneTransfer | undefined",
+                        "code": "(): undefined | PaneTransfer",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -43774,17 +43963,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "PaneTransfer",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(): PaneTransfer | undefined",
+                                "code": "(): undefined | PaneTransfer",
                                 "kind": "callSignature"
                             }
                         ]
@@ -43802,7 +43991,8 @@
                     "source": "typescript"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -43826,7 +44016,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             }
         ],
@@ -43879,13 +44070,13 @@
             },
             {
                 "name": "createHeaderComponent",
-                "code": "(options: CreateComponentOptions): IPanePart | undefined",
+                "code": "(options: CreateComponentOptions): undefined | IPanePart",
                 "kind": "property",
                 "type": {
                     "type": "reflection",
                     "value": {
                         "name": "__type",
-                        "code": "(options: CreateComponentOptions): IPanePart | undefined",
+                        "code": "(options: CreateComponentOptions): undefined | IPanePart",
                         "kind": "typeLiteral",
                         "signatures": [
                             {
@@ -43907,17 +44098,17 @@
                                     "type": "or",
                                     "values": [
                                         {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
                                             "type": "reference",
                                             "value": "IPanePart",
                                             "source": "dockview-core"
-                                        },
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "undefined"
                                         }
                                     ]
                                 },
-                                "code": "(options: CreateComponentOptions): IPanePart | undefined",
+                                "code": "(options: CreateComponentOptions): undefined | IPanePart",
                                 "kind": "callSignature"
                             }
                         ]
@@ -43986,7 +44177,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -44006,7 +44198,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -44026,7 +44219,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -44046,7 +44240,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -44078,7 +44273,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -44098,7 +44294,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -44126,7 +44323,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -44146,7 +44344,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -44166,7 +44365,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -44206,7 +44406,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -44226,7 +44427,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -44246,7 +44448,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -44306,7 +44509,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -44318,7 +44522,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -44331,22 +44536,12 @@
             },
             {
                 "name": "getParameters",
-                "code": "<T extends Parameters = Parameters>(): T",
+                "code": "(): T",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "getParameters",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "reference",
-                                    "value": "Parameters",
-                                    "source": "dockview-core"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [],
                         "returnType": {
                             "type": "reference",
@@ -44354,7 +44549,7 @@
                             "source": "dockview-core",
                             "refersToTypeParameter": true
                         },
-                        "code": "<T extends Parameters = Parameters>(): T",
+                        "code": "(): T",
                         "kind": "callSignature"
                     }
                 ]
@@ -45503,19 +45698,19 @@
             },
             {
                 "name": "position",
-                "code": "Box | 'null'",
+                "code": "'null' | Box",
                 "kind": "property",
                 "type": {
                     "type": "or",
                     "values": [
                         {
+                            "type": "literal",
+                            "value": null
+                        },
+                        {
                             "type": "reference",
                             "value": "Box",
                             "source": "dockview-core"
-                        },
-                        {
-                            "type": "literal",
-                            "value": null
                         }
                     ]
                 },
@@ -45830,76 +46025,6 @@
         ],
         "extends": []
     },
-    "SplitViewOptions": {
-        "kind": "interface",
-        "name": "SplitViewOptions",
-        "children": [
-            {
-                "name": "descriptor",
-                "code": "ISplitViewDescriptor",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "ISplitViewDescriptor",
-                    "source": "dockview-core"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "margin",
-                "code": "number",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "number"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "orientation",
-                "code": "Orientation",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Orientation",
-                    "source": "dockview-core"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "proportionalLayout",
-                "code": "boolean",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "boolean"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "styles",
-                "code": "ISplitviewStyles",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "ISplitviewStyles",
-                    "source": "dockview-core"
-                },
-                "flags": {
-                    "isOptional": true
-                }
-            }
-        ],
-        "extends": []
-    },
     "SplitviewFrameworkOptions": {
         "kind": "interface",
         "name": "SplitviewFrameworkOptions",
@@ -45972,7 +46097,8 @@
                     "source": "dockview-core"
                 },
                 "flags": {
-                    "isOptional": true
+                    "isOptional": true,
+                    "isInherited": true
                 }
             },
             {
@@ -45982,6 +46108,82 @@
                 "type": {
                     "type": "intrinsic",
                     "value": "boolean"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
+                "name": "margin",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "orientation",
+                "code": "Orientation",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "Orientation",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "proportionalLayout",
+                "code": "boolean",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "boolean"
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            },
+            {
+                "name": "styles",
+                "code": "ISplitviewStyles",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "ISplitviewStyles",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isOptional": true,
+                    "isInherited": true
+                }
+            }
+        ],
+        "extends": [
+            "SplitViewOptions"
+        ]
+    },
+    "SplitViewOptions": {
+        "kind": "interface",
+        "name": "SplitViewOptions",
+        "children": [
+            {
+                "name": "descriptor",
+                "code": "ISplitViewDescriptor",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "ISplitViewDescriptor",
+                    "source": "dockview-core"
                 },
                 "flags": {
                     "isOptional": true
@@ -46038,9 +46240,7 @@
                 }
             }
         ],
-        "extends": [
-            "SplitViewOptions"
-        ]
+        "extends": []
     },
     "SplitviewPanelApi": {
         "kind": "interface",
@@ -46055,7 +46255,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -46075,7 +46276,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -46095,7 +46297,8 @@
                     "value": "string"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -46115,7 +46318,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -46135,7 +46339,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -46155,7 +46360,8 @@
                     "value": "boolean"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -46183,7 +46389,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -46223,7 +46430,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -46243,7 +46451,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -46263,7 +46472,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -46283,7 +46493,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -46303,7 +46514,8 @@
                     ]
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 }
             },
             {
@@ -46315,7 +46527,8 @@
                     "value": "number"
                 },
                 "flags": {
-                    "isReadonly": true
+                    "isReadonly": true,
+                    "isInherited": true
                 },
                 "comment": {
                     "summary": [
@@ -46328,22 +46541,12 @@
             },
             {
                 "name": "getParameters",
-                "code": "<T extends Parameters = Parameters>(): T",
+                "code": "(): T",
                 "kind": "method",
                 "signature": [
                     {
                         "name": "getParameters",
-                        "typeParameters": [
-                            {
-                                "name": "T",
-                                "extends": {
-                                    "type": "reference",
-                                    "value": "Parameters",
-                                    "source": "dockview-core"
-                                },
-                                "default": "Parameters"
-                            }
-                        ],
+                        "typeParameters": [],
                         "parameters": [],
                         "returnType": {
                             "type": "reference",
@@ -46351,7 +46554,7 @@
                             "source": "dockview-core",
                             "refersToTypeParameter": true
                         },
-                        "code": "<T extends Parameters = Parameters>(): T",
+                        "code": "(): T",
                         "kind": "callSignature"
                     }
                 ]
@@ -46646,7 +46849,9 @@
                     "value": "DockviewPanelApi",
                     "source": "dockview-core"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "containerApi",
@@ -46657,7 +46862,9 @@
                     "value": "DockviewApi",
                     "source": "dockview-core"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "params",
@@ -46668,7 +46875,9 @@
                     "value": "Parameters",
                     "source": "dockview-core"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "tabLocation",
@@ -46689,7 +46898,9 @@
                     "type": "intrinsic",
                     "value": "string"
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             }
         ],
         "extends": [
@@ -47135,6 +47346,62 @@
         },
         "kind": "typeAlias"
     },
+    "CspNonceProvider": {
+        "name": "CspNonceProvider",
+        "code": "(targetDocument: Document): undefined | string | string",
+        "typeParameters": [],
+        "type": {
+            "type": "or",
+            "values": [
+                {
+                    "type": "reflection",
+                    "value": {
+                        "name": "__type",
+                        "code": "(targetDocument: Document): undefined | string",
+                        "kind": "typeLiteral",
+                        "signatures": [
+                            {
+                                "name": "__type",
+                                "typeParameters": [],
+                                "parameters": [
+                                    {
+                                        "name": "targetDocument",
+                                        "code": "targetDocument: Document",
+                                        "type": {
+                                            "type": "reference",
+                                            "value": "Document",
+                                            "source": "typescript"
+                                        },
+                                        "kind": "parameter"
+                                    }
+                                ],
+                                "returnType": {
+                                    "type": "or",
+                                    "values": [
+                                        {
+                                            "type": "intrinsic",
+                                            "value": "undefined"
+                                        },
+                                        {
+                                            "type": "intrinsic",
+                                            "value": "string"
+                                        }
+                                    ]
+                                },
+                                "code": "(targetDocument: Document): undefined | string",
+                                "kind": "callSignature"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "intrinsic",
+                    "value": "string"
+                }
+            ]
+        },
+        "kind": "typeAlias"
+    },
     "Direction": {
         "name": "Direction",
         "comment": {
@@ -47175,30 +47442,21 @@
         "kind": "typeAlias"
     },
     "DistributeSizing": {
+        "kind": "typeAlias",
         "name": "DistributeSizing",
-        "code": "{ type: 'distribute' }",
-        "typeParameters": [],
-        "type": {
-            "type": "reflection",
-            "value": {
-                "name": "__type",
-                "code": "{ type: 'distribute' }",
-                "kind": "typeLiteral",
-                "properties": [
-                    {
-                        "name": "type",
-                        "code": "'distribute'",
-                        "kind": "property",
-                        "type": {
-                            "type": "literal",
-                            "value": "distribute"
-                        },
-                        "flags": {}
-                    }
-                ]
+        "children": [
+            {
+                "name": "type",
+                "code": "'distribute'",
+                "kind": "property",
+                "type": {
+                    "type": "literal",
+                    "value": "distribute"
+                },
+                "flags": {}
             }
-        },
-        "kind": "typeAlias"
+        ],
+        "extends": []
     },
     "DockviewComponentOptions": {
         "name": "DockviewComponentOptions",
@@ -47544,86 +47802,77 @@
         "kind": "typeAlias"
     },
     "DroptargetOverlayModel": {
+        "kind": "typeAlias",
         "name": "DroptargetOverlayModel",
-        "code": "{ activationSize?: MeasuredValue, size?: MeasuredValue, smallHeightBoundary?: number, smallWidthBoundary?: number }",
-        "typeParameters": [],
-        "type": {
-            "type": "reflection",
-            "value": {
-                "name": "__type",
-                "code": "{ activationSize?: MeasuredValue, size?: MeasuredValue, smallHeightBoundary?: number, smallWidthBoundary?: number }",
-                "kind": "typeLiteral",
-                "properties": [
-                    {
-                        "name": "activationSize",
-                        "code": "MeasuredValue",
-                        "kind": "property",
-                        "type": {
-                            "type": "reference",
-                            "value": "MeasuredValue",
-                            "source": "dockview-core"
-                        },
-                        "flags": {
-                            "isOptional": true
+        "children": [
+            {
+                "name": "activationSize",
+                "code": "MeasuredValue",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "MeasuredValue",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
+                "name": "size",
+                "code": "MeasuredValue",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "MeasuredValue",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
+                "name": "smallHeightBoundary",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {
+                    "isOptional": true
+                },
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Override the height threshold (in pixels) below which the overlay switches\nto a thin-border indicator instead of a half-height highlight. Set to 0 to\nalways show the half-height overlay regardless of element size."
                         }
-                    },
-                    {
-                        "name": "size",
-                        "code": "MeasuredValue",
-                        "kind": "property",
-                        "type": {
-                            "type": "reference",
-                            "value": "MeasuredValue",
-                            "source": "dockview-core"
-                        },
-                        "flags": {
-                            "isOptional": true
+                    ]
+                }
+            },
+            {
+                "name": "smallWidthBoundary",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {
+                    "isOptional": true
+                },
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Override the width threshold (in pixels) below which the overlay switches\nto a thin-border indicator instead of a half-width highlight. Set to 0 to\nalways show the half-width overlay regardless of element size."
                         }
-                    },
-                    {
-                        "name": "smallHeightBoundary",
-                        "code": "number",
-                        "kind": "property",
-                        "type": {
-                            "type": "intrinsic",
-                            "value": "number"
-                        },
-                        "flags": {
-                            "isOptional": true
-                        },
-                        "comment": {
-                            "summary": [
-                                {
-                                    "kind": "text",
-                                    "text": "Override the height threshold (in pixels) below which the overlay switches\nto a thin-border indicator instead of a half-height highlight. Set to 0 to\nalways show the half-height overlay regardless of element size."
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "name": "smallWidthBoundary",
-                        "code": "number",
-                        "kind": "property",
-                        "type": {
-                            "type": "intrinsic",
-                            "value": "number"
-                        },
-                        "flags": {
-                            "isOptional": true
-                        },
-                        "comment": {
-                            "summary": [
-                                {
-                                    "kind": "text",
-                                    "text": "Override the width threshold (in pixels) below which the overlay switches\nto a thin-border indicator instead of a half-width highlight. Set to 0 to\nalways show the half-width overlay regardless of element size."
-                                }
-                            ]
-                        }
-                    }
-                ]
+                    ]
+                }
             }
-        },
-        "kind": "typeAlias"
+        ],
+        "extends": []
     },
     "EdgeGroupPosition": {
         "name": "EdgeGroupPosition",
@@ -47785,6 +48034,33 @@
         },
         "kind": "typeAlias"
     },
+    "InvisibleSizing": {
+        "kind": "typeAlias",
+        "name": "InvisibleSizing",
+        "children": [
+            {
+                "name": "cachedVisibleSize",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {}
+            },
+            {
+                "name": "type",
+                "code": "'invisible'",
+                "kind": "property",
+                "type": {
+                    "type": "literal",
+                    "value": "invisible"
+                },
+                "flags": {}
+            }
+        ],
+        "extends": []
+    },
     "ISerializedNode": {
         "name": "ISerializedNode",
         "code": "ISerializedBranchNode | ISerializedLeafNode",
@@ -47806,86 +48082,41 @@
         },
         "kind": "typeAlias"
     },
-    "InvisibleSizing": {
-        "name": "InvisibleSizing",
-        "code": "{ cachedVisibleSize: number, type: 'invisible' }",
-        "typeParameters": [],
-        "type": {
-            "type": "reflection",
-            "value": {
-                "name": "__type",
-                "code": "{ cachedVisibleSize: number, type: 'invisible' }",
-                "kind": "typeLiteral",
-                "properties": [
-                    {
-                        "name": "cachedVisibleSize",
-                        "code": "number",
-                        "kind": "property",
-                        "type": {
-                            "type": "intrinsic",
-                            "value": "number"
-                        },
-                        "flags": {}
-                    },
-                    {
-                        "name": "type",
-                        "code": "'invisible'",
-                        "kind": "property",
-                        "type": {
-                            "type": "literal",
-                            "value": "invisible"
-                        },
-                        "flags": {}
-                    }
-                ]
-            }
-        },
-        "kind": "typeAlias"
-    },
     "MeasuredValue": {
+        "kind": "typeAlias",
         "name": "MeasuredValue",
-        "code": "{ type: 'percentage' | 'pixels', value: number }",
-        "typeParameters": [],
-        "type": {
-            "type": "reflection",
-            "value": {
-                "name": "__type",
-                "code": "{ type: 'percentage' | 'pixels', value: number }",
-                "kind": "typeLiteral",
-                "properties": [
-                    {
-                        "name": "type",
-                        "code": "'percentage' | 'pixels'",
-                        "kind": "property",
-                        "type": {
-                            "type": "or",
-                            "values": [
-                                {
-                                    "type": "literal",
-                                    "value": "percentage"
-                                },
-                                {
-                                    "type": "literal",
-                                    "value": "pixels"
-                                }
-                            ]
+        "children": [
+            {
+                "name": "type",
+                "code": "'percentage' | 'pixels'",
+                "kind": "property",
+                "type": {
+                    "type": "or",
+                    "values": [
+                        {
+                            "type": "literal",
+                            "value": "percentage"
                         },
-                        "flags": {}
-                    },
-                    {
-                        "name": "value",
-                        "code": "number",
-                        "kind": "property",
-                        "type": {
-                            "type": "intrinsic",
-                            "value": "number"
-                        },
-                        "flags": {}
-                    }
-                ]
+                        {
+                            "type": "literal",
+                            "value": "pixels"
+                        }
+                    ]
+                },
+                "flags": {}
+            },
+            {
+                "name": "value",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {}
             }
-        },
-        "kind": "typeAlias"
+        ],
+        "extends": []
     },
     "PaneviewComponentOptions": {
         "name": "PaneviewComponentOptions",
@@ -47940,40 +48171,31 @@
         "kind": "typeAlias"
     },
     "SplitSizing": {
+        "kind": "typeAlias",
         "name": "SplitSizing",
-        "code": "{ index: number, type: 'split' }",
-        "typeParameters": [],
-        "type": {
-            "type": "reflection",
-            "value": {
-                "name": "__type",
-                "code": "{ index: number, type: 'split' }",
-                "kind": "typeLiteral",
-                "properties": [
-                    {
-                        "name": "index",
-                        "code": "number",
-                        "kind": "property",
-                        "type": {
-                            "type": "intrinsic",
-                            "value": "number"
-                        },
-                        "flags": {}
-                    },
-                    {
-                        "name": "type",
-                        "code": "'split'",
-                        "kind": "property",
-                        "type": {
-                            "type": "literal",
-                            "value": "split"
-                        },
-                        "flags": {}
-                    }
-                ]
+        "children": [
+            {
+                "name": "index",
+                "code": "number",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "number"
+                },
+                "flags": {}
+            },
+            {
+                "name": "type",
+                "code": "'split'",
+                "kind": "property",
+                "type": {
+                    "type": "literal",
+                    "value": "split"
+                },
+                "flags": {}
             }
-        },
-        "kind": "typeAlias"
+        ],
+        "extends": []
     },
     "SplitviewComponentOptions": {
         "name": "SplitviewComponentOptions",
@@ -48132,7 +48354,7 @@
     },
     "applyTabGroupAccent": {
         "name": "applyTabGroupAccent",
-        "code": "(el: HTMLElement, color: string | undefined, palette: TabGroupColorPalette | undefined): void",
+        "code": "(el: HTMLElement, color: undefined | string, palette: undefined | TabGroupColorPalette): void",
         "signature": {
             "name": "applyTabGroupAccent",
             "comment": {
@@ -48173,17 +48395,17 @@
                 },
                 {
                     "name": "color",
-                    "code": "color: string | undefined",
+                    "code": "color: undefined | string",
                     "type": {
                         "type": "or",
                         "values": [
                             {
                                 "type": "intrinsic",
-                                "value": "string"
+                                "value": "undefined"
                             },
                             {
                                 "type": "intrinsic",
-                                "value": "undefined"
+                                "value": "string"
                             }
                         ]
                     },
@@ -48191,18 +48413,18 @@
                 },
                 {
                     "name": "palette",
-                    "code": "palette: TabGroupColorPalette | undefined",
+                    "code": "palette: undefined | TabGroupColorPalette",
                     "type": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "TabGroupColorPalette",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     },
@@ -48213,7 +48435,7 @@
                 "type": "intrinsic",
                 "value": "void"
             },
-            "code": "(el: HTMLElement, color: string | undefined, palette: TabGroupColorPalette | undefined): void",
+            "code": "(el: HTMLElement, color: undefined | string, palette: undefined | TabGroupColorPalette): void",
             "kind": "callSignature"
         },
         "kind": "function"
@@ -48637,19 +48859,10 @@
     },
     "isGridBranchNode": {
         "name": "isGridBranchNode",
-        "code": "<T extends IGridView>(node: GridNode<T>): node is GridBranchNode<T>",
+        "code": "(node: GridNode<T>): node is GridBranchNode<T>",
         "signature": {
             "name": "isGridBranchNode",
-            "typeParameters": [
-                {
-                    "name": "T",
-                    "extends": {
-                        "type": "reference",
-                        "value": "IGridView",
-                        "source": "dockview-core"
-                    }
-                }
-            ],
+            "typeParameters": [],
             "parameters": [
                 {
                     "name": "node",
@@ -48687,7 +48900,7 @@
                     ]
                 }
             },
-            "code": "<T extends IGridView>(node: GridNode<T>): node is GridBranchNode<T>",
+            "code": "(node: GridNode<T>): node is GridBranchNode<T>",
             "kind": "callSignature"
         },
         "kind": "function"
@@ -48878,7 +49091,7 @@
     },
     "resolveTabGroupAccent": {
         "name": "resolveTabGroupAccent",
-        "code": "(color: string | undefined, palette: TabGroupColorPalette | undefined): undefined | string",
+        "code": "(color: undefined | string, palette: undefined | TabGroupColorPalette): undefined | string",
         "signature": {
             "name": "resolveTabGroupAccent",
             "comment": {
@@ -48893,17 +49106,17 @@
             "parameters": [
                 {
                     "name": "color",
-                    "code": "color: string | undefined",
+                    "code": "color: undefined | string",
                     "type": {
                         "type": "or",
                         "values": [
                             {
                                 "type": "intrinsic",
-                                "value": "string"
+                                "value": "undefined"
                             },
                             {
                                 "type": "intrinsic",
-                                "value": "undefined"
+                                "value": "string"
                             }
                         ]
                     },
@@ -48911,18 +49124,18 @@
                 },
                 {
                     "name": "palette",
-                    "code": "palette: TabGroupColorPalette | undefined",
+                    "code": "palette: undefined | TabGroupColorPalette",
                     "type": {
                         "type": "or",
                         "values": [
                             {
+                                "type": "intrinsic",
+                                "value": "undefined"
+                            },
+                            {
                                 "type": "reference",
                                 "value": "TabGroupColorPalette",
                                 "source": "dockview-core"
-                            },
-                            {
-                                "type": "intrinsic",
-                                "value": "undefined"
                             }
                         ]
                     },
@@ -48942,7 +49155,7 @@
                     }
                 ]
             },
-            "code": "(color: string | undefined, palette: TabGroupColorPalette | undefined): undefined | string",
+            "code": "(color: undefined | string, palette: undefined | TabGroupColorPalette): undefined | string",
             "kind": "callSignature"
         },
         "kind": "function"
@@ -49048,6 +49261,35 @@
                 "type": {
                     "type": "reference",
                     "value": "GridviewApi",
+                    "source": "dockview-core"
+                },
+                "flags": {}
+            }
+        ],
+        "extends": []
+    },
+    "IDockviewGroupDragGhostProps": {
+        "kind": "interface",
+        "name": "IDockviewGroupDragGhostProps",
+        "children": [
+            {
+                "name": "api",
+                "code": "DockviewApi",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "DockviewApi",
+                    "source": "dockview-core"
+                },
+                "flags": {}
+            },
+            {
+                "name": "group",
+                "code": "IDockviewGroupPanel",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "IDockviewGroupPanel",
                     "source": "dockview-core"
                 },
                 "flags": {}
@@ -49316,6 +49558,42 @@
                         {
                             "kind": "text",
                             "text": " renders an inline text input to rename the tab group.\n\nIf omitted, no context menu is shown on chip right-click.\nReturn an empty array to suppress the menu for specific cases."
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "groupDragGhostComponent",
+                "code": "React.FunctionComponent<IDockviewGroupDragGhostProps>",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "React.FunctionComponent",
+                    "source": "@types/react",
+                    "typeArguments": [
+                        {
+                            "type": "reference",
+                            "value": "IDockviewGroupDragGhostProps",
+                            "source": "dockview"
+                        }
+                    ]
+                },
+                "flags": {
+                    "isOptional": true
+                },
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Component rendered as the drag ghost (the small floating chip) while\na group of panels is being dragged. If omitted, the default\n"
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"Multiple Panels (N)\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " ghost is used.\n\nNote: the ghost is captured by the browser at drag start, so the\ncomponent must render fast / synchronously enough to be visible\nbefore the browser snapshots it."
                         }
                     ]
                 }
@@ -49639,7 +49917,9 @@
                     "source": "dockview",
                     "refersToTypeParameter": true
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             }
         ],
         "extends": [
@@ -49652,7 +49932,7 @@
         "children": [
             {
                 "name": "components",
-                "code": "Record<string, React.FunctionComponent<IGridviewPanelProps<any>>>",
+                "code": "Record<string, React.FunctionComponent<IGridviewPanelProps>>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -49671,13 +49951,7 @@
                                 {
                                     "type": "reference",
                                     "value": "IGridviewPanelProps",
-                                    "source": "dockview",
-                                    "typeArguments": [
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "any"
-                                        }
-                                    ]
+                                    "source": "dockview"
                                 }
                             ]
                         }
@@ -49764,7 +50038,9 @@
                     "source": "dockview",
                     "refersToTypeParameter": true
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             },
             {
                 "name": "title",
@@ -49787,7 +50063,7 @@
         "children": [
             {
                 "name": "components",
-                "code": "Record<string, React.FunctionComponent<IPaneviewPanelProps<any>>>",
+                "code": "Record<string, React.FunctionComponent<IPaneviewPanelProps>>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -49806,13 +50082,7 @@
                                 {
                                     "type": "reference",
                                     "value": "IPaneviewPanelProps",
-                                    "source": "dockview",
-                                    "typeArguments": [
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "any"
-                                        }
-                                    ]
+                                    "source": "dockview"
                                 }
                             ]
                         }
@@ -49965,7 +50235,9 @@
                     "source": "dockview",
                     "refersToTypeParameter": true
                 },
-                "flags": {}
+                "flags": {
+                    "isInherited": true
+                }
             }
         ],
         "extends": [
@@ -49978,7 +50250,7 @@
         "children": [
             {
                 "name": "components",
-                "code": "Record<string, React.FunctionComponent<ISplitviewPanelProps<any>>>",
+                "code": "Record<string, React.FunctionComponent<ISplitviewPanelProps>>",
                 "kind": "property",
                 "type": {
                     "type": "reference",
@@ -49997,13 +50269,7 @@
                                 {
                                     "type": "reference",
                                     "value": "ISplitviewPanelProps",
-                                    "source": "dockview",
-                                    "typeArguments": [
-                                        {
-                                            "type": "intrinsic",
-                                            "value": "any"
-                                        }
-                                    ]
+                                    "source": "dockview"
                                 }
                             ]
                         }
@@ -50261,528 +50527,48 @@
         },
         "kind": "typeAlias"
     },
+    "DockviewDefaultTab": {
+        "name": "DockviewDefaultTab",
+        "code": "",
+        "kind": "variable"
+    },
+    "DockviewReact": {
+        "name": "DockviewReact",
+        "code": "",
+        "kind": "variable"
+    },
+    "GridviewReact": {
+        "name": "GridviewReact",
+        "code": "",
+        "kind": "variable"
+    },
+    "PaneviewReact": {
+        "name": "PaneviewReact",
+        "code": "",
+        "kind": "variable"
+    },
     "ReactPartContext": {
         "name": "ReactPartContext",
         "code": "",
         "kind": "variable"
     },
-    "DockviewDefaultTab": {
-        "kind": "function",
-        "name": "DockviewDefaultTab",
-        "children": [
-            {
-                "name": "contextTypes",
-                "code": "ValidationMap<any>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "ValidationMap",
-                    "source": "@types/prop-types",
-                    "typeArguments": [
-                        {
-                            "type": "intrinsic",
-                            "value": "any"
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "defaultProps",
-                "code": "Partial<IDockviewDefaultTabProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Partial",
-                    "source": "typescript",
-                    "typeArguments": [
-                        {
-                            "type": "reference",
-                            "value": "IDockviewDefaultTabProps",
-                            "source": "dockview"
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "displayName",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "propTypes",
-                "code": "React.WeakValidationMap<IDockviewDefaultTabProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "React.WeakValidationMap",
-                    "source": "@types/react",
-                    "typeArguments": [
-                        {
-                            "type": "reference",
-                            "value": "IDockviewDefaultTabProps",
-                            "source": "dockview"
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            }
-        ],
-        "extends": []
-    },
-    "DockviewReact": {
-        "kind": "function",
-        "name": "DockviewReact",
-        "children": [
-            {
-                "name": "$$typeof",
-                "code": "symbol",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "symbol"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isReadonly": true
-                }
-            },
-            {
-                "name": "defaultProps",
-                "code": "Partial<React.RefAttributes<HTMLDivElement> & IDockviewReactProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Partial",
-                    "source": "typescript",
-                    "typeArguments": [
-                        {
-                            "type": "intersection",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "React.RefAttributes",
-                                    "source": "@types/react",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "HTMLDivElement",
-                                            "source": "typescript"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "reference",
-                                    "value": "IDockviewReactProps",
-                                    "source": "dockview"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "displayName",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "propTypes",
-                "code": "React.WeakValidationMap<React.RefAttributes<HTMLDivElement> & IDockviewReactProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "React.WeakValidationMap",
-                    "source": "@types/react",
-                    "typeArguments": [
-                        {
-                            "type": "intersection",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "React.RefAttributes",
-                                    "source": "@types/react",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "HTMLDivElement",
-                                            "source": "typescript"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "reference",
-                                    "value": "IDockviewReactProps",
-                                    "source": "dockview"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            }
-        ],
-        "extends": []
-    },
-    "GridviewReact": {
-        "kind": "function",
-        "name": "GridviewReact",
-        "children": [
-            {
-                "name": "$$typeof",
-                "code": "symbol",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "symbol"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isReadonly": true
-                }
-            },
-            {
-                "name": "defaultProps",
-                "code": "Partial<React.RefAttributes<HTMLDivElement> & IGridviewReactProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Partial",
-                    "source": "typescript",
-                    "typeArguments": [
-                        {
-                            "type": "intersection",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "React.RefAttributes",
-                                    "source": "@types/react",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "HTMLDivElement",
-                                            "source": "typescript"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "reference",
-                                    "value": "IGridviewReactProps",
-                                    "source": "dockview"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "displayName",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "propTypes",
-                "code": "React.WeakValidationMap<React.RefAttributes<HTMLDivElement> & IGridviewReactProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "React.WeakValidationMap",
-                    "source": "@types/react",
-                    "typeArguments": [
-                        {
-                            "type": "intersection",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "React.RefAttributes",
-                                    "source": "@types/react",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "HTMLDivElement",
-                                            "source": "typescript"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "reference",
-                                    "value": "IGridviewReactProps",
-                                    "source": "dockview"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            }
-        ],
-        "extends": []
-    },
-    "PaneviewReact": {
-        "kind": "function",
-        "name": "PaneviewReact",
-        "children": [
-            {
-                "name": "$$typeof",
-                "code": "symbol",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "symbol"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isReadonly": true
-                }
-            },
-            {
-                "name": "defaultProps",
-                "code": "Partial<React.RefAttributes<HTMLDivElement> & IPaneviewReactProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Partial",
-                    "source": "typescript",
-                    "typeArguments": [
-                        {
-                            "type": "intersection",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "React.RefAttributes",
-                                    "source": "@types/react",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "HTMLDivElement",
-                                            "source": "typescript"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "reference",
-                                    "value": "IPaneviewReactProps",
-                                    "source": "dockview"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "displayName",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "propTypes",
-                "code": "React.WeakValidationMap<React.RefAttributes<HTMLDivElement> & IPaneviewReactProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "React.WeakValidationMap",
-                    "source": "@types/react",
-                    "typeArguments": [
-                        {
-                            "type": "intersection",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "React.RefAttributes",
-                                    "source": "@types/react",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "HTMLDivElement",
-                                            "source": "typescript"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "reference",
-                                    "value": "IPaneviewReactProps",
-                                    "source": "dockview"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            }
-        ],
-        "extends": []
-    },
     "SplitviewReact": {
-        "kind": "function",
         "name": "SplitviewReact",
-        "children": [
-            {
-                "name": "$$typeof",
-                "code": "symbol",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "symbol"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isReadonly": true
+        "code": "",
+        "kind": "variable"
+    },
+    "usePortalsLifecycle": {
+        "name": "usePortalsLifecycle",
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A React Hook that returns an array of portals to be rendered by the user of this hook\nand a disposable function to add a portal. Calling dispose removes this portal from the\nportal array"
                 }
-            },
-            {
-                "name": "defaultProps",
-                "code": "Partial<React.RefAttributes<HTMLDivElement> & ISplitviewReactProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "Partial",
-                    "source": "typescript",
-                    "typeArguments": [
-                        {
-                            "type": "intersection",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "React.RefAttributes",
-                                    "source": "@types/react",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "HTMLDivElement",
-                                            "source": "typescript"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "reference",
-                                    "value": "ISplitviewReactProps",
-                                    "source": "dockview"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "displayName",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            },
-            {
-                "name": "propTypes",
-                "code": "React.WeakValidationMap<React.RefAttributes<HTMLDivElement> & ISplitviewReactProps>",
-                "kind": "property",
-                "type": {
-                    "type": "reference",
-                    "value": "React.WeakValidationMap",
-                    "source": "@types/react",
-                    "typeArguments": [
-                        {
-                            "type": "intersection",
-                            "values": [
-                                {
-                                    "type": "reference",
-                                    "value": "React.RefAttributes",
-                                    "source": "@types/react",
-                                    "typeArguments": [
-                                        {
-                                            "type": "reference",
-                                            "value": "HTMLDivElement",
-                                            "source": "typescript"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "type": "reference",
-                                    "value": "ISplitviewReactProps",
-                                    "source": "dockview"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "flags": {
-                    "isExternal": true,
-                    "isOptional": true
-                }
-            }
-        ],
-        "extends": []
+            ]
+        },
+        "code": "",
+        "kind": "variable"
     },
     "isReactComponent": {
         "name": "isReactComponent",
@@ -50810,78 +50596,24 @@
         },
         "kind": "function"
     },
-    "usePortalsLifecycle": {
-        "name": "usePortalsLifecycle",
-        "code": "(): [React.ReactPortal[],(portal: React.ReactPortal): IDisposable]",
-        "signature": {
-            "name": "usePortalsLifecycle",
-            "comment": {
-                "summary": [
-                    {
-                        "kind": "text",
-                        "text": "A React Hook that returns an array of portals to be rendered by the user of this hook\nand a disposable function to add a portal. Calling dispose removes this portal from the\nportal array"
-                    }
-                ]
-            },
-            "typeParameters": [],
-            "parameters": [],
-            "returnType": {
-                "type": "tuple",
-                "values": [
-                    {
-                        "type": "array",
-                        "value": {
-                            "type": "reference",
-                            "value": "React.ReactPortal",
-                            "source": "@types/react"
-                        }
-                    },
-                    {
-                        "type": "reflection",
-                        "value": {
-                            "name": "__type",
-                            "code": "(portal: React.ReactPortal): IDisposable",
-                            "kind": "typeLiteral",
-                            "signatures": [
-                                {
-                                    "name": "__type",
-                                    "typeParameters": [],
-                                    "parameters": [
-                                        {
-                                            "name": "portal",
-                                            "code": "portal: React.ReactPortal",
-                                            "type": {
-                                                "type": "reference",
-                                                "value": "React.ReactPortal",
-                                                "source": "@types/react"
-                                            },
-                                            "kind": "parameter"
-                                        }
-                                    ],
-                                    "returnType": {
-                                        "type": "reference",
-                                        "value": "IDisposable",
-                                        "source": "dockview-core"
-                                    },
-                                    "code": "(portal: React.ReactPortal): IDisposable",
-                                    "kind": "callSignature"
-                                }
-                            ]
-                        }
-                    }
-                ]
-            },
-            "code": "(): [React.ReactPortal[],(portal: React.ReactPortal): IDisposable]",
-            "kind": "callSignature"
-        },
-        "kind": "function"
-    },
     "VueProps": {
         "kind": "interface",
         "name": "VueProps",
         "children": [
             {
                 "name": "defaultTabComponent",
+                "code": "string",
+                "kind": "property",
+                "type": {
+                    "type": "intrinsic",
+                    "value": "string"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
+                "name": "groupDragGhostComponent",
                 "code": "string",
                 "kind": "property",
                 "type": {
@@ -50977,38 +50709,67 @@
         "kind": "typeAlias"
     },
     "VueEvents": {
+        "kind": "typeAlias",
         "name": "VueEvents",
-        "code": "{ ready: [[event: DockviewReadyEvent]] }",
-        "typeParameters": [],
-        "type": {
-            "type": "reflection",
-            "value": {
-                "name": "__type",
-                "code": "{ ready: [[event: DockviewReadyEvent]] }",
-                "kind": "typeLiteral",
-                "properties": [
-                    {
-                        "name": "ready",
-                        "code": "[[event: DockviewReadyEvent]]",
-                        "kind": "property",
-                        "type": {
-                            "type": "tuple",
-                            "values": [
-                                {
-                                    "type": "namedTupleMember",
-                                    "values": {
-                                        "type": "reference",
-                                        "value": "DockviewReadyEvent",
-                                        "source": "dockview-core"
-                                    }
-                                }
-                            ]
-                        },
-                        "flags": {}
-                    }
-                ]
+        "children": [
+            {
+                "name": "didDrop",
+                "code": "[[event: DockviewDidDropEvent]]",
+                "kind": "property",
+                "type": {
+                    "type": "tuple",
+                    "values": [
+                        {
+                            "type": "namedTupleMember",
+                            "values": {
+                                "type": "reference",
+                                "value": "DockviewDidDropEvent",
+                                "source": "dockview-core"
+                            }
+                        }
+                    ]
+                },
+                "flags": {}
+            },
+            {
+                "name": "ready",
+                "code": "[[event: DockviewReadyEvent]]",
+                "kind": "property",
+                "type": {
+                    "type": "tuple",
+                    "values": [
+                        {
+                            "type": "namedTupleMember",
+                            "values": {
+                                "type": "reference",
+                                "value": "DockviewReadyEvent",
+                                "source": "dockview-core"
+                            }
+                        }
+                    ]
+                },
+                "flags": {}
+            },
+            {
+                "name": "willDrop",
+                "code": "[[event: DockviewWillDropEvent]]",
+                "kind": "property",
+                "type": {
+                    "type": "tuple",
+                    "values": [
+                        {
+                            "type": "namedTupleMember",
+                            "values": {
+                                "type": "reference",
+                                "value": "DockviewWillDropEvent",
+                                "source": "dockview-core"
+                            }
+                        }
+                    ]
+                },
+                "flags": {}
             }
-        },
-        "kind": "typeAlias"
+        ],
+        "extends": []
     }
 }


### PR DESCRIPTION
## Summary
- Closes #1167. The group drag ghost previously rendered hard-coded `"Multiple Panels (N)"`, blocking i18n. Adds a `createGroupDragGhostComponent` option (parallel to `createTabGroupChipComponent`) that lets consumers replace the entire ghost with their own renderer. Default behavior is unchanged when no factory is supplied.
- New `IGroupDragGhostRenderer` interface exported from `dockview-core`: `{ element: HTMLElement; init({ group, api }); dispose?() }`.
- Plumbed `groupDragGhostComponent` props through `dockview` (React), `dockview-vue`, and `dockview-angular`, mirroring the existing chip component wiring.

## Test plan
- [x] `dockview-core` — 2 new tests in `groupDragHandler.spec.ts` cover custom factory invocation/disposal and the default-ghost fallback. Full suite 909/909 passing.
- [x] `dockview` (React) — 6 tests in `reactGroupDragGhostPart.spec.ts`. Full suite 50/50 passing.
- [x] `dockview-vue` — 1 new test in `dockview.spec.ts` asserting `createGroupDragGhostComponent` flows through `updateOptions`. Full suite 78/78 passing.
- [x] `dockview-angular` — 4 tests in `angular-group-drag-ghost-renderer.spec.ts`. Full suite 126/126 passing.
- [x] `yarn lint` clean (0 errors).
- [ ] Manual smoke: drag a group with a custom component to confirm the ghost renders the user's content. (Maintainer to verify locally — automated DnD coverage is hard for `setDragImage` snapshotting.)

## Notes for reviewers
- The factory is invoked inside `GroupDragHandler.getData` only when set; otherwise the original `"Multiple Panels (N)"` ghost is preserved verbatim.
- `addGhostImage` already removes the ghost element via `setTimeout(0)`; the custom renderer's `dispose()` is scheduled on the same tick so the framework portal/component is torn down together.
- The browser captures the ghost at drag start, so framework components must render fast / synchronously to be visible before the snapshot. This is documented in the new JSDoc; users who hit timing issues can still construct a raw `HTMLElement` in their factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)