### PR TITLE
test(dockview-core): regression cover for #1020 (addGroup + moveTo with always renderer)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -9280,6 +9280,13 @@ describe('dockviewComponent', () => {
             // until a resize fired. The fix wires _onDidMovePanel to
             // debouncedUpdateAllPositions on the dockview component so every
             // programmatic move re-runs the overlay positioning pass.
+
+            // An earlier test in this file enables fake timers without
+            // restoring them, which makes the requestAnimationFrame await
+            // below hang and time out. Force real timers here so the
+            // animation-frame callback actually fires.
+            jest.useRealTimers();
+
             const c = document.createElement('div');
             const dv = new DockviewComponent(c, {
                 createComponent(options) {

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -9271,6 +9271,66 @@ describe('dockviewComponent', () => {
             // The most recent size (400px) should be preserved
             expect(panel1.group.api.width).toBe(400);
         });
+
+        test('issue 1020: addGroup + moveTo with defaultRenderer="always" repositions panel overlay', async () => {
+            // Reproduces https://github.com/mathuo/dockview/issues/1020
+            // The user split a group by creating a new adjacent group and
+            // moving the active panel into it. With defaultRenderer="always"
+            // the panel's content overlay stayed at the old grid coordinates
+            // until a resize fired. The fix wires _onDidMovePanel to
+            // debouncedUpdateAllPositions on the dockview component so every
+            // programmatic move re-runs the overlay positioning pass.
+            const c = document.createElement('div');
+            const dv = new DockviewComponent(c, {
+                createComponent(options) {
+                    return new PanelContentPartTest(options.id, options.name);
+                },
+                defaultRenderer: 'always',
+            });
+            dv.layout(1000, 1000);
+
+            const panel1 = dv.addPanel({
+                id: 'panel1',
+                component: 'default',
+            });
+
+            expect(panel1.api.renderer).toBe('always');
+            const sourceGroup = panel1.api.group;
+
+            const updateSpy = jest.spyOn(
+                dv.overlayRenderContainer,
+                'updateAllPositions'
+            );
+
+            // Mirror the user's exact onClick pattern.
+            const newGroup = dv.api.addGroup({
+                direction: 'right',
+                referenceGroup: sourceGroup,
+            });
+            panel1.api.moveTo({
+                group: newGroup,
+                skipSetActive: false,
+            });
+
+            // Move is wired correctly.
+            expect(panel1.group).toBe(newGroup);
+            expect(newGroup.activePanel?.id).toBe('panel1');
+            // The single-panel source group should have been cleaned up.
+            expect(dv.groups).not.toContain(sourceGroup);
+
+            // The fix schedules updateAllPositions on the next animation
+            // frame via debouncedUpdateAllPositions(). Without the
+            // _onDidMovePanel listener this assertion fails — the overlay
+            // would only reposition on the next external resize.
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            expect(updateSpy).toHaveBeenCalled();
+
+            // Content node must still be in the DOM tree.
+            expect(panel1.view.content.element.parentElement).toBeTruthy();
+
+            updateSpy.mockRestore();
+            dv.dispose();
+        });
     });
 
     describe('renderer: always with fromJSON', () => {


### PR DESCRIPTION
## Summary
- Adds a regression test reproducing the exact pattern from #1020: `addGroup({ direction: 'right', referenceGroup })` followed immediately by `panel.api.moveTo({ group: newGroup })` with `defaultRenderer: 'always'`.
- The test spies on `overlayRenderContainer.updateAllPositions` and asserts it fires on the next animation frame — i.e. the `_onDidMovePanel → debouncedUpdateAllPositions` wiring at `dockviewComponent.ts:645-652` is exercised.
- No production code changes. The underlying fix has been on `master` since 208dad8f (`fix: complete fix for drag-to-edge overlay positioning with defaultRenderer="always"`, Dec 2025). Verified locally that the test fails when that listener is commented out and passes once restored.

Closes #1020

## Test plan
- [x] `yarn jest --selectProjects dockview-core --testPathPatterns dockviewComponent.spec -t "issue 1020"` passes
- [x] Same test fails when the `_onDidMovePanel` listener in `dockviewComponent.ts` is commented out (sanity check that the assertion is load-bearing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)