### PR TITLE
fix(dockview-core): keep tab renderer params in sync with setTitle (#914)

### DIFF
--- a/packages/dockview-core/src/__tests__/__mocks__/mockDockviewPanelModel.ts
+++ b/packages/dockview-core/src/__tests__/__mocks__/mockDockviewPanelModel.ts
@@ -37,6 +37,10 @@ export class DockviewPanelModelMock implements IDockviewPanelModel {
         //
     }
 
+    setTitle(title: string): void {
+        //
+    }
+
     layout(width: number, height: number): void {
         //
     }

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -10647,4 +10647,26 @@ describe('dockviewComponent', () => {
             dv.dispose();
         });
     });
+
+    test('issue #914: api.setTitle reflected by createTabRenderer output', () => {
+        // Regression test for #914 — the header overflow dropdown lazily
+        // builds a fresh tab renderer via panel.view.createTabRenderer(...)
+        // each time it opens. Prior to the fix that renderer was initialised
+        // with a snapshot of the panel's init params, so a title updated via
+        // api.setTitle (which only updated DockviewPanel._title and fired
+        // onDidTitleChange) was not reflected in the dropdown entry.
+        const panel = dockview.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            title: 'original',
+        });
+
+        panel.api.setTitle('renamed');
+
+        const overflowTab = panel.view.createTabRenderer('headerOverflow');
+
+        // DefaultTab renders the title into a child div with textContent.
+        expect(overflowTab.element.textContent).toContain('renamed');
+        expect(overflowTab.element.textContent).not.toContain('original');
+    });
 });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
@@ -51,6 +51,10 @@ class TestModel implements IDockviewPanelModel {
         //
     }
 
+    setTitle(title: string): void {
+        //
+    }
+
     layout(width: number, height: number): void {
         //
     }

--- a/packages/dockview-core/src/__tests__/dockview/dockviewPanel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewPanel.spec.ts
@@ -20,6 +20,7 @@ describe('dockviewPanel', () => {
             update: jest.fn(),
             init: jest.fn(),
             dispose: jest.fn(),
+            setTitle: jest.fn(),
         });
 
         const cut = new DockviewPanel(
@@ -67,6 +68,7 @@ describe('dockviewPanel', () => {
         const model = fromPartial<IDockviewPanelModel>({
             update: jest.fn(),
             init: jest.fn(),
+            setTitle: jest.fn(),
         });
 
         const cut = new DockviewPanel(
@@ -112,6 +114,7 @@ describe('dockviewPanel', () => {
             update: jest.fn(),
             init: jest.fn(),
             dispose: jest.fn(),
+            setTitle: jest.fn(),
         });
 
         const cut = new DockviewPanel(
@@ -148,6 +151,7 @@ describe('dockviewPanel', () => {
             update: jest.fn(),
             init: jest.fn(),
             dispose: jest.fn(),
+            setTitle: jest.fn(),
         });
 
         const cut = new DockviewPanel(
@@ -185,6 +189,7 @@ describe('dockviewPanel', () => {
             update: jest.fn(),
             init: jest.fn(),
             dispose: jest.fn(),
+            setTitle: jest.fn(),
         });
 
         const cut = new DockviewPanel(
@@ -223,6 +228,7 @@ describe('dockviewPanel', () => {
             update: jest.fn(),
             init: jest.fn(),
             dispose: jest.fn(),
+            setTitle: jest.fn(),
         });
 
         const cut = new DockviewPanel(

--- a/packages/dockview-core/src/dockview/dockviewPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewPanel.ts
@@ -172,6 +172,11 @@ export class DockviewPanel
 
         if (didTitleChange) {
             this._title = title;
+            // keep the view-model's cached init params in sync so that tab
+            // renderers constructed lazily (e.g. the header overflow
+            // dropdown via createTabRenderer) see the updated title
+            // (#914).
+            this.view.setTitle(title);
             this.api._onDidTitleChange.fire({ title });
         }
     }

--- a/packages/dockview-core/src/dockview/dockviewPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewPanelModel.ts
@@ -18,6 +18,7 @@ export interface IDockviewPanelModel extends IDisposable {
     layout(width: number, height: number): void;
     init(params: GroupPanelPartInitParameters): void;
     createTabRenderer(tabLocation: TabLocation): ITabRenderer;
+    setTitle(title: string): void;
 }
 
 export class DockviewPanelModel implements IDockviewPanelModel {
@@ -62,6 +63,15 @@ export class DockviewPanelModel implements IDockviewPanelModel {
 
         this.content.init(params);
         this.tab.init({ ...params, tabLocation: 'header' });
+    }
+
+    setTitle(title: string): void {
+        // keep the cached init params in sync so that tab renderers created
+        // lazily after the title changes (e.g. for the header overflow
+        // dropdown) see the current title rather than the stale original.
+        if (this._params) {
+            this._params.title = title;
+        }
     }
 
     layout(width: number, height: number): void {


### PR DESCRIPTION
## Summary

Fixes #914 — the header overflow dropdown lazily builds a fresh tab renderer for each overflowed panel via `panel.view.createTabRenderer(...)`. That renderer is initialised from `DockviewPanelModel._params`, a snapshot captured once at panel init. `api.setTitle(...)` only updated `DockviewPanel._title` and fired `onDidTitleChange`, so the lazy-built tab read the stale original title and the title-change event never fired after construction.

- Add a small `setTitle(title)` hook on `IDockviewPanelModel` / `DockviewPanelModel` that updates the cached `_params.title`.
- Call it from `DockviewPanel.setTitle(...)` so the model's snapshot stays current.

This is approach (A) from the triage report — the smallest diff that keeps `_params` as the canonical source of truth. Anyone supplying a custom tab component via `createTabComponent` (whose ephemeral renderer reads `params.title` in `init`) also benefits.

## Test plan

- [x] New regression test `issue #914: api.setTitle reflected by createTabRenderer output` in `dockviewComponent.spec.ts` exercises the bug directly: add a panel with title `'original'`, call `api.setTitle('renamed')`, invoke `panel.view.createTabRenderer('headerOverflow')`, and assert the rendered tab's `textContent` contains `'renamed'` and not `'original'`.
- [x] Verified the new test **fails** on master without the fix (received `"original"`, expected to contain `"renamed"`).
- [x] `npx jest --testPathPatterns dockviewComponent.spec --testNamePattern "title"` — 3 passed.
- [x] `npx jest --testPathPatterns dockviewPanelModel` — 6 passed.
- [x] Full `dockview-core` suite: **906 / 906 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)