### PR TITLE
docs: canonicalize dockview-react as the React install across docs, R…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,10 @@ NX handles build ordering automatically via `dependsOn: ["^build"]`. The depende
 ### Monorepo Structure
 
 -   **packages/dockview-core** - Core layout engine (TypeScript, framework-agnostic, zero dependencies)
--   **packages/dockview** - React bindings and components
+-   **packages/dockview-react** - Canonical React bindings package — what docs, READMEs, and examples point users at (`npm install dockview-react`). Re-exports the implementation from `packages/dockview`.
+-   **packages/dockview** - Legacy alias kept for backwards compatibility. Still holds the actual React source; `dockview-react` re-exports from it.
 -   **packages/dockview-vue** - Vue 3 bindings and components
 -   **packages/dockview-angular** - Angular bindings and components
--   **packages/dockview-react** - Re-export wrapper (`export * from 'dockview'`)
 -   **packages/docs** - Documentation website (Docusaurus v3)
 
 ### Key Components

--- a/README.md
+++ b/README.md
@@ -41,15 +41,14 @@ Please see the website: https://dockview.dev
 | Package | Description | Version |
 | --- | --- | --- |
 | [`dockview-core`](https://www.npmjs.com/package/dockview-core) | Core layout engine — zero dependencies, vanilla TypeScript | [![npm version](https://badge.fury.io/js/dockview-core.svg)](https://www.npmjs.com/package/dockview-core) |
-| [`dockview`](https://www.npmjs.com/package/dockview) | React bindings (peer: `react` ≥16.8) | [![npm version](https://badge.fury.io/js/dockview.svg)](https://www.npmjs.com/package/dockview) |
+| [`dockview-react`](https://www.npmjs.com/package/dockview-react) | React bindings (peer: `react` ≥16.8) | [![npm version](https://badge.fury.io/js/dockview-react.svg)](https://www.npmjs.com/package/dockview-react) |
 | [`dockview-vue`](https://www.npmjs.com/package/dockview-vue) | Vue 3 bindings (peer: `vue` ≥3.4) | [![npm version](https://badge.fury.io/js/dockview-vue.svg)](https://www.npmjs.com/package/dockview-vue) |
 | [`dockview-angular`](https://www.npmjs.com/package/dockview-angular) | Angular bindings (peer: `@angular/core` ≥21) | [![npm version](https://badge.fury.io/js/dockview-angular.svg)](https://www.npmjs.com/package/dockview-angular) |
-| [`dockview-react`](https://www.npmjs.com/package/dockview-react) | Re-export of `dockview` for migration convenience | [![npm version](https://badge.fury.io/js/dockview-react.svg)](https://www.npmjs.com/package/dockview-react) |
 
 ## Installation
 
 ```bash
-npm install dockview          # React
+npm install dockview-react    # React
 npm install dockview-vue      # Vue
 npm install dockview-angular  # Angular
 npm install dockview-core     # Vanilla TypeScript
@@ -58,8 +57,8 @@ npm install dockview-core     # Vanilla TypeScript
 ## Quick Start (React)
 
 ```tsx
-import { DockviewReact } from 'dockview';
-import 'dockview/dist/styles/dockview.css';
+import { DockviewReact } from 'dockview-react';
+import 'dockview-react/dist/styles/dockview.css';
 
 const components = {
     default: (props) => <div>Hello {props.params.title}</div>,
@@ -101,7 +100,7 @@ yarn format     # Run Prettier
 Build order is managed automatically by NX:
 
 ```
-dockview-core → dockview → dockview-react
+dockview-core → dockview-react
 dockview-core → dockview-vue
 dockview-core → dockview-angular
 ```
@@ -116,4 +115,4 @@ MIT — see [LICENSE](./LICENSE) for details.
 
 ---
 
-Want to verify our builds? Go [here](https://www.npmjs.com/package/dockview#user-content-provenance).
+Want to verify our builds? Go [here](https://www.npmjs.com/package/dockview-react#user-content-provenance).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24,8 +24,8 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 | Package | Framework | Install |
 |---|---|---|
 | dockview-core | Vanilla TypeScript | `npm install dockview-core` |
-| dockview | React | `npm install dockview` |
-| dockview-react | React (alias) | `npm install dockview-react` |
+| dockview-react | React | `npm install dockview-react` |
+| dockview | React (legacy alias) | `npm install dockview` |
 | dockview-vue | Vue 3 | `npm install dockview-vue` |
 | dockview-angular | Angular | `npm install dockview-angular` |
 
@@ -80,19 +80,19 @@ Apply a theme to a parent element:
 Install:
 
 ```
-npm install dockview
+npm install dockview-react
 ```
 
 Import the stylesheet:
 
 ```css
-@import 'dockview/dist/styles/dockview.css';
+@import 'dockview-react/dist/styles/dockview.css';
 ```
 
 Render the component:
 
 ```tsx
-import { DockviewReact } from 'dockview';
+import { DockviewReact } from 'dockview-react';
 
 const components = {
     myComponent: (props) => <div>Hello World</div>,
@@ -251,6 +251,6 @@ Custom themes can be created using CSS custom properties (CSS variables).
 - API Reference: https://dockview.dev/docs/api/dockview/overview
 - Live Demo: https://dockview.dev/demo
 - GitHub: https://github.com/mathuo/dockview
-- npm: https://www.npmjs.com/package/dockview
+- npm: https://www.npmjs.com/package/dockview-react
 - Blog / Release Notes: https://dockview.dev/blog
 - License: MIT

--- a/llms.txt
+++ b/llms.txt
@@ -23,8 +23,8 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 | Package | Framework | Install |
 |---|---|---|
 | dockview-core | Vanilla TypeScript | `npm install dockview-core` |
-| dockview | React | `npm install dockview` |
-| dockview-react | React (alias) | `npm install dockview-react` |
+| dockview-react | React | `npm install dockview-react` |
+| dockview | React (legacy alias) | `npm install dockview` |
 | dockview-vue | Vue 3 | `npm install dockview-vue` |
 | dockview-angular | Angular | `npm install dockview-angular` |
 
@@ -38,6 +38,6 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 - API Reference: https://dockview.dev/docs/api/dockview/overview
 - Live Demo: https://dockview.dev/demo
 - GitHub: https://github.com/mathuo/dockview
-- npm: https://www.npmjs.com/package/dockview
+- npm: https://www.npmjs.com/package/dockview-react
 - Blog / Release Notes: https://dockview.dev/blog
 - License: MIT

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,16 +1,22 @@
 # Project Structure
 
-This mono-repository has a number of packages containing the code for the [dockview](https://www.npmjs.com/package/dockview) library and the documentation website [dockview.dev](dockview.dev).
+This mono-repository has a number of packages containing the code for the dockview library and the documentation website [dockview.dev](dockview.dev).
 
 ## dockview-core
 
 -   Contains the core logic for the dockview library.
 -   Written entirely in vanilla JavaScript/TypeScript.
 
+## dockview-react
+
+-   Depends on `dockview-core` (via the `dockview` package).
+-   Exports a `React` wrapper.
+-   Published as [dockview-react](https://www.npmjs.com/package/dockview-react) on npm — the canonical install name.
+
 ## dockview
 
--   Depends on `dockview-core`.
--   Exports a `React` wrapper.
+-   Legacy alias of `dockview-react`, kept for backwards compatibility.
+-   Still holds the underlying React source that `dockview-react` re-exports.
 -   Published as [dockview](https://www.npmjs.com/package/dockview) on npm.
 
 ## docs

--- a/packages/dockview-react/AGENTS.md
+++ b/packages/dockview-react/AGENTS.md
@@ -1,12 +1,12 @@
 # AGENTS.md - dockview-react
 
-Thin re-export wrapper providing an alternative package name.
+Canonical React bindings package — the public install name users should reach for (`npm install dockview-react`). All documentation, READMEs, and examples point at this package.
 
 ## Overview
 
 - Entire source is one line: `export * from 'dockview'`
-- Exists so users can `npm install dockview-react` as an alternative to `npm install dockview`
-- No unique source code; all functionality comes from the `dockview` package
+- Re-exports the implementation from the `dockview` package, which is kept as a legacy alias for backwards compatibility
+- No unique source code in this package; functionality lives in the `dockview` package
 
 ## Build
 

--- a/packages/dockview-react/README.md
+++ b/packages/dockview-react/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <h1>dockview-react</h1>
 
-<p>Re-export wrapper for the <code>dockview</code> package — use <code>dockview</code> directly for new projects</p>
+<p>React bindings for dockview — zero dependency layout manager supporting tabs, groups, grids and splitviews</p>
 
 </div>
 
@@ -40,18 +40,44 @@ Please see the website: https://dockview.dev
 
 ## Quick Start
 
-This package re-exports everything from [`dockview`](https://www.npmjs.com/package/dockview). For new projects, we recommend installing `dockview` directly:
-
-```
-npm install dockview
-```
-
-If you're already using `dockview-react`, it continues to work — all exports are identical to `dockview`:
+Dockview has a peer dependency on `react >= 16.8.0` and `react-dom >= 16.8.0`. Install from [npm](https://www.npmjs.com/package/dockview-react):
 
 ```
 npm install dockview-react
 ```
 
-See the [`dockview` package](https://www.npmjs.com/package/dockview) and the [documentation](https://dockview.dev) for usage examples.
+Import the stylesheet:
+
+```css
+@import 'dockview-react/dist/styles/dockview.css';
+```
+
+Apply a theme and render the component:
+
+```tsx
+import { DockviewReact } from 'dockview-react';
+
+const components = {
+    myComponent: (props) => <div>Hello World</div>,
+};
+
+function App() {
+    return (
+        <div className="dockview-theme-dark" style={{ height: '400px' }}>
+            <DockviewReact
+                components={components}
+                onReady={(event) => {
+                    event.api.addPanel({
+                        id: 'panel_1',
+                        component: 'myComponent',
+                    });
+                }}
+            />
+        </div>
+    );
+}
+```
+
+See the [documentation](https://dockview.dev) for full examples.
 
 Want to verify our builds? Go [here](https://www.npmjs.com/package/dockview-react#Provenance).

--- a/packages/dockview/AGENTS.md
+++ b/packages/dockview/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md - dockview
 
-Primary React bindings package. This is what most React users install (`npm install dockview`).
+Legacy React bindings package, kept as an alias for backwards compatibility. New projects should install [`dockview-react`](../dockview-react/AGENTS.md) instead — see the repo-root README and docs site for the canonical install instructions.
+
+Note: this package still contains the actual React source. `dockview-react` is the thin re-export wrapper that has become the canonical public name. Don't move source between packages without coordinating a publish plan.
 
 ## Overview
 

--- a/packages/docs/docs/core/panels/tabs.mdx
+++ b/packages/docs/docs/core/panels/tabs.mdx
@@ -596,7 +596,7 @@ Controls how tabs animate when reordered via drag-and-drop.
 
 <FrameworkSpecific framework="React">
 ```tsx
-import { themeAbyss } from 'dockview';
+import { themeAbyss } from 'dockview-react';
 
 const myTheme = { ...themeAbyss, tabAnimation: 'smooth' };
 


### PR DESCRIPTION
…EADMEs, and llms.txt

Update the public-facing materials so React users are pointed at `dockview-react` instead of `dockview`. The `dockview` package remains as a legacy alias for backwards compatibility, retained in the llms.txt / llms-full.txt package tables and noted in internal agent docs. Package source and build chain are unchanged.

## Description

<!-- What does this PR do and why? -->

## Type of change

<!-- Check the one that applies -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
