### PR TITLE
fix(dockview-vue): accept components via prop (resolves #1301)

### DIFF
--- a/packages/dockview-vue/src/__tests__/dockview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/dockview.spec.ts
@@ -465,9 +465,10 @@ describe('DockviewVue components prop (issue #1301)', () => {
         const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
 
         expect(() =>
-            (api as any).component.options.createRightHeaderActionComponent?.(
-                { api: {}, model: {} } as any
-            )
+            (api as any).component.options.createRightHeaderActionComponent?.({
+                api: {},
+                model: {},
+            } as any)
         ).not.toThrow();
     });
 
@@ -480,9 +481,10 @@ describe('DockviewVue components prop (issue #1301)', () => {
         const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
 
         expect(() =>
-            (api as any).component.options.createLeftHeaderActionComponent?.(
-                { api: {}, model: {} } as any
-            )
+            (api as any).component.options.createLeftHeaderActionComponent?.({
+                api: {},
+                model: {},
+            } as any)
         ).not.toThrow();
     });
 
@@ -495,9 +497,10 @@ describe('DockviewVue components prop (issue #1301)', () => {
         const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
 
         expect(() =>
-            (api as any).component.options.createPrefixHeaderActionComponent?.(
-                { api: {}, model: {} } as any
-            )
+            (api as any).component.options.createPrefixHeaderActionComponent?.({
+                api: {},
+                model: {},
+            } as any)
         ).not.toThrow();
     });
 

--- a/packages/dockview-vue/src/__tests__/dockview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/dockview.spec.ts
@@ -297,3 +297,260 @@ describe('DockviewVue Component', () => {
         expect(emitted![0][0]).toBe(fakeEvent);
     });
 });
+
+// Regression coverage for https://github.com/mathuo/dockview/issues/1301
+// `<script setup>` users (and anyone not using the Options API) need to be
+// able to supply panel components without registering globally in main.ts.
+describe('DockviewVue components prop (issue #1301)', () => {
+    let wrapper: ReturnType<typeof mount>;
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    function mountBare(props: Record<string, any> = {}) {
+        // NOTE: no `global.components` here — this is the scenario that used
+        // to require `app.component(...)` in main.ts.
+        return mount(DockviewVue, { props, attachTo: document.body });
+    }
+
+    test('addPanel resolves component from props.components without any registration', async () => {
+        wrapper = mountBare({
+            components: { Panel: MockPanel },
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            api.addPanel({
+                id: 'panel-1',
+                component: 'Panel',
+                title: 'Panel 1',
+            })
+        ).not.toThrow();
+
+        expect(api.getPanel('panel-1')).toBeDefined();
+    });
+
+    test('addPanel still throws a helpful error when component is not in the map', async () => {
+        wrapper = mountBare({
+            components: { Panel: MockPanel },
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            api.addPanel({
+                id: 'panel-bad',
+                component: 'DoesNotExist',
+                title: 'Bad',
+            })
+        ).toThrow("Failed to find Vue Component 'DoesNotExist'");
+    });
+
+    test('tabComponents map resolves tab components without registration', async () => {
+        wrapper = mountBare({
+            components: { Panel: MockPanel },
+            tabComponents: { CustomTab: MockTab },
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            api.addPanel({
+                id: 'panel-1',
+                component: 'Panel',
+                tabComponent: 'CustomTab',
+                title: 'Panel 1',
+            })
+        ).not.toThrow();
+
+        expect(api.getPanel('panel-1')).toBeDefined();
+    });
+
+    test('defaultTabComponent accepts a component object directly', async () => {
+        wrapper = mountBare({
+            components: { Panel: MockPanel },
+            defaultTabComponent: MockTab,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            api.addPanel({
+                id: 'panel-1',
+                component: 'Panel',
+                title: 'Panel 1',
+            })
+        ).not.toThrow();
+
+        expect(api.getPanel('panel-1')).toBeDefined();
+    });
+
+    test('defaultTabComponent still works as a string (backward compat)', async () => {
+        wrapper = mount(DockviewVue, {
+            props: {
+                defaultTabComponent: 'MockTab',
+                components: { Panel: MockPanel },
+            },
+            attachTo: document.body,
+            // String form must continue to work with the legacy global
+            // registration path too — that's the contract we promised.
+            global: { components: { MockTab } },
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+        const updateSpy = vi.spyOn(api, 'updateOptions');
+
+        await wrapper.setProps({ defaultTabComponent: 'MockTab2' });
+        await nextTick();
+
+        expect(updateSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ defaultTabComponent: 'MockTab2' })
+        );
+    });
+
+    test('switching defaultTabComponent from string to component uses sentinel', async () => {
+        wrapper = mount(DockviewVue, {
+            props: {
+                defaultTabComponent: 'MockTab',
+                components: { Panel: MockPanel },
+            },
+            attachTo: document.body,
+            global: { components: { MockTab } },
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+        const updateSpy = vi.spyOn(api, 'updateOptions');
+
+        await wrapper.setProps({ defaultTabComponent: MockTab2 });
+        await nextTick();
+
+        // Sentinel name routes core back into createTabComponent, which then
+        // returns our component object via resolveComponent.
+        expect(updateSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                defaultTabComponent: 'props.defaultTabComponent',
+            })
+        );
+    });
+
+    test('watermarkComponent accepts a component object directly', async () => {
+        wrapper = mountBare({
+            watermarkComponent: MockWatermark,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        // Should not throw on createWatermarkComponent invocation — we proxy
+        // any call to verify resolveComponent doesn't reject the object.
+        expect(() =>
+            (api as any).component.options.createWatermarkComponent?.()
+        ).not.toThrow();
+    });
+
+    test('rightHeaderActionsComponent accepts a component object directly', async () => {
+        wrapper = mountBare({
+            rightHeaderActionsComponent: MockHeaderAction,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            (api as any).component.options.createRightHeaderActionComponent?.(
+                { api: {}, model: {} } as any
+            )
+        ).not.toThrow();
+    });
+
+    test('leftHeaderActionsComponent accepts a component object directly', async () => {
+        wrapper = mountBare({
+            leftHeaderActionsComponent: MockHeaderAction,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            (api as any).component.options.createLeftHeaderActionComponent?.(
+                { api: {}, model: {} } as any
+            )
+        ).not.toThrow();
+    });
+
+    test('prefixHeaderActionsComponent accepts a component object directly', async () => {
+        wrapper = mountBare({
+            prefixHeaderActionsComponent: MockHeaderAction,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            (api as any).component.options.createPrefixHeaderActionComponent?.(
+                { api: {}, model: {} } as any
+            )
+        ).not.toThrow();
+    });
+
+    test('tabGroupChipComponent accepts a component object directly', async () => {
+        wrapper = mountBare({
+            tabGroupChipComponent: MockHeaderAction,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            (api as any).component.options.createTabGroupChipComponent?.()
+        ).not.toThrow();
+    });
+
+    test('groupDragGhostComponent accepts a component object directly', async () => {
+        wrapper = mountBare({
+            groupDragGhostComponent: MockHeaderAction,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        expect(() =>
+            (api as any).component.options.createGroupDragGhostComponent?.()
+        ).not.toThrow();
+    });
+
+    test('switching components map at runtime is picked up on next addPanel', async () => {
+        wrapper = mountBare({
+            components: { Panel: MockPanel },
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as DockviewApi;
+
+        api.addPanel({ id: 'panel-1', component: 'Panel', title: 'P1' });
+        expect(api.getPanel('panel-1')).toBeDefined();
+
+        const NewPanel = {
+            name: 'NewPanel',
+            props: ['params'],
+            template: '<div class="new-panel">New</div>',
+        };
+
+        await wrapper.setProps({ components: { Panel: NewPanel } });
+        await nextTick();
+
+        // The next addPanel should resolve against the updated map — no
+        // rerender of existing panels (we explicitly chose read-at-create).
+        expect(() =>
+            api.addPanel({ id: 'panel-2', component: 'Panel', title: 'P2' })
+        ).not.toThrow();
+    });
+});

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -222,8 +222,7 @@ describe('GridviewVue components prop resolves without registration', () => {
         });
         await flushPromises();
 
-        const api = (wrapper.emitted('ready')![0][0] as any)
-            .api as GridviewApi;
+        const api = (wrapper.emitted('ready')![0][0] as any).api as GridviewApi;
 
         expect(() =>
             api.addPanel({ id: 'cell-1', component: 'Cell' })
@@ -242,8 +241,7 @@ describe('GridviewVue components prop resolves without registration', () => {
         });
         await flushPromises();
 
-        const api = (wrapper.emitted('ready')![0][0] as any)
-            .api as GridviewApi;
+        const api = (wrapper.emitted('ready')![0][0] as any).api as GridviewApi;
 
         expect(() =>
             api.addPanel({ id: 'bad', component: 'NotRegistered' })

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -1,12 +1,22 @@
-import { vi, describe, test, expect, beforeEach } from 'vitest';
+import { vi, describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { defineComponent } from 'vue';
 import {
     createGridview,
+    GridviewApi,
     PROPERTY_KEYS_GRIDVIEW,
     Orientation,
 } from 'dockview-core';
+import GridviewVue from '../gridview/gridview.vue';
 import { VueGridviewPanelView } from '../gridview/view';
 import { VuePart } from '../utils';
 import * as gridviewTypes from '../gridview/types';
+
+const MockGridComponent = defineComponent({
+    name: 'MockGridComponent',
+    props: ['params', 'api', 'containerApi'],
+    template: '<div class="mock-grid">Grid</div>',
+});
 
 describe('GridviewVue Component', () => {
     test('should export component types', () => {
@@ -191,5 +201,52 @@ describe('VueGridviewPanelView', () => {
         expect(component).toBeDefined();
 
         initSpy.mockRestore();
+    });
+});
+
+// Regression coverage for https://github.com/mathuo/dockview/issues/1301
+describe('GridviewVue components prop resolves without registration', () => {
+    let wrapper: ReturnType<typeof mount>;
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    test('addPanel resolves component from props.components alone', async () => {
+        wrapper = mount(GridviewVue, {
+            props: {
+                orientation: Orientation.HORIZONTAL,
+                components: { Cell: MockGridComponent },
+            },
+            attachTo: document.body,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any)
+            .api as GridviewApi;
+
+        expect(() =>
+            api.addPanel({ id: 'cell-1', component: 'Cell' })
+        ).not.toThrow();
+
+        expect(api.getPanel('cell-1')).toBeDefined();
+    });
+
+    test('throws when component name is not in the map and not registered', async () => {
+        wrapper = mount(GridviewVue, {
+            props: {
+                orientation: Orientation.HORIZONTAL,
+                components: { Cell: MockGridComponent },
+            },
+            attachTo: document.body,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any)
+            .api as GridviewApi;
+
+        expect(() =>
+            api.addPanel({ id: 'bad', component: 'NotRegistered' })
+        ).toThrow("Failed to find Vue Component 'NotRegistered'");
     });
 });

--- a/packages/dockview-vue/src/__tests__/paneview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/paneview.spec.ts
@@ -185,3 +185,52 @@ describe('PaneviewVue events', () => {
         expect(emitted![0][0]).toBe(fakeEvent);
     });
 });
+
+// Regression coverage for https://github.com/mathuo/dockview/issues/1301
+describe('PaneviewVue components prop resolves without registration', () => {
+    let wrapper: ReturnType<typeof mount>;
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    test('addPanel resolves component from props.components alone', async () => {
+        // No `global.components` and no `app.component()` — the user's
+        // `<script setup>` scenario.
+        wrapper = mount(PaneviewVue, {
+            props: { components: { MyPane: MockPaneComponent } },
+            attachTo: document.body,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as PaneviewApi;
+
+        expect(() =>
+            api.addPanel({
+                id: 'pane-1',
+                component: 'MyPane',
+                title: 'Pane',
+            })
+        ).not.toThrow();
+
+        expect(api.getPanel('pane-1')).toBeDefined();
+    });
+
+    test('throws when component name is not in the map and not registered', async () => {
+        wrapper = mount(PaneviewVue, {
+            props: { components: { MyPane: MockPaneComponent } },
+            attachTo: document.body,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as PaneviewApi;
+
+        expect(() =>
+            api.addPanel({
+                id: 'pane-bad',
+                component: 'NotRegistered',
+                title: 'Bad',
+            })
+        ).toThrow("Failed to find Vue Component 'NotRegistered'");
+    });
+});

--- a/packages/dockview-vue/src/__tests__/splitview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/splitview.spec.ts
@@ -1,12 +1,22 @@
-import { vi, describe, test, expect } from 'vitest';
+import { vi, describe, test, expect, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { defineComponent } from 'vue';
 import {
     createSplitview,
     Orientation,
     PROPERTY_KEYS_SPLITVIEW,
+    SplitviewApi,
 } from 'dockview-core';
+import SplitviewVue from '../splitview/splitview.vue';
 import { VueSplitviewPanelView } from '../splitview/view';
 import { VuePart } from '../utils';
 import * as splitviewTypes from '../splitview/types';
+
+const MockSplitComponent = defineComponent({
+    name: 'MockSplitComponent',
+    props: ['params', 'api', 'containerApi'],
+    template: '<div class="mock-split">Split</div>',
+});
 
 describe('SplitviewVue Component', () => {
     test('should export component types', () => {
@@ -131,5 +141,52 @@ describe('VueSplitviewPanelView', () => {
         expect(initSpy).toHaveBeenCalled();
 
         initSpy.mockRestore();
+    });
+});
+
+// Regression coverage for https://github.com/mathuo/dockview/issues/1301
+describe('SplitviewVue components prop resolves without registration', () => {
+    let wrapper: ReturnType<typeof mount>;
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    test('addPanel resolves component from props.components alone', async () => {
+        wrapper = mount(SplitviewVue, {
+            props: {
+                orientation: Orientation.HORIZONTAL,
+                components: { Pane: MockSplitComponent },
+            },
+            attachTo: document.body,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any)
+            .api as SplitviewApi;
+
+        expect(() =>
+            api.addPanel({ id: 'pane-1', component: 'Pane' })
+        ).not.toThrow();
+
+        expect(api.getPanel('pane-1')).toBeDefined();
+    });
+
+    test('throws when component name is not in the map and not registered', async () => {
+        wrapper = mount(SplitviewVue, {
+            props: {
+                orientation: Orientation.HORIZONTAL,
+                components: { Pane: MockSplitComponent },
+            },
+            attachTo: document.body,
+        });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any)
+            .api as SplitviewApi;
+
+        expect(() =>
+            api.addPanel({ id: 'bad', component: 'NotRegistered' })
+        ).toThrow("Failed to find Vue Component 'NotRegistered'");
     });
 });

--- a/packages/dockview-vue/src/__tests__/utils.spec.ts
+++ b/packages/dockview-vue/src/__tests__/utils.spec.ts
@@ -21,6 +21,7 @@ import {
     VuePart,
     findComponent,
     mountVueComponent,
+    resolveComponent,
 } from '../utils';
 
 const mockUpdate = vi.fn();
@@ -95,6 +96,155 @@ describe('findComponent', () => {
 
         expect(() => findComponent(mockInstance, 'non-existent')).toThrow(
             "Failed to find Vue Component 'non-existent'"
+        );
+    });
+
+    test('should find component in explicit components map without instance/app registration', () => {
+        const testComponent = { template: '<div>Explicit</div>' };
+        const mockInstance = {
+            components: {},
+            appContext: { components: {} },
+            parent: null,
+        } as any;
+
+        const found = findComponent(mockInstance, 'explicit', {
+            explicit: testComponent as any,
+        });
+        expect(found).toBe(testComponent);
+    });
+
+    test('explicit components map takes priority over instance components', () => {
+        const instanceComponent = { template: '<div>Instance</div>' };
+        const explicitComponent = { template: '<div>Explicit</div>' };
+        const mockInstance = {
+            components: { 'shared-name': instanceComponent },
+            appContext: { components: {} },
+            parent: null,
+        } as any;
+
+        const found = findComponent(mockInstance, 'shared-name', {
+            'shared-name': explicitComponent as any,
+        });
+        expect(found).toBe(explicitComponent);
+    });
+
+    test('explicit components map takes priority over app context', () => {
+        const globalComponent = { template: '<div>Global</div>' };
+        const explicitComponent = { template: '<div>Explicit</div>' };
+        const mockInstance = {
+            components: {},
+            appContext: { components: { 'shared-name': globalComponent } },
+            parent: null,
+        } as any;
+
+        const found = findComponent(mockInstance, 'shared-name', {
+            'shared-name': explicitComponent as any,
+        });
+        expect(found).toBe(explicitComponent);
+    });
+
+    test('falls through to instance walk when name not in components map', () => {
+        const instanceComponent = { template: '<div>Instance</div>' };
+        const mockInstance = {
+            components: { 'only-in-instance': instanceComponent },
+            appContext: { components: {} },
+            parent: null,
+        } as any;
+
+        const found = findComponent(mockInstance, 'only-in-instance', {
+            other: { template: '<div>Other</div>' } as any,
+        });
+        expect(found).toBe(instanceComponent);
+    });
+
+    test('falls through to app context when name not in components map or instance', () => {
+        const globalComponent = { template: '<div>Global</div>' };
+        const mockInstance = {
+            components: {},
+            appContext: { components: { 'only-global': globalComponent } },
+            parent: null,
+        } as any;
+
+        const found = findComponent(mockInstance, 'only-global', {
+            other: { template: '<div>Other</div>' } as any,
+        });
+        expect(found).toBe(globalComponent);
+    });
+
+    test('still throws when name not in components map and not registered anywhere', () => {
+        const mockInstance = {
+            components: {},
+            appContext: { components: {} },
+            parent: null,
+        } as any;
+
+        expect(() =>
+            findComponent(mockInstance, 'missing', {
+                other: { template: '<div>Other</div>' } as any,
+            })
+        ).toThrow("Failed to find Vue Component 'missing'");
+    });
+
+    test('treats empty components map identically to no map', () => {
+        const globalComponent = { template: '<div>Global</div>' };
+        const mockInstance = {
+            components: {},
+            appContext: { components: { foo: globalComponent } },
+            parent: null,
+        } as any;
+
+        const found = findComponent(mockInstance, 'foo', {});
+        expect(found).toBe(globalComponent);
+    });
+});
+
+describe('resolveComponent', () => {
+    const mockInstance = {
+        components: {},
+        appContext: { components: {} },
+        parent: null,
+    } as any;
+
+    test('returns undefined when value is undefined', () => {
+        expect(resolveComponent(undefined, mockInstance)).toBeUndefined();
+    });
+
+    test('returns the component directly when value is a component object', () => {
+        const component = { template: '<div>Direct</div>' } as any;
+        expect(resolveComponent(component, mockInstance)).toBe(component);
+    });
+
+    test('looks up string names via findComponent', () => {
+        const component = { template: '<div>Named</div>' };
+        const inst = {
+            components: { 'my-name': component },
+            appContext: { components: {} },
+            parent: null,
+        } as any;
+
+        expect(resolveComponent('my-name', inst)).toBe(component);
+    });
+
+    test('looks up string names in the components map when provided', () => {
+        const component = { template: '<div>Mapped</div>' };
+        expect(
+            resolveComponent('mapped', mockInstance, {
+                mapped: component as any,
+            })
+        ).toBe(component);
+    });
+
+    test('returns the component object even when components map does not contain it', () => {
+        // Direct component refs bypass the map entirely.
+        const component = { template: '<div>Direct</div>' } as any;
+        expect(
+            resolveComponent(component, mockInstance, { other: {} as any })
+        ).toBe(component);
+    });
+
+    test('throws when string name is not resolvable', () => {
+        expect(() => resolveComponent('missing', mockInstance)).toThrow(
+            "Failed to find Vue Component 'missing'"
         );
     });
 });

--- a/packages/dockview-vue/src/composables/useViewComponent.ts
+++ b/packages/dockview-vue/src/composables/useViewComponent.ts
@@ -90,7 +90,11 @@ export function useViewComponent<
                         id: string;
                         name?: string;
                     }) => {
-                        const component = findComponent(inst, options.name!);
+                        const component = findComponent(
+                            inst,
+                            options.name!,
+                            (props as any).components
+                        );
                         return config.createView(
                             options.id,
                             options.name,
@@ -118,7 +122,11 @@ export function useViewComponent<
 
         const frameworkOptions = {
             createComponent(options: { id: string; name?: string }) {
-                const component = findComponent(inst, options.name!);
+                const component = findComponent(
+                    inst,
+                    options.name!,
+                    (props as any).components
+                );
                 return config.createView(
                     options.id,
                     options.name,

--- a/packages/dockview-vue/src/dockview/dockview.vue
+++ b/packages/dockview-vue/src/dockview/dockview.vue
@@ -23,8 +23,11 @@ import {
     VueRenderer,
     VueWatermarkRenderer,
     findComponent,
+    resolveComponent,
 } from '../utils';
 import type { IDockviewVueProps, VueEvents } from './types';
+
+const DEFAULT_VUE_TAB = 'props.defaultTabComponent';
 
 function extractCoreOptions(props: IDockviewVueProps): DockviewOptions {
     const coreOptions = (
@@ -65,7 +68,7 @@ watch(
             instance.value.updateOptions({
                 createTabGroupChipComponent: newValue
                     ? () => {
-                          const component = findComponent(inst, newValue);
+                          const component = resolveComponent(newValue, inst);
                           return new VueTabGroupChipRenderer(component!, inst);
                       }
                     : undefined,
@@ -81,7 +84,7 @@ watch(
             instance.value.updateOptions({
                 createGroupDragGhostComponent: newValue
                     ? () => {
-                          const component = findComponent(inst, newValue);
+                          const component = resolveComponent(newValue, inst);
                           return new VueGroupDragGhostRenderer(
                               component!,
                               inst
@@ -97,13 +100,26 @@ watch(
     () => props.defaultTabComponent,
     (newValue) => {
         if (instance.value) {
+            const coreDefault =
+                typeof newValue === 'string'
+                    ? newValue
+                    : newValue
+                      ? DEFAULT_VUE_TAB
+                      : undefined;
             instance.value.updateOptions({
-                defaultTabComponent: newValue,
+                defaultTabComponent: coreDefault,
                 createTabComponent(options) {
-                    let component = findComponent(inst, options.name);
+                    let component =
+                        options.name === DEFAULT_VUE_TAB
+                            ? null
+                            : findComponent(
+                                  inst,
+                                  options.name,
+                                  props.tabComponents
+                              );
 
                     if (!component && newValue) {
-                        component = findComponent(inst, newValue);
+                        component = resolveComponent(newValue, inst) ?? null;
                     }
 
                     if (component) {
@@ -123,7 +139,7 @@ watch(
             instance.value.updateOptions({
                 createWatermarkComponent: newValue
                     ? () => {
-                          const component = findComponent(inst, newValue);
+                          const component = resolveComponent(newValue, inst);
                           return new VueWatermarkRenderer(component!, inst);
                       }
                     : undefined,
@@ -139,7 +155,7 @@ watch(
             instance.value.updateOptions({
                 createRightHeaderActionComponent: newValue
                     ? (group) => {
-                          const component = findComponent(inst, newValue);
+                          const component = resolveComponent(newValue, inst);
                           return new VueHeaderActionsRenderer(
                               component!,
                               inst,
@@ -159,7 +175,7 @@ watch(
             instance.value.updateOptions({
                 createLeftHeaderActionComponent: newValue
                     ? (group) => {
-                          const component = findComponent(inst, newValue);
+                          const component = resolveComponent(newValue, inst);
                           return new VueHeaderActionsRenderer(
                               component!,
                               inst,
@@ -179,7 +195,7 @@ watch(
             instance.value.updateOptions({
                 createPrefixHeaderActionComponent: newValue
                     ? (group) => {
-                          const component = findComponent(inst, newValue);
+                          const component = resolveComponent(newValue, inst);
                           return new VueHeaderActionsRenderer(
                               component!,
                               inst,
@@ -203,14 +219,26 @@ onMounted(() => {
 
     const frameworkOptions: DockviewFrameworkOptions = {
         createComponent(options) {
-            const component = findComponent(inst, options.name);
+            const component = findComponent(
+                inst,
+                options.name,
+                props.components
+            );
             return new VueRenderer(component!, inst);
         },
         createTabComponent(options) {
-            let component = findComponent(inst, options.name);
+            let component =
+                options.name === DEFAULT_VUE_TAB
+                    ? null
+                    : findComponent(
+                          inst,
+                          options.name,
+                          props.tabComponents
+                      );
 
             if (!component && props.defaultTabComponent) {
-                component = findComponent(inst, props.defaultTabComponent);
+                component =
+                    resolveComponent(props.defaultTabComponent, inst) ?? null;
             }
 
             if (component) {
@@ -220,9 +248,9 @@ onMounted(() => {
         },
         createWatermarkComponent: props.watermarkComponent
             ? () => {
-                  const component = findComponent(
-                      inst,
-                      props.watermarkComponent!
+                  const component = resolveComponent(
+                      props.watermarkComponent,
+                      inst
                   );
 
                   return new VueWatermarkRenderer(component!, inst);
@@ -230,27 +258,27 @@ onMounted(() => {
             : undefined,
         createLeftHeaderActionComponent: props.leftHeaderActionsComponent
             ? (group) => {
-                  const component = findComponent(
-                      inst,
-                      props.leftHeaderActionsComponent!
+                  const component = resolveComponent(
+                      props.leftHeaderActionsComponent,
+                      inst
                   );
                   return new VueHeaderActionsRenderer(component!, inst, group);
               }
             : undefined,
         createPrefixHeaderActionComponent: props.prefixHeaderActionsComponent
             ? (group) => {
-                  const component = findComponent(
-                      inst,
-                      props.prefixHeaderActionsComponent!
+                  const component = resolveComponent(
+                      props.prefixHeaderActionsComponent,
+                      inst
                   );
                   return new VueHeaderActionsRenderer(component!, inst, group);
               }
             : undefined,
         createRightHeaderActionComponent: props.rightHeaderActionsComponent
             ? (group) => {
-                  const component = findComponent(
-                      inst,
-                      props.rightHeaderActionsComponent!
+                  const component = resolveComponent(
+                      props.rightHeaderActionsComponent,
+                      inst
                   );
                   return new VueHeaderActionsRenderer(component!, inst, group);
               }
@@ -259,29 +287,35 @@ onMounted(() => {
             if (!options.component) {
                 return undefined;
             }
-            const component = findComponent(inst, options.component as string);
+            const component = findComponent(
+                inst,
+                options.component as string,
+                props.components
+            );
             return new VueContextMenuItemRenderer(component!, inst);
         },
     };
 
     const coreOptions = extractCoreOptions(props);
 
-    if (props.defaultTabComponent) {
+    if (typeof props.defaultTabComponent === 'string') {
         frameworkOptions.defaultTabComponent = props.defaultTabComponent;
+    } else if (props.defaultTabComponent) {
+        frameworkOptions.defaultTabComponent = DEFAULT_VUE_TAB;
     }
 
     if (props.tabGroupChipComponent) {
-        const chipComponentName = props.tabGroupChipComponent;
+        const chipValue = props.tabGroupChipComponent;
         coreOptions.createTabGroupChipComponent = () => {
-            const component = findComponent(inst, chipComponentName);
+            const component = resolveComponent(chipValue, inst);
             return new VueTabGroupChipRenderer(component!, inst);
         };
     }
 
     if (props.groupDragGhostComponent) {
-        const ghostComponentName = props.groupDragGhostComponent;
+        const ghostValue = props.groupDragGhostComponent;
         coreOptions.createGroupDragGhostComponent = () => {
-            const component = findComponent(inst, ghostComponentName);
+            const component = resolveComponent(ghostValue, inst);
             return new VueGroupDragGhostRenderer(component!, inst);
         };
     }

--- a/packages/dockview-vue/src/dockview/dockview.vue
+++ b/packages/dockview-vue/src/dockview/dockview.vue
@@ -230,11 +230,7 @@ onMounted(() => {
             let component =
                 options.name === DEFAULT_VUE_TAB
                     ? null
-                    : findComponent(
-                          inst,
-                          options.name,
-                          props.tabComponents
-                      );
+                    : findComponent(inst, options.name, props.tabComponents);
 
             if (!component && props.defaultTabComponent) {
                 component =

--- a/packages/dockview-vue/src/dockview/types.ts
+++ b/packages/dockview-vue/src/dockview/types.ts
@@ -4,15 +4,18 @@ import {
     type DockviewReadyEvent,
     type DockviewWillDropEvent,
 } from 'dockview-core';
+import type { VueComponent } from '../utils';
 
 export interface VueProps {
-    watermarkComponent?: string;
-    defaultTabComponent?: string;
-    rightHeaderActionsComponent?: string;
-    leftHeaderActionsComponent?: string;
-    prefixHeaderActionsComponent?: string;
-    tabGroupChipComponent?: string;
-    groupDragGhostComponent?: string;
+    components?: Record<string, VueComponent>;
+    tabComponents?: Record<string, VueComponent>;
+    watermarkComponent?: string | VueComponent;
+    defaultTabComponent?: string | VueComponent;
+    rightHeaderActionsComponent?: string | VueComponent;
+    leftHeaderActionsComponent?: string | VueComponent;
+    prefixHeaderActionsComponent?: string | VueComponent;
+    tabGroupChipComponent?: string | VueComponent;
+    groupDragGhostComponent?: string | VueComponent;
 }
 
 export type VueEvents = {

--- a/packages/dockview-vue/src/gridview/types.ts
+++ b/packages/dockview-vue/src/gridview/types.ts
@@ -3,6 +3,7 @@ import type {
     GridviewOptions,
     GridviewPanelApi,
 } from 'dockview-core';
+import type { VueComponent } from '../utils';
 
 export interface GridviewReadyEvent {
     api: GridviewApi;
@@ -15,7 +16,7 @@ export interface IGridviewVuePanelProps<T extends Record<string, any> = any> {
 }
 
 export interface IGridviewVueProps extends GridviewOptions {
-    components: Record<string, string>;
+    components?: Record<string, VueComponent>;
 }
 
 export type GridviewVueEvents = {

--- a/packages/dockview-vue/src/paneview/types.ts
+++ b/packages/dockview-vue/src/paneview/types.ts
@@ -4,6 +4,7 @@ import type {
     PaneviewOptions,
     PaneviewPanelApi,
 } from 'dockview-core';
+import type { VueComponent } from '../utils';
 
 export interface PaneviewReadyEvent {
     api: PaneviewApi;
@@ -17,7 +18,7 @@ export interface IPaneviewVuePanelProps<T extends Record<string, any> = any> {
 }
 
 export interface IPaneviewVueProps extends PaneviewOptions {
-    components: Record<string, string>;
+    components?: Record<string, VueComponent>;
 }
 
 export type PaneviewVueEvents = {

--- a/packages/dockview-vue/src/splitview/types.ts
+++ b/packages/dockview-vue/src/splitview/types.ts
@@ -3,6 +3,7 @@ import type {
     SplitviewOptions,
     SplitviewPanelApi,
 } from 'dockview-core';
+import type { VueComponent } from '../utils';
 
 export interface SplitviewReadyEvent {
     api: SplitviewApi;
@@ -15,7 +16,7 @@ export interface ISplitviewVuePanelProps<T extends Record<string, any> = any> {
 }
 
 export interface ISplitviewVueProps extends SplitviewOptions {
-    components: Record<string, string>;
+    components?: Record<string, VueComponent>;
 }
 
 export type SplitviewVueEvents = {

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -50,8 +50,13 @@ export type VueComponent<T = any> = DefineComponent<T>;
 
 export function findComponent(
     parent: ComponentInternalInstance,
-    name: string
+    name: string,
+    components?: Record<string, VueComponent | undefined>
 ): VueComponent | null {
+    if (components && components[name]) {
+        return components[name] as VueComponent;
+    }
+
     let instance = parent as any;
     let component: any = null;
 
@@ -69,6 +74,20 @@ export function findComponent(
     }
 
     return component as VueComponent;
+}
+
+export function resolveComponent(
+    value: string | VueComponent | undefined,
+    parent: ComponentInternalInstance,
+    components?: Record<string, VueComponent | undefined>
+): VueComponent | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (typeof value !== 'string') {
+        return value;
+    }
+    return findComponent(parent, value, components) ?? undefined;
 }
 
 /**

--- a/packages/docs/docs/core/panels/register.mdx
+++ b/packages/docs/docs/core/panels/register.mdx
@@ -81,33 +81,34 @@ const api = createDockview(parentElement, {
 
 
 <FrameworkSpecific framework='Vue'>
-```tsx
-const App = {
-    name: 'App',
-    components: {
-        'component_1': VueComponent1,
-        'component_2': VueComponent2,
-    },
-    methods: {
-        onReady(event: DockviewReadyEvent) {
-            event.api.addPanel({
-                id: 'panel_1',
-                component: 'component_1'
-            });
 
-               event.api.addPanel({
-                id: 'panel_2',
-                component: 'component_2'
-            });
-        },
-    },
-    template: `
-      <dockview-vue
+Pass your panel components directly to `<DockviewVue>` via the `components`
+prop. This is the recommended pattern and works with `<script setup>` — no
+global `app.component(...)` registration is required.
+
+```vue
+<script setup lang="ts">
+import { DockviewVue, type DockviewReadyEvent } from 'dockview-vue';
+import VueComponent1 from './VueComponent1.vue';
+import VueComponent2 from './VueComponent2.vue';
+
+function onReady(event: DockviewReadyEvent) {
+    event.api.addPanel({ id: 'panel_1', component: 'component_1' });
+    event.api.addPanel({ id: 'panel_2', component: 'component_2' });
+}
+</script>
+
+<template>
+    <DockviewVue
+        :components="{ component_1: VueComponent1, component_2: VueComponent2 }"
         @ready="onReady"
-      >
-      </dockview-vue>`,
-};
+    />
+</template>
 ```
+
+Legacy Options-API style is still supported — components registered on any
+ancestor via `components: { ... }` (or globally via `app.component(...)`) are
+resolved by name as before.
 </FrameworkSpecific>
 
 <FrameworkSpecific framework='Angular'>

--- a/packages/docs/docs/overview/quickstart.mdx
+++ b/packages/docs/docs/overview/quickstart.mdx
@@ -124,29 +124,42 @@ export default function App() {
 </FrameworkSpecific>
 
 <FrameworkSpecific framework='Vue'>
-```ts
-import { DockviewVue, DockviewReadyEvent, IDockviewPanelProps } from 'dockview-vue';
-import { defineComponent, PropType } from 'vue';
+```vue
+<script setup lang="ts">
+import {
+    DockviewVue,
+    type DockviewReadyEvent,
+    type IDockviewPanelProps,
+} from 'dockview-vue';
+import { defineComponent, type PropType } from 'vue';
 
 const MyPanel = defineComponent({
     name: 'MyPanel',
-    props: { params: { type: Object as PropType<IDockviewPanelProps>, required: true } },
+    props: {
+        params: { type: Object as PropType<IDockviewPanelProps>, required: true },
+    },
     template: `<div style="padding: 16px">{{ params.api.title }}</div>`,
 });
 
-const App = defineComponent({
-    name: 'App',
-    components: { 'dockview-vue': DockviewVue, 'my-panel': MyPanel },
-    methods: {
-        onReady(event: DockviewReadyEvent) {
-            event.api.addPanel({ id: 'panel_1', component: 'my-panel', title: 'Panel 1' });
-            event.api.addPanel({ id: 'panel_2', component: 'my-panel', title: 'Panel 2',
-                position: { referencePanel: 'panel_1', direction: 'right' }
-            });
-        },
-    },
-    template: `<dockview-vue style="width:100%;height:100%" class="dockview-theme-abyss" @ready="onReady" />`,
-});
+function onReady(event: DockviewReadyEvent) {
+    event.api.addPanel({ id: 'panel_1', component: 'my-panel', title: 'Panel 1' });
+    event.api.addPanel({
+        id: 'panel_2',
+        component: 'my-panel',
+        title: 'Panel 2',
+        position: { referencePanel: 'panel_1', direction: 'right' },
+    });
+}
+</script>
+
+<template>
+    <DockviewVue
+        style="width:100%;height:100%"
+        class="dockview-theme-abyss"
+        :components="{ 'my-panel': MyPanel }"
+        @ready="onReady"
+    />
+</template>
 ```
 </FrameworkSpecific>
 


### PR DESCRIPTION
## Summary

- Adds `components` and `tabComponents` map props to `<DockviewVue>`, and lets every singular slot prop (`defaultTabComponent`, `watermarkComponent`, `*HeaderActionsComponent`, `tabGroupChipComponent`, `groupDragGhostComponent`) accept a component object directly — matching the React (`packages/dockview/src/dockview/dockview.tsx`) and Angular (`packages/dockview-angular/src/lib/dockview/types.ts`) APIs.
- Resolves #1301: `<script setup>` users were forced to register every panel component globally via `app.component(...)` in `main.ts`, because `findComponent` only walked the instance-component tree and the app registry — neither of which `<script setup>` imports populate. Now `<DockviewVue :components="{ Foo: MyFoo }" />` works without any global registration.
- Fully additive — the existing Options-API local-registration and global `app.component(...)` paths still resolve as before.
- `defaultTabComponent` as a component object uses a `DEFAULT_VUE_TAB` sentinel routed through `createTabComponent`, mirroring React's `DEFAULT_REACT_TAB`.
- Also fixes the mistyped `components: Record<string, string>` on splitview/gridview/paneview types (now `Record<string, VueComponent>` and actually wired through `useViewComponent`).

## Test plan

- [x] All 110 unit tests pass (78 baseline + 32 new) — `yarn workspace dockview-vue run test --run`
- [x] `vue-tsc` type check clean — `yarn workspace dockview-vue run build:types`
- [x] New tests cover: `findComponent` map-priority/fallthrough/error paths, `resolveComponent` all branches, `<DockviewVue>` with bare `components` prop (no global registration), `tabComponents` map, every singular slot prop accepting a component object, sentinel routing for `defaultTabComponent`, runtime map swap, equivalent coverage for splitview/gridview/paneview
- [ ] Manual smoke in a `<script setup>` app to confirm the reporter's scenario (recommended before merge)
- [ ] Docs preview build clean (`packages/docs/docs/core/panels/register.mdx`, `packages/docs/docs/overview/quickstart.mdx` rewritten to show the new `<script setup>` + `:components` pattern)

Fixes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)