### PR TITLE
feat(dockview-angular): close API gaps + add 15 missing templates

### DIFF
--- a/packages/dockview-angular/src/__tests__/angular-header-actions-renderer.spec.ts
+++ b/packages/dockview-angular/src/__tests__/angular-header-actions-renderer.spec.ts
@@ -1,0 +1,240 @@
+import { TestBed } from '@angular/core/testing';
+import {
+    ApplicationRef,
+    Component,
+    EnvironmentInjector,
+    Injector,
+} from '@angular/core';
+import { AngularHeaderActionsRenderer } from '../lib/dockview/angular-header-actions-renderer';
+
+@Component({
+    standalone: false,
+    selector: 'header-actions-host',
+    template: `
+        <div class="header-actions-host">
+            <span class="panels">{{ panels?.length }}</span>
+            <span class="active">{{ activePanel?.id || '-' }}</span>
+            <span class="active-group">{{ isGroupActive ? 'yes' : 'no' }}</span>
+            <span class="header-position">{{ headerPosition }}</span>
+            <span class="location">{{ location?.type || '-' }}</span>
+        </div>
+    `,
+})
+class HeaderActionsHostComponent {
+    api: any = undefined;
+    containerApi: any = undefined;
+    panels: { id: string }[] = [];
+    activePanel?: { id: string };
+    isGroupActive = false;
+    group: any = undefined;
+    headerPosition: string = 'top';
+    location: any = undefined;
+}
+
+interface EventEmitter<T> {
+    fire(value: T): void;
+    subscribe(handler: (value: T) => void): { dispose(): void };
+}
+
+function makeEmitter<T>(): EventEmitter<T> {
+    const handlers = new Set<(value: T) => void>();
+    return {
+        fire: (value) => handlers.forEach((h) => h(value)),
+        subscribe: (handler) => {
+            handlers.add(handler);
+            return {
+                dispose: () => {
+                    handlers.delete(handler);
+                },
+            };
+        },
+    };
+}
+
+describe('AngularHeaderActionsRenderer', () => {
+    let injector: Injector;
+    let environmentInjector: EnvironmentInjector;
+    let application: ApplicationRef;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [HeaderActionsHostComponent],
+        }).compileComponents();
+
+        injector = TestBed.inject(Injector);
+        environmentInjector = TestBed.inject(EnvironmentInjector);
+        application = TestBed.inject(ApplicationRef);
+    });
+
+    afterEach(() => {
+        TestBed.resetTestingModule();
+    });
+
+    function makeStubGroup() {
+        const onDidAddPanel = makeEmitter<void>();
+        const onDidRemovePanel = makeEmitter<void>();
+        const onDidActivePanelChange = makeEmitter<void>();
+        const onDidActiveChange = makeEmitter<void>();
+        const onDidLocationChange = makeEmitter<{ location: any }>();
+
+        const panels: { id: string }[] = [];
+        const groupApi = {
+            isActive: false,
+            location: { type: 'grid' },
+            onDidActiveChange: onDidActiveChange.subscribe,
+            onDidLocationChange: onDidLocationChange.subscribe,
+        };
+        const group = {
+            api: groupApi,
+            model: {
+                panels,
+                activePanel: undefined as { id: string } | undefined,
+                headerPosition: 'top',
+                onDidAddPanel: onDidAddPanel.subscribe,
+                onDidRemovePanel: onDidRemovePanel.subscribe,
+                onDidActivePanelChange: onDidActivePanelChange.subscribe,
+            },
+        };
+
+        return {
+            group,
+            emitters: {
+                onDidAddPanel,
+                onDidRemovePanel,
+                onDidActivePanelChange,
+                onDidActiveChange,
+                onDidLocationChange,
+            },
+        };
+    }
+
+    it('seeds the component with the full IDockviewHeaderActionsProps surface', () => {
+        const { group } = makeStubGroup();
+        const renderer = new AngularHeaderActionsRenderer(
+            HeaderActionsHostComponent,
+            group as any,
+            injector,
+            environmentInjector
+        );
+
+        const containerApi = { tag: 'container' } as any;
+        renderer.init({ api: group.api as any, containerApi });
+        application.tick();
+
+        expect(renderer.element.querySelector('.panels')!.textContent).toBe(
+            '0'
+        );
+        expect(renderer.element.querySelector('.active')!.textContent).toBe(
+            '-'
+        );
+        expect(
+            renderer.element.querySelector('.active-group')!.textContent
+        ).toBe('no');
+        expect(
+            renderer.element.querySelector('.header-position')!.textContent
+        ).toBe('top');
+        expect(renderer.element.querySelector('.location')!.textContent).toBe(
+            'grid'
+        );
+
+        renderer.dispose();
+    });
+
+    it('updates panels when the group emits add / remove events', () => {
+        const { group, emitters } = makeStubGroup();
+        const renderer = new AngularHeaderActionsRenderer(
+            HeaderActionsHostComponent,
+            group as any,
+            injector,
+            environmentInjector
+        );
+
+        renderer.init({
+            api: group.api as any,
+            containerApi: {} as any,
+        });
+        application.tick();
+
+        group.model.panels.push({ id: 'p1' });
+        emitters.onDidAddPanel.fire();
+        application.tick();
+        expect(renderer.element.querySelector('.panels')!.textContent).toBe(
+            '1'
+        );
+
+        group.model.panels.length = 0;
+        emitters.onDidRemovePanel.fire();
+        application.tick();
+        expect(renderer.element.querySelector('.panels')!.textContent).toBe(
+            '0'
+        );
+
+        renderer.dispose();
+    });
+
+    it('tracks active panel, active group, and location changes', () => {
+        const { group, emitters } = makeStubGroup();
+        const renderer = new AngularHeaderActionsRenderer(
+            HeaderActionsHostComponent,
+            group as any,
+            injector,
+            environmentInjector
+        );
+
+        renderer.init({
+            api: group.api as any,
+            containerApi: {} as any,
+        });
+        application.tick();
+
+        group.model.activePanel = { id: 'panel-7' };
+        emitters.onDidActivePanelChange.fire();
+        application.tick();
+        expect(renderer.element.querySelector('.active')!.textContent).toBe(
+            'panel-7'
+        );
+
+        group.api.isActive = true;
+        emitters.onDidActiveChange.fire();
+        application.tick();
+        expect(
+            renderer.element.querySelector('.active-group')!.textContent
+        ).toBe('yes');
+
+        emitters.onDidLocationChange.fire({ location: { type: 'floating' } });
+        application.tick();
+        expect(renderer.element.querySelector('.location')!.textContent).toBe(
+            'floating'
+        );
+
+        renderer.dispose();
+    });
+
+    it('disposes subscriptions and view on dispose()', () => {
+        const { group, emitters } = makeStubGroup();
+        const renderer = new AngularHeaderActionsRenderer(
+            HeaderActionsHostComponent,
+            group as any,
+            injector,
+            environmentInjector
+        );
+
+        renderer.init({
+            api: group.api as any,
+            containerApi: {} as any,
+        });
+        application.tick();
+
+        renderer.dispose();
+
+        // After dispose, firing further events must not throw — disposal
+        // should have unsubscribed every handler.
+        expect(() => {
+            group.model.panels.push({ id: 'late' });
+            emitters.onDidAddPanel.fire();
+            emitters.onDidActivePanelChange.fire();
+            emitters.onDidActiveChange.fire();
+            emitters.onDidLocationChange.fire({ location: { type: 'grid' } });
+        }).not.toThrow();
+    });
+});

--- a/packages/dockview-angular/src/__tests__/component-factory.spec.ts
+++ b/packages/dockview-angular/src/__tests__/component-factory.spec.ts
@@ -285,20 +285,27 @@ describe('AngularFrameworkComponentFactory', () => {
     });
 
     describe('createHeaderActionsComponent', () => {
+        const stubGroup = {} as any;
+
         it('should create header actions component successfully', () => {
-            const renderer =
-                factory.createHeaderActionsComponent('header-test');
+            const renderer = factory.createHeaderActionsComponent(
+                'header-test',
+                stubGroup
+            );
 
             expect(renderer).toBeDefined();
-            expect(renderer.element).toBeTruthy();
-            expect(renderer.element.tagName).toBe(
-                'TEST-HEADER-ACTIONS-COMPONENT'
-            );
+            expect(renderer!.element).toBeTruthy();
+            // The renderer wraps the user component in a host div; the inner
+            // component is mounted on init() by dockview-core.
+            expect(renderer!.element.tagName).toBe('DIV');
+            expect(renderer!.element.className).toContain('dv-angular-part');
         });
 
         it('should return undefined for unknown component', () => {
-            const renderer =
-                factory.createHeaderActionsComponent('unknown-header');
+            const renderer = factory.createHeaderActionsComponent(
+                'unknown-header',
+                stubGroup
+            );
 
             expect(renderer).toBeUndefined();
         });
@@ -313,7 +320,8 @@ describe('AngularFrameworkComponentFactory', () => {
 
             const renderer =
                 factoryWithoutHeaderActions.createHeaderActionsComponent(
-                    'test'
+                    'test',
+                    stubGroup
                 );
 
             expect(renderer).toBeUndefined();

--- a/packages/dockview-angular/src/__tests__/dockview-angular.component.spec.ts
+++ b/packages/dockview-angular/src/__tests__/dockview-angular.component.spec.ts
@@ -105,6 +105,42 @@ describe('DockviewAngularComponent', () => {
 
         expect(component.getDockviewApi()).toBeDefined();
     });
+
+    it('forwards every PROPERTY_KEYS_DOCKVIEW input to dockview-core on update', () => {
+        // Regression for the missing-input gap: scrollbars, disableTabsOverflowList,
+        // theme, defaultRenderer, defaultHeaderPosition, disableDnd, dndStrategy,
+        // dndEdges, and noPanelsOverlay used to have no @Input() declared, so
+        // PROPERTY_KEYS_DOCKVIEW.forEach found `undefined` for them and they
+        // were silently unsettable from Angular templates.
+        component.ngOnInit();
+        const api = component.getDockviewApi()!;
+        const updateOptionsSpy = jest.spyOn(api, 'updateOptions');
+
+        const cases: Array<[string, unknown]> = [
+            ['scrollbars', 'native'],
+            ['disableTabsOverflowList', true],
+            ['defaultRenderer', 'always'],
+            ['defaultHeaderPosition', 'bottom'],
+            ['disableDnd', true],
+            ['dndStrategy', 'pointer'],
+            ['noPanelsOverlay', 'emptyGroup'],
+            ['theme', { name: 't', className: 'dv-t' }],
+        ];
+
+        for (const [key, value] of cases) {
+            updateOptionsSpy.mockClear();
+            (component as any)[key] = value;
+            component.ngOnChanges({
+                [key]: {
+                    currentValue: value,
+                    previousValue: undefined,
+                    firstChange: false,
+                    isFirstChange: () => false,
+                },
+            });
+            expect(updateOptionsSpy).toHaveBeenCalledWith({ [key]: value });
+        }
+    });
 });
 
 @Component({

--- a/packages/dockview-angular/src/lib/dockview/angular-header-actions-renderer.ts
+++ b/packages/dockview-angular/src/lib/dockview/angular-header-actions-renderer.ts
@@ -1,0 +1,144 @@
+import {
+    Type,
+    Injector,
+    EnvironmentInjector,
+    ApplicationRef,
+    ComponentRef,
+    EmbeddedViewRef,
+    TemplateRef,
+    createComponent,
+} from '@angular/core';
+import {
+    DockviewApi,
+    DockviewCompositeDisposable,
+    DockviewGroupLocation,
+    DockviewGroupPanel,
+    DockviewGroupPanelApi,
+    IDockviewHeaderActionsProps,
+    IDockviewPanel,
+    IHeaderActionsRenderer,
+} from 'dockview-core';
+
+/**
+ * Angular implementation of a header-actions renderer. Mirrors the React
+ * `ReactHeaderActionsRendererPart`: dockview-core only provides `api`,
+ * `containerApi`, and `group` at init time, so this renderer augments the
+ * component instance with the rest of `IDockviewHeaderActionsProps`
+ * (`panels`, `activePanel`, `isGroupActive`, `headerPosition`, `location`)
+ * and subscribes to the relevant events to keep them up to date.
+ */
+export class AngularHeaderActionsRenderer implements IHeaderActionsRenderer {
+    private readonly _element: HTMLElement;
+    private componentRef: ComponentRef<unknown> | null = null;
+    private viewRef: EmbeddedViewRef<unknown> | null = null;
+    private readonly appRef: ApplicationRef;
+    private subscriptions: DockviewCompositeDisposable | null = null;
+
+    get element(): HTMLElement {
+        return this._element;
+    }
+
+    constructor(
+        private readonly component: Type<unknown> | TemplateRef<unknown>,
+        private readonly group: DockviewGroupPanel,
+        private readonly injector: Injector,
+        private readonly environmentInjector?: EnvironmentInjector
+    ) {
+        this._element = document.createElement('div');
+        this._element.className = 'dv-angular-part';
+        this._element.style.height = '100%';
+        this._element.style.width = '100%';
+        this.appRef = injector.get(ApplicationRef);
+    }
+
+    init(parameters: {
+        containerApi: DockviewApi;
+        api: DockviewGroupPanelApi;
+    }): void {
+        if (this.component instanceof TemplateRef) {
+            // TemplateRef-based header actions cannot receive @Input()s;
+            // render the template once and leave it static.
+            this.viewRef = this.component.createEmbeddedView({}, this.injector);
+            this._element.appendChild(this.viewRef.rootNodes[0] as HTMLElement);
+            this.appRef.attachView(this.viewRef);
+            this.viewRef.markForCheck();
+            return;
+        }
+
+        this.componentRef = createComponent(this.component, {
+            environmentInjector:
+                this.environmentInjector ||
+                (this.injector as EnvironmentInjector),
+            elementInjector: this.injector,
+        });
+
+        const initialProps: IDockviewHeaderActionsProps = {
+            api: parameters.api,
+            containerApi: parameters.containerApi,
+            panels: this.group.model.panels,
+            activePanel: this.group.model.activePanel,
+            isGroupActive: this.group.api.isActive,
+            group: this.group,
+            headerPosition: this.group.model.headerPosition,
+            location: parameters.api.location,
+        };
+        this.assign(initialProps);
+
+        const hostView = this.componentRef.hostView as EmbeddedViewRef<unknown>;
+        const rootNode = hostView.rootNodes[0] as HTMLElement;
+        this._element.appendChild(rootNode);
+        this.appRef.attachView(hostView);
+        this.componentRef.changeDetectorRef.markForCheck();
+
+        this.subscriptions = new DockviewCompositeDisposable(
+            this.group.model.onDidAddPanel(() => {
+                this.assign({ panels: this.group.model.panels });
+            }),
+            this.group.model.onDidRemovePanel(() => {
+                this.assign({ panels: this.group.model.panels });
+            }),
+            this.group.model.onDidActivePanelChange(() => {
+                this.assign({
+                    activePanel: this.group.model
+                        .activePanel as IDockviewPanel | undefined,
+                });
+            }),
+            parameters.api.onDidActiveChange(() => {
+                this.assign({ isGroupActive: this.group.api.isActive });
+            }),
+            parameters.api.onDidLocationChange((event) => {
+                this.assign({
+                    location: event.location as DockviewGroupLocation,
+                });
+            })
+        );
+    }
+
+    dispose(): void {
+        this.subscriptions?.dispose();
+        this.subscriptions = null;
+        if (this.componentRef) {
+            this.appRef.detachView(this.componentRef.hostView);
+            this.componentRef.destroy();
+            this.componentRef = null;
+        }
+        if (this.viewRef) {
+            this.appRef.detachView(this.viewRef);
+            this.viewRef.destroy();
+            this.viewRef = null;
+        }
+    }
+
+    private assign(partial: Partial<IDockviewHeaderActionsProps>): void {
+        if (!this.componentRef) {
+            return;
+        }
+        const instance = this.componentRef.instance as Record<string, unknown>;
+        for (const key of Object.keys(partial) as Array<
+            keyof IDockviewHeaderActionsProps
+        >) {
+            instance[key] = partial[key];
+        }
+        this.componentRef.changeDetectorRef.markForCheck();
+    }
+}

--- a/packages/dockview-angular/src/lib/dockview/angular-header-actions-renderer.ts
+++ b/packages/dockview-angular/src/lib/dockview/angular-header-actions-renderer.ts
@@ -99,8 +99,9 @@ export class AngularHeaderActionsRenderer implements IHeaderActionsRenderer {
             }),
             this.group.model.onDidActivePanelChange(() => {
                 this.assign({
-                    activePanel: this.group.model
-                        .activePanel as IDockviewPanel | undefined,
+                    activePanel: this.group.model.activePanel as
+                        | IDockviewPanel
+                        | undefined,
                 });
             }),
             parameters.api.onDidActiveChange(() => {

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -33,6 +33,11 @@ import {
     ContextMenuItemConfig,
     ContextMenuItem,
     DockviewTabGroupColorEntry,
+    DockviewHeaderPosition,
+    DockviewDndStrategy,
+    DockviewPanelRenderer,
+    DockviewTheme,
+    DroptargetOverlayModel,
 } from 'dockview-core';
 import { AngularFrameworkComponentFactory } from '../utils/component-factory';
 import { AngularRenderer } from '../utils/angular-renderer';
@@ -102,6 +107,15 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Input() locked?: boolean;
     @Input() disableAutoResizing?: boolean;
     @Input() singleTabMode?: 'fullwidth' | 'default';
+    @Input() theme?: DockviewTheme;
+    @Input() scrollbars?: 'native' | 'custom';
+    @Input() disableTabsOverflowList?: boolean;
+    @Input() defaultRenderer?: DockviewPanelRenderer;
+    @Input() defaultHeaderPosition?: DockviewHeaderPosition;
+    @Input() disableDnd?: boolean;
+    @Input() dndStrategy?: DockviewDndStrategy;
+    @Input() dndEdges?: false | DroptargetOverlayModel;
+    @Input() noPanelsOverlay?: 'emptyGroup' | 'watermark';
     @Input() getTabContextMenuItems?: (
         params: GetTabContextMenuItemsParams
     ) => (ContextMenuItem | { component: Type<any> | TemplateRef<any> })[];
@@ -292,21 +306,24 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             createLeftHeaderActionComponent: this.leftHeaderActionsComponent
                 ? (group) => {
                       return componentFactory.createHeaderActionsComponent(
-                          'left'
+                          'left',
+                          group
                       )!;
                   }
                 : undefined,
             createRightHeaderActionComponent: this.rightHeaderActionsComponent
                 ? (group) => {
                       return componentFactory.createHeaderActionsComponent(
-                          'right'
+                          'right',
+                          group
                       )!;
                   }
                 : undefined,
             createPrefixHeaderActionComponent: this.prefixHeaderActionsComponent
                 ? (group) => {
                       return componentFactory.createHeaderActionsComponent(
-                          'prefix'
+                          'prefix',
+                          group
                       )!;
                   }
                 : undefined,

--- a/packages/dockview-angular/src/lib/utils/component-factory.ts
+++ b/packages/dockview-angular/src/lib/utils/component-factory.ts
@@ -10,11 +10,13 @@ import {
     IWatermarkRenderer,
     IHeaderActionsRenderer,
     CreateComponentOptions,
+    DockviewGroupPanel,
     GridviewPanel,
     SplitviewPanel,
     IPanePart,
 } from 'dockview-core';
 import { AngularRenderer } from './angular-renderer';
+import { AngularHeaderActionsRenderer } from '../dockview/angular-header-actions-renderer';
 import { AngularGridviewPanel } from '../gridview/angular-gridview-panel';
 import { AngularSplitviewPanel } from '../splitview/angular-splitview-panel';
 import { AngularPanePart } from '../paneview/angular-pane-part';
@@ -148,21 +150,22 @@ export class AngularFrameworkComponentFactory {
     }
 
     createHeaderActionsComponent(
-        name: string
+        name: string,
+        group: DockviewGroupPanel
     ): IHeaderActionsRenderer | undefined {
         const component = this.headerActionsComponents?.[name];
         if (!component) {
             return undefined;
         }
 
-        const renderer = new AngularRenderer({
+        // Dedicated renderer (not AngularRenderer) so the component instance
+        // receives the full IDockviewHeaderActionsProps surface and stays in
+        // sync with group/panel state via event subscriptions.
+        return new AngularHeaderActionsRenderer(
             component,
-            injector: this.injector,
-            environmentInjector: this.environmentInjector,
-        });
-
-        // Initialize with empty props - dockview-core will call init() again with actual IGroupHeaderProps
-        renderer.init({});
-        return renderer;
+            group,
+            this.injector,
+            this.environmentInjector
+        );
     }
 }

--- a/packages/docs/docs/core/groups/controls.mdx
+++ b/packages/docs/docs/core/groups/controls.mdx
@@ -68,11 +68,37 @@ import PrefixComponent from './PrefixComponent.vue';
 </FrameworkSpecific>
 
 <FrameworkSpecific framework='Angular'>
+Each header-action component receives the full `IDockviewHeaderActionsProps`
+surface as `@Input()`s. `panels`, `activePanel`, `isGroupActive`, and
+`location` are kept in sync as the group changes.
+
 ```ts
-import { Component } from '@angular/core';
-import { LeftComponent } from './left.component';
-import { RightComponent } from './right.component';
-import { PrefixComponent } from './prefix.component';
+import { Component, Input } from '@angular/core';
+import {
+    DockviewApi,
+    DockviewGroupLocation,
+    DockviewGroupPanel,
+    DockviewGroupPanelApi,
+    DockviewHeaderPosition,
+    IDockviewPanel,
+} from 'dockview-core';
+
+@Component({
+    selector: 'left-component',
+    template: `<div><!-- content --></div>`,
+})
+export class LeftComponent {
+    @Input() api!: DockviewGroupPanelApi;
+    @Input() containerApi!: DockviewApi;
+    @Input() group!: DockviewGroupPanel;
+    @Input() panels!: IDockviewPanel[];
+    @Input() activePanel?: IDockviewPanel;
+    @Input() isGroupActive!: boolean;
+    @Input() headerPosition!: DockviewHeaderPosition;
+    @Input() location?: DockviewGroupLocation;
+}
+
+// `RightComponent` and `PrefixComponent` declare the same set of inputs.
 
 @Component({
     selector: 'app-root',

--- a/packages/docs/docs/core/panels/register.mdx
+++ b/packages/docs/docs/core/panels/register.mdx
@@ -111,12 +111,18 @@ const App = {
 </FrameworkSpecific>
 
 <FrameworkSpecific framework='Angular'>
+Declare an `@Input()` for each field you want to receive. The `params` input
+receives the entire object passed to `api.addPanel({ params: ... })`, and is
+updated in place when you call `panel.api.updateParameters(...)`. `api`,
+`group`, and `containerApi` are always provided.
+
 ```tsx
 @Component({
     selector: 'panel-component-1',
-    template: `<div>Panel Content 1</div>`
+    template: `<div>Panel Content 1 — {{ params?.myCustomKey }}</div>`
 })
 export class PanelComponent1 {
+    @Input() params: { myCustomKey?: string };
     @Input() api: DockviewPanelApi;
     @Input() group: any;
     @Input() containerApi: DockviewApi;
@@ -127,6 +133,7 @@ export class PanelComponent1 {
     template: `<div>Panel Content 2</div>`
 })
 export class PanelComponent2 {
+    @Input() params: Record<string, unknown>;
     @Input() api: DockviewPanelApi;
 }
 

--- a/packages/docs/docs/core/scrollbars.mdx
+++ b/packages/docs/docs/core/scrollbars.mdx
@@ -16,6 +16,16 @@ When there are more tabs than can fit in the header, Dockview shows a scrollable
 ```
 </FrameworkSpecific>
 
+<FrameworkSpecific framework='Angular'>
+```html
+<dv-dockview
+    scrollbars="native"
+    [components]="components"
+    (ready)="onReady($event)">
+</dv-dockview>
+```
+</FrameworkSpecific>
+
 <FrameworkSpecific framework='JavaScript'>
 ```ts
 const api = createDockview(element, {
@@ -30,6 +40,16 @@ You can also disable the overflow tab list entirely with `disableTabsOverflowLis
 <FrameworkSpecific framework='React'>
 ```tsx
 <DockviewReact disableTabsOverflowList={true} onReady={onReady} components={components} />
+```
+</FrameworkSpecific>
+
+<FrameworkSpecific framework='Angular'>
+```html
+<dv-dockview
+    [disableTabsOverflowList]="true"
+    [components]="components"
+    (ready)="onReady($event)">
+</dv-dockview>
 ```
 </FrameworkSpecific>
 

--- a/packages/docs/docs/core/theming.mdx
+++ b/packages/docs/docs/core/theming.mdx
@@ -22,6 +22,27 @@ The `hideBorders` option removes the borders rendered between groups in the grid
 ```
 </FrameworkSpecific>
 
+<FrameworkSpecific framework='Angular'>
+```ts
+import { themeAbyss } from 'dockview-core';
+
+@Component({
+    template: `
+        <dv-dockview
+            [hideBorders]="true"
+            [theme]="theme"
+            [components]="components"
+            (ready)="onReady($event)">
+        </dv-dockview>
+    `,
+})
+export class AppComponent {
+    theme = themeAbyss;
+    // ...
+}
+```
+</FrameworkSpecific>
+
 <FrameworkSpecific framework='JavaScript'>
 ```ts
 const api = createDockview(element, {

--- a/packages/docs/sandboxes/react/dockview/floating-groups/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/floating-groups/src/app.tsx
@@ -274,12 +274,9 @@ const RightComponent = (props: IDockviewHeaderActionsProps) => {
             props.group.api.moveTo({ group });
         } else {
             props.containerApi.addFloatingGroup(props.group, {
-                position: {
-                    width: 400,
-                    height: 300,
-                    bottom: 50,
-                    right: 50,
-                },
+                width: 400,
+                height: 300,
+                position: { bottom: 50, right: 50 },
             });
         }
     };

--- a/packages/docs/templates/dockview/basic/angular/src/index.ts
+++ b/packages/docs/templates/dockview/basic/angular/src/index.ts
@@ -9,11 +9,13 @@ import 'dockview-core/dist/styles/dockview.css';
 // Default panel component
 @Component({
     selector: 'default-panel',
-    template: `<div>{{ title || 'Default Panel' }}</div>`
+    template: `<div>{{ title }}{{ params?.subtitle ? ' — ' + params.subtitle : '' }}</div>`
 })
 export class DefaultPanelComponent {
+    // `params` receives the object passed to `api.addPanel({ params: ... })`.
+    @Input() params: { subtitle?: string };
     @Input() api: any;
-    
+
     get title() {
         return this.api?.title || this.api?.id || 'Panel';
     }
@@ -49,6 +51,7 @@ export class AppComponent {
         api.addPanel({
             id: 'panel_1',
             component: 'default',
+            params: { subtitle: 'with params' },
         });
 
         api.addPanel({

--- a/packages/docs/templates/dockview/demo-dockview/angular/src/index.ts
+++ b/packages/docs/templates/dockview/demo-dockview/angular/src/index.ts
@@ -1,0 +1,409 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnInit,
+    OnDestroy,
+    ChangeDetectorRef,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewGroupPanel,
+    DockviewGroupPanelApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+    SerializedDockview,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+const STORAGE_KEY = 'angular_demo_dockview_layout';
+
+interface LogLine {
+    text: string;
+    timestamp: string;
+}
+
+// A simple service-like singleton for cross-component logging. Avoids the
+// React demo's hook-based propagation while keeping the panels and the log
+// pane decoupled.
+class Logger {
+    private subscribers = new Set<(lines: LogLine[]) => void>();
+    private lines: LogLine[] = [];
+
+    log(message: string) {
+        this.lines = [
+            { text: message, timestamp: new Date().toLocaleTimeString() },
+            ...this.lines.slice(0, 199),
+        ];
+        this.subscribers.forEach((s) => s(this.lines));
+    }
+
+    subscribe(cb: (lines: LogLine[]) => void): () => void {
+        cb(this.lines);
+        this.subscribers.add(cb);
+        return () => this.subscribers.delete(cb);
+    }
+}
+
+const logger = new Logger();
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="height: 100%; overflow: auto; color: white; position: relative;">
+            <span
+                style="position: absolute; top: 50%; left: 50%;
+                       transform: translate(-50%, -50%); pointer-events: none;
+                       font-size: 42px; opacity: 0.5;">
+                {{ api?.title }}
+            </span>
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+}
+
+@Component({
+    selector: 'iframe-panel',
+    template: `
+        <iframe
+            (mousedown)="onActivate()"
+            style="width: 100%; height: 100%; border: 0;"
+            src="https://dockview.dev">
+        </iframe>
+    `,
+})
+export class IframePanelComponent {
+    @Input() api!: DockviewPanelApi;
+
+    onActivate() {
+        if (!this.api.isActive) {
+            this.api.setActive();
+        }
+    }
+}
+
+@Component({
+    selector: 'log-panel',
+    template: `
+        <div style="height: 100%; overflow: auto; color: white; font-family: monospace; font-size: 11px;">
+            <div *ngFor="let line of lines" style="padding: 2px 6px;">
+                <span style="color: #888;">{{ line.timestamp }}</span>
+                <span style="margin-left: 8px;">{{ line.text }}</span>
+            </div>
+        </div>
+    `,
+})
+export class LogPanelComponent implements OnInit, OnDestroy {
+    @Input() api!: DockviewPanelApi;
+    lines: LogLine[] = [];
+    private unsubscribe?: () => void;
+
+    constructor(private cd: ChangeDetectorRef) {}
+
+    ngOnInit() {
+        this.unsubscribe = logger.subscribe((lines) => {
+            this.lines = lines;
+            this.cd.markForCheck();
+        });
+    }
+    ngOnDestroy() {
+        this.unsubscribe?.();
+    }
+}
+
+@Component({
+    selector: 'watermark-panel',
+    template: `<div style="color: white; padding: 16px;">No panels open</div>`,
+})
+export class WatermarkComponent {}
+
+@Component({
+    selector: 'left-header-actions',
+    template: `
+        <div style="height: 100%; color: white; padding: 0 4px; display: flex; align-items: center;">
+            <div
+                (click)="addPanel()"
+                title="Add Panel"
+                style="display: flex; align-items: center; justify-content: center; width: 30px; height: 100%; cursor: pointer; font-size: 18px;">
+                <span class="material-symbols-outlined">add</span>
+            </div>
+        </div>
+    `,
+})
+export class LeftHeaderActionsComponent {
+    @Input() containerApi!: DockviewApi;
+    @Input() group!: DockviewGroupPanel;
+
+    addPanel() {
+        const id = `panel_${Date.now()}`;
+        this.containerApi.addPanel({
+            id,
+            title: id,
+            component: 'default',
+            position: { referenceGroup: this.group },
+        });
+    }
+}
+
+@Component({
+    selector: 'right-header-actions',
+    template: `
+        <div style="height: 100%; color: white; padding: 0 4px; display: flex; align-items: center;">
+            <div
+                (click)="toggleFloat()"
+                [title]="isFloating ? 'Dock group' : 'Float group'"
+                style="display: flex; align-items: center; justify-content: center; width: 30px; height: 100%; cursor: pointer; font-size: 18px;">
+                <span class="material-symbols-outlined">
+                    {{ isFloating ? 'jump_to_element' : 'back_to_tab' }}
+                </span>
+            </div>
+        </div>
+    `,
+})
+export class RightHeaderActionsComponent implements OnInit, OnDestroy {
+    @Input() api!: DockviewGroupPanelApi;
+    @Input() containerApi!: DockviewApi;
+    @Input() group!: DockviewGroupPanel;
+
+    isFloating = false;
+    private disposable?: { dispose(): void };
+
+    constructor(private cd: ChangeDetectorRef) {}
+
+    ngOnInit() {
+        this.isFloating = this.api.location.type === 'floating';
+        this.disposable = this.group.api.onDidLocationChange((event) => {
+            this.isFloating = event.location.type === 'floating';
+            this.cd.markForCheck();
+        });
+    }
+    ngOnDestroy() {
+        this.disposable?.dispose();
+    }
+
+    toggleFloat() {
+        if (this.isFloating) {
+            const dest = this.containerApi.addGroup();
+            this.group.api.moveTo({ group: dest });
+        } else {
+            this.containerApi.addFloatingGroup(this.group, {
+                width: 400,
+                height: 300,
+                position: { right: 50, bottom: 50 },
+            });
+        }
+    }
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="display: flex; flex-direction: column; height: 100%;">
+            <div style="padding: 4px 8px; display: flex; gap: 4px; flex-wrap: wrap; background: #1a1a1a;">
+                <button (click)="addPanel()">Add Panel</button>
+                <button (click)="addIframe()">Add Iframe</button>
+                <button (click)="addLog()">Add Log</button>
+                <button (click)="addGroup()">Add Group</button>
+                <button (click)="save()">Save</button>
+                <button (click)="load()">Load</button>
+                <button (click)="clear()">Clear</button>
+                <span style="color: #888; margin-left: auto; align-self: center;">
+                    panels={{ panelCount }} groups={{ groupCount }}
+                    active={{ activePanelId || '-' }}
+                </span>
+            </div>
+            <div style="flex-grow: 1;">
+                <dv-dockview
+                    [components]="components"
+                    [watermarkComponent]="watermarkComponent"
+                    [leftHeaderActionsComponent]="leftHeaderActionsComponent"
+                    [rightHeaderActionsComponent]="rightHeaderActionsComponent"
+                    className="dockview-theme-abyss"
+                    (ready)="onReady($event)">
+                </dv-dockview>
+            </div>
+        </div>
+    `,
+})
+export class AppComponent implements OnDestroy {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+        iframe: IframePanelComponent,
+        log: LogPanelComponent,
+    };
+    watermarkComponent = WatermarkComponent;
+    leftHeaderActionsComponent = LeftHeaderActionsComponent;
+    rightHeaderActionsComponent = RightHeaderActionsComponent;
+
+    panelCount = 0;
+    groupCount = 0;
+    activePanelId = '';
+
+    private api?: DockviewApi;
+    private disposables: { dispose(): void }[] = [];
+    private counter = 0;
+
+    constructor(private cd: ChangeDetectorRef) {}
+
+    onReady(event: DockviewReadyEvent) {
+        this.api = event.api;
+
+        this.disposables.push(
+            this.api.onDidAddPanel((panel) => {
+                this.panelCount = this.api!.panels.length;
+                logger.log(`Added panel ${panel.id}`);
+                this.cd.markForCheck();
+            }),
+            this.api.onDidRemovePanel((panel) => {
+                this.panelCount = this.api!.panels.length;
+                logger.log(`Removed panel ${panel.id}`);
+                this.cd.markForCheck();
+            }),
+            this.api.onDidAddGroup(() => {
+                this.groupCount = this.api!.groups.length;
+                this.cd.markForCheck();
+            }),
+            this.api.onDidRemoveGroup(() => {
+                this.groupCount = this.api!.groups.length;
+                this.cd.markForCheck();
+            }),
+            this.api.onDidActivePanelChange((panel) => {
+                this.activePanelId = panel?.id ?? '';
+                this.cd.markForCheck();
+            })
+        );
+
+        if (!this.tryLoad()) {
+            this.loadDefaultLayout();
+        }
+    }
+
+    addPanel() {
+        if (!this.api) return;
+        const id = this.nextId('panel');
+        this.api.addPanel({ id, component: 'default', title: id });
+    }
+
+    addIframe() {
+        if (!this.api) return;
+        const id = this.nextId('iframe');
+        this.api.addPanel({ id, component: 'iframe', title: id });
+    }
+
+    addLog() {
+        if (!this.api) return;
+        this.api.addPanel({
+            id: 'log',
+            component: 'log',
+            title: 'Log',
+            position: { direction: 'below' },
+        });
+    }
+
+    addGroup() {
+        if (!this.api) return;
+        this.api.addGroup();
+    }
+
+    save() {
+        if (!this.api) return;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(this.api.toJSON()));
+        logger.log('Saved layout');
+    }
+
+    load() {
+        if (this.tryLoad()) {
+            logger.log('Loaded layout');
+        }
+    }
+
+    clear() {
+        this.api?.clear();
+        localStorage.removeItem(STORAGE_KEY);
+        logger.log('Cleared layout');
+    }
+
+    private tryLoad(): boolean {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw || !this.api) {
+            return false;
+        }
+        try {
+            const json = JSON.parse(raw) as SerializedDockview;
+            this.api.fromJSON(json);
+            return true;
+        } catch (err) {
+            console.error(err);
+            return false;
+        }
+    }
+
+    private loadDefaultLayout() {
+        if (!this.api) return;
+        const panel1 = this.api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            title: 'Panel 1',
+        });
+        this.api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            title: 'Panel 2',
+            position: { referencePanel: panel1 },
+        });
+        this.api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            title: 'Panel 3',
+            position: { referencePanel: panel1, direction: 'right' },
+        });
+        this.api.addPanel({
+            id: 'panel_4',
+            component: 'default',
+            title: 'Panel 4',
+            position: { referencePanel: 'panel_3', direction: 'below' },
+        });
+        this.api.addPanel({
+            id: 'log',
+            component: 'log',
+            title: 'Log',
+            position: { direction: 'below' },
+        });
+        panel1.api.setActive();
+    }
+
+    private nextId(prefix: string): string {
+        return `${prefix}_${++this.counter}`;
+    }
+
+    ngOnDestroy() {
+        this.disposables.forEach((d) => d.dispose());
+    }
+}
+
+@NgModule({
+    declarations: [
+        AppComponent,
+        DefaultPanelComponent,
+        IframePanelComponent,
+        LogPanelComponent,
+        WatermarkComponent,
+        LeftHeaderActionsComponent,
+        RightHeaderActionsComponent,
+    ],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/demo-dockview/react/src/panelActions.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/panelActions.tsx
@@ -33,9 +33,9 @@ export const PanelActions = (props: {
                                     const panel = props.api?.getPanel(x);
                                     if (panel) {
                                         props.api?.addFloatingGroup(panel, {
+                                            width: 400,
+                                            height: 300,
                                             position: {
-                                                width: 400,
-                                                height: 300,
                                                 bottom: 50,
                                                 right: 50,
                                             },

--- a/packages/docs/templates/dockview/dnd-events/angular/src/index.ts
+++ b/packages/docs/templates/dockview/dnd-events/angular/src/index.ts
@@ -1,0 +1,135 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnDestroy,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="height: 100%;">
+            <div>{{ api?.title }}</div>
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="display: flex; flex-direction: column; height: 100%;">
+            <div>
+                <button (click)="togglePanelDrag()">
+                    Panel Drag: {{ disablePanelDrag ? 'disabled' : 'enabled' }}
+                </button>
+                <button (click)="toggleGroupDrag()">
+                    Group Drag: {{ disableGroupDrag ? 'disabled' : 'enabled' }}
+                </button>
+                <button (click)="toggleOverlay()">
+                    Overlay: {{ disableOverlay ? 'disabled' : 'enabled' }}
+                </button>
+            </div>
+            <div style="flex-grow: 1;">
+                <dv-dockview
+                    [components]="components"
+                    className="dockview-theme-abyss"
+                    (ready)="onReady($event)">
+                </dv-dockview>
+            </div>
+        </div>
+    `,
+})
+export class AppComponent implements OnDestroy {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+
+    disablePanelDrag = false;
+    disableGroupDrag = false;
+    disableOverlay = false;
+
+    private disposables: { dispose(): void }[] = [];
+
+    togglePanelDrag() {
+        this.disablePanelDrag = !this.disablePanelDrag;
+    }
+    toggleGroupDrag() {
+        this.disableGroupDrag = !this.disableGroupDrag;
+    }
+    toggleOverlay() {
+        this.disableOverlay = !this.disableOverlay;
+    }
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+
+        this.disposables.push(
+            api.onWillDragPanel((e) => {
+                if (!this.disablePanelDrag) {
+                    return;
+                }
+                if (e.nativeEvent instanceof DragEvent) {
+                    e.nativeEvent.preventDefault();
+                }
+            }),
+            api.onWillDragGroup((e) => {
+                if (!this.disableGroupDrag) {
+                    return;
+                }
+                if (e.nativeEvent instanceof DragEvent) {
+                    e.nativeEvent.preventDefault();
+                }
+            }),
+            api.onWillShowOverlay((e) => {
+                if (!this.disableOverlay) {
+                    return;
+                }
+                e.preventDefault();
+            })
+        );
+
+        api.addPanel({ id: 'panel_1', component: 'default' });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            position: { direction: 'right', referencePanel: 'panel_1' },
+        });
+        api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            position: { direction: 'below', referencePanel: 'panel_1' },
+        });
+        api.addPanel({ id: 'panel_4', component: 'default' });
+        api.addPanel({ id: 'panel_5', component: 'default' });
+    }
+
+    ngOnDestroy() {
+        this.disposables.forEach((d) => d.dispose());
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/dnd-external/angular/src/index.ts
+++ b/packages/docs/templates/dockview/dnd-external/angular/src/index.ts
@@ -1,0 +1,172 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnDestroy,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewDidDropEvent,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+    positionToDirection,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+@Component({
+    selector: 'default-panel',
+    template: `<div style="padding: 20px;"><div>{{ params?.title }}</div></div>`,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+    @Input() params!: { title: string };
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="display: flex; flex-direction: column; height: 100%;">
+            <div style="margin: 2px 0;">
+                <span
+                    tabindex="-1"
+                    draggable="true"
+                    (dragstart)="onExternalDragStart($event)"
+                    style="background: orange; padding: 0 8px; border-radius: 4px; width: 100px; cursor: pointer;">
+                    Drag me into the dock
+                </span>
+                <div
+                    (dragover)="$event.preventDefault()"
+                    (drop)="onDropOutside($event)"
+                    style="padding: 0 4px; background: black; color: white; border-radius: 2px;">
+                    Drop a tab or group here to inspect the attached metadata
+                </div>
+            </div>
+            <dv-dockview
+                [components]="components"
+                [dndEdges]="dndEdges"
+                className="dockview-theme-abyss"
+                (ready)="onReady($event)"
+                (didDrop)="onDidDrop($event)">
+            </dv-dockview>
+        </div>
+    `,
+})
+export class AppComponent implements OnDestroy {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+
+    dndEdges = {
+        size: { value: 100, type: 'pixels' as const },
+        activationSize: { value: 5, type: 'percentage' as const },
+    };
+
+    private disposables: { dispose(): void }[] = [];
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+
+        api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            params: { title: 'Panel 1' },
+        });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            params: { title: 'Panel 2' },
+        });
+        api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            params: { title: 'Panel 3' },
+        });
+        api.addPanel({
+            id: 'panel_4',
+            component: 'default',
+            params: { title: 'Panel 4' },
+            position: { referencePanel: 'panel_1', direction: 'right' },
+        });
+
+        this.disposables.push(
+            // Attach custom metadata when an internal panel/group drag starts —
+            // an external drop zone can then read it via dataTransfer.
+            api.onWillDragPanel((event) => {
+                if (!(event.nativeEvent instanceof DragEvent)) {
+                    return;
+                }
+                event.nativeEvent.dataTransfer?.setData(
+                    'text/plain',
+                    'Some custom panel data transfer data'
+                );
+            }),
+            api.onWillDragGroup((event) => {
+                if (!(event.nativeEvent instanceof DragEvent)) {
+                    return;
+                }
+                event.nativeEvent.dataTransfer?.setData(
+                    'text/plain',
+                    'Some custom group data transfer data'
+                );
+            }),
+            // Accept arbitrary outside drags into the dock.
+            api.onUnhandledDragOverEvent((event) => {
+                event.accept();
+            })
+        );
+    }
+
+    onExternalDragStart(event: DragEvent) {
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', 'nothing');
+        }
+    }
+
+    onDropOutside(event: DragEvent) {
+        event.preventDefault();
+        const dt = event.dataTransfer;
+        if (!dt) {
+            return;
+        }
+        let text = 'The following dataTransfer data was found:\n';
+        for (let i = 0; i < dt.items.length; i++) {
+            const item = dt.items[i];
+            text += `type=${item.type},data=${dt.getData(item.type)}\n`;
+        }
+        alert(text);
+    }
+
+    onDidDrop(event: DockviewDidDropEvent) {
+        event.api.addPanel({
+            id: 'dropped_' + Date.now(),
+            component: 'default',
+            params: { title: 'Dropped' },
+            position: {
+                direction: positionToDirection(event.position),
+                referenceGroup: event.group || undefined,
+            },
+        });
+    }
+
+    ngOnDestroy() {
+        this.disposables.forEach((d) => d.dispose());
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/floating-groups/angular/src/index.ts
+++ b/packages/docs/templates/dockview/floating-groups/angular/src/index.ts
@@ -99,12 +99,9 @@ export class RightHeaderActionsComponent {
             this.group.api.moveTo({ group });
         } else {
             this.containerApi.addFloatingGroup(this.group, {
-                position: {
-                    width: 400,
-                    height: 300,
-                    bottom: 50,
-                    right: 50,
-                }
+                width: 400,
+                height: 300,
+                position: { bottom: 50, right: 50 },
             });
         }
     }

--- a/packages/docs/templates/dockview/floating-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/floating-groups/react/src/app.tsx
@@ -265,12 +265,9 @@ const RightComponent = (props: IDockviewHeaderActionsProps) => {
             props.group.api.moveTo({ group });
         } else {
             props.containerApi.addFloatingGroup(props.group, {
-                position: {
-                    width: 400,
-                    height: 300,
-                    bottom: 50,
-                    right: 50,
-                }
+                width: 400,
+                height: 300,
+                position: { bottom: 50, right: 50 },
             });
         }
     };

--- a/packages/docs/templates/dockview/layout/angular/src/index.ts
+++ b/packages/docs/templates/dockview/layout/angular/src/index.ts
@@ -1,0 +1,134 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnDestroy,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+const STORAGE_KEY = 'dockview_persistence_layout';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div
+            style="height: 100%; padding: 20px; background: var(--dv-group-view-background-color);">
+            {{ params?.title }}
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+    @Input() params!: { title: string };
+}
+
+@Component({
+    selector: 'watermark-panel',
+    template: `<div style="color: white; padding: 8px;">watermark</div>`,
+})
+export class WatermarkComponent {}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%; display: flex; flex-direction: column;">
+            <div style="height: 25px;">
+                <button (click)="clearLayout()">Reset Layout</button>
+            </div>
+            <div style="flex-grow: 1; overflow: hidden;">
+                <dv-dockview
+                    [components]="components"
+                    [watermarkComponent]="watermarkComponent"
+                    className="dockview-theme-abyss"
+                    (ready)="onReady($event)">
+                </dv-dockview>
+            </div>
+        </div>
+    `,
+})
+export class AppComponent implements OnDestroy {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+    watermarkComponent = WatermarkComponent;
+
+    private api?: DockviewApi;
+    private layoutDisposable?: { dispose(): void };
+
+    onReady(event: DockviewReadyEvent) {
+        this.api = event.api;
+
+        const layoutString = localStorage.getItem(STORAGE_KEY);
+        let restored = false;
+        if (layoutString) {
+            try {
+                this.api.fromJSON(JSON.parse(layoutString));
+                restored = true;
+            } catch (err) {
+                console.error(err);
+            }
+        }
+        if (!restored) {
+            this.loadDefaultLayout(this.api);
+        }
+
+        this.layoutDisposable = this.api.onDidLayoutChange(() => {
+            localStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify(this.api!.toJSON())
+            );
+        });
+    }
+
+    clearLayout() {
+        localStorage.removeItem(STORAGE_KEY);
+        if (this.api) {
+            this.api.clear();
+            this.loadDefaultLayout(this.api);
+        }
+    }
+
+    ngOnDestroy() {
+        this.layoutDisposable?.dispose();
+    }
+
+    private loadDefaultLayout(api: DockviewApi) {
+        api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            params: { title: 'Panel 1' },
+        });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            params: { title: 'Panel 2' },
+        });
+        api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            params: { title: 'Panel 3' },
+        });
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent, WatermarkComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/locked/angular/src/index.ts
+++ b/packages/docs/templates/dockview/locked/angular/src/index.ts
@@ -1,0 +1,71 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { Component, Type, NgModule, Input } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="height: 100%; padding: 10px;">
+            {{ api?.title }}
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api: any;
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%;">
+            <dv-dockview
+                [components]="components"
+                [locked]="true"
+                className="dockview-theme-abyss"
+                (ready)="onReady($event)">
+            </dv-dockview>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+
+        api.addPanel({ id: 'panel_1', component: 'default' });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            position: { direction: 'right', referencePanel: 'panel_1' },
+        });
+        api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            position: { direction: 'below', referencePanel: 'panel_1' },
+        });
+        api.addPanel({ id: 'panel_4', component: 'default' });
+        api.addPanel({ id: 'panel_5', component: 'default' });
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/maximize-group/angular/src/index.ts
+++ b/packages/docs/templates/dockview/maximize-group/angular/src/index.ts
@@ -1,0 +1,239 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnInit,
+    OnDestroy,
+    ChangeDetectorRef,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewGroupPanel,
+    DockviewGroupPanelApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+    SerializedDockview,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+const STORAGE_KEY = 'maximize.layout';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div
+            style="height: 100%; padding: 20px; background: var(--dv-group-view-background-color);">
+            {{ params?.title }}
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+    @Input() params!: { title: string };
+}
+
+@Component({
+    selector: 'watermark-panel',
+    template: `<div style="color: white; padding: 8px;">watermark</div>`,
+})
+export class WatermarkComponent {}
+
+@Component({
+    selector: 'left-header-actions',
+    template: `
+        <div style="height: 100%; color: white; padding: 0px 4px;">
+            <div
+                (click)="addPanel()"
+                title="Add Panel"
+                style="display: flex; align-items: center; justify-content: center; width: 30px; height: 100%; cursor: pointer; font-size: 18px;">
+                <span class="material-symbols-outlined">add</span>
+            </div>
+        </div>
+    `,
+})
+export class LeftHeaderActionsComponent {
+    @Input() containerApi!: DockviewApi;
+    @Input() group!: DockviewGroupPanel;
+
+    addPanel() {
+        const id = Date.now().toString();
+        this.containerApi.addPanel({
+            id,
+            title: `Tab ${id}`,
+            component: 'default',
+            position: { referenceGroup: this.group },
+        });
+    }
+}
+
+@Component({
+    selector: 'right-header-actions',
+    template: `
+        <div style="height: 100%; color: white; padding: 0px 4px;">
+            <div
+                (click)="toggle()"
+                [title]="maximized ? 'Exit maximize' : 'Maximize'"
+                style="display: flex; align-items: center; justify-content: center; width: 30px; height: 100%; cursor: pointer; font-size: 18px;">
+                <span class="material-symbols-outlined">
+                    {{ maximized ? 'jump_to_element' : 'back_to_tab' }}
+                </span>
+            </div>
+        </div>
+    `,
+})
+export class RightHeaderActionsComponent implements OnInit, OnDestroy {
+    @Input() api!: DockviewGroupPanelApi;
+    @Input() containerApi!: DockviewApi;
+
+    maximized = false;
+    private disposable?: { dispose(): void };
+
+    constructor(private cd: ChangeDetectorRef) {}
+
+    ngOnInit() {
+        this.maximized = this.api.isMaximized();
+        this.disposable = this.containerApi.onDidMaximizedGroupChange(() => {
+            this.maximized = this.api.isMaximized();
+            this.cd.markForCheck();
+        });
+    }
+
+    ngOnDestroy() {
+        this.disposable?.dispose();
+    }
+
+    toggle() {
+        if (this.maximized) {
+            this.api.exitMaximized();
+        } else {
+            this.api.maximize();
+        }
+    }
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%; display: flex; flex-direction: column;">
+            <div style="height: 25px;">
+                <button (click)="save()">Save</button>
+                <button (click)="load()">Load</button>
+                <button (click)="clear()">Clear</button>
+            </div>
+            <div style="flex-grow: 1;">
+                <dv-dockview
+                    [components]="components"
+                    [watermarkComponent]="watermarkComponent"
+                    [leftHeaderActionsComponent]="leftHeaderActionsComponent"
+                    [rightHeaderActionsComponent]="rightHeaderActionsComponent"
+                    className="dockview-theme-abyss"
+                    (ready)="onReady($event)">
+                </dv-dockview>
+            </div>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+    watermarkComponent = WatermarkComponent;
+    leftHeaderActionsComponent = LeftHeaderActionsComponent;
+    rightHeaderActionsComponent = RightHeaderActionsComponent;
+
+    private api?: DockviewApi;
+    private layout: SerializedDockview | null = null;
+
+    constructor() {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+            try {
+                this.layout = JSON.parse(stored);
+            } catch {
+                this.layout = null;
+            }
+        }
+    }
+
+    onReady(event: DockviewReadyEvent) {
+        this.api = event.api;
+        this.loadLayout();
+    }
+
+    save() {
+        if (!this.api) {
+            return;
+        }
+        this.layout = this.api.toJSON();
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(this.layout));
+    }
+
+    load() {
+        if (this.api) {
+            this.loadLayout();
+        }
+    }
+
+    clear() {
+        this.api?.clear();
+        this.layout = null;
+        localStorage.removeItem(STORAGE_KEY);
+    }
+
+    private loadLayout() {
+        if (!this.api) {
+            return;
+        }
+        this.api.clear();
+        if (this.layout) {
+            try {
+                this.api.fromJSON(this.layout);
+                return;
+            } catch (err) {
+                console.error(err);
+                this.api.clear();
+            }
+        }
+        this.loadDefaultLayout();
+    }
+
+    private loadDefaultLayout() {
+        if (!this.api) {
+            return;
+        }
+        this.api.addPanel({ id: 'panel_1', component: 'default', params: { title: 'Panel 1' } });
+        this.api.addPanel({ id: 'panel_2', component: 'default', params: { title: 'Panel 2' } });
+        this.api.addPanel({ id: 'panel_3', component: 'default', params: { title: 'Panel 3' } });
+        this.api.addPanel({ id: 'panel_4', component: 'default', params: { title: 'Panel 4' } });
+        this.api.addPanel({
+            id: 'panel_5',
+            component: 'default',
+            params: { title: 'Panel 5' },
+            position: { direction: 'right' },
+        });
+        this.api.addPanel({ id: 'panel_6', component: 'default', params: { title: 'Panel 6' } });
+    }
+}
+
+@NgModule({
+    declarations: [
+        AppComponent,
+        DefaultPanelComponent,
+        WatermarkComponent,
+        LeftHeaderActionsComponent,
+        RightHeaderActionsComponent,
+    ],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/nested/angular/src/index.ts
+++ b/packages/docs/templates/dockview/nested/angular/src/index.ts
@@ -1,0 +1,113 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { Component, NgModule, Input, Type } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div
+            style="height: 100%; padding: 20px; background: var(--dv-group-view-background-color);">
+            {{ params?.title }}
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+    @Input() params!: { title: string };
+}
+
+@Component({
+    selector: 'inner-dockview',
+    template: `
+        <dv-dockview
+            [components]="components"
+            className="nested-dockview"
+            (ready)="onReady($event)">
+        </dv-dockview>
+    `,
+})
+export class InnerDockviewComponent {
+    // Inner dockview reuses the outer DefaultPanelComponent; it's registered
+    // here under the same key so panels can be added recursively.
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+        api.addPanel({
+            id: 'inner_panel_1',
+            component: 'default',
+            params: { title: 'Inner 1' },
+        });
+        api.addPanel({
+            id: 'inner_panel_2',
+            component: 'default',
+            params: { title: 'Inner 2' },
+        });
+        api.addPanel({
+            id: 'inner_panel_3',
+            component: 'default',
+            params: { title: 'Inner 3' },
+        });
+    }
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%;">
+            <dv-dockview
+                [components]="components"
+                className="dockview-theme-abyss"
+                (ready)="onReady($event)">
+            </dv-dockview>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+        innerDockview: InnerDockviewComponent,
+    };
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+        api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            params: { title: 'Panel 1' },
+        });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            params: { title: 'Panel 2' },
+        });
+        api.addPanel({
+            id: 'panel_3',
+            component: 'innerDockview',
+            params: { title: 'Inner Dock' },
+            position: { referencePanel: 'panel_2', direction: 'right' },
+        });
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent, InnerDockviewComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/popout-group/angular/src/index.ts
+++ b/packages/docs/templates/dockview/popout-group/angular/src/index.ts
@@ -1,0 +1,231 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnInit,
+    OnDestroy,
+    ChangeDetectorRef,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewGroupPanel,
+    DockviewGroupPanelApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+    SerializedDockview,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+const STORAGE_KEY = 'popout.layout';
+let panelCount = 0;
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div
+            style="height: 100%; padding: 20px; background: var(--dv-group-view-background-color);">
+            <button (click)="logWindow()">Print</button>
+            <span style="margin-left: 8px;">{{ api?.title }}</span>
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+
+    logWindow() {
+        console.log(this.api.getWindow());
+    }
+}
+
+@Component({
+    selector: 'watermark-panel',
+    template: `<div style="color: white; padding: 8px;">watermark</div>`,
+})
+export class WatermarkComponent {}
+
+@Component({
+    selector: 'left-header-actions',
+    template: `
+        <div style="height: 100%; color: white; padding: 0px 4px;">
+            <div
+                (click)="addPanel()"
+                title="Add Panel"
+                style="display: flex; align-items: center; justify-content: center; width: 30px; height: 100%; cursor: pointer; font-size: 18px;">
+                <span class="material-symbols-outlined">add</span>
+            </div>
+        </div>
+    `,
+})
+export class LeftHeaderActionsComponent {
+    @Input() containerApi!: DockviewApi;
+    @Input() group!: DockviewGroupPanel;
+
+    addPanel() {
+        const id = (++panelCount).toString();
+        this.containerApi.addPanel({
+            id,
+            title: `Tab ${id}`,
+            component: 'default',
+            position: { referenceGroup: this.group },
+        });
+    }
+}
+
+@Component({
+    selector: 'right-header-actions',
+    template: `
+        <div style="height: 100%; color: white; padding: 0px 4px;">
+            <div
+                (click)="toggle()"
+                [title]="popout ? 'Dock' : 'Popout'"
+                style="display: flex; align-items: center; justify-content: center; width: 30px; height: 100%; cursor: pointer; font-size: 18px;">
+                <span class="material-symbols-outlined">
+                    {{ popout ? 'jump_to_element' : 'back_to_tab' }}
+                </span>
+            </div>
+        </div>
+    `,
+})
+export class RightHeaderActionsComponent implements OnInit, OnDestroy {
+    @Input() api!: DockviewGroupPanelApi;
+    @Input() containerApi!: DockviewApi;
+    @Input() group!: DockviewGroupPanel;
+
+    popout = false;
+    private disposable?: { dispose(): void };
+
+    constructor(private cd: ChangeDetectorRef) {}
+
+    ngOnInit() {
+        this.popout = this.api.location.type === 'popout';
+        this.disposable = this.group.api.onDidLocationChange((event) => {
+            this.popout = event.location.type === 'popout';
+            this.cd.markForCheck();
+        });
+    }
+
+    ngOnDestroy() {
+        this.disposable?.dispose();
+    }
+
+    toggle() {
+        if (this.popout) {
+            const group = this.containerApi.addGroup();
+            this.group.api.moveTo({ group });
+        } else {
+            this.containerApi.addPopoutGroup(this.group, {
+                popoutUrl: '/popout/index.html',
+            });
+        }
+    }
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%; display: flex; flex-direction: column;">
+            <div style="height: 25px;">
+                <button (click)="save()">Save</button>
+                <button (click)="load()">Load</button>
+                <button (click)="clear()">Clear</button>
+            </div>
+            <div style="flex-grow: 1;">
+                <dv-dockview
+                    [components]="components"
+                    [watermarkComponent]="watermarkComponent"
+                    [leftHeaderActionsComponent]="leftHeaderActionsComponent"
+                    [rightHeaderActionsComponent]="rightHeaderActionsComponent"
+                    className="dockview-theme-abyss"
+                    (ready)="onReady($event)">
+                </dv-dockview>
+            </div>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+    watermarkComponent = WatermarkComponent;
+    leftHeaderActionsComponent = LeftHeaderActionsComponent;
+    rightHeaderActionsComponent = RightHeaderActionsComponent;
+
+    private api?: DockviewApi;
+    private layout: SerializedDockview | null = null;
+
+    constructor() {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+            try {
+                this.layout = JSON.parse(stored);
+            } catch {
+                this.layout = null;
+            }
+        }
+    }
+
+    onReady(event: DockviewReadyEvent) {
+        this.api = event.api;
+        this.loadLayout();
+    }
+
+    save() {
+        if (!this.api) {
+            return;
+        }
+        this.layout = this.api.toJSON();
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(this.layout));
+    }
+
+    load() {
+        if (this.api) {
+            this.loadLayout();
+        }
+    }
+
+    clear() {
+        this.api?.clear();
+        this.layout = null;
+        localStorage.removeItem(STORAGE_KEY);
+    }
+
+    private loadLayout() {
+        if (!this.api) {
+            return;
+        }
+        this.api.clear();
+        if (this.layout) {
+            try {
+                this.api.fromJSON(this.layout);
+                return;
+            } catch (err) {
+                console.error(err);
+                this.api.clear();
+            }
+        }
+        this.api.addPanel({ id: 'panel_1', component: 'default' });
+    }
+}
+
+@NgModule({
+    declarations: [
+        AppComponent,
+        DefaultPanelComponent,
+        WatermarkComponent,
+        LeftHeaderActionsComponent,
+        RightHeaderActionsComponent,
+    ],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/render-mode/angular/src/index.ts
+++ b/packages/docs/templates/dockview/render-mode/angular/src/index.ts
@@ -1,0 +1,157 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnInit,
+    OnDestroy,
+    ChangeDetectorRef,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewPanelRenderer,
+    DockviewReadyEvent,
+    SerializedDockview,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+const STORAGE_KEY = 'dv_rendermode_state';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="height: 100%; overflow: auto; color: white;">
+            <div style="height: 1000px; padding: 20px; overflow: auto;">
+                <div>{{ api?.title }}</div>
+                <div>
+                    {{ mode }}
+                    <button (click)="toggleMode()">Toggle render mode</button>
+                </div>
+            </div>
+        </div>
+    `,
+})
+export class DefaultPanelComponent implements OnInit, OnDestroy {
+    @Input() api!: DockviewPanelApi;
+
+    mode: DockviewPanelRenderer = 'onlyWhenVisible';
+    private disposable?: { dispose(): void };
+
+    constructor(private cd: ChangeDetectorRef) {}
+
+    ngOnInit() {
+        this.mode = this.api.renderer;
+        this.disposable = this.api.onDidRendererChange((event) => {
+            this.mode = event.renderer;
+            this.cd.markForCheck();
+        });
+    }
+
+    ngOnDestroy() {
+        this.disposable?.dispose();
+    }
+
+    toggleMode() {
+        const next: DockviewPanelRenderer =
+            this.mode === 'onlyWhenVisible' ? 'always' : 'onlyWhenVisible';
+        this.api.setRenderer(next);
+    }
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%; display: flex; flex-direction: column;">
+            <div>
+                <button (click)="save()">Save</button>
+                <button (click)="load()">Load</button>
+                <input
+                    type="range"
+                    min="1"
+                    max="100"
+                    [value]="size"
+                    (input)="size = +$any($event.target).value" />
+            </div>
+            <div [style.height.%]="size" [style.width.%]="size">
+                <dv-dockview
+                    [components]="components"
+                    className="dockview-theme-abyss"
+                    (ready)="onReady($event)">
+                </dv-dockview>
+            </div>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+
+    size = 100;
+    private api?: DockviewApi;
+
+    onReady(event: DockviewReadyEvent) {
+        this.api = event.api;
+        this.api.addPanel({ id: 'panel_1', component: 'default', title: 'Panel 1' });
+        this.api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            title: 'Panel 2',
+            position: { referencePanel: 'panel_1', direction: 'within' },
+        });
+        this.api.addPanel({ id: 'panel_3', component: 'default', title: 'Panel 3' });
+        this.api.addPanel({
+            id: 'panel_4',
+            component: 'default',
+            title: 'Panel 4',
+            position: { referencePanel: 'panel_3', direction: 'below' },
+        });
+    }
+
+    save() {
+        if (!this.api) {
+            return;
+        }
+        localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ size: this.size, state: this.api.toJSON() })
+        );
+    }
+
+    load() {
+        if (!this.api) {
+            return;
+        }
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+            return;
+        }
+        try {
+            const json = JSON.parse(raw) as {
+                size: number;
+                state: SerializedDockview;
+            };
+            this.size = json.size;
+            this.api.fromJSON(json.state);
+        } catch (err) {
+            console.error(err);
+        }
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/resize-container/angular/src/index.ts
+++ b/packages/docs/templates/dockview/resize-container/angular/src/index.ts
@@ -1,0 +1,108 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { Component, NgModule, Input, Type } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="padding: 20px; color: white;">{{ params?.title }}</div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+    @Input() params!: { title: string };
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%; display: flex; flex-direction: column;">
+            <input
+                type="range"
+                min="1"
+                max="100"
+                [value]="size"
+                (input)="size = +$any($event.target).value" />
+            <div [style.height.%]="size" [style.width.%]="size">
+                <dv-dockview
+                    [components]="components"
+                    className="dockview-theme-abyss"
+                    (ready)="onReady($event)">
+                </dv-dockview>
+            </div>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+    size = 50;
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+
+        const panel1 = api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            params: { title: 'Panel 1' },
+        });
+        panel1.group.locked = true;
+        panel1.group.header.hidden = true;
+
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            params: { title: 'Panel 2' },
+        });
+        api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            params: { title: 'Panel 3' },
+        });
+        api.addPanel({
+            id: 'panel_4',
+            component: 'default',
+            params: { title: 'Panel 4' },
+            position: { referencePanel: 'panel_1', direction: 'right' },
+        });
+        api.addPanel({
+            id: 'panel_5',
+            component: 'default',
+            params: { title: 'Panel 5' },
+            position: { referencePanel: 'panel_3', direction: 'right' },
+        });
+        api.addPanel({
+            id: 'panel_6',
+            component: 'default',
+            params: { title: 'Panel 6' },
+            position: { referencePanel: 'panel_5', direction: 'below' },
+        });
+        api.addPanel({
+            id: 'panel_7',
+            component: 'default',
+            params: { title: 'Panel 7' },
+            position: { referencePanel: 'panel_6', direction: 'right' },
+        });
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/resize/angular/src/index.ts
+++ b/packages/docs/templates/dockview/resize/angular/src/index.ts
@@ -1,0 +1,116 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { Component, NgModule, Input, Type } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="height: 100%; padding: 8px; color: white;">
+            <div style="height: 25px;">{{ api?.title }}</div>
+            <div style="display: flex; gap: 4px; align-items: center; margin-bottom: 4px;">
+                <span>Width:</span>
+                <input
+                    type="number"
+                    min="50"
+                    step="1"
+                    [value]="width"
+                    (input)="width = +$any($event.target).value" />
+                <button style="width: 100px;" (click)="resizeGroupWidth()">
+                    Resize Group
+                </button>
+                <button style="width: 100px;" (click)="resizePanelWidth()">
+                    Resize panel
+                </button>
+            </div>
+            <div style="display: flex; gap: 4px; align-items: center;">
+                <span>Height:</span>
+                <input
+                    type="number"
+                    min="50"
+                    step="1"
+                    [value]="height"
+                    (input)="height = +$any($event.target).value" />
+                <button style="width: 100px;" (click)="resizeGroupHeight()">
+                    Resize Group
+                </button>
+                <button style="width: 100px;" (click)="resizePanelHeight()">
+                    Resize Panel
+                </button>
+            </div>
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+
+    width = 100;
+    height = 100;
+
+    resizeGroupWidth() {
+        this.api.group.api.setSize({ width: this.width });
+    }
+    resizePanelWidth() {
+        this.api.setSize({ width: this.width });
+    }
+    resizeGroupHeight() {
+        this.api.group.api.setSize({ height: this.height });
+    }
+    resizePanelHeight() {
+        this.api.setSize({ height: this.height });
+    }
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%;">
+            <dv-dockview
+                [components]="components"
+                className="dockview-theme-abyss"
+                (ready)="onReady($event)">
+            </dv-dockview>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+        api.addPanel({ id: 'panel_1', component: 'default' });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            position: { direction: 'right', referencePanel: 'panel_1' },
+        });
+        api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            position: { direction: 'below', referencePanel: 'panel_1' },
+        });
+        api.addPanel({ id: 'panel_4', component: 'default' });
+        api.addPanel({ id: 'panel_5', component: 'default' });
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/scrollbars/angular/src/index.ts
+++ b/packages/docs/templates/dockview/scrollbars/angular/src/index.ts
@@ -1,0 +1,101 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { Component, NgModule, Type } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+const TEXT =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+const PARAGRAPH = (TEXT + '\n\n').repeat(20);
+
+@Component({
+    selector: 'fixed-height-panel',
+    template: `<div style="height: 100%; color: white;">{{ text }}</div>`,
+})
+export class FixedHeightPanelComponent {
+    text = PARAGRAPH;
+}
+
+@Component({
+    selector: 'overflow-panel',
+    template: `<div style="height: 2000px; overflow: auto; color: white;">{{ text }}</div>`,
+})
+export class OverflowPanelComponent {
+    text = PARAGRAPH;
+}
+
+@Component({
+    selector: 'user-overflow-panel',
+    template: `
+        <div style="height: 100%; color: white;">
+            <div style="height: 100%; overflow: auto;">{{ text }}</div>
+        </div>
+    `,
+})
+export class UserOverflowPanelComponent {
+    text = PARAGRAPH;
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%;">
+            <dv-dockview
+                [components]="components"
+                className="dockview-theme-abyss"
+                (ready)="onReady($event)">
+            </dv-dockview>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        fixedHeightContainer: FixedHeightPanelComponent,
+        overflowContainer: OverflowPanelComponent,
+        userDefinedOverflowContainer: UserOverflowPanelComponent,
+    };
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+        api.addPanel({
+            id: 'panel_1',
+            component: 'fixedHeightContainer',
+            title: 'Panel 1',
+        });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'overflowContainer',
+            title: 'Panel 2',
+            position: { direction: 'right' },
+        });
+        api.addPanel({
+            id: 'panel_3',
+            component: 'userDefinedOverflowContainer',
+            title: 'Panel 3',
+            position: { direction: 'right' },
+        });
+    }
+}
+
+@NgModule({
+    declarations: [
+        AppComponent,
+        FixedHeightPanelComponent,
+        OverflowPanelComponent,
+        UserOverflowPanelComponent,
+    ],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/tabview/angular/src/index.ts
+++ b/packages/docs/templates/dockview/tabview/angular/src/index.ts
@@ -1,0 +1,95 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { Component, NgModule, Input, Type, OnDestroy } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+    DockviewTheme,
+    TabAnimation,
+    themeAbyss,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="height: 100%; color: white; padding: 8px;">
+            {{ api?.title }}
+        </div>
+    `,
+})
+export class DefaultPanelComponent {
+    @Input() api!: DockviewPanelApi;
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%; display: flex; flex-direction: column;">
+            <div style="padding: 4px 8px;">
+                <button (click)="toggle()">tabAnimation: {{ tabAnimation }}</button>
+            </div>
+            <div style="flex-grow: 1;">
+                <dv-dockview
+                    [components]="components"
+                    [theme]="theme"
+                    [disableFloatingGroups]="true"
+                    className="dockview-theme-abyss"
+                    (ready)="onReady($event)">
+                </dv-dockview>
+            </div>
+        </div>
+    `,
+})
+export class AppComponent implements OnDestroy {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+
+    tabAnimation: TabAnimation = 'default';
+    theme: DockviewTheme = { ...themeAbyss, tabAnimation: this.tabAnimation };
+
+    private overlayDisposable?: { dispose(): void };
+
+    toggle() {
+        this.tabAnimation =
+            this.tabAnimation === 'smooth' ? 'default' : 'smooth';
+        this.theme = { ...themeAbyss, tabAnimation: this.tabAnimation };
+    }
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+
+        this.overlayDisposable = api.onWillShowOverlay((e) => {
+            if (e.kind === 'header_space' || e.kind === 'tab') {
+                return;
+            }
+            e.preventDefault();
+        });
+
+        api.addPanel({ id: 'panel_1', component: 'default' });
+        api.addPanel({ id: 'panel_2', component: 'default' });
+        api.addPanel({ id: 'panel_3', component: 'default' });
+        api.addPanel({ id: 'panel_4', component: 'default' });
+        api.addPanel({ id: 'panel_5', component: 'default' });
+    }
+
+    ngOnDestroy() {
+        this.overlayDisposable?.dispose();
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/update-parameters/angular/src/index.ts
+++ b/packages/docs/templates/dockview/update-parameters/angular/src/index.ts
@@ -1,0 +1,132 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnDestroy,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+interface CustomParams {
+    myValue: number;
+}
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="padding: 20px; color: white;">
+            <div>{{ api?.title }}</div>
+            <button (click)="toggle()">{{ running ? 'Stop' : 'Start' }}</button>
+            <span>value: {{ params?.myValue }}</span>
+        </div>
+    `,
+})
+export class DefaultPanelComponent implements OnDestroy {
+    @Input() api!: DockviewPanelApi;
+    // Updated every second via api.updateParameters while running.
+    @Input() params!: CustomParams;
+
+    running = false;
+    private interval: ReturnType<typeof setInterval> | undefined;
+
+    toggle() {
+        if (this.running) {
+            this.stop();
+        } else {
+            this.start();
+        }
+    }
+
+    private start() {
+        this.running = true;
+        this.api.updateParameters({ myValue: Date.now() });
+        this.interval = setInterval(() => {
+            this.api.updateParameters({ myValue: Date.now() });
+        }, 1000);
+    }
+
+    private stop() {
+        this.running = false;
+        if (this.interval) {
+            clearInterval(this.interval);
+            this.interval = undefined;
+        }
+    }
+
+    ngOnDestroy() {
+        this.stop();
+    }
+}
+
+@Component({
+    selector: 'default-tab',
+    template: `
+        <div>
+            <div>custom tab: {{ api?.title }}</div>
+            <span>value: {{ params?.myValue }}</span>
+        </div>
+    `,
+})
+export class DefaultTabComponent {
+    @Input() api!: DockviewPanelApi;
+    @Input() params!: CustomParams;
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%;">
+            <dv-dockview
+                [components]="components"
+                [tabComponents]="tabComponents"
+                className="dockview-theme-abyss"
+                (ready)="onReady($event)">
+            </dv-dockview>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+    tabComponents: Record<string, Type<any>> = {
+        default: DefaultTabComponent,
+    };
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+        api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            tabComponent: 'default',
+            params: { myValue: Date.now() },
+        });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            tabComponent: 'default',
+            params: { myValue: Date.now() },
+        });
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent, DefaultTabComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));

--- a/packages/docs/templates/dockview/update-title/angular/src/index.ts
+++ b/packages/docs/templates/dockview/update-title/angular/src/index.ts
@@ -1,0 +1,117 @@
+import 'zone.js';
+import '@angular/compiler';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import {
+    Component,
+    NgModule,
+    Input,
+    Type,
+    OnInit,
+    OnDestroy,
+    ChangeDetectorRef,
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+    DockviewAngularModule,
+    DockviewApi,
+    DockviewPanelApi,
+    DockviewReadyEvent,
+} from 'dockview-angular';
+import 'dockview-core/dist/styles/dockview.css';
+
+@Component({
+    selector: 'default-panel',
+    template: `
+        <div style="padding: 20px; color: white;">
+            <div>
+                <span style="color: grey;">props.api.title=</span>
+                <span>{{ api?.title }}</span>
+            </div>
+            <input [value]="title" (input)="title = $any($event.target).value" />
+            <button (click)="apply()">Change</button>
+        </div>
+    `,
+})
+export class DefaultPanelComponent implements OnInit, OnDestroy {
+    @Input() api!: DockviewPanelApi;
+
+    title = '';
+
+    private titleDisposable?: { dispose(): void };
+
+    constructor(private cd: ChangeDetectorRef) {}
+
+    ngOnInit() {
+        this.title = this.api?.title ?? '';
+        // Reflect external title changes back into the input field.
+        this.titleDisposable = this.api?.onDidTitleChange(() => {
+            this.title = this.api.title ?? '';
+            this.cd.markForCheck();
+        });
+    }
+
+    ngOnDestroy() {
+        this.titleDisposable?.dispose();
+    }
+
+    apply() {
+        this.api?.setTitle(this.title);
+    }
+}
+
+@Component({
+    selector: 'app-root',
+    template: `
+        <div style="height: 100%;">
+            <dv-dockview
+                [components]="components"
+                className="dockview-theme-abyss"
+                (ready)="onReady($event)">
+            </dv-dockview>
+        </div>
+    `,
+})
+export class AppComponent {
+    components: Record<string, Type<any>> = {
+        default: DefaultPanelComponent,
+    };
+
+    onReady(event: DockviewReadyEvent) {
+        const api: DockviewApi = event.api;
+
+        const panel = api.addPanel({
+            id: 'panel_1',
+            component: 'default',
+            title: 'Panel 1',
+        });
+        api.addPanel({
+            id: 'panel_2',
+            component: 'default',
+            title: 'Panel 2',
+            position: { referencePanel: panel.id },
+        });
+        const panel3 = api.addPanel({
+            id: 'panel_3',
+            component: 'default',
+            title: 'Panel 3',
+            position: { referencePanel: panel.id, direction: 'right' },
+        });
+        api.addPanel({
+            id: 'panel_4',
+            component: 'default',
+            title: 'Panel 4',
+            position: { referencePanel: panel3.id },
+        });
+    }
+}
+
+@NgModule({
+    declarations: [AppComponent, DefaultPanelComponent],
+    imports: [BrowserModule, DockviewAngularModule],
+    bootstrap: [AppComponent],
+})
+export class AppModule {}
+
+platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary

Triggered by [issue #1293](https://github.com/mathuo/dockview/issues/1293) — a user couldn't figure out how to receive `params` in an Angular panel. Investigating that uncovered a wider set of gaps in the Angular bindings and supporting docs/templates. This PR closes them.

### dockview-angular implementation

- Adds 9 missing `@Input()`s on `DockviewAngularComponent`: `scrollbars`, `disableTabsOverflowList`, `theme`, `defaultRenderer`, `defaultHeaderPosition`, `disableDnd`, `dndStrategy`, `dndEdges`, `noPanelsOverlay`. They were already in `PROPERTY_KEYS_DOCKVIEW` so the forwarding wiring picked them up — but with no inputs declared they were silently unsettable from Angular templates.
- New dedicated `AngularHeaderActionsRenderer` (mirrors `ReactHeaderActionsRendererPart`). The generic `AngularRenderer` only received `api`, `containerApi`, `group` from core, so header-action components never received `panels`, `activePanel`, `isGroupActive`, `headerPosition`, or `location` from `IDockviewHeaderActionsProps`. The new renderer seeds the full surface and subscribes to add/remove/active/location events to keep it in sync.
- Regression tests for both: every new `@Input()` is exercised through `ngOnChanges`; the new renderer has a dedicated 4-case spec covering initial state, panel add/remove, active panel/group, location, and clean disposal.

### Docs

- `register.mdx` — Angular example now declares `@Input() params` (the original #1293 fix) with a short explainer.
- `theming.mdx` — adds Angular block for `hideBorders` + `theme`.
- `scrollbars.mdx` — adds Angular blocks for `scrollbars` + `disableTabsOverflowList` (now backed by real inputs).
- `groups/controls.mdx` — Angular block now defines the Left/Right/Prefix header-action components with the full `IDockviewHeaderActionsProps` input surface.
- `templates/dockview/basic/angular/` — `DefaultPanelComponent` demonstrates the `params` round-trip.

### Templates

15 Angular template variants added — these were silently missing, and the `<CodeRunner>` had no Angular tab content for them: `demo-dockview`, `dnd-events`, `dnd-external`, `layout`, `locked`, `maximize-group`, `nested`, `popout-group`, `render-mode`, `resize`, `resize-container`, `scrollbars`, `tabview`, `update-parameters`, `update-title`. Each matches its React reference in scope, uses the NgModule + `platformBrowserDynamic` bootstrap pattern shared with the existing Angular templates, and uses native `[value]` + `(input)` instead of `[(ngModel)]` so no FormsModule dependency is added to the SystemJS boilerplate.

### Pre-existing fix bundled in

`FloatingGroupOptions.position` is `AnchorPosition` (only `top/bottom/left/right`); `width` and `height` belong at the top level. Four call sites had this mis-nested, producing `TS2353` in the docs typecheck. Fixed in `floating-groups/{angular,react}`, `demo-dockview/react/panelActions.tsx`, and the corresponding sandbox. Behaviour is unchanged at runtime — the extra keys were already being ignored.

## Test plan

- [x] `yarn workspace dockview-angular test` — 131/131 pass
- [x] `yarn workspace dockview-docs build-templates` — all 15 new Angular templates produce `static/templates/dockview/<name>/angular/index.html`
- [x] `yarn workspace dockview-docs typecheck` — no new errors from this PR (remaining errors are all pre-existing in other templates)
- [x] `yarn format:check` — clean across all 5 projects
- [x] `yarn lint` — 0 errors (warnings unchanged from baseline)
- [x] `yarn workspace dockview-angular build:angular` — clean ng-packagr build
- [ ] Visual smoke-check the new Angular tabs in the docs site for any obvious runtime issues — recommend doing this before merge

Closes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)