### PR TITLE
fix(dockview-core): cancel pending popout restorations on fromJSON re-entry (#1304)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -8018,6 +8018,116 @@ describe('dockviewComponent', () => {
             });
         });
 
+        test('issue #1304: re-entrant fromJSON cancels pending popout restorations', async () => {
+            jest.useFakeTimers();
+            try {
+                const container = document.createElement('div');
+
+                const openSpy = jest.fn().mockImplementation(setupMockWindow);
+                window.open = openSpy;
+
+                const dockview = new DockviewComponent(container, {
+                    createComponent(options) {
+                        switch (options.name) {
+                            case 'default':
+                                return new PanelContentPartTest(
+                                    options.id,
+                                    options.name
+                                );
+                            default:
+                                throw new Error(`unsupported`);
+                        }
+                    },
+                });
+
+                dockview.layout(1000, 1000);
+
+                const popoutLayout = {
+                    grid: {
+                        root: {
+                            type: 'branch' as const,
+                            data: [
+                                {
+                                    type: 'leaf' as const,
+                                    data: {
+                                        views: [],
+                                        id: '1',
+                                        activeView: undefined as any,
+                                    },
+                                    visible: false,
+                                },
+                            ],
+                        },
+                        orientation: Orientation.VERTICAL,
+                        width: 1000,
+                        height: 1000,
+                    },
+                    panels: {
+                        id_0: {
+                            id: 'id_0',
+                            contentComponent: 'default',
+                        },
+                    },
+                    activeGroup: '2',
+                    popoutGroups: [
+                        {
+                            data: {
+                                views: ['id_0'],
+                                activeView: 'id_0',
+                                id: '2',
+                            },
+                            gridReferenceGroup: '1',
+                            position: {
+                                top: 500,
+                                left: 500,
+                                width: 100,
+                                height: 100,
+                            },
+                        },
+                    ],
+                };
+
+                const emptyLayout = {
+                    grid: {
+                        root: { type: 'branch' as const, data: [] },
+                        orientation: Orientation.VERTICAL,
+                        width: 1000,
+                        height: 1000,
+                    },
+                    panels: {},
+                };
+
+                expect(() => {
+                    dockview.fromJSON(popoutLayout as any);
+                    dockview.fromJSON(popoutLayout as any);
+                    dockview.fromJSON(emptyLayout as any);
+                }).not.toThrow();
+
+                // Drain any timers — none should still be in flight, but if
+                // any survive they must not call window.open or throw.
+                jest.runAllTimers();
+                await dockview.popoutRestorationPromise;
+
+                // Final layout is empty, no popouts should have opened.
+                expect(openSpy).not.toHaveBeenCalled();
+                expect(dockview.groups).toHaveLength(0);
+                expect(dockview.panels).toHaveLength(0);
+
+                // The component should still be usable — loading a fresh
+                // layout after the sequence must succeed.
+                expect(() => {
+                    dockview.fromJSON(popoutLayout as any);
+                }).not.toThrow();
+
+                jest.runAllTimers();
+                await dockview.popoutRestorationPromise;
+
+                dockview.dispose();
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
         test('dispose of dockview instance when popup is open', async () => {
             const container = document.createElement('div');
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1888,6 +1888,17 @@ export class DockviewComponent
         data: SerializedDockview,
         options?: { reuseExistingPanels: boolean }
     ): void {
+        // Cancel any popout-restoration timers queued by a previous fromJSON
+        // that haven't fired yet. Each cleanup also disposes the orphan group
+        // that was registered in _groups synchronously but never parented
+        // into a popout window — otherwise the upcoming clear() would call
+        // gridview.remove() on an unparented element and throw
+        // "Invalid grid element". See issue #1304.
+        for (const cleanup of [...this._popoutRestorationCleanups]) {
+            cleanup();
+        }
+        this._popoutRestorationCleanups.clear();
+
         const existingPanels = new Map<string, IDockviewPanel>();
 
         let tempGroup: DockviewGroupPanel | undefined;
@@ -2157,6 +2168,25 @@ export class DockviewComponent
                     const cleanup = () => {
                         this._popoutRestorationCleanups.delete(cleanup);
                         clearTimeout(handle);
+                        // The group was registered in _groups synchronously
+                        // but the timer that would parent it into the popout
+                        // window never ran. Dispose the orphan here so the
+                        // next clear() doesn't trip over an unparented
+                        // element. See issue #1304.
+                        if (
+                            !this.isDisposed &&
+                            this._groups.has(group.id) &&
+                            group.element.parentElement === null
+                        ) {
+                            for (const panel of [...group.panels]) {
+                                this.removePanel(panel, {
+                                    removeEmptyGroup: false,
+                                });
+                            }
+                            group.dispose();
+                            this._groups.delete(group.id);
+                            this._onDidRemoveGroup.fire(group);
+                        }
                         resolve();
                     };
                     const handle = setTimeout(() => {


### PR DESCRIPTION
## Summary

Fixes #1304 — `api.fromJSON(popoutLayout); api.fromJSON(popoutLayout); api.fromJSON(emptyLayout);` (or any sequence where a `fromJSON` runs before the previous call's popout-restoration `setTimeout` fires) throws `Uncaught Error: Invalid grid element` and leaves the component unusable until page reload.

### Root cause

The popout-restoration path in `fromJSON` synchronously calls `createGroupFromSerializedState(data)` — which registers the popout group in `_groups` — and then queues a `setTimeout` that *later* calls `addPopoutGroup(...)` to parent the element into the popout window.

If `fromJSON` is called again before that timer fires, the new call's `clear()` iterates `_groups`, hits the orphan popout group (still typed `location.type === 'grid'`), and calls `super.doRemoveGroup → gridview.remove(orphan)`. `gridview.remove` calls `getGridLocation(orphan.element)`, which throws `Invalid grid element` because the orphan's element has no parent.

Same family as issue #851 (dispose-during-restoration), which introduced `_popoutRestorationCleanups` — but those cleanups only ran on `dispose()` (not on re-entrant `fromJSON`) and only cleared the timer (not the orphan group itself).

### Fix

In `packages/dockview-core/src/dockview/dockviewComponent.ts`:

1. At the top of `fromJSON`, run any pending `_popoutRestorationCleanups` from a prior call before touching `_groups`.
2. Strengthen each cleanup closure: in addition to `clearTimeout`, dispose the orphan group's panels and the group itself (and fire `_onDidRemoveGroup`) when the timer is cancelled before parenting.

### Side note

Because the original failure occurred inside `clear()` (which runs *before* the `try` block in `fromJSON`), the partial cleanup left the orphan in `_groups` permanently — every subsequent `fromJSON` re-threw on the same orphan. That's why the user observed "layout loading breaks completely until page reload."

## Test plan

- [x] New regression test `issue #1304: re-entrant fromJSON cancels pending popout restorations` reproduces the exact sequence from the bug report; asserts no throw, asserts `window.open` was not called, asserts the component is still usable for a subsequent `fromJSON`.
- [x] Existing `issue #851: fromJSON popout restoration is cancelled on dispose` still passes (regression coverage for the related dispose path).
- [x] Full `dockviewComponent.spec.ts` — 203/203 pass.
- [ ] Manual smoke against the reproduction `package.json` / `index.html` / `main.js` in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)