### PR TITLE
fix(dockview-core): add drop target for tab group chip

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
@@ -545,6 +545,124 @@ describe('tabs', () => {
             const index = simulateDropOnTab(tabs, 1, 'right');
             expect(index).toBe(2);
         });
+
+        test('dropping on a group chip inserts before the group (group is first in tabs)', () => {
+            // [chip, A(0,in groupX), B(1,in groupX), C(2)]
+            // Drag C over the chip → insert before groupX at index 0.
+            // sourceIndex=2, insertionIndex=0, 2 < 0 is false → adjustedIndex=0.
+            const { tabs, group } = createTabsForDropTest();
+            tabs.openPanel(createMockPanel('panel-a'), 0);
+            tabs.openPanel(createMockPanel('panel-b'), 1);
+            tabs.openPanel(createMockPanel('panel-c'), 2);
+
+            const noopEvent = () => ({ dispose: jest.fn() });
+            const groupX = {
+                id: 'group-x',
+                panelIds: ['panel-a', 'panel-b'],
+                collapsed: false,
+                label: '',
+                color: undefined,
+                onDidChange: noopEvent,
+                onDidPanelChange: noopEvent,
+                onDidCollapseChange: noopEvent,
+            };
+            (group.model as any).getTabGroups = () => [groupX];
+            tabs.updateTabGroups();
+
+            LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+                [
+                    new PanelTransfer(
+                        'test-accessor-id',
+                        'test-group-id',
+                        'panel-c'
+                    ),
+                ],
+                PanelTransfer.prototype
+            );
+
+            const chipEl = (tabs as any)._tabGroupManager._chipRenderers.get(
+                'group-x'
+            ).chip.element as HTMLElement;
+            jest.spyOn(chipEl, 'offsetWidth', 'get').mockReturnValue(40);
+            jest.spyOn(chipEl, 'offsetHeight', 'get').mockReturnValue(30);
+
+            const drops: TabDropIndexEvent[] = [];
+            tabs.onDrop((e) => drops.push(e));
+
+            fireEvent.dragEnter(chipEl);
+            fireEvent(
+                chipEl,
+                createOffsetDragOverEvent({ clientX: 10, clientY: 0 })
+            );
+
+            const dropzone = chipEl.querySelector('.dv-drop-target-dropzone');
+            expect(dropzone).not.toBeNull();
+
+            fireEvent.drop(dropzone!);
+
+            expect(drops.length).toBe(1);
+            expect(drops[0].index).toBe(0);
+            expect(drops[0].targetTabGroupId).toBeNull();
+        });
+
+        test('dropping a cross-group panel on a chip inserts before the group at firstTabIdx', () => {
+            // [X(0), chip, A(1,in groupY), B(2,in groupY)]
+            // External drag (different group) onto chip → insert at index 1
+            // (firstTabIdx of groupY). sourceIndex=-1 → no adjustment.
+            const { tabs, group } = createTabsForDropTest();
+            tabs.openPanel(createMockPanel('panel-x'), 0);
+            tabs.openPanel(createMockPanel('panel-a'), 1);
+            tabs.openPanel(createMockPanel('panel-b'), 2);
+
+            const noopEvent = () => ({ dispose: jest.fn() });
+            const groupY = {
+                id: 'group-y',
+                panelIds: ['panel-a', 'panel-b'],
+                collapsed: false,
+                label: '',
+                color: undefined,
+                onDidChange: noopEvent,
+                onDidPanelChange: noopEvent,
+                onDidCollapseChange: noopEvent,
+            };
+            (group.model as any).getTabGroups = () => [groupY];
+            tabs.updateTabGroups();
+
+            LocalSelectionTransfer.getInstance<PanelTransfer>().setData(
+                [
+                    new PanelTransfer(
+                        'test-accessor-id',
+                        'other-group-id',
+                        'panel-z'
+                    ),
+                ],
+                PanelTransfer.prototype
+            );
+
+            const chipEl = (tabs as any)._tabGroupManager._chipRenderers.get(
+                'group-y'
+            ).chip.element as HTMLElement;
+            jest.spyOn(chipEl, 'offsetWidth', 'get').mockReturnValue(40);
+            jest.spyOn(chipEl, 'offsetHeight', 'get').mockReturnValue(30);
+
+            const drops: TabDropIndexEvent[] = [];
+            tabs.onDrop((e) => drops.push(e));
+
+            fireEvent.dragEnter(chipEl);
+            fireEvent(
+                chipEl,
+                createOffsetDragOverEvent({ clientX: 10, clientY: 0 })
+            );
+
+            const dropzone = chipEl.querySelector('.dv-drop-target-dropzone');
+            expect(dropzone).not.toBeNull();
+
+            fireEvent.drop(dropzone!);
+
+            expect(drops.length).toBe(1);
+            expect(drops[0].index).toBe(1);
+            expect(drops[0].targetTabGroupId).toBeNull();
+        });
     });
 
     describe('delete', () => {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -13,6 +13,8 @@ import { ITabGroup } from '../../tabGroup';
 import { applyTabGroupAccent } from '../../tabGroupAccent';
 import { TabGroupChip } from './tabGroupChip';
 import { ITabGroupChipRenderer } from '../../framework';
+import { Droptarget, DroptargetEvent } from '../../../dnd/droptarget';
+import { getPanelData } from '../../../dnd/dataTransfer';
 import {
     ITabGroupIndicator,
     NoneTabGroupIndicator,
@@ -37,12 +39,17 @@ export interface TabGroupManagerCallbacks {
         chip: ITabGroupChipRenderer,
         event: DragEvent
     ): void;
+    onChipDrop(tabGroup: ITabGroup, event: DroptargetEvent): void;
 }
 
 export class TabGroupManager {
     private readonly _chipRenderers = new Map<
         string,
-        { chip: ITabGroupChipRenderer; disposable: IDisposable }
+        {
+            chip: ITabGroupChipRenderer;
+            disposable: IDisposable;
+            dropTarget: Droptarget;
+        }
     >();
     private _indicator: ITabGroupIndicator | null = null;
     private _skipNextCollapseAnimation = false;
@@ -50,7 +57,11 @@ export class TabGroupManager {
 
     get chipRenderers(): ReadonlyMap<
         string,
-        { chip: ITabGroupChipRenderer; disposable: IDisposable }
+        {
+            chip: ITabGroupChipRenderer;
+            disposable: IDisposable;
+            dropTarget: Droptarget;
+        }
     > {
         return this._chipRenderers;
     }
@@ -122,6 +133,13 @@ export class TabGroupManager {
         }
         for (const tabGroup of this._ctx.group.model.getTabGroups()) {
             this._positionChipForGroup(tabGroup);
+        }
+    }
+
+    updateDirection(): void {
+        const isVertical = this._ctx.getDirection() === 'vertical';
+        for (const [, entry] of this._chipRenderers) {
+            entry.dropTarget.setTargetZones(isVertical ? ['top'] : ['left']);
         }
     }
 
@@ -333,8 +351,52 @@ export class TabGroupManager {
             );
         }
 
+        // The chip sits before its group's first tab in the DOM, so it
+        // covers the "drop before the group" position. Without a drop
+        // target here, dropping a tab over the chip is a dead zone —
+        // particularly visible when the group is first in the tabs list
+        // and there's no preceding tab whose right zone covers position 0.
+        // The smooth animation path already shifts the chip's margin to
+        // open a gap, so suppress the overlay in that mode.
+        const isVertical = this._ctx.getDirection() === 'vertical';
+        const dropTarget = new Droptarget(chip.element, {
+            acceptedTargetZones: isVertical ? ['top'] : ['left'],
+            overlayModel: {
+                activationSize: { value: 100, type: 'percentage' },
+            },
+            canDisplayOverlay: (event, position) => {
+                if (this._ctx.group.locked) {
+                    return false;
+                }
+                if (this._ctx.accessor.options.disableDnd) {
+                    return false;
+                }
+                const data = getPanelData();
+                if (data && this._ctx.accessor.id === data.viewId) {
+                    if (
+                        this._ctx.accessor.options.theme?.tabAnimation ===
+                        'smooth'
+                    ) {
+                        return false;
+                    }
+                    return true;
+                }
+                return this._ctx.group.model.canDisplayOverlay(
+                    event,
+                    position,
+                    'tab'
+                );
+            },
+        });
+        disposables.push(
+            dropTarget,
+            dropTarget.onDrop((event) => {
+                this._callbacks.onChipDrop(tabGroup, event);
+            })
+        );
+
         const disposable = new CompositeDisposable(...disposables);
-        this._chipRenderers.set(tabGroup.id, { chip, disposable });
+        this._chipRenderers.set(tabGroup.id, { chip, disposable, dropTarget });
 
         // Group is born collapsed (cross-group drop, layout restore, etc.):
         // its tabs are about to be added without the collapsed class. Skip

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -1138,10 +1138,7 @@ export class Tabs extends CompositeDisposable {
      * removal shifts the insertion index down by one). Always clears
      * `targetTabGroupId` so the dropped tab lands outside the group.
      */
-    private _handleChipDrop(
-        tabGroup: ITabGroup,
-        event: DroptargetEvent
-    ): void {
+    private _handleChipDrop(tabGroup: ITabGroup, event: DroptargetEvent): void {
         const firstPanelId = tabGroup.panelIds[0];
         if (!firstPanelId) {
             return;
@@ -1155,9 +1152,7 @@ export class Tabs extends CompositeDisposable {
         const data = getPanelData();
         const sourceIndex =
             data && data.groupId === this.group.id && data.panelId
-                ? this._tabs.findIndex(
-                      (x) => x.value.panel.id === data.panelId
-                  )
+                ? this._tabs.findIndex((x) => x.value.panel.id === data.panelId)
                 : -1;
         const adjustedIndex =
             insertionIndex -

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -31,6 +31,7 @@ import { ITabGroup } from '../../tabGroup';
 import { TabGroupChip } from './tabGroupChip';
 import { TabGroupManager } from './tabGroups';
 import { ITabGroupChipRenderer } from '../../framework';
+import { DroptargetEvent } from '../../../dnd/droptarget';
 
 interface TabAnimationState {
     sourceTabId: string;
@@ -217,6 +218,7 @@ export class Tabs extends CompositeDisposable {
         for (const tab of this._tabs) {
             tab.value.setDirection(value);
         }
+        this._tabGroupManager.updateDirection();
     }
 
     constructor(
@@ -261,6 +263,9 @@ export class Tabs extends CompositeDisposable {
                 },
                 onChipDragStart: (tabGroup, chip, event) => {
                     this._handleChipDragStart(tabGroup, chip, event);
+                },
+                onChipDrop: (tabGroup, event) => {
+                    this._handleChipDrop(tabGroup, event);
                 },
             }
         );
@@ -1124,6 +1129,44 @@ export class Tabs extends CompositeDisposable {
 
         // Build a composite drag image showing chip + group tabs
         this._tabGroupManager.setGroupDragImage(event, tabGroup, chip.element);
+    }
+
+    /**
+     * A drop on a tab group chip means "insert before this group". Resolve to
+     * the index of the group's first tab, adjusting for same-group removal
+     * (when the source tab is currently to the left of the target slot, its
+     * removal shifts the insertion index down by one). Always clears
+     * `targetTabGroupId` so the dropped tab lands outside the group.
+     */
+    private _handleChipDrop(
+        tabGroup: ITabGroup,
+        event: DroptargetEvent
+    ): void {
+        const firstPanelId = tabGroup.panelIds[0];
+        if (!firstPanelId) {
+            return;
+        }
+        const insertionIndex = this._tabs.findIndex(
+            (x) => x.value.panel.id === firstPanelId
+        );
+        if (insertionIndex === -1) {
+            return;
+        }
+        const data = getPanelData();
+        const sourceIndex =
+            data && data.groupId === this.group.id && data.panelId
+                ? this._tabs.findIndex(
+                      (x) => x.value.panel.id === data.panelId
+                  )
+                : -1;
+        const adjustedIndex =
+            insertionIndex -
+            (sourceIndex !== -1 && sourceIndex < insertionIndex ? 1 : 0);
+        this._onDrop.fire({
+            event: event.nativeEvent,
+            index: adjustedIndex,
+            targetTabGroupId: null,
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary

When a tab group is the first item in a tabs container, the chip sits before the group's first tab in the DOM and covers the position-0 drop slot. The chip had no `Droptarget` and the tabs container's `dragover` handler bails for individual tab drags in default animation mode (`tabs.ts:318-324`), so hovering over the chip was a dead zone — no overlay, no drop.

- Attach a `Droptarget` to `chip.element` in `TabGroupManager._ensureChipForGroup`, accepting only the leading zone (`left` horizontal / `top` vertical) at 100% activation, so the whole chip = "before this group".
- `canDisplayOverlay` mirrors `Tab`'s pattern: respects `locked`/`disableDnd`, suppresses the overlay in `smooth` mode (the gap-shift animation already covers that case), delegates to `group.model.canDisplayOverlay` for cross-accessor drags.
- New `onChipDrop` callback wired from `TabGroupManager` → `Tabs._handleChipDrop`, which resolves the insertion index to the group's first tab and applies the standard same-group source-removal adjustment.
- `updateDirection()` on `TabGroupManager` refreshes target zones when the header direction changes.

## Test plan

- [x] `yarn jest --selectProjects dockview-core` (920 passed, +2 new regression tests)
- [ ] Manual: default animation mode — drag a tab over the chip of the first-positioned group → overlay appears on chip's leading edge, drop inserts the tab before the group.
- [ ] Manual: smooth animation mode — drag a tab over the chip → existing gap-shift animation still works (chip's Droptarget overlay is suppressed).
- [ ] Manual: vertical header direction — same as above with the top zone.
- [ ] Manual: locked group — chip does not accept drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)