### PR TITLE
feat(dockview-core): dedicated floating-group drag handle

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
@@ -239,6 +239,31 @@ describe('voidContainer', () => {
             cut.dispose();
         });
 
+        test('floating group with a title bar: void dragstart is NOT prevented (drags like a grid group)', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                options: {},
+            });
+            const group = fromPartial<DockviewGroupPanel>({
+                api: { location: { type: 'floating' } },
+            });
+            const cut = new VoidContainer(accessor, group);
+
+            // a title-bar floating window's overlay carries this class; the
+            // void container is then no longer the move handle, so a plain
+            // drag should redock rather than being gated behind shift.
+            const overlay = document.createElement('div');
+            overlay.className =
+                'dv-resize-container dv-resize-container-with-titlebar';
+            overlay.appendChild(cut.element);
+
+            const event = new Event('dragstart') as DragEvent;
+            const spy = jest.spyOn(event, 'preventDefault');
+            fireEvent(cut.element, event);
+            expect(spy).toHaveBeenCalledTimes(0);
+
+            cut.dispose();
+        });
+
         test('edge group with zero panels: dragstart is prevented', () => {
             const accessor = fromPartial<DockviewComponent>({
                 options: {},

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -5659,6 +5659,97 @@ describe('dockviewComponent', () => {
             expect(dockview.groups.length).toBe(0);
         });
 
+        const createDockview = () =>
+            new DockviewComponent(document.createElement('div'), {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+
+        test('renders a dedicated title bar by default', () => {
+            const dockview = createDockview();
+            dockview.layout(1000, 500);
+
+            dockview.addPanel({
+                id: 'panel_1',
+                component: 'default',
+                floating: true,
+            });
+
+            const overlay = dockview.floatingGroups[0].overlay.element;
+            expect(overlay.querySelector('.dv-floating-titlebar')).toBeTruthy();
+
+            // the overlay stacks the handle above the group via flex column
+            expect(
+                overlay.classList.contains('dv-resize-container-with-titlebar')
+            ).toBeTruthy();
+
+            dockview.dispose();
+        });
+
+        test('floatingGroupDragHandle: "tabbar" omits the title bar', () => {
+            const dockview = new DockviewComponent(
+                document.createElement('div'),
+                {
+                    createComponent(options) {
+                        switch (options.name) {
+                            case 'default':
+                                return new PanelContentPartTest(
+                                    options.id,
+                                    options.name
+                                );
+                            default:
+                                throw new Error(`unsupported`);
+                        }
+                    },
+                    floatingGroupDragHandle: 'tabbar',
+                }
+            );
+            dockview.layout(1000, 500);
+
+            dockview.addPanel({
+                id: 'panel_1',
+                component: 'default',
+                floating: true,
+            });
+
+            const overlay = dockview.floatingGroups[0].overlay.element;
+            expect(overlay.querySelector('.dv-floating-titlebar')).toBeNull();
+            expect(
+                overlay.classList.contains('dv-resize-container-with-titlebar')
+            ).toBeFalsy();
+
+            dockview.dispose();
+        });
+
+        test('per-group dragHandle override beats the component option', () => {
+            const dockview = createDockview();
+            dockview.layout(1000, 500);
+
+            const panel = dockview.addPanel({
+                id: 'panel_1',
+                component: 'default',
+            });
+
+            // component default is 'titlebar'; override to 'tabbar' for this group
+            dockview.addFloatingGroup(panel.api.group, {
+                dragHandle: 'tabbar',
+            });
+
+            const overlay = dockview.floatingGroups[0].overlay.element;
+            expect(overlay.querySelector('.dv-floating-titlebar')).toBeNull();
+
+            dockview.dispose();
+        });
+
         test('move a floating group of one tab to a new fixed group', () => {
             const container = document.createElement('div');
 

--- a/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
@@ -713,4 +713,152 @@ describe('overlay', () => {
             overlay.dispose();
         });
     });
+
+    describe('header', () => {
+        test('inserts the header above the content and flags the container', () => {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            const header = document.createElement('div');
+            header.className = 'dv-floating-titlebar';
+
+            document.body.appendChild(container);
+
+            const overlay = new Overlay({
+                height: 200,
+                width: 100,
+                left: 10,
+                top: 20,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content,
+                header,
+            });
+
+            expect(
+                overlay.element.classList.contains(
+                    'dv-resize-container-with-titlebar'
+                )
+            ).toBeTruthy();
+
+            // header is rendered before the content
+            const children = Array.from(overlay.element.children);
+            expect(children.indexOf(header)).toBeLessThan(
+                children.indexOf(content)
+            );
+
+            overlay.dispose();
+        });
+
+        test('headerHeight reflects the header element, 0 when absent', () => {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            const header = document.createElement('div');
+
+            Object.defineProperty(header, 'offsetHeight', {
+                configurable: true,
+                value: 22,
+            });
+
+            document.body.appendChild(container);
+
+            const withHeader = new Overlay({
+                height: 200,
+                width: 100,
+                left: 10,
+                top: 20,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content,
+                header,
+            });
+            expect(withHeader.headerHeight).toBe(22);
+            withHeader.dispose();
+
+            const withoutHeader = new Overlay({
+                height: 200,
+                width: 100,
+                left: 10,
+                top: 20,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content: document.createElement('div'),
+            });
+            expect(withoutHeader.headerHeight).toBe(0);
+            withoutHeader.dispose();
+        });
+
+        test('setupDrag on the header moves the overlay', () => {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            const header = document.createElement('div');
+
+            document.body.appendChild(container);
+
+            const overlay = new Overlay({
+                height: 50,
+                width: 50,
+                left: 10,
+                top: 10,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content,
+                header,
+            });
+
+            jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 0,
+                        top: 0,
+                        width: 100,
+                        height: 100,
+                    })
+            );
+            jest.spyOn(
+                overlay.element,
+                'getBoundingClientRect'
+            ).mockImplementation(() =>
+                mockGetBoundingClientRect({
+                    left: 10,
+                    top: 10,
+                    width: 50,
+                    height: 50,
+                })
+            );
+
+            overlay.setupDrag(header);
+
+            const down = new MouseEvent('pointerdown', {
+                clientX: 20,
+                clientY: 20,
+                bubbles: true,
+            }) as any;
+            down.pointerId = 1;
+            header.dispatchEvent(down);
+
+            const move = new MouseEvent('pointermove', {
+                clientX: 40,
+                clientY: 40,
+                bubbles: true,
+            }) as any;
+            move.pointerId = 1;
+            window.dispatchEvent(move);
+
+            expect(
+                overlay.element.classList.contains(
+                    'dv-resize-container-dragging'
+                )
+            ).toBeTruthy();
+
+            const up = new MouseEvent('pointerup', { bubbles: true }) as any;
+            up.pointerId = 1;
+            window.dispatchEvent(up);
+
+            overlay.dispose();
+        });
+    });
 });

--- a/packages/dockview-core/src/dockview/components/titlebar/floatingTitleBar.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/floatingTitleBar.ts
@@ -1,0 +1,77 @@
+import { DockviewComponent } from '../../dockviewComponent';
+import { addDisposableListener, Emitter, Event } from '../../../events';
+import { CompositeDisposable } from '../../../lifecycle';
+import { DockviewGroupPanel } from '../../dockviewGroupPanel';
+import { quasiPreventDefault } from '../../../dom';
+import { GroupDragSource } from './groupDragSource';
+
+/**
+ * A dedicated, blank drag handle rendered above a floating group's tab bar.
+ *
+ * It plays the same dual role the tab-bar void container plays today: a plain
+ * pointer-drag moves the floating window (wired by the overlay via
+ * `setupDrag`), while a shift+drag (mouse) or long-press (touch) detaches the
+ * group to redock it into the grid. The redock half is provided by the shared
+ * {@link GroupDragSource}; the move half is owned by the overlay.
+ *
+ * The bar is intentionally contentless — styling is driven entirely through
+ * the `--dv-floating-titlebar-*` theme variables.
+ */
+export class FloatingTitleBar extends CompositeDisposable {
+    private readonly _element: HTMLElement;
+    private readonly dragSource: GroupDragSource;
+
+    private readonly _onDragStart = new Emitter<DragEvent | PointerEvent>();
+    readonly onDragStart = this._onDragStart.event;
+
+    get element(): HTMLElement {
+        return this._element;
+    }
+
+    constructor(
+        private readonly accessor: DockviewComponent,
+        private readonly group: DockviewGroupPanel
+    ) {
+        super();
+
+        this._element = document.createElement('div');
+        this._element.className = 'dv-floating-titlebar';
+
+        this.addDisposables(
+            this._onDragStart,
+            addDisposableListener(this._element, 'pointerdown', () => {
+                this.accessor.doSetGroupActive(this.group);
+            }),
+            // Shift+pointerdown marks the event so the overlay's
+            // move-the-float drag doesn't fire alongside the HTML5 redock
+            // drag. See VoidContainer for the same disambiguation.
+            addDisposableListener(
+                this._element,
+                'pointerdown',
+                (e) => {
+                    if (e.shiftKey) {
+                        quasiPreventDefault(e);
+                    }
+                },
+                true
+            )
+        );
+
+        this.dragSource = new GroupDragSource({
+            element: this._element,
+            accessor: this.accessor,
+            group: this.group,
+        });
+
+        this.addDisposables(
+            this.dragSource,
+            this.dragSource.onDragStart((event) => {
+                this._onDragStart.fire(event);
+            })
+        );
+    }
+
+    updateDragAndDropState(): void {
+        this.dragSource.updateDragAndDropState();
+    }
+}

--- a/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
@@ -1,0 +1,244 @@
+import {
+    LocalSelectionTransfer,
+    PanelTransfer,
+} from '../../../dnd/dataTransfer';
+import {
+    DragSourceOptions,
+    html5Backend,
+    IDragGhostSpec,
+    IDragSource,
+    pointerBackend,
+} from '../../../dnd/backend';
+import { DockviewComponent } from '../../dockviewComponent';
+import { Emitter, Event } from '../../../events';
+import {
+    CompositeDisposable,
+    Disposable,
+    MutableDisposable,
+} from '../../../lifecycle';
+import { DockviewGroupPanel } from '../../dockviewGroupPanel';
+import { toggleClass } from '../../../dom';
+import { resolveDndCapabilities } from '../../dndCapabilities';
+
+// Floating-group redock via touch: require a deliberate long press so the
+// "move the float around" gesture doesn't double-trigger the redock ghost.
+// Infinity pressTolerance disables the pre-arm flick override; any motion
+// during the wait is treated as drag-the-float, not redock intent.
+const FLOATING_REDOCK_INITIATION_DELAY_MS = 500;
+
+export interface GroupDragSourceOptions {
+    readonly element: HTMLElement;
+    readonly accessor: DockviewComponent;
+    readonly group: DockviewGroupPanel;
+}
+
+/**
+ * The drag-source half of a group drag handle: html5 + pointer drag sources
+ * that publish a group-level `PanelTransfer`, the "Multiple Panels (N)" ghost,
+ * and the floating-group disambiguation that keeps the redock gesture from
+ * firing alongside the overlay's move-the-float gesture.
+ *
+ * Shared by the tab-bar void container and the dedicated floating title bar so
+ * both grab handles redock identically.
+ */
+export class GroupDragSource extends CompositeDisposable {
+    private readonly _element: HTMLElement;
+    private readonly accessor: DockviewComponent;
+    private readonly group: DockviewGroupPanel;
+    private readonly html5DragSource: IDragSource;
+    private readonly pointerDragSource: IDragSource;
+    private readonly panelTransfer =
+        LocalSelectionTransfer.getInstance<PanelTransfer>();
+
+    private readonly _onDragStart = new Emitter<DragEvent | PointerEvent>();
+    readonly onDragStart = this._onDragStart.event;
+
+    constructor(options: GroupDragSourceOptions) {
+        super();
+
+        this._element = options.element;
+        this.accessor = options.accessor;
+        this.group = options.group;
+
+        const caps = resolveDndCapabilities(this.accessor.options);
+
+        this._element.draggable = caps.html5;
+        toggleClass(this._element, 'dv-draggable', caps.html5 || caps.pointer);
+
+        this.addDisposables(this._onDragStart);
+
+        const buildMultiPanelsGhost = (): HTMLElement => {
+            const ghostEl = document.createElement('div');
+            const style = window.getComputedStyle(this._element);
+            const bgColor = style.getPropertyValue(
+                '--dv-activegroup-visiblepanel-tab-background-color'
+            );
+            const color = style.getPropertyValue(
+                '--dv-activegroup-visiblepanel-tab-color'
+            );
+            ghostEl.style.backgroundColor = bgColor;
+            ghostEl.style.color = color;
+            ghostEl.style.padding = '2px 8px';
+            ghostEl.style.height = '24px';
+            ghostEl.style.fontSize = '11px';
+            ghostEl.style.lineHeight = '20px';
+            ghostEl.style.borderRadius = '12px';
+            ghostEl.style.whiteSpace = 'nowrap';
+            ghostEl.style.boxSizing = 'border-box';
+            // HTML5 setDragImage snapshots the element as appended to the
+            // document; a default block-level div would stretch to the
+            // body's width and render as a viewport-wide bar.
+            ghostEl.style.display = 'inline-block';
+            ghostEl.textContent = `Multiple Panels (${this.group.size})`;
+            return ghostEl;
+        };
+
+        const buildGhostSpec = (): IDragGhostSpec => {
+            const createGhost =
+                this.accessor.options.createGroupDragGhostComponent;
+            if (createGhost) {
+                const renderer = createGhost(this.group);
+                renderer.init({
+                    group: this.group,
+                    api: this.accessor.api,
+                });
+                return {
+                    element: renderer.element,
+                    offsetX: 30,
+                    offsetY: -10,
+                    dispose: renderer.dispose
+                        ? () => renderer.dispose?.()
+                        : undefined,
+                };
+            }
+            return {
+                element: buildMultiPanelsGhost(),
+                offsetX: 30,
+                offsetY: -10,
+            };
+        };
+
+        const sharedDragOptions: DragSourceOptions = {
+            getData: () => {
+                this.panelTransfer.setData(
+                    [new PanelTransfer(this.accessor.id, this.group.id, null)],
+                    PanelTransfer.prototype
+                );
+                return {
+                    dispose: () => {
+                        this.panelTransfer.clearData(PanelTransfer.prototype);
+                    },
+                };
+            },
+            createGhost: buildGhostSpec,
+            onDragStart: (event) => {
+                this._onDragStart.fire(event);
+            },
+        };
+
+        this.html5DragSource = html5Backend.createDragSource(this._element, {
+            ...sharedDragOptions,
+            disabled: !caps.html5,
+            isCancelled: (event) => {
+                // HTML5: floating groups need shift+drag as the explicit
+                // detach gesture (otherwise click-and-drag conflicts with
+                // moving the floating group itself).
+                if (
+                    this.group.api.location.type === 'floating' &&
+                    !(event as DragEvent).shiftKey
+                ) {
+                    return true;
+                }
+                if (
+                    this.group.api.location.type === 'edge' &&
+                    this.group.size === 0
+                ) {
+                    return true;
+                }
+                return false;
+            },
+        });
+
+        const isFloating = () => this.group?.api?.location?.type === 'floating';
+
+        this.pointerDragSource = pointerBackend.createDragSource(
+            this._element,
+            {
+                ...sharedDragOptions,
+                disabled: !caps.pointer,
+                touchOnly: !caps.pointerHandlesMouse,
+                // Floating groups share this element with the overlay's
+                // move-the-float drag. Without a longer hold + tolerance
+                // override, both gestures commit simultaneously and the
+                // user sees the float follow their finger *and* a ghost.
+                touchInitiationDelay: () =>
+                    isFloating() ? FLOATING_REDOCK_INITIATION_DELAY_MS : 250,
+                pressTolerance: () => (isFloating() ? Infinity : 8),
+                isCancelled: () => {
+                    if (
+                        !resolveDndCapabilities(this.accessor.options).pointer
+                    ) {
+                        return true;
+                    }
+                    // Pointer: long-press IS the deliberate gesture, so
+                    // floating groups don't need the shift gate.
+                    if (
+                        this.group.api.location.type === 'edge' &&
+                        this.group.size === 0
+                    ) {
+                        return true;
+                    }
+                    return false;
+                },
+                onDragStart: (event) => {
+                    // Redock just committed — abort any in-flight overlay
+                    // move so the float stops following the finger while
+                    // the ghost takes over.
+                    this.getFloatingOverlay()?.cancelPendingDrag();
+                    this._onDragStart.fire(event);
+                },
+            }
+        );
+
+        // Mirror direction: once the overlay's move-the-float gesture has
+        // actually moved something, cancel the pending redock arm so the
+        // ghost doesn't appear mid-drag if the user holds past 500ms.
+        const overlayMoveSub = new MutableDisposable();
+        const refreshOverlayMoveSub = () => {
+            const overlay = this.getFloatingOverlay();
+            overlayMoveSub.value = overlay
+                ? overlay.onDidStartMoving(() => {
+                      this.pointerDragSource.cancelPending();
+                  })
+                : Disposable.NONE;
+        };
+        refreshOverlayMoveSub();
+        this.addDisposables(overlayMoveSub);
+        const locationChange = this.group?.api?.onDidLocationChange;
+        if (locationChange) {
+            this.addDisposables(locationChange(refreshOverlayMoveSub));
+        }
+
+        this.addDisposables(this.html5DragSource, this.pointerDragSource);
+    }
+
+    updateDragAndDropState(): void {
+        const caps = resolveDndCapabilities(this.accessor.options);
+        this._element.draggable = caps.html5;
+        toggleClass(this._element, 'dv-draggable', caps.html5 || caps.pointer);
+        this.html5DragSource.setDisabled(!caps.html5);
+        this.pointerDragSource.setDisabled(!caps.pointer);
+        this.pointerDragSource.setTouchOnly(!caps.pointerHandlesMouse);
+    }
+
+    private getFloatingOverlay() {
+        if (!this.group) {
+            return undefined;
+        }
+        return this.accessor.floatingGroups?.find(
+            (fg) => fg.group === this.group
+        )?.overlay;
+    }
+}
+
+export { FLOATING_REDOCK_INITIATION_DELAY_MS };

--- a/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
@@ -30,6 +30,16 @@ export interface GroupDragSourceOptions {
     readonly element: HTMLElement;
     readonly accessor: DockviewComponent;
     readonly group: DockviewGroupPanel;
+    /**
+     * Whether this element is the floating window's move handle. Only the move
+     * handle needs the floating disambiguation (shift for mouse / long-press
+     * for touch) that keeps the redock gesture from firing alongside the
+     * move-the-float gesture. Other handles on a floating group (e.g. the tab
+     * bar's void container when a dedicated title bar is the move handle) drag
+     * to redock with a plain drag, exactly like a group in the main grid.
+     * Defaults to `() => true`.
+     */
+    readonly isFloatingMoveHandle?: () => boolean;
 }
 
 /**
@@ -53,12 +63,16 @@ export class GroupDragSource extends CompositeDisposable {
     private readonly _onDragStart = new Emitter<DragEvent | PointerEvent>();
     readonly onDragStart = this._onDragStart.event;
 
+    private readonly isFloatingMoveHandle: () => boolean;
+
     constructor(options: GroupDragSourceOptions) {
         super();
 
         this._element = options.element;
         this.accessor = options.accessor;
         this.group = options.group;
+        this.isFloatingMoveHandle =
+            options.isFloatingMoveHandle ?? (() => true);
 
         const caps = resolveDndCapabilities(this.accessor.options);
 
@@ -140,11 +154,14 @@ export class GroupDragSource extends CompositeDisposable {
             ...sharedDragOptions,
             disabled: !caps.html5,
             isCancelled: (event) => {
-                // HTML5: floating groups need shift+drag as the explicit
-                // detach gesture (otherwise click-and-drag conflicts with
-                // moving the floating group itself).
+                // HTML5: when this element is the floating window's move
+                // handle, redock needs shift+drag (otherwise click-and-drag
+                // conflicts with moving the float). A non-move-handle (e.g. the
+                // void container when a title bar moves the float) redocks with
+                // a plain drag, like a group in the main grid.
                 if (
                     this.group.api.location.type === 'floating' &&
+                    this.isFloatingMoveHandle() &&
                     !(event as DragEvent).shiftKey
                 ) {
                     return true;
@@ -159,7 +176,11 @@ export class GroupDragSource extends CompositeDisposable {
             },
         });
 
-        const isFloating = () => this.group?.api?.location?.type === 'floating';
+        // Only the move handle needs the touch disambiguation; other handles
+        // redock with the normal grid press behaviour.
+        const isFloating = () =>
+            this.group?.api?.location?.type === 'floating' &&
+            this.isFloatingMoveHandle();
 
         this.pointerDragSource = pointerBackend.createDragSource(
             this._element,

--- a/packages/dockview-core/src/dockview/components/titlebar/voidContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/voidContainer.ts
@@ -69,6 +69,12 @@ export class VoidContainer extends CompositeDisposable {
             element: this._element,
             accessor: this.accessor,
             group: this.group,
+            // The void container is the float's move handle only when there is
+            // no dedicated title bar. When a title bar moves the float (the
+            // overlay is `.dv-resize-container-with-titlebar`), the void
+            // container redocks with a plain drag, like a group in the grid.
+            isFloatingMoveHandle: () =>
+                !this._element.closest('.dv-resize-container-with-titlebar'),
         });
 
         const canDisplayOverlay = (

--- a/packages/dockview-core/src/dockview/components/titlebar/voidContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/voidContainer.ts
@@ -1,46 +1,23 @@
-import {
-    getPanelData,
-    LocalSelectionTransfer,
-    PanelTransfer,
-} from '../../../dnd/dataTransfer';
+import { getPanelData } from '../../../dnd/dataTransfer';
 import {
     DroptargetEvent,
     IDropTarget,
     Position,
     WillShowOverlayEvent,
 } from '../../../dnd/droptarget';
-import {
-    DragSourceOptions,
-    html5Backend,
-    IDragGhostSpec,
-    IDragSource,
-    pointerBackend,
-} from '../../../dnd/backend';
+import { html5Backend, pointerBackend } from '../../../dnd/backend';
 import { DockviewComponent } from '../../dockviewComponent';
 import { addDisposableListener, Emitter, Event } from '../../../events';
-import {
-    CompositeDisposable,
-    Disposable,
-    MutableDisposable,
-} from '../../../lifecycle';
+import { CompositeDisposable } from '../../../lifecycle';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
-import { quasiPreventDefault, toggleClass } from '../../../dom';
-import { resolveDndCapabilities } from '../../dndCapabilities';
-
-// Floating-group redock via touch: require a deliberate long press so the
-// "move the float around" gesture doesn't double-trigger the redock ghost.
-// Infinity pressTolerance disables the pre-arm flick override; any motion
-// during the wait is treated as drag-the-float, not redock intent.
-const FLOATING_REDOCK_INITIATION_DELAY_MS = 500;
+import { quasiPreventDefault } from '../../../dom';
+import { GroupDragSource } from './groupDragSource';
 
 export class VoidContainer extends CompositeDisposable {
     private readonly _element: HTMLElement;
     private readonly dropTarget: IDropTarget;
     private readonly pointerDropTarget: IDropTarget;
-    private readonly html5DragSource: IDragSource;
-    private readonly pointerDragSource: IDragSource;
-    private readonly panelTransfer =
-        LocalSelectionTransfer.getInstance<PanelTransfer>();
+    private readonly dragSource: GroupDragSource;
 
     private readonly _onDrop = new Emitter<DroptargetEvent>();
     readonly onDrop: Event<DroptargetEvent> = this._onDrop.event;
@@ -60,14 +37,8 @@ export class VoidContainer extends CompositeDisposable {
     ) {
         super();
 
-        const caps = resolveDndCapabilities(this.accessor.options);
-
         this._element = document.createElement('div');
-
         this._element.className = 'dv-void-container';
-        this._element.draggable = caps.html5;
-
-        toggleClass(this._element, 'dv-draggable', caps.html5 || caps.pointer);
 
         this.addDisposables(
             this._onDrop,
@@ -91,6 +62,14 @@ export class VoidContainer extends CompositeDisposable {
                 true
             )
         );
+
+        // The drag-source (move-the-float disambiguation, redock ghost and
+        // group-level PanelTransfer) is shared with the floating title bar.
+        this.dragSource = new GroupDragSource({
+            element: this._element,
+            accessor: this.accessor,
+            group: this.group,
+        });
 
         const canDisplayOverlay = (
             event: DragEvent | PointerEvent,
@@ -131,165 +110,16 @@ export class VoidContainer extends CompositeDisposable {
             }
         );
 
-        const buildMultiPanelsGhost = (): HTMLElement => {
-            const ghostEl = document.createElement('div');
-            const style = window.getComputedStyle(this._element);
-            const bgColor = style.getPropertyValue(
-                '--dv-activegroup-visiblepanel-tab-background-color'
-            );
-            const color = style.getPropertyValue(
-                '--dv-activegroup-visiblepanel-tab-color'
-            );
-            ghostEl.style.backgroundColor = bgColor;
-            ghostEl.style.color = color;
-            ghostEl.style.padding = '2px 8px';
-            ghostEl.style.height = '24px';
-            ghostEl.style.fontSize = '11px';
-            ghostEl.style.lineHeight = '20px';
-            ghostEl.style.borderRadius = '12px';
-            ghostEl.style.whiteSpace = 'nowrap';
-            ghostEl.style.boxSizing = 'border-box';
-            // HTML5 setDragImage snapshots the element as appended to the
-            // document; a default block-level div would stretch to the
-            // body's width and render as a viewport-wide bar.
-            ghostEl.style.display = 'inline-block';
-            ghostEl.textContent = `Multiple Panels (${this.group.size})`;
-            return ghostEl;
-        };
-
-        const buildGhostSpec = (): IDragGhostSpec => {
-            const createGhost =
-                this.accessor.options.createGroupDragGhostComponent;
-            if (createGhost) {
-                const renderer = createGhost(this.group);
-                renderer.init({
-                    group: this.group,
-                    api: this.accessor.api,
-                });
-                return {
-                    element: renderer.element,
-                    offsetX: 30,
-                    offsetY: -10,
-                    dispose: renderer.dispose
-                        ? () => renderer.dispose?.()
-                        : undefined,
-                };
-            }
-            return {
-                element: buildMultiPanelsGhost(),
-                offsetX: 30,
-                offsetY: -10,
-            };
-        };
-
-        const sharedDragOptions: DragSourceOptions = {
-            getData: () => {
-                this.panelTransfer.setData(
-                    [new PanelTransfer(this.accessor.id, this.group.id, null)],
-                    PanelTransfer.prototype
-                );
-                return {
-                    dispose: () => {
-                        this.panelTransfer.clearData(PanelTransfer.prototype);
-                    },
-                };
-            },
-            createGhost: buildGhostSpec,
-            onDragStart: (event) => {
-                this._onDragStart.fire(event);
-            },
-        };
-
-        this.html5DragSource = html5Backend.createDragSource(this._element, {
-            ...sharedDragOptions,
-            disabled: !caps.html5,
-            isCancelled: (event) => {
-                // HTML5: floating groups need shift+drag as the explicit
-                // detach gesture (otherwise click-and-drag conflicts with
-                // moving the floating group itself).
-                if (
-                    this.group.api.location.type === 'floating' &&
-                    !(event as DragEvent).shiftKey
-                ) {
-                    return true;
-                }
-                if (
-                    this.group.api.location.type === 'edge' &&
-                    this.group.size === 0
-                ) {
-                    return true;
-                }
-                return false;
-            },
-        });
-
-        const isFloating = () => this.group?.api?.location?.type === 'floating';
-
-        this.pointerDragSource = pointerBackend.createDragSource(
-            this._element,
-            {
-                ...sharedDragOptions,
-                disabled: !caps.pointer,
-                touchOnly: !caps.pointerHandlesMouse,
-                // Floating groups share this element with the overlay's
-                // move-the-float drag. Without a longer hold + tolerance
-                // override, both gestures commit simultaneously and the
-                // user sees the float follow their finger *and* a ghost.
-                touchInitiationDelay: () =>
-                    isFloating() ? FLOATING_REDOCK_INITIATION_DELAY_MS : 250,
-                pressTolerance: () => (isFloating() ? Infinity : 8),
-                isCancelled: () => {
-                    if (
-                        !resolveDndCapabilities(this.accessor.options).pointer
-                    ) {
-                        return true;
-                    }
-                    // Pointer: long-press IS the deliberate gesture, so
-                    // floating groups don't need the shift gate.
-                    if (
-                        this.group.api.location.type === 'edge' &&
-                        this.group.size === 0
-                    ) {
-                        return true;
-                    }
-                    return false;
-                },
-                onDragStart: (event) => {
-                    // Redock just committed — abort any in-flight overlay
-                    // move so the float stops following the finger while
-                    // the ghost takes over.
-                    this.getFloatingOverlay()?.cancelPendingDrag();
-                    this._onDragStart.fire(event);
-                },
-            }
-        );
-
-        // Mirror direction: once the overlay's move-the-float gesture has
-        // actually moved something, cancel the pending redock arm so the
-        // ghost doesn't appear mid-drag if the user holds past 500ms.
-        const overlayMoveSub = new MutableDisposable();
-        const refreshOverlayMoveSub = () => {
-            const overlay = this.getFloatingOverlay();
-            overlayMoveSub.value = overlay
-                ? overlay.onDidStartMoving(() => {
-                      this.pointerDragSource.cancelPending();
-                  })
-                : Disposable.NONE;
-        };
-        refreshOverlayMoveSub();
-        this.addDisposables(overlayMoveSub);
-        const locationChange = this.group?.api?.onDidLocationChange;
-        if (locationChange) {
-            this.addDisposables(locationChange(refreshOverlayMoveSub));
-        }
-
         this.onWillShowOverlay = Event.any(
             this.dropTarget.onWillShowOverlay,
             this.pointerDropTarget.onWillShowOverlay
         );
 
         this.addDisposables(
-            this.html5DragSource,
+            this.dragSource,
+            this.dragSource.onDragStart((event) => {
+                this._onDragStart.fire(event);
+            }),
             this.dropTarget.onDrop((event) => {
                 this._onDrop.fire(event);
             }),
@@ -297,26 +127,11 @@ export class VoidContainer extends CompositeDisposable {
                 this._onDrop.fire(event);
             }),
             this.dropTarget,
-            this.pointerDropTarget,
-            this.pointerDragSource
+            this.pointerDropTarget
         );
     }
 
     updateDragAndDropState(): void {
-        const caps = resolveDndCapabilities(this.accessor.options);
-        this._element.draggable = caps.html5;
-        toggleClass(this._element, 'dv-draggable', caps.html5 || caps.pointer);
-        this.html5DragSource.setDisabled(!caps.html5);
-        this.pointerDragSource.setDisabled(!caps.pointer);
-        this.pointerDragSource.setTouchOnly(!caps.pointerHandlesMouse);
-    }
-
-    private getFloatingOverlay() {
-        if (!this.group) {
-            return undefined;
-        }
-        return this.accessor.floatingGroups?.find(
-            (fg) => fg.group === this.group
-        )?.overlay;
+        this.dragSource.updateDragAndDropState();
     }
 }

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -65,6 +65,7 @@ import {
     GroupDragEvent,
     TabDragEvent,
 } from './components/titlebar/tabsContainer';
+import { FloatingTitleBar } from './components/titlebar/floatingTitleBar';
 import { assertModule, ModuleRegistry } from './modules';
 import { AllModules } from './allModules';
 import { IFloatingGroupHost } from './floatingGroupService';
@@ -212,6 +213,11 @@ export interface FloatingGroupOptions {
     height?: number;
     width?: number;
     position?: AnchorPosition;
+    /**
+     * Override the component-level `floatingGroupDragHandle` option for this
+     * group only. See {@link DockviewOptions.floatingGroupDragHandle}.
+     */
+    dragHandle?: 'titlebar' | 'tabbar';
 }
 
 interface FloatingGroupOptionsInternal extends FloatingGroupOptions {
@@ -1387,9 +1393,23 @@ export class DockviewComponent
 
         const anchoredBox = getAnchoredBox();
 
+        const dragHandleMode =
+            options?.dragHandle ??
+            this.options.floatingGroupDragHandle ??
+            'titlebar';
+
+        // `'titlebar'` renders a dedicated grab bar above the group's tab bar
+        // and uses it as the move handle; `'tabbar'` falls back to the legacy
+        // behaviour of moving via the tab-bar void container.
+        const titleBar =
+            dragHandleMode === 'titlebar'
+                ? new FloatingTitleBar(this, group)
+                : undefined;
+
         const overlay = new Overlay({
             container: this._floatingOverlayHost ?? this.gridview.element,
             content: group.element,
+            header: titleBar?.element,
             ...anchoredBox,
             minimumInViewportWidth:
                 this.options.floatingGroupBounds === 'boundedWithinViewport'
@@ -1405,20 +1425,37 @@ export class DockviewComponent
                       DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE),
         });
 
-        const el = group.element.querySelector('.dv-void-container');
+        const dragHandle =
+            titleBar?.element ??
+            group.element.querySelector('.dv-void-container');
 
-        if (!el) {
+        if (!dragHandle) {
             throw new Error('dockview: failed to find drag handle');
         }
 
-        overlay.setupDrag(<HTMLElement>el, {
+        overlay.setupDrag(<HTMLElement>dragHandle, {
             inDragMode:
                 typeof options?.inDragMode === 'boolean'
                     ? options.inDragMode
                     : false,
         });
 
-        service.add(group, overlay);
+        const floatingGroupPanel = service.add(group, overlay);
+
+        if (titleBar) {
+            // Tie the title bar's lifetime to the floating group and surface
+            // its redock drag through the same public `onWillDragGroup` event
+            // the tab-bar handle uses.
+            floatingGroupPanel.addDisposables(
+                titleBar,
+                titleBar.onDragStart((event) => {
+                    this._onWillDragGroup.fire({
+                        nativeEvent: event,
+                        group,
+                    });
+                })
+            );
+        }
 
         group.model.location = { type: 'floating' };
 

--- a/packages/dockview-core/src/dockview/floatingGroupService.ts
+++ b/packages/dockview-core/src/dockview/floatingGroupService.ts
@@ -90,8 +90,15 @@ export class FloatingGroupService implements IFloatingGroupService {
                 this._host.fireLayoutChange();
             }),
             group.onDidChange((event) => {
+                // `event.height` is the group's requested *content* height.
+                // When a dedicated title bar is present the overlay's outer
+                // box is taller by the header, so add it back to preserve the
+                // requested content size.
                 overlay.setBounds({
-                    height: event?.height,
+                    height:
+                        typeof event?.height === 'number'
+                            ? event.height + overlay.headerHeight
+                            : event?.height,
                     width: event?.width,
                 });
             }),

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -115,6 +115,18 @@ export interface DockviewOptions {
               minimumHeightWithinViewport?: number;
               minimumWidthWithinViewport?: number;
           };
+    /**
+     * Selects which element moves a floating group when dragged.
+     *
+     * - `'titlebar'` (default): a dedicated, blank drag-handle bar is rendered
+     *   above the group's tab bar. Dragging it moves the floating window;
+     *   shift+drag (mouse) / long-press (touch) redocks into the grid. Style
+     *   it with the `--dv-floating-titlebar-*` theme variables.
+     * - `'tabbar'`: the legacy behaviour — the empty space in the tab bar
+     *   (the "void container") doubles as the move handle. No dedicated bar
+     *   is rendered.
+     */
+    floatingGroupDragHandle?: 'titlebar' | 'tabbar';
     popoutUrl?: string;
     nonce?: CspNonceProvider;
     defaultRenderer?: DockviewPanelRenderer;
@@ -261,6 +273,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         singleTabMode: undefined,
         disableFloatingGroups: undefined,
         floatingGroupBounds: undefined,
+        floatingGroupDragHandle: undefined,
         popoutUrl: undefined,
         nonce: undefined,
         defaultRenderer: undefined,

--- a/packages/dockview-core/src/overlay/overlay.scss
+++ b/packages/dockview-core/src/overlay/overlay.scss
@@ -34,6 +34,40 @@
     }
 }
 
+// When a dedicated drag-handle title bar is present the overlay stacks the
+// handle above the group as a flex column so the group shrinks to fit beneath
+// it. Resize handles are position:absolute and stay out of the flex flow.
+.dv-resize-container-with-titlebar {
+    display: flex;
+    flex-direction: column;
+
+    > .dv-floating-titlebar {
+        flex: 0 0 auto;
+    }
+
+    > .dv-groupview {
+        height: auto;
+        flex: 1 1 0;
+        min-height: 0;
+    }
+}
+
+.dv-floating-titlebar {
+    box-sizing: border-box;
+    flex-shrink: 0;
+    height: var(--dv-floating-titlebar-height, 22px);
+    background-color: var(--dv-floating-titlebar-background-color);
+    border-bottom: var(--dv-floating-titlebar-border-bottom, none);
+    user-select: none;
+    // Without touch-action: none, mobile browsers interpret a drag on the bar
+    // as a scroll/zoom and fire pointercancel, losing the move gesture.
+    touch-action: none;
+
+    &.dv-draggable {
+        cursor: grab;
+    }
+}
+
 .dv-resize-container {
     --dv-overlay-z-index: var(--dv-overlay-z-index, 999);
 

--- a/packages/dockview-core/src/overlay/overlay.ts
+++ b/packages/dockview-core/src/overlay/overlay.ts
@@ -82,10 +82,26 @@ export class Overlay extends CompositeDisposable {
         return this._isVisible;
     }
 
+    /**
+     * Height of the optional drag-handle header, or 0 when none is present.
+     * Used to translate between the overlay's outer box and the content area
+     * available to the group beneath the header.
+     */
+    get headerHeight(): number {
+        return this.options.header?.offsetHeight ?? 0;
+    }
+
     constructor(
         private readonly options: AnchoredBox & {
             container: HTMLElement;
             content: HTMLElement;
+            /**
+             * Optional dedicated drag handle rendered above the content (a
+             * floating window title bar). When provided the resize container
+             * lays its children out as a flex column so the content shrinks
+             * to fit beneath the handle.
+             */
+            header?: HTMLElement;
             minimumInViewportWidth?: number;
             minimumInViewportHeight?: number;
         }
@@ -110,6 +126,15 @@ export class Overlay extends CompositeDisposable {
         this.setupResize('topright');
         this.setupResize('bottomleft');
         this.setupResize('bottomright');
+
+        if (this.options.header) {
+            toggleClass(
+                this._element,
+                'dv-resize-container-with-titlebar',
+                true
+            );
+            this._element.appendChild(this.options.header);
+        }
 
         this._element.appendChild(this.options.content);
         this.options.container.appendChild(this._element);

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -33,6 +33,14 @@
     --dv-drag-over-border: none;
     --dv-floating-group-dragging-opacity: 0.5;
 
+    // Dedicated floating-group drag handle ("title bar"). The bar itself is
+    // contentless; these variables control its appearance.
+    --dv-floating-titlebar-height: 22px;
+    --dv-floating-titlebar-background-color: var(
+        --dv-tabs-and-actions-container-background-color
+    );
+    --dv-floating-titlebar-border-bottom: var(--dv-floating-border);
+
     // Tab group color palette
     --dv-tab-group-color-grey: #5f6368;
     --dv-tab-group-color-blue: #1a73e8;
@@ -220,7 +228,6 @@
     --dv-paneview-header-border-color: var(--dv-color-abyss-lighter);
 
     --dv-paneview-active-outline-color: #596f99;
-
 }
 
 @mixin dockview-theme-dracula-mixin {

--- a/packages/dockview-core/src/theme/_space-mixin.scss
+++ b/packages/dockview-core/src/theme/_space-mixin.scss
@@ -48,6 +48,25 @@
         }
     }
 
+    // When a floating window has a dedicated drag-handle bar, the bar — not the
+    // group below it — is the top of the rounded card. Move the top border and
+    // rounded top corners onto the handle and flatten the group's top so the
+    // two read as a single card.
+    .dv-resize-container-with-titlebar {
+        > .dv-floating-titlebar {
+            border: var(--dv-floating-group-border);
+            border-bottom: none;
+            border-top-left-radius: var(--dv-border-radius);
+            border-top-right-radius: var(--dv-border-radius);
+        }
+
+        .dv-groupview {
+            border-top: none;
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
+        }
+    }
+
     .dv-tabs-overflow-container,
     .dv-tabs-overflow-dropdown-default {
         border-radius: var(--dv-dropdown-border-radius);

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -788,6 +788,7 @@ const DockviewDemo = (props: {
                                             }
                                             onReady={onReady}
                                             theme={effectiveTheme}
+                                            floatingGroupDragHandle="titlebar"
                                             getTabContextMenuItems={
                                                 getTabContextMenuItems
                                             }


### PR DESCRIPTION
## Description

Adds a dedicated, configurable drag handle for floating groups. All changes are in `dockview-core`.

New option `floatingGroupDragHandle?: 'titlebar' | 'tabbar'`:
- `'titlebar'` **(default)** — a dedicated blank grab bar is rendered above the tab bar; drag it to move the window, **shift+drag (mouse) / long-press (touch)** to redock into the grid. Styleable via the `--dv-floating-titlebar-*` theme variables.
- `'tabbar'` — legacy behaviour: the tab bar's empty "void container" doubles as the move handle.

Also in this PR:
- The floating void container redocks on a plain drag.
- A border/corner fix for the floating drag handle in spaced layouts (`_space-mixin.scss`).

> **Notable behaviour change:** floating groups now show the dedicated title-bar handle by default. Pass `floatingGroupDragHandle: 'tabbar'` to keep the previous look.

This is the first of two stacked PRs split out of #1310; the nested multi-grid floating/popout layouts build on top of it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

- `yarn test` in `dockview-core` — 1009 tests pass (adds `overlay.spec.ts`, `voidContainer.spec.ts`, and floating drag-handle coverage in `dockviewComponent.spec.ts`).
- Manual: float a group; confirm the title-bar grab strip appears above the tabs, drag it to move the window, shift+drag / long-press to redock. Set `floatingGroupDragHandle: 'tabbar'` and confirm the legacy void-container handle behaviour.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented
