### PR TITLE
fix(dockview-core): respect group.locked on void/header drop target (#990)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
@@ -36,6 +36,9 @@ describe('tabsContainer', () => {
         const groupPanelMock = jest.fn<Partial<DockviewGroupPanel>, []>(() => {
             return {
                 model: groupView,
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: false,
+                }),
             };
         });
 
@@ -93,6 +96,9 @@ describe('tabsContainer', () => {
                 id: 'testgroupid',
                 model: groupView,
                 panels: [],
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: false,
+                }),
             };
         });
 
@@ -166,6 +172,9 @@ describe('tabsContainer', () => {
                 id: 'testgroupid',
                 model: groupView,
                 panels: [],
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: false,
+                }),
             };
         });
 
@@ -206,6 +215,76 @@ describe('tabsContainer', () => {
         ).toBe(1);
     });
 
+    test.each([true, 'no-drop-target' as const])(
+        'that dropping over the empty space does not render a drop target when group is locked=%p (regression #990)',
+        (lockedValue) => {
+            const accessor = fromPartial<DockviewComponent>({
+                id: 'testcomponentid',
+                onDidAddPanel: jest.fn(),
+                onDidRemovePanel: jest.fn(),
+                options: {},
+                onDidOptionsChange: jest
+                    .fn()
+                    .mockReturnValue({ dispose: jest.fn() }),
+            });
+
+            const groupView = fromPartial<DockviewGroupPanelModel>({
+                canDisplayOverlay: jest.fn(),
+            });
+
+            const groupPanel = fromPartial<DockviewGroupPanel>({
+                id: 'testgroupid',
+                model: groupView,
+                panels: [],
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: lockedValue,
+                }),
+            });
+
+            const cut = new TabsContainer(accessor, groupPanel);
+
+            cut.openPanel(new TestPanel('panel1', jest.fn() as any));
+            cut.openPanel(new TestPanel('panel2', jest.fn() as any));
+
+            const emptySpace = cut.element
+                .getElementsByClassName('dv-void-container')
+                .item(0) as HTMLElement;
+
+            if (!emptySpace!) {
+                fail('element not found');
+            }
+
+            jest.spyOn(emptySpace!, 'offsetHeight', 'get').mockImplementation(
+                () => 100
+            );
+            jest.spyOn(emptySpace!, 'offsetWidth', 'get').mockImplementation(
+                () => 100
+            );
+
+            // simulate an internal same-accessor drag (the buggy path):
+            // the void container previously short-circuited to `return true`
+            // for same-accessor drags regardless of the group's locked state.
+            LocalSelectionTransfer.getInstance().setData(
+                [
+                    new PanelTransfer(
+                        'testcomponentid',
+                        'anothergroupid',
+                        'panel1'
+                    ),
+                ],
+                PanelTransfer.prototype
+            );
+
+            fireEvent.dragEnter(emptySpace!);
+            fireEvent.dragOver(emptySpace!);
+
+            expect(
+                cut.element.getElementsByClassName('dv-drop-target-dropzone')
+                    .length
+            ).toBe(0);
+        }
+    );
+
     test('that dropping the first tab should render a drop target', () => {
         const accessor = fromPartial<DockviewComponent>({
             id: 'testcomponentid',
@@ -232,6 +311,9 @@ describe('tabsContainer', () => {
                 id: 'testgroupid',
                 model: groupView,
                 panels: [],
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: false,
+                }),
             };
         });
 
@@ -297,6 +379,9 @@ describe('tabsContainer', () => {
             return {
                 id: 'testgroupid',
                 model: groupView,
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: false,
+                }),
             };
         });
 
@@ -1402,6 +1487,9 @@ describe('tabsContainer', () => {
         const groupPanelMock = jest.fn<Partial<DockviewGroupPanel>, []>(() => {
             return {
                 model: groupView,
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: false,
+                }),
             };
         });
 

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
@@ -2,6 +2,11 @@ import { VoidContainer } from '../../../../dockview/components/titlebar/voidCont
 import { fromPartial } from '@total-typescript/shoehorn';
 import { DockviewComponent } from '../../../../dockview/dockviewComponent';
 import { DockviewGroupPanel } from '../../../../dockview/dockviewGroupPanel';
+import { DockviewGroupPanelModel } from '../../../../dockview/dockviewGroupPanelModel';
+import {
+    LocalSelectionTransfer,
+    PanelTransfer,
+} from '../../../../dnd/dataTransfer';
 import { fireEvent } from '@testing-library/dom';
 
 describe('voidContainer', () => {
@@ -203,6 +208,102 @@ describe('voidContainer', () => {
 
             fireEvent.dragStart(cut.element);
             expect(spy).toHaveBeenCalledTimes(0);
+
+            cut.dispose();
+        });
+    });
+
+    describe('locked group (regression #990)', () => {
+        function setup(lockedValue: boolean | 'no-drop-target') {
+            const accessor = fromPartial<DockviewComponent>({
+                id: 'testcomponentid',
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+
+            const groupView = fromPartial<DockviewGroupPanelModel>({
+                canDisplayOverlay: jest.fn().mockReturnValue(true),
+                dropTargetContainer: undefined,
+            });
+
+            const group = fromPartial<DockviewGroupPanel>({
+                id: 'testgroupid',
+                model: groupView,
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: lockedValue,
+                }),
+            });
+
+            const cut = new VoidContainer(accessor, group);
+
+            jest.spyOn(cut.element, 'offsetHeight', 'get').mockImplementation(
+                () => 100
+            );
+            jest.spyOn(cut.element, 'offsetWidth', 'get').mockImplementation(
+                () => 100
+            );
+
+            return { cut, groupView };
+        }
+
+        afterEach(() => {
+            LocalSelectionTransfer.getInstance().clearData(
+                PanelTransfer.prototype
+            );
+        });
+
+        test.each([true, 'no-drop-target' as const])(
+            'does not display a drop overlay when locked=%p, even for same-accessor drags',
+            (lockedValue) => {
+                const { cut, groupView } = setup(lockedValue);
+
+                LocalSelectionTransfer.getInstance().setData(
+                    [
+                        new PanelTransfer(
+                            'testcomponentid',
+                            'anothergroupid',
+                            'panel1'
+                        ),
+                    ],
+                    PanelTransfer.prototype
+                );
+
+                fireEvent.dragEnter(cut.element);
+                fireEvent.dragOver(cut.element);
+
+                expect(
+                    cut.element.parentElement?.getElementsByClassName(
+                        'dv-drop-target-dropzone'
+                    ).length ?? 0
+                ).toBe(0);
+                // short-circuited before consulting the group model
+                expect(groupView.canDisplayOverlay).not.toHaveBeenCalled();
+
+                cut.dispose();
+            }
+        );
+
+        test('still displays a drop overlay for same-accessor drags when not locked', () => {
+            const { cut } = setup(false);
+
+            LocalSelectionTransfer.getInstance().setData(
+                [
+                    new PanelTransfer(
+                        'testcomponentid',
+                        'anothergroupid',
+                        'panel1'
+                    ),
+                ],
+                PanelTransfer.prototype
+            );
+
+            fireEvent.dragEnter(cut.element);
+            fireEvent.dragOver(cut.element);
+
+            expect(
+                cut.element.getElementsByClassName('dv-drop-target-dropzone')
+                    .length
+            ).toBe(1);
 
             cut.dispose();
         });

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -4,6 +4,7 @@ import { DockviewGroupPanel } from '../dockview/dockviewGroupPanel';
 import {
     DockviewGroupChangeEvent,
     DockviewGroupLocation,
+    DockviewGroupPanelLocked,
 } from '../dockview/dockviewGroupPanelModel';
 import { DockviewHeaderPosition } from '../dockview/options';
 import { Emitter, Event } from '../events';
@@ -39,6 +40,13 @@ export interface DockviewGroupPanelApi extends GridviewPanelApi {
      */
     readonly onDidCollapsedChange: Event<DockviewGroupPanelCollapsedChangeEvent>;
     readonly location: DockviewGroupLocation;
+    /**
+     * Whether this group is locked against drop interactions.
+     * - `true`: panels cannot be dropped into the group (center / tabs),
+     *   but the group can still be split from its edges.
+     * - `'no-drop-target'`: all drop zones are disabled for this group.
+     */
+    locked: DockviewGroupPanelLocked;
     /**
      * If you require the Window object
      */
@@ -94,6 +102,20 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             throw new Error(NOT_INITIALIZED_MESSAGE);
         }
         return this._group.model.location;
+    }
+
+    get locked(): DockviewGroupPanelLocked {
+        if (!this._group) {
+            throw new Error(NOT_INITIALIZED_MESSAGE);
+        }
+        return this._group.locked;
+    }
+
+    set locked(value: DockviewGroupPanelLocked) {
+        if (!this._group) {
+            throw new Error(NOT_INITIALIZED_MESSAGE);
+        }
+        this._group.locked = value;
     }
 
     constructor(

--- a/packages/dockview-core/src/dockview/components/titlebar/voidContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/voidContainer.ts
@@ -64,6 +64,13 @@ export class VoidContainer extends CompositeDisposable {
         this.dropTarget = new Droptarget(this._element, {
             acceptedTargetZones: ['center'],
             canDisplayOverlay: (event, position) => {
+                if (this.group.api.locked) {
+                    // Dropping on the void/header space adds the panel
+                    // to this group, which `locked` is meant to prevent
+                    // (both `true` and `'no-drop-target'`).
+                    return false;
+                }
+
                 const data = getPanelData();
 
                 if (data && this.accessor.id === data.viewId) {


### PR DESCRIPTION
## Summary
- Fixes #990 — `locked = true` and `locked = 'no-drop-target'` were both being silently ignored when dropping a panel onto a locked group's empty tab strip.
- The `VoidContainer` drop target short-circuited to `return true` for any same-accessor drag, never consulting `group.locked`. Dropping on the header space is functionally "add to this group", so both locked modes should reject it.
- Also exposes `locked` on `DockviewGroupPanelApi` so internal call sites (and consumers) go through the api surface rather than reaching into the model.

## Test plan
- [x] New regression tests in `voidContainer.spec.ts` cover both `locked: true` and `locked: 'no-drop-target'` for the previously-bypassed same-accessor drag path, and a non-locked control case.
- [x] New `tabsContainer.spec.ts` regression test exercises the same scenario through the public `TabsContainer` surface.
- [x] Full `dockview-core` suite: 910/910 passing.
- [ ] Manual verification against the locked example sandbox (dragging panel 1 into a `no-drop-target` group should now be blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)