### PR TITLE
fix(dockview-core): recompute target location after popout single-panel move (#1004)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -6916,6 +6916,170 @@ describe('dockviewComponent', () => {
             expect(dockview.groups.length).toBe(3);
         });
 
+        // Regression test for issue #1004: when a single-panel popout group is
+        // dragged back into the dock as a panel (not as the whole group), the
+        // empty reference group it left in the grid gets cascade-removed by
+        // doRemoveGroup. The popout branch of moveGroupOrPanel used to compute
+        // the target grid location before that cascade-removal, which left a
+        // stale index that either misplaced the panel or threw "Invalid index"
+        // at the far edge.
+        const collectGridPanelOrder = (gridRoot: any): string[] => {
+            const result: string[] = [];
+            const walk = (node: any): void => {
+                if (node.type === 'leaf') {
+                    for (const view of node.data.views) {
+                        result.push(view);
+                    }
+                } else if (node.type === 'branch') {
+                    for (const child of node.data) {
+                        walk(child);
+                    }
+                }
+            };
+            walk(gridRoot);
+            return result;
+        };
+
+        test('issue #1004: panel from single-panel popout lands at correct index past original slot', async () => {
+            const container = document.createElement('div');
+
+            window.open = () => setupMockWindow();
+
+            const dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+
+            dockview.layout(1000, 500);
+
+            dockview.addPanel({
+                id: 'panel_1',
+                component: 'default',
+            });
+            const panel2 = dockview.addPanel({
+                id: 'panel_2',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            const panel3 = dockview.addPanel({
+                id: 'panel_3',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            dockview.addPanel({
+                id: 'panel_4',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+
+            // Pop out panel_2 (sole panel in its group, so the whole group is
+            // popped out and the original slot becomes an empty invisible
+            // reference group in the main grid).
+            await dockview.addPopoutGroup(panel2);
+            expect(panel2.api.location.type).toBe('popout');
+
+            // Drop the panel back onto the right edge of panel_3's group —
+            // a neighbor following the original slot. Pre-fix this placed the
+            // new group after panel_4 instead of between panel_3 and panel_4.
+            panel2.api.moveTo({
+                group: panel3.api.group,
+                position: 'right',
+            });
+
+            expect(panel2.api.location.type).toBe('grid');
+            expect(dockview.panels.length).toBe(4);
+            // The empty popout reference group should have been cleaned up.
+            expect(dockview.groups.length).toBe(4);
+
+            const gridOrder = collectGridPanelOrder(
+                JSON.parse(JSON.stringify(dockview.toJSON())).grid.root
+            );
+            expect(gridOrder).toEqual([
+                'panel_1',
+                'panel_3',
+                'panel_2',
+                'panel_4',
+            ]);
+        });
+
+        test('issue #1004: panel from single-panel popout dropped past far edge does not throw', async () => {
+            const container = document.createElement('div');
+
+            window.open = () => setupMockWindow();
+
+            const dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+
+            dockview.layout(1000, 500);
+
+            dockview.addPanel({
+                id: 'panel_1',
+                component: 'default',
+            });
+            const panel2 = dockview.addPanel({
+                id: 'panel_2',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            dockview.addPanel({
+                id: 'panel_3',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            const panel4 = dockview.addPanel({
+                id: 'panel_4',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+
+            await dockview.addPopoutGroup(panel2);
+            expect(panel2.api.location.type).toBe('popout');
+
+            // Drop on the far right edge — pre-fix this threw "Invalid index"
+            // because the stale target index pointed past the end of the grid
+            // after the empty reference group was cascade-removed.
+            expect(() =>
+                panel2.api.moveTo({
+                    group: panel4.api.group,
+                    position: 'right',
+                })
+            ).not.toThrow();
+
+            expect(panel2.api.location.type).toBe('grid');
+            expect(dockview.panels.length).toBe(4);
+            expect(dockview.groups.length).toBe(4);
+
+            const gridOrder = collectGridPanelOrder(
+                JSON.parse(JSON.stringify(dockview.toJSON())).grid.root
+            );
+            expect(gridOrder).toEqual([
+                'panel_1',
+                'panel_3',
+                'panel_4',
+                'panel_2',
+            ]);
+        });
+
         test('add a popout group', async () => {
             const container = document.createElement('div');
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2856,8 +2856,11 @@ export class DockviewComponent
                      * the source group is a popout group with a single panel
                      *
                      * 1. remove the panel from the group without triggering any events
-                     * 2. remove the popout group
-                     * 3. create a new group at the requested location and add that panel
+                     * 2. remove the popout group — this may cascade-remove the empty
+                     *    reference group it left behind in the main grid (see
+                     *    doRemoveGroup for popout groups), which can shift grid indices
+                     * 3. recompute the target location now that the grid is stable
+                     * 4. create a new group at the recomputed location and add that panel
                      */
 
                     const popoutGroup = this._popoutGroups.find(
@@ -2877,7 +2880,15 @@ export class DockviewComponent
 
                     this.doRemoveGroup(sourceGroup, { skipActive: true });
 
-                    const newGroup = this.createGroupAtLocation(targetLocation);
+                    const updatedTargetLocation = getRelativeLocation(
+                        this.gridview.orientation,
+                        getGridLocation(destinationGroup.element),
+                        destinationTarget
+                    );
+
+                    const newGroup = this.createGroupAtLocation(
+                        updatedTargetLocation
+                    );
                     this.movingLock(() =>
                         newGroup.model.openPanel(removedPanel, {
                             skipSetActive: true,


### PR DESCRIPTION
## Summary

Fixes #1004.

When a single-panel popout window's panel was dragged back into the main dock at an extremity drop target (left/right/top/bottom of a neighbor group), the panel either landed at the wrong grid position or threw `Invalid index` at the far edge, losing the panel.

**Root cause** — popping out a single-panel group leaves an empty, invisible reference group in the main grid. The popout branch of `moveGroupOrPanel` (`packages/dockview-core/src/dockview/dockviewComponent.ts`) computed `targetLocation` *before* removing the popout group; that removal cascades through `doRemoveGroup` to delete the empty reference group too, shifting every following grid index down by one. The stale `targetLocation` was then passed to `createGroupAtLocation`, producing the wrong index (or a `BranchNode.addChild: Invalid index` throw at the far edge — matching the reporter's stack trace exactly).

**Fix** — recompute `targetLocation` from `destinationGroup.element` *after* `doRemoveGroup(sourceGroup)`, mirroring the existing pattern a few lines below in the grid-source branch (`// after deleting the group we need to re-evaulate the ref location`).

## Test plan

- [x] New regression test: `issue #1004: panel from single-panel popout lands at correct index past original slot` — drops the panel right of `panel_3` (the neighbor following the original popout slot) and asserts grid order `[panel_1, panel_3, panel_2, panel_4]`. Confirmed to fail on the unpatched code with the panel ending up at the far right.
- [x] New regression test: `issue #1004: panel from single-panel popout dropped past far edge does not throw` — drops past the right-most neighbor. Confirmed to throw `Invalid index` at `BranchNode.addChild` on the unpatched code (matches reporter's stack trace).
- [x] Full `popout group` describe block passes (25 tests).
- [x] Full `dockviewComponent.spec.ts` suite: 195 passing on this branch vs. 193 on master (the +2 are the new tests). The 1 unrelated pre-existing failure (`issue 1020`) fails identically on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)