### PR TITLE
refactor(dockview-core): consolidate advanced drag-and-drop behind a module + add dropOverlayModel

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -68,6 +68,7 @@ DockviewUnhandledDragOverEvent
 DockviewWillDropEvent
 DockviewWillShowOverlayLocationEvent
 DraggablePaneviewPanel
+DropOverlayModelParams
 DroptargetOverlayModel
 EdgeGroupOptions
 EdgeGroupPosition

--- a/packages/dockview-core/src/__tests__/dockview/advancedDnDService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/advancedDnDService.spec.ts
@@ -1,0 +1,52 @@
+import {
+    AdvancedDnDService,
+    IAdvancedDnDHost,
+} from '../../dockview/advancedDnDService';
+
+describe('AdvancedDnDService', () => {
+    function createHost() {
+        return {
+            fireWillDragPanel: jest.fn(),
+            fireWillDragGroup: jest.fn(),
+            fireWillDrop: jest.fn(),
+            fireWillShowOverlay: jest.fn(),
+        } satisfies IAdvancedDnDHost;
+    }
+
+    test('dispatch methods forward to the host emitters', () => {
+        const host = createHost();
+        const service = new AdvancedDnDService(host);
+
+        const panelEvent = {} as never;
+        const groupEvent = {} as never;
+        const dropEvent = {} as never;
+        const overlayEvent = {} as never;
+
+        service.dispatchWillDragPanel(panelEvent);
+        service.dispatchWillDragGroup(groupEvent);
+        service.dispatchWillDrop(dropEvent);
+        service.dispatchWillShowOverlay(overlayEvent);
+
+        expect(host.fireWillDragPanel).toHaveBeenCalledWith(panelEvent);
+        expect(host.fireWillDragGroup).toHaveBeenCalledWith(groupEvent);
+        expect(host.fireWillDrop).toHaveBeenCalledWith(dropEvent);
+        expect(host.fireWillShowOverlay).toHaveBeenCalledWith(overlayEvent);
+    });
+
+    test('a dispatch only fires its own host emitter', () => {
+        const host = createHost();
+        const service = new AdvancedDnDService(host);
+
+        service.dispatchWillDrop({} as never);
+
+        expect(host.fireWillDrop).toHaveBeenCalledTimes(1);
+        expect(host.fireWillDragPanel).not.toHaveBeenCalled();
+        expect(host.fireWillDragGroup).not.toHaveBeenCalled();
+        expect(host.fireWillShowOverlay).not.toHaveBeenCalled();
+    });
+
+    test('dispose is a no-op and does not throw', () => {
+        const service = new AdvancedDnDService(createHost());
+        expect(() => service.dispose()).not.toThrow();
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/advancedDnDService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/advancedDnDService.spec.ts
@@ -5,6 +5,8 @@ import {
 import { DockviewComponentOptions } from '../../dockview/options';
 import { DockviewApi } from '../../api/component.api';
 import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { IContentRenderer } from '../../dockview/types';
 
 describe('AdvancedDnDService', () => {
     function createHost(
@@ -106,8 +108,70 @@ describe('AdvancedDnDService', () => {
         });
     });
 
+    describe('overlay model resolution', () => {
+        test('forwards location + group to the option and returns its result', () => {
+            const model = { size: { value: 30, type: 'percentage' as const } };
+            const dropOverlayModel = jest.fn(() => model);
+            const service = new AdvancedDnDService(
+                createHost({ dropOverlayModel })
+            );
+            const group = {} as DockviewGroupPanel;
+
+            const result = service.resolveOverlayModel('content', group);
+
+            expect(dropOverlayModel).toHaveBeenCalledWith({
+                location: 'content',
+                group,
+            });
+            expect(result).toBe(model);
+        });
+
+        test('returns undefined when no option is configured', () => {
+            const service = new AdvancedDnDService(createHost());
+            expect(service.resolveOverlayModel('tab')).toBeUndefined();
+        });
+    });
+
     test('dispose is a no-op and does not throw', () => {
         const service = new AdvancedDnDService(createHost());
         expect(() => service.dispose()).not.toThrow();
+    });
+});
+
+class TestContentPart implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+describe('dropOverlayModel integration', () => {
+    test('is consulted for tab, content and header_space targets (not edge)', () => {
+        const container = document.createElement('div');
+        const dropOverlayModel = jest.fn(() => undefined);
+
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestContentPart(),
+            dropOverlayModel,
+        });
+        dockview.layout(800, 600);
+        dockview.addPanel({ id: 'p1', component: 'default' });
+
+        const locations = dropOverlayModel.mock.calls.map(
+            (call) => (call[0] as { location: string }).location
+        );
+
+        expect(locations).toContain('tab');
+        expect(locations).toContain('content');
+        expect(locations).toContain('header_space');
+        expect(locations).not.toContain('edge');
+
+        dockview.dispose();
     });
 });

--- a/packages/dockview-core/src/__tests__/dockview/advancedDnDService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/advancedDnDService.spec.ts
@@ -2,47 +2,108 @@ import {
     AdvancedDnDService,
     IAdvancedDnDHost,
 } from '../../dockview/advancedDnDService';
+import { DockviewComponentOptions } from '../../dockview/options';
+import { DockviewApi } from '../../api/component.api';
+import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
 
 describe('AdvancedDnDService', () => {
-    function createHost() {
+    function createHost(
+        options: Partial<DockviewComponentOptions> = {}
+    ): IAdvancedDnDHost & {
+        fireWillDragPanel: jest.Mock;
+        fireWillDragGroup: jest.Mock;
+        fireWillDrop: jest.Mock;
+        fireWillShowOverlay: jest.Mock;
+    } {
         return {
+            options: options as DockviewComponentOptions,
+            api: {} as DockviewApi,
             fireWillDragPanel: jest.fn(),
             fireWillDragGroup: jest.fn(),
             fireWillDrop: jest.fn(),
             fireWillShowOverlay: jest.fn(),
-        } satisfies IAdvancedDnDHost;
+        };
     }
 
-    test('dispatch methods forward to the host emitters', () => {
-        const host = createHost();
-        const service = new AdvancedDnDService(host);
+    describe('hook dispatch', () => {
+        test('dispatch methods forward to the host emitters', () => {
+            const host = createHost();
+            const service = new AdvancedDnDService(host);
 
-        const panelEvent = {} as never;
-        const groupEvent = {} as never;
-        const dropEvent = {} as never;
-        const overlayEvent = {} as never;
+            const panelEvent = {} as never;
+            const groupEvent = {} as never;
+            const dropEvent = {} as never;
+            const overlayEvent = {} as never;
 
-        service.dispatchWillDragPanel(panelEvent);
-        service.dispatchWillDragGroup(groupEvent);
-        service.dispatchWillDrop(dropEvent);
-        service.dispatchWillShowOverlay(overlayEvent);
+            service.dispatchWillDragPanel(panelEvent);
+            service.dispatchWillDragGroup(groupEvent);
+            service.dispatchWillDrop(dropEvent);
+            service.dispatchWillShowOverlay(overlayEvent);
 
-        expect(host.fireWillDragPanel).toHaveBeenCalledWith(panelEvent);
-        expect(host.fireWillDragGroup).toHaveBeenCalledWith(groupEvent);
-        expect(host.fireWillDrop).toHaveBeenCalledWith(dropEvent);
-        expect(host.fireWillShowOverlay).toHaveBeenCalledWith(overlayEvent);
+            expect(host.fireWillDragPanel).toHaveBeenCalledWith(panelEvent);
+            expect(host.fireWillDragGroup).toHaveBeenCalledWith(groupEvent);
+            expect(host.fireWillDrop).toHaveBeenCalledWith(dropEvent);
+            expect(host.fireWillShowOverlay).toHaveBeenCalledWith(overlayEvent);
+        });
+
+        test('a dispatch only fires its own host emitter', () => {
+            const host = createHost();
+            const service = new AdvancedDnDService(host);
+
+            service.dispatchWillDrop({} as never);
+
+            expect(host.fireWillDrop).toHaveBeenCalledTimes(1);
+            expect(host.fireWillDragPanel).not.toHaveBeenCalled();
+            expect(host.fireWillDragGroup).not.toHaveBeenCalled();
+            expect(host.fireWillShowOverlay).not.toHaveBeenCalled();
+        });
     });
 
-    test('a dispatch only fires its own host emitter', () => {
-        const host = createHost();
-        const service = new AdvancedDnDService(host);
+    describe('group drag ghost', () => {
+        test('returns undefined when no custom factory is configured', () => {
+            const service = new AdvancedDnDService(createHost());
+            expect(
+                service.buildGroupDragGhost({} as DockviewGroupPanel)
+            ).toBeUndefined();
+        });
 
-        service.dispatchWillDrop({} as never);
+        test('resolves the custom factory and initialises the renderer', () => {
+            const element = document.createElement('div');
+            const init = jest.fn();
+            const dispose = jest.fn();
+            const factory = jest.fn(() => ({ element, init, dispose }));
 
-        expect(host.fireWillDrop).toHaveBeenCalledTimes(1);
-        expect(host.fireWillDragPanel).not.toHaveBeenCalled();
-        expect(host.fireWillDragGroup).not.toHaveBeenCalled();
-        expect(host.fireWillShowOverlay).not.toHaveBeenCalled();
+            const host = createHost({
+                createGroupDragGhostComponent: factory as never,
+            });
+            const service = new AdvancedDnDService(host);
+            const group = {} as DockviewGroupPanel;
+
+            const spec = service.buildGroupDragGhost(group);
+
+            expect(factory).toHaveBeenCalledWith(group);
+            expect(init).toHaveBeenCalledWith({ group, api: host.api });
+            expect(spec).toMatchObject({ element, offsetX: 30, offsetY: -10 });
+
+            // dispose forwarder calls through to the renderer's dispose
+            spec!.dispose!();
+            expect(dispose).toHaveBeenCalledTimes(1);
+        });
+
+        test('omits a dispose forwarder when the renderer has none', () => {
+            const factory = jest.fn(() => ({
+                element: document.createElement('div'),
+                init: jest.fn(),
+            }));
+            const service = new AdvancedDnDService(
+                createHost({
+                    createGroupDragGhostComponent: factory as never,
+                })
+            );
+
+            const spec = service.buildGroupDragGhost({} as DockviewGroupPanel);
+            expect(spec!.dispose).toBeUndefined();
+        });
     });
 
     test('dispose is a no-op and does not throw', () => {

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
@@ -1,6 +1,7 @@
 import { VoidContainer } from '../../../../dockview/components/titlebar/voidContainer';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { DockviewComponent } from '../../../../dockview/dockviewComponent';
+import { AdvancedDnDService } from '../../../../dockview/advancedDnDService';
 import { DockviewGroupPanel } from '../../../../dockview/dockviewGroupPanel';
 import { DockviewGroupPanelModel } from '../../../../dockview/dockviewGroupPanelModel';
 import {
@@ -615,6 +616,10 @@ describe('voidContainer', () => {
                 api: fakeApi as any,
                 options: { createGroupDragGhostComponent: factory },
                 doSetGroupActive: jest.fn(),
+                // The custom-ghost resolution now lives in AdvancedDnDService;
+                // delegate to the real service so this still exercises it.
+                buildGroupDragGhost: (g: any) =>
+                    new AdvancedDnDService(accessor).buildGroupDragGhost(g),
             });
             const group = fromPartial<DockviewGroupPanel>({
                 id: 'g1',

--- a/packages/dockview-core/src/dockview/advancedDnDService.ts
+++ b/packages/dockview-core/src/dockview/advancedDnDService.ts
@@ -1,5 +1,6 @@
 import { IDisposable } from '../lifecycle';
 import { IDragGhostSpec } from '../dnd/backend';
+import { DroptargetOverlayModel } from '../dnd/droptarget';
 import { DockviewApi } from '../api/component.api';
 import {
     GroupDragEvent,
@@ -7,7 +8,10 @@ import {
 } from './components/titlebar/tabsContainer';
 import { DockviewWillDropEvent } from './dockviewGroupPanelModel';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
-import { DockviewWillShowOverlayLocationEvent } from './events';
+import {
+    DockviewGroupDropLocation,
+    DockviewWillShowOverlayLocationEvent,
+} from './events';
 import { DockviewComponentOptions } from './options';
 import { defineModule } from './modules';
 
@@ -45,6 +49,14 @@ export interface IAdvancedDnDService extends IDisposable {
      * `undefined` is also what happens when this module is absent.
      */
     buildGroupDragGhost(group: DockviewGroupPanel): IDragGhostSpec | undefined;
+    /**
+     * Resolve the app-supplied overlay model for a group drop target via the
+     * `dropOverlayModel` option, or `undefined` to keep the target's default.
+     */
+    resolveOverlayModel(
+        location: DockviewGroupDropLocation,
+        group?: DockviewGroupPanel
+    ): DroptargetOverlayModel | undefined;
 }
 
 /**
@@ -99,6 +111,13 @@ export class AdvancedDnDService implements IAdvancedDnDService {
                 ? () => renderer.dispose?.()
                 : undefined,
         };
+    }
+
+    resolveOverlayModel(
+        location: DockviewGroupDropLocation,
+        group?: DockviewGroupPanel
+    ): DroptargetOverlayModel | undefined {
+        return this.host.options.dropOverlayModel?.({ location, group });
     }
 
     dispose(): void {

--- a/packages/dockview-core/src/dockview/advancedDnDService.ts
+++ b/packages/dockview-core/src/dockview/advancedDnDService.ts
@@ -94,9 +94,7 @@ export class AdvancedDnDService implements IAdvancedDnDService {
         this.host.fireWillShowOverlay(event);
     }
 
-    buildGroupDragGhost(
-        group: DockviewGroupPanel
-    ): IDragGhostSpec | undefined {
+    buildGroupDragGhost(group: DockviewGroupPanel): IDragGhostSpec | undefined {
         const createGhost = this.host.options.createGroupDragGhostComponent;
         if (!createGhost) {
             return undefined;
@@ -107,9 +105,7 @@ export class AdvancedDnDService implements IAdvancedDnDService {
             element: renderer.element,
             offsetX: GROUP_DRAG_GHOST_OFFSET_X,
             offsetY: GROUP_DRAG_GHOST_OFFSET_Y,
-            dispose: renderer.dispose
-                ? () => renderer.dispose?.()
-                : undefined,
+            dispose: renderer.dispose ? () => renderer.dispose?.() : undefined,
         };
     }
 

--- a/packages/dockview-core/src/dockview/advancedDnDService.ts
+++ b/packages/dockview-core/src/dockview/advancedDnDService.ts
@@ -1,11 +1,19 @@
 import { IDisposable } from '../lifecycle';
+import { IDragGhostSpec } from '../dnd/backend';
+import { DockviewApi } from '../api/component.api';
 import {
     GroupDragEvent,
     TabDragEvent,
 } from './components/titlebar/tabsContainer';
 import { DockviewWillDropEvent } from './dockviewGroupPanelModel';
+import { DockviewGroupPanel } from './dockviewGroupPanel';
 import { DockviewWillShowOverlayLocationEvent } from './events';
+import { DockviewComponentOptions } from './options';
 import { defineModule } from './modules';
+
+/** Cursor offset of the group drag ghost, matched to the long-shipped default. */
+const GROUP_DRAG_GHOST_OFFSET_X = 30;
+const GROUP_DRAG_GHOST_OFFSET_Y = -10;
 
 /**
  * The narrow surface the {@link AdvancedDnDService} needs from the host
@@ -17,6 +25,8 @@ import { defineModule } from './modules';
  * `disableDnd` guard) stays on the component, ahead of the dispatch.
  */
 export interface IAdvancedDnDHost {
+    readonly options: DockviewComponentOptions;
+    readonly api: DockviewApi;
     fireWillDragPanel(event: TabDragEvent): void;
     fireWillDragGroup(event: GroupDragEvent): void;
     fireWillDrop(event: DockviewWillDropEvent): void;
@@ -28,6 +38,13 @@ export interface IAdvancedDnDService extends IDisposable {
     dispatchWillDragGroup(event: GroupDragEvent): void;
     dispatchWillDrop(event: DockviewWillDropEvent): void;
     dispatchWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void;
+    /**
+     * Resolve the custom group drag ghost from
+     * `createGroupDragGhostComponent`, or `undefined` when no factory is
+     * configured (the caller then renders the default chip). Returning
+     * `undefined` is also what happens when this module is absent.
+     */
+    buildGroupDragGhost(group: DockviewGroupPanel): IDragGhostSpec | undefined;
 }
 
 /**
@@ -63,6 +80,25 @@ export class AdvancedDnDService implements IAdvancedDnDService {
 
     dispatchWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void {
         this.host.fireWillShowOverlay(event);
+    }
+
+    buildGroupDragGhost(
+        group: DockviewGroupPanel
+    ): IDragGhostSpec | undefined {
+        const createGhost = this.host.options.createGroupDragGhostComponent;
+        if (!createGhost) {
+            return undefined;
+        }
+        const renderer = createGhost(group);
+        renderer.init({ group, api: this.host.api });
+        return {
+            element: renderer.element,
+            offsetX: GROUP_DRAG_GHOST_OFFSET_X,
+            offsetY: GROUP_DRAG_GHOST_OFFSET_Y,
+            dispose: renderer.dispose
+                ? () => renderer.dispose?.()
+                : undefined,
+        };
     }
 
     dispose(): void {

--- a/packages/dockview-core/src/dockview/advancedDnDService.ts
+++ b/packages/dockview-core/src/dockview/advancedDnDService.ts
@@ -1,0 +1,80 @@
+import { IDisposable } from '../lifecycle';
+import {
+    GroupDragEvent,
+    TabDragEvent,
+} from './components/titlebar/tabsContainer';
+import { DockviewWillDropEvent } from './dockviewGroupPanelModel';
+import { DockviewWillShowOverlayLocationEvent } from './events';
+import { defineModule } from './modules';
+
+/**
+ * The narrow surface the {@link AdvancedDnDService} needs from the host
+ * (the `DockviewComponent`).
+ *
+ * The `onWill*` emitters stay on the component so the public event shape is
+ * unchanged whether or not this module is registered — the service is only the
+ * dispatch point those fires are routed through. Engine policy (e.g. the
+ * `disableDnd` guard) stays on the component, ahead of the dispatch.
+ */
+export interface IAdvancedDnDHost {
+    fireWillDragPanel(event: TabDragEvent): void;
+    fireWillDragGroup(event: GroupDragEvent): void;
+    fireWillDrop(event: DockviewWillDropEvent): void;
+    fireWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void;
+}
+
+export interface IAdvancedDnDService extends IDisposable {
+    dispatchWillDragPanel(event: TabDragEvent): void;
+    dispatchWillDragGroup(event: GroupDragEvent): void;
+    dispatchWillDrop(event: DockviewWillDropEvent): void;
+    dispatchWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void;
+}
+
+/**
+ * Owns the dispatch of the advanced drag-and-drop hooks — `onWillDragPanel`,
+ * `onWillDragGroup`, `onWillDrop` and `onWillShowOverlay`.
+ *
+ * At this stage the service is a thin dispatcher that forwards to the host's
+ * emitters; the customisation surface it gates (custom drop overlays, custom
+ * group drag ghosts, hook veto/transform behaviour) is currently inlined in
+ * core and is extracted into this service in later phases. Routing the
+ * dispatch through a module slot is what lets that customisation layer move
+ * into a separately-distributed package in a future major version without
+ * changing the public event surface.
+ *
+ * The service holds no drag state of its own — the gesture is driven by the
+ * DnD backends, and the per-group subscriptions live on the component's group
+ * lifecycle (so groups created mid-move are not missed).
+ */
+export class AdvancedDnDService implements IAdvancedDnDService {
+    constructor(private readonly host: IAdvancedDnDHost) {}
+
+    dispatchWillDragPanel(event: TabDragEvent): void {
+        this.host.fireWillDragPanel(event);
+    }
+
+    dispatchWillDragGroup(event: GroupDragEvent): void {
+        this.host.fireWillDragGroup(event);
+    }
+
+    dispatchWillDrop(event: DockviewWillDropEvent): void {
+        this.host.fireWillDrop(event);
+    }
+
+    dispatchWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void {
+        this.host.fireWillShowOverlay(event);
+    }
+
+    dispose(): void {
+        // no-op — see class doc: the service holds no state to tear down.
+    }
+}
+
+export const AdvancedDnDModule = defineModule<
+    'advancedDnDService',
+    IAdvancedDnDHost
+>({
+    name: 'AdvancedDnD',
+    serviceKey: 'advancedDnDService',
+    create: (host) => new AdvancedDnDService(host),
+});

--- a/packages/dockview-core/src/dockview/allModules.ts
+++ b/packages/dockview-core/src/dockview/allModules.ts
@@ -7,6 +7,7 @@ import { TabGroupChipsModule } from './tabGroupChipsService';
 import { ContextMenuModule } from './contextMenu';
 import { RootDropTargetModule } from './rootDropTargetService';
 import { HeaderActionsModule } from './headerActionsService';
+import { AdvancedDnDModule } from './advancedDnDService';
 
 /**
  * Internal list of all built-in modules. Registered automatically by
@@ -21,4 +22,5 @@ export const AllModules: DockviewModule<any>[] = [
     ContextMenuModule,
     RootDropTargetModule,
     HeaderActionsModule,
+    AdvancedDnDModule,
 ];

--- a/packages/dockview-core/src/dockview/components/panel/content.ts
+++ b/packages/dockview-core/src/dockview/components/panel/content.ts
@@ -1,5 +1,6 @@
 import {
     CompositeDisposable,
+    Disposable,
     IDisposable,
     MutableDisposable,
 } from '../../../lifecycle';
@@ -110,6 +111,7 @@ export class ContentContainer
             acceptedTargetZones: ['top', 'bottom', 'left', 'right', 'center'],
             canDisplayOverlay,
             getOverrideTarget,
+            overlayModel: this.accessor.resolveDropOverlayModel?.('content'),
         });
 
         this.pointerDropTarget = pointerBackend.createDropTarget(this.element, {
@@ -122,9 +124,21 @@ export class ContentContainer
             },
             className: 'dv-drop-target-content',
             getOverrideTarget,
+            overlayModel: this.accessor.resolveDropOverlayModel?.('content'),
         });
 
-        this.addDisposables(this.dropTarget, this.pointerDropTarget);
+        this.addDisposables(
+            this.dropTarget,
+            this.pointerDropTarget,
+            // Re-apply the app-supplied overlay model when options change.
+            // `{}` resets to the built-in default (all fields optional).
+            this.accessor.onDidOptionsChange?.(() => {
+                const model =
+                    this.accessor.resolveDropOverlayModel?.('content') ?? {};
+                this.dropTarget.setOverlayModel(model);
+                this.pointerDropTarget.setOverlayModel(model);
+            }) ?? Disposable.NONE
+        );
     }
 
     show(): void {

--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -11,6 +11,7 @@ import { ITabRenderer } from '../../types';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import {
     DroptargetEvent,
+    DroptargetOverlayModel,
     IDropTarget,
     Position,
     WillShowOverlayEvent,
@@ -247,7 +248,16 @@ export class Tab extends CompositeDisposable {
         this._element.appendChild(this.content.element);
     }
 
-    private _buildOverlayModel() {
+    private _buildOverlayModel(): DroptargetOverlayModel {
+        // An app-supplied model (the dropOverlayModel option) takes precedence
+        // over the theme-derived default for this tab.
+        const custom = this.accessor.resolveDropOverlayModel?.(
+            'tab',
+            this.group
+        );
+        if (custom) {
+            return custom;
+        }
         // 'line' themes render a 4px insertion strip at the tab edge via the
         // anchor container's small-boundary path.  'fill' themes render a
         // half-width highlighted area, so we disable the small-boundary path

--- a/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
@@ -122,22 +122,13 @@ export class GroupDragSource extends CompositeDisposable {
         };
 
         const buildGhostSpec = (): IDragGhostSpec => {
-            const createGhost =
-                this.accessor.options.createGroupDragGhostComponent;
-            if (createGhost) {
-                const renderer = createGhost(this.group);
-                renderer.init({
-                    group: this.group,
-                    api: this.accessor.api,
-                });
-                return {
-                    element: renderer.element,
-                    offsetX: 30,
-                    offsetY: -10,
-                    dispose: renderer.dispose
-                        ? () => renderer.dispose?.()
-                        : undefined,
-                };
+            // The custom-ghost resolution (createGroupDragGhostComponent) is
+            // owned by the AdvancedDnD module; core keeps the default chip and
+            // falls back to it when no custom ghost is produced (incl. when
+            // the module is absent).
+            const customGhost = this.accessor.buildGroupDragGhost?.(this.group);
+            if (customGhost) {
+                return customGhost;
             }
             return {
                 element: buildMultiPanelsGhost(),

--- a/packages/dockview-core/src/dockview/components/titlebar/voidContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/voidContainer.ts
@@ -8,7 +8,7 @@ import {
 import { html5Backend, pointerBackend } from '../../../dnd/backend';
 import { DockviewComponent } from '../../dockviewComponent';
 import { addDisposableListener, Emitter, Event } from '../../../events';
-import { CompositeDisposable } from '../../../lifecycle';
+import { CompositeDisposable, Disposable } from '../../../lifecycle';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import { quasiPreventDefault } from '../../../dom';
 import { GroupDragSource } from './groupDragSource';
@@ -105,6 +105,10 @@ export class VoidContainer extends CompositeDisposable {
             acceptedTargetZones: ['center'],
             canDisplayOverlay,
             getOverrideTarget: () => group.model.dropTargetContainer?.model,
+            overlayModel: this.accessor.resolveDropOverlayModel?.(
+                'header_space',
+                this.group
+            ),
         });
 
         this.pointerDropTarget = pointerBackend.createDropTarget(
@@ -113,6 +117,10 @@ export class VoidContainer extends CompositeDisposable {
                 acceptedTargetZones: ['center'],
                 canDisplayOverlay,
                 getOverrideTarget: () => group.model.dropTargetContainer?.model,
+                overlayModel: this.accessor.resolveDropOverlayModel?.(
+                    'header_space',
+                    this.group
+                ),
             }
         );
 
@@ -133,7 +141,18 @@ export class VoidContainer extends CompositeDisposable {
                 this._onDrop.fire(event);
             }),
             this.dropTarget,
-            this.pointerDropTarget
+            this.pointerDropTarget,
+            // Re-apply the app-supplied overlay model when options change.
+            // `{}` resets to the built-in default (all fields optional).
+            this.accessor.onDidOptionsChange?.(() => {
+                const model =
+                    this.accessor.resolveDropOverlayModel?.(
+                        'header_space',
+                        this.group
+                    ) ?? {};
+                this.dropTarget.setOverlayModel(model);
+                this.pointerDropTarget.setOverlayModel(model);
+            }) ?? Disposable.NONE
         );
     }
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -92,6 +92,7 @@ import { PopupService } from './components/popupService';
 import { IContextMenuHost, IContextMenuService } from './contextMenu';
 import { IRootDropTargetHost } from './rootDropTargetService';
 import { IAdvancedDnDHost } from './advancedDnDService';
+import { IDragGhostSpec } from '../dnd/backend';
 import { DropTargetAnchorContainer } from '../dnd/dropTargetAnchorContainer';
 import { themeAbyss } from './theme';
 import {
@@ -638,6 +639,15 @@ export class DockviewComponent
 
     fireWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void {
         this._onWillShowOverlay.fire(event);
+    }
+
+    /**
+     * Resolve the custom group drag ghost (via the AdvancedDnD module), or
+     * `undefined` to fall back to the default chip. Returns `undefined` when
+     * the module is absent — the default ghost then renders.
+     */
+    buildGroupDragGhost(group: DockviewGroupPanel): IDragGhostSpec | undefined {
+        return this._advancedDnDService?.buildGroupDragGhost(group);
     }
 
     /**

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -91,6 +91,7 @@ import { StrictEventsSequencing } from './strictEventsSequencing';
 import { PopupService } from './components/popupService';
 import { IContextMenuHost, IContextMenuService } from './contextMenu';
 import { IRootDropTargetHost } from './rootDropTargetService';
+import { IAdvancedDnDHost } from './advancedDnDService';
 import { DropTargetAnchorContainer } from '../dnd/dropTargetAnchorContainer';
 import { themeAbyss } from './theme';
 import {
@@ -361,7 +362,8 @@ export class DockviewComponent
         ITabGroupChipsHost,
         IContextMenuHost,
         IRootDropTargetHost,
-        IHeaderActionsHost
+        IHeaderActionsHost,
+        IAdvancedDnDHost
 {
     private readonly nextGroupId = sequentialNumberGenerator();
     private readonly _deserializer = new DefaultDockviewDeserialzier(this);
@@ -585,6 +587,13 @@ export class DockviewComponent
         return this._moduleRegistry.services.rootDropTargetService!;
     }
 
+    private get _advancedDnDService() {
+        // Optional — callers `?.`-guard so the module can be removed from
+        // AllModules. Absent ⇒ the onWill* hooks simply don't fire (≡ no
+        // subscriber), which is invisible to apps not customising DnD.
+        return this._moduleRegistry.services.advancedDnDService;
+    }
+
     get headerActionsService() {
         return this._moduleRegistry.services.headerActionsService;
     }
@@ -609,6 +618,26 @@ export class DockviewComponent
         );
         this._onUnhandledDragOverEvent.fire(event);
         return event.isAccepted;
+    }
+
+    // IAdvancedDnDHost — the emitters stay here so the public onWill* event
+    // shape is unchanged; AdvancedDnDService routes the per-group fires
+    // through these. Engine guards (e.g. disableDnd) run on the component
+    // ahead of the dispatch.
+    fireWillDragPanel(event: TabDragEvent): void {
+        this._onWillDragPanel.fire(event);
+    }
+
+    fireWillDragGroup(event: GroupDragEvent): void {
+        this._onWillDragGroup.fire(event);
+    }
+
+    fireWillDrop(event: DockviewWillDropEvent): void {
+        this._onWillDrop.fire(event);
+    }
+
+    fireWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void {
+        this._onWillShowOverlay.fire(event);
     }
 
     /**
@@ -4024,10 +4053,10 @@ export class DockviewComponent
         if (!this._groups.has(view.id)) {
             const disposable = new CompositeDisposable(
                 view.model.onTabDragStart((event) => {
-                    this._onWillDragPanel.fire(event);
+                    this._advancedDnDService?.dispatchWillDragPanel(event);
                 }),
                 view.model.onGroupDragStart((event) => {
-                    this._onWillDragGroup.fire(event);
+                    this._advancedDnDService?.dispatchWillDragGroup(event);
                 }),
                 view.model.onMove((event) => {
                     const { groupId, itemId, target, index, tabGroupId } =
@@ -4049,15 +4078,17 @@ export class DockviewComponent
                     this._onDidDrop.fire(event);
                 }),
                 view.model.onWillDrop((event) => {
-                    this._onWillDrop.fire(event);
+                    this._advancedDnDService?.dispatchWillDrop(event);
                 }),
                 view.model.onWillShowOverlay((event) => {
                     if (this.options.disableDnd) {
+                        // Engine policy — stays in core, ahead of any
+                        // customisation dispatch.
                         event.preventDefault();
                         return;
                     }
 
-                    this._onWillShowOverlay.fire(event);
+                    this._advancedDnDService?.dispatchWillShowOverlay(event);
                 }),
                 view.model.onUnhandledDragOverEvent((event) => {
                     this._onUnhandledDragOverEvent.fire(event);

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -7,7 +7,11 @@ import {
     Gridview,
     SerializedGridview,
 } from '../gridview/gridview';
-import { directionToPosition, Position } from '../dnd/droptarget';
+import {
+    directionToPosition,
+    DroptargetOverlayModel,
+    Position,
+} from '../dnd/droptarget';
 import { tail, sequenceEquals } from '../array';
 import { DockviewPanel, IDockviewPanel } from './dockviewPanel';
 import { CompositeDisposable, Disposable } from '../lifecycle';
@@ -49,6 +53,7 @@ import {
     DockviewTabGroupChangeEvent,
     DockviewTabGroupCollapsedChangeEvent,
     DockviewTabGroupPanelChangeEvent,
+    DockviewGroupDropLocation,
 } from './events';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
 import { DockviewPanelModel } from './dockviewPanelModel';
@@ -648,6 +653,17 @@ export class DockviewComponent
      */
     buildGroupDragGhost(group: DockviewGroupPanel): IDragGhostSpec | undefined {
         return this._advancedDnDService?.buildGroupDragGhost(group);
+    }
+
+    /**
+     * Resolve the app-supplied drop overlay model (via the AdvancedDnD module)
+     * for a group drop target, or `undefined` to keep the target's default.
+     */
+    resolveDropOverlayModel(
+        location: DockviewGroupDropLocation,
+        group?: DockviewGroupPanel
+    ): DroptargetOverlayModel | undefined {
+        return this._advancedDnDService?.resolveOverlayModel(location, group);
     }
 
     /**

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -17,6 +17,7 @@ import { ITabGroupChipsService } from './tabGroupChipsService';
 import { IContextMenuService } from './contextMenu';
 import { IRootDropTargetService } from './rootDropTargetService';
 import { IHeaderActionsService } from './headerActionsService';
+import { IAdvancedDnDService } from './advancedDnDService';
 
 export interface ServiceCollection {
     floatingGroupService?: IFloatingGroupService;
@@ -27,6 +28,7 @@ export interface ServiceCollection {
     contextMenuService?: IContextMenuService;
     rootDropTargetService?: IRootDropTargetService;
     headerActionsService?: IHeaderActionsService;
+    advancedDnDService?: IAdvancedDnDService;
 }
 
 export interface DockviewModule<THost = unknown> {

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -57,6 +57,13 @@ export interface ContextMenuItemConfig {
 
 export type ContextMenuItem = BuiltInContextMenuItem | ContextMenuItemConfig;
 
+export interface DropOverlayModelParams {
+    /** Which of a group's drop targets the overlay is for. `'edge'` is shaped by `dndEdges`, not this option. */
+    location: DockviewGroupDropLocation;
+    /** The group the target belongs to, where known (tab / header_space / content). */
+    group?: DockviewGroupPanel;
+}
+
 export interface GetTabContextMenuItemsParams {
     panel: IDockviewPanel;
     group: DockviewGroupPanel;
@@ -213,6 +220,20 @@ export interface DockviewOptions {
         group: DockviewGroupPanel
     ) => IGroupDragGhostRenderer;
     /**
+     * Shape the drop overlay shown over a group's drop targets — the tab
+     * strip (`'tab'`), the header void space (`'header_space'`) and the
+     * panel content area (`'content'`). Return a {@link DroptargetOverlayModel}
+     * to override that target's default overlay (size, activation threshold,
+     * small-element boundaries), or `undefined` to keep the default.
+     *
+     * `group` is provided where known (tab / header_space). The outer-layout
+     * edge overlay is shaped by `dndEdges`, not this option, so `'edge'` is
+     * not dispatched here.
+     */
+    dropOverlayModel?: (
+        params: DropOverlayModelParams
+    ) => DroptargetOverlayModel | undefined;
+    /**
      * Replace the built-in tab group color palette with a user-defined list.
      *
      * Each entry has an `id` (stored on `tabGroup.color` and serialized),
@@ -293,6 +314,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         getTabGroupChipContextMenuItems: undefined,
         createTabGroupChipComponent: undefined,
         createGroupDragGhostComponent: undefined,
+        dropOverlayModel: undefined,
         tabGroupColors: undefined,
         tabGroupAccent: undefined,
     };


### PR DESCRIPTION
## Description

Consolidates the advanced drag-and-drop surface behind a single internal module (`AdvancedDnDModule` / `AdvancedDnDService`) and adds a `dropOverlayModel` option for per-target overlay shaping. The public event surface is unchanged and the module auto-registers, so behaviour is identical today. Three self-contained commits:

**1. Route `onWill*` dispatch through the module.** The per-group hook dispatch (`onWillDragPanel` / `onWillDragGroup` / `onWillDrop` / `onWillShowOverlay`) routes through `AdvancedDnDService`. The emitters stay on the component (public event shape unchanged); the component implements a narrow `IAdvancedDnDHost` and the service forwards to it. The `disableDnd` engine guard stays in core, ahead of the dispatch. Per-group subscriptions stay on the component's group lifecycle (not re-driven off `onDidAddGroup`, which is suppressed during internal moves), so groups created mid-move aren't missed.

**2. Move custom group-drag-ghost resolution into the module.** `createGroupDragGhostComponent` resolution moves out of `GroupDragSource` into `AdvancedDnDService.buildGroupDragGhost`. Core keeps the default "Multiple Panels (N)" chip and falls back to it whenever the service yields no custom ghost.

**3. Add `dropOverlayModel` option (new public API).**
```ts
dropOverlayModel?: (params: {
  location: DockviewGroupDropLocation; // 'tab' | 'header_space' | 'content'
  group?: DockviewGroupPanel;
}) => DroptargetOverlayModel | undefined;
```
Shapes the drop overlay (size / activation threshold / small-element boundaries) on a group's tab strip, header void space, and content area. The tab/content/void targets consult it at construction and re-apply on `updateOptions`; an app model takes precedence over the tab's theme default. The edge overlay keeps its dedicated `dndEdges` path and is not dispatched here. `group` is passed for `tab` / `header_space`; the content target passes location only (no direct group-panel handle internally), which is why `group` is optional.

## Type of change

- [ ] Bug fix
- [x] New feature (`dropOverlayModel`)
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / cleanup (module consolidation)
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

- `advancedDnDService.spec.ts` covers dispatch forwarding, ghost resolution (custom factory + default chip), overlay-model forwarding, and an integration test asserting `dropOverlayModel` is consulted for `tab` / `content` / `header_space` (never `edge`).
- Existing `onWill*` and custom-ghost / default-chip integration tests pass unchanged.
- No behaviour change for apps not using these hooks/options — the module auto-registers and defaults match today.

## Checklist

- [x] `yarn test` passes (full `dockview-core` suite: 1036)
- [x] eslint clean on changed files; typecheck clean
- [x] I have added or updated tests
- [ ] `yarn format` / `npm run gen` not run in this environment — please run in CI
- [x] No breaking changes (additive option; event surface unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)