### PR TITLE
fix(dockview-core): refresh live watermark when createWatermarkComponent changes

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -4497,6 +4497,74 @@ describe('dockviewComponent', () => {
         expect(dockview.groups.length).toBe(0);
     });
 
+    test('updateOptions({ createWatermarkComponent }) swaps live watermarks', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                switch (options.name) {
+                    case 'default':
+                        return new PanelContentPartTest(
+                            options.id,
+                            options.name
+                        );
+                    default:
+                        throw new Error(`unsupported`);
+                }
+            },
+        });
+
+        // No groups → dockview-level watermark mounted with the default renderer.
+        expect(
+            dockview.element.querySelectorAll('.dv-watermark-container').length
+        ).toBe(1);
+        expect(
+            dockview.element.querySelectorAll(
+                '.dv-watermark-container .dv-watermark-custom'
+            ).length
+        ).toBe(0);
+
+        const customRenderers: HTMLElement[] = [];
+
+        dockview.updateOptions({
+            createWatermarkComponent: () => {
+                const el = document.createElement('div');
+                el.className = 'dv-watermark-custom';
+                customRenderers.push(el);
+                return {
+                    element: el,
+                    init: () => {
+                        /* noop */
+                    },
+                };
+            },
+        });
+
+        // Same dockview-level container, but now wrapping the custom element.
+        expect(
+            dockview.element.querySelectorAll('.dv-watermark-container').length
+        ).toBe(1);
+        expect(
+            dockview.element.querySelectorAll(
+                '.dv-watermark-container .dv-watermark-custom'
+            ).length
+        ).toBe(1);
+        expect(customRenderers).toHaveLength(1);
+
+        // Toggling back to the default factory disposes the custom one and
+        // re-creates the default watermark in place.
+        dockview.updateOptions({ createWatermarkComponent: undefined });
+
+        expect(
+            dockview.element.querySelectorAll('.dv-watermark-container').length
+        ).toBe(1);
+        expect(
+            dockview.element.querySelectorAll(
+                '.dv-watermark-container .dv-watermark-custom'
+            ).length
+        ).toBe(0);
+    });
+
     test('that deserializing an empty layout has zero groups and a watermark', () => {
         const container = document.createElement('div');
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1520,6 +1520,18 @@ export class DockviewComponent
             }
         }
 
+        if ('createWatermarkComponent' in options) {
+            if (this._watermark) {
+                this._watermark.element.parentElement!.remove();
+                this._watermark.dispose?.();
+                this._watermark = null;
+            }
+            this.updateWatermark();
+            for (const group of this.groups) {
+                group.model.refreshWatermark();
+            }
+        }
+
         if ('tabGroupColors' in options || 'tabGroupAccent' in options) {
             this._tabGroupColorPalette.setEntries(
                 this._options.tabGroupColors ?? DEFAULT_TAB_GROUP_COLORS

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -964,6 +964,15 @@ export class DockviewGroupPanelModel
         this.tabsContainer.refreshTabGroupAccent();
     }
 
+    refreshWatermark(): void {
+        if (this.watermark) {
+            this.watermark.element.remove();
+            this.watermark.dispose?.();
+            this.watermark = undefined;
+        }
+        this.updateContainer();
+    }
+
     getTabGroupForPanel(panelId: string): ITabGroup | undefined {
         return this._findTabGroupForPanel(panelId);
     }

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -321,7 +321,32 @@ const colors = [
 let count = 0;
 
 const WatermarkComponent = () => {
-    return <div>custom watermark</div>;
+    return (
+        <div
+            style={{
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 8,
+                color: 'rgba(255,255,255,0.55)',
+                fontFamily: 'monospace',
+                pointerEvents: 'none',
+            }}
+        >
+            <span
+                className="material-symbols-outlined"
+                style={{ fontSize: 32, opacity: 0.7 }}
+            >
+                dashboard
+            </span>
+            <div style={{ fontSize: 13 }}>Custom watermark</div>
+            <div style={{ fontSize: 11, opacity: 0.7 }}>
+                Drag a tab here or add a panel
+            </div>
+        </div>
+    );
 };
 
 const ThemeContext = React.createContext<DockviewTheme | undefined>(undefined);

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/gridActions.tsx
@@ -227,11 +227,7 @@ function usePopover() {
     };
 }
 
-export const GridActions = (props: {
-    api?: DockviewApi;
-    hasCustomWatermark: boolean;
-    toggleCustomWatermark: () => void;
-}) => {
+export const GridActions = (props: { api?: DockviewApi }) => {
     const onClear = () => {
         props.api?.clear();
     };

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/settingsModal.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/settingsModal.tsx
@@ -57,11 +57,7 @@ export const ControlsContent = (props: {
     return (
         <>
             <Section title="Grid">
-                <GridActions
-                    api={props.api}
-                    hasCustomWatermark={props.hasCustomWatermark}
-                    toggleCustomWatermark={props.toggleCustomWatermark}
-                />
+                <GridActions api={props.api} />
             </Section>
 
             {props.api && props.activePanel && (
@@ -116,6 +112,19 @@ export const ControlsContent = (props: {
                             terminal
                         </span>
                         <span>Events Log</span>
+                    </button>
+                    <button
+                        onClick={props.toggleCustomWatermark}
+                        style={toggleBtn(props.hasCustomWatermark)}
+                        title="Use a custom watermark component (visible when no grid groups are present)"
+                    >
+                        <span
+                            className="material-symbols-outlined"
+                            style={{ fontSize: 14 }}
+                        >
+                            branding_watermark
+                        </span>
+                        <span>Custom watermark</span>
                     </button>
                     {props.showLogs && (
                         <button


### PR DESCRIPTION
## Summary

`DockviewComponent.updateOptions({ createWatermarkComponent })` previously stored the new factory but did **not** dispose any already-mounted watermarks, so the live UI kept rendering the old watermark until the next group add/remove cycle. This makes the watermark non-reactive — passing a new `watermarkComponent` to `DockviewReact` (or directly calling `updateOptions`) had no visible effect.

This PR:
- Adds `DockviewGroupPanelModel.refreshWatermark()` to dispose and re-create a group's per-group watermark from the current factory.
- Wires `updateOptions` to detect `createWatermarkComponent` changes, tear down `_watermark`, call `updateWatermark()` to re-mount the dockview-level watermark, and call `refreshWatermark()` on every group. One global factory swap → all watermarks refreshed.
- Demo: surfaces a **"Custom watermark"** toggle in the Controls → View section of the demo sandbox so the path can be exercised live. Replaces the placeholder `<div>custom watermark</div>` with a visible custom watermark UI.

Closes #515  
Refs #1014

## Test plan

- [x] New jest test `updateOptions({ createWatermarkComponent }) swaps live watermarks` in `dockviewComponent.spec.ts` — verifies the live element swap and revert-to-default.
- [x] Full `dockview-core` test suite: 906 passing.
- [x] `yarn format:check` clean.
- [x] `yarn lint` clean (0 errors).
- [ ] Manual: open `/demo`, toggle Controls → View → Custom watermark with the layout populated (no visible change while groups exist) and with the layout cleared (default ↔ custom watermark swaps on click).

🤖 Generated with [Claude Code](https://claude.com/claude-code)