### PR TITLE
fix: charset in merged styles

### DIFF
--- a/packages/dockview-core/gulpfile.js
+++ b/packages/dockview-core/gulpfile.js
@@ -5,7 +5,7 @@ const concat = require('gulp-concat');
 gulp.task('sass', () => {
     return gulp
         .src('./src/**/*.scss')
-        .pipe(gulpSass().on('error', gulpSass.logError))
+        .pipe(gulpSass({ charset: false }).on('error', gulpSass.logError))
         .pipe(concat('dockview.css'))
         .pipe(gulp.dest('./dist/styles/'));
 });

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -22,7 +22,7 @@
      * Empty space between tabs (and the scrollbar lane) keeps pan-x so a
      * flick on those areas produces native momentum scroll. The tab and
      * chip elements themselves opt out (`touch-action: none`) so the
-     * pointer drag source owns the gesture from pointerdown — a flick on
+     * pointer drag source owns the gesture from pointerdown - a flick on
      * a tab or chip always becomes a drag, regardless of direction.
      */
     touch-action: pan-x;
@@ -240,7 +240,7 @@
     }
 }
 
-// Tab group underline — positioned by CSS, sized and drawn by JS via SVG
+// Tab group underline - positioned by CSS, sized and drawn by JS via SVG
 .dv-tab-group-underline {
     position: absolute;
     bottom: 0;
@@ -294,7 +294,7 @@
             // height (not width) must be zeroed to remove the tab from flow.
             height: 0 !important;
             min-height: 0 !important;
-            // Cancel the base rule's width: 0 — collapsing width in vertical
+            // Cancel the base rule's width: 0 - collapsing width in vertical
             // mode causes the dragging tab to animate on the x-axis, which is
             // wrong. Width should stay at its natural (auto) value.
             width: auto !important;

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -23,7 +23,7 @@
     --dv-active-sash-transition-duration: 0.1s;
     --dv-active-sash-transition-delay: 0.5s;
 
-    // spacing variables — overridden by dockview-design-space-mixin / .dockview-spaced
+    // spacing variables - overridden by dockview-design-space-mixin / .dockview-spaced
     --dv-spacing-padding: 0px;
     --dv-tab-border-radius: 0px;
     --dv-sash-border-radius: 0px;
@@ -1113,7 +1113,7 @@
     }
 }
 
-// Tab group indicator 'none' mode — uses a JS-positioned continuous bar
+// Tab group indicator 'none' mode - uses a JS-positioned continuous bar
 // (NoneTabGroupIndicator) instead of per-tab box-shadows, so the indicator
 // spans the full tab group width without gaps in spaced themes.
 // The flat bar always sits at the bottom (or left for vertical) edge of


### PR DESCRIPTION
## Description

The generated and merged dockview.css includes a invalid positioned @charset. 
Cause of this are non-ascii characters in comments of processed style files (scss).
(— was used instead of -, commonly used by ai).

This PR replaces all non-ascii characters with similar ascii characters and disable the charset generation for gulp to prevent this from happen again.

Its extremely unlikely to use non-ascii characters in style

## Type of change

<!-- Check the one that applies -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [x] Build / CI / tooling

## Affected packages

<!-- Check all that apply -->

- [x] `dockview-core`
- [x] `dockview` (vanilla JS)
- [x] `dockview-react`
- [x] `dockview-vue`
- [x] `dockview-angular`
- [ ] `docs`

## How to test

<!-- How can a reviewer verify this change? Link to a sandbox, describe steps, or reference tests. -->

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented
