### PR TITLE
fix(dockview-core): cancel popout restoration on dispose (#851)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -6668,6 +6668,102 @@ describe('dockviewComponent', () => {
             windowObject!.close();
         });
 
+        test('issue #851: fromJSON popout restoration is cancelled on dispose', async () => {
+            jest.useFakeTimers();
+            try {
+                const container = document.createElement('div');
+
+                const openSpy = jest.fn().mockImplementation(() => {
+                    return setupMockWindow();
+                });
+                window.open = openSpy;
+
+                const dockview = new DockviewComponent(container, {
+                    createComponent(options) {
+                        switch (options.name) {
+                            case 'default':
+                                return new PanelContentPartTest(
+                                    options.id,
+                                    options.name
+                                );
+                            default:
+                                throw new Error(`unsupported`);
+                        }
+                    },
+                });
+
+                dockview.layout(1000, 1000);
+
+                dockview.fromJSON({
+                    activeGroup: 'group-1',
+                    grid: {
+                        root: {
+                            type: 'branch',
+                            data: [
+                                {
+                                    type: 'leaf',
+                                    data: {
+                                        views: ['panel1'],
+                                        id: 'group-1',
+                                        activeView: 'panel1',
+                                    },
+                                    size: 1000,
+                                },
+                            ],
+                            size: 1000,
+                        },
+                        height: 1000,
+                        width: 1000,
+                        orientation: Orientation.VERTICAL,
+                    },
+                    popoutGroups: [
+                        {
+                            data: {
+                                views: ['panel2'],
+                                id: 'group-2',
+                                activeView: 'panel2',
+                            },
+                            position: null,
+                        },
+                    ],
+                    panels: {
+                        panel1: {
+                            id: 'panel1',
+                            contentComponent: 'default',
+                            title: 'panel1',
+                        },
+                        panel2: {
+                            id: 'panel2',
+                            contentComponent: 'default',
+                            title: 'panel2',
+                        },
+                    },
+                });
+
+                // Dispose BEFORE the popout-restoration timer has had a chance
+                // to fire. This simulates the React StrictMode mount -> dispose
+                // -> remount sequence that triggers issue #851.
+                expect(openSpy).not.toHaveBeenCalled();
+                dockview.dispose();
+
+                // Advance any timers and microtasks. With the fix in place the
+                // queued popout restoration is cancelled in dispose() and the
+                // guard inside the timeout body short-circuits any survivors,
+                // so window.open MUST NOT be called.
+                jest.runAllTimers();
+                await Promise.resolve();
+                jest.runAllTimers();
+
+                expect(openSpy).not.toHaveBeenCalled();
+
+                // The restoration promise should still resolve cleanly so
+                // callers awaiting it don't hang.
+                await dockview.popoutRestorationPromise;
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
         test('grid -> floating -> popout -> popout closed', async () => {
             const container = document.createElement('div');
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -444,6 +444,7 @@ export class DockviewComponent
     }[] = [];
     private readonly _rootDropTarget: Droptarget;
     private _popoutRestorationPromise: Promise<void> = Promise.resolve();
+    private readonly _popoutRestorationCleanups = new Set<() => void>();
 
     private readonly _onDidRemoveGroup = new Emitter<DockviewGroupPanel>();
     readonly onDidRemoveGroup: Event<DockviewGroupPanel> =
@@ -715,6 +716,15 @@ export class DockviewComponent
                 this._bufferOnDidLayoutChange.fire();
             }),
             Disposable.from(() => {
+                // Cancel any pending popout-restoration timers scheduled by
+                // fromJSON so they don't open new browser windows after
+                // dispose, and resolve their promises so callers awaiting
+                // popoutRestorationPromise don't hang. See issue #851.
+                for (const cleanup of [...this._popoutRestorationCleanups]) {
+                    cleanup();
+                }
+                this._popoutRestorationCleanups.clear();
+
                 // iterate over a copy of the array since .dispose() mutates the original array
                 for (const group of [...this._floatingGroups]) {
                     group.dispose();
@@ -2096,7 +2106,23 @@ export class DockviewComponent
 
                 // Add a small delay for each popup after the first to avoid browser popup blocking
                 const popoutPromise = new Promise<void>((resolve) => {
-                    setTimeout(() => {
+                    const cleanup = () => {
+                        this._popoutRestorationCleanups.delete(cleanup);
+                        clearTimeout(handle);
+                        resolve();
+                    };
+                    const handle = setTimeout(() => {
+                        this._popoutRestorationCleanups.delete(cleanup);
+                        // Guard against the component being disposed before
+                        // this timer fires. Under React StrictMode the
+                        // component is mounted -> disposed -> remounted, and
+                        // without this guard the first instance's queued
+                        // restoration would open a second popout window.
+                        // See issue #851.
+                        if (this.isDisposed) {
+                            resolve();
+                            return;
+                        }
                         this.addPopoutGroup(group, {
                             position: position ?? undefined,
                             overridePopoutGroup: gridReferenceGroup
@@ -2109,6 +2135,7 @@ export class DockviewComponent
                         });
                         resolve();
                     }, index * DESERIALIZATION_POPOUT_DELAY_MS); // 100ms delay between each popup
+                    this._popoutRestorationCleanups.add(cleanup);
                 });
 
                 popoutPromises.push(popoutPromise);


### PR DESCRIPTION
## Summary

- Fixes [#851](https://github.com/mathuo/dockview/issues/851) — duplicate popouts when the page is refreshed under React StrictMode.
- `DockviewComponent.fromJSON` schedules popout-group restoration via `setTimeout`, but the timer callbacks were neither cancelled when the component was disposed nor guarded against `isDisposed`. Under StrictMode the component mounts -> disposes -> remounts, and the first instance's queued restoration still fired, opening a second popout window with a fresh sequential target name.
- Now each restoration timer is tracked in a cleanup set on the component, cleared by the main `Disposable.from(...)` block in `dispose()`, and the timeout body early-returns when `this.isDisposed`. Pending promises resolve during cleanup so callers awaiting `popoutRestorationPromise` don't hang.

## Test plan

- [x] New regression test `dockviewComponent › popout group › issue #851: fromJSON popout restoration is cancelled on dispose` — schedules a popout via `fromJSON`, disposes before the timer fires, runs all fake timers, and asserts `window.open` is never called.
- [x] Test verified to fail without the production change (`Received number of calls: 1`) and pass with it.
- [x] Full `popout group` suite still green (24 tests).

```
yarn jest --testPathPatterns dockviewComponent.spec --testNamePattern "issue #851"   # 1 passed
yarn jest --testPathPatterns dockviewComponent.spec --testNamePattern "popout"       # 24 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)