### PR TITLE
feat(dockview-core): layout-mutation transaction events (onWillMutateLayout / onDidMutateLayout)

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -48,6 +48,8 @@ DockviewGroupPanelModel
 DockviewHeaderDirection
 DockviewHeaderPosition
 DockviewIDisposable
+DockviewLayoutMutationEvent
+DockviewLayoutMutationKind
 DockviewMaximizedGroupChanged
 DockviewMutableDisposable
 DockviewOptions

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -79,6 +79,51 @@ describe('layout mutation events', () => {
         expect(did).toEqual(['move']);
     });
 
+    test('removeGroup brackets one "remove" transaction', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        will.length = 0;
+        did.length = 0;
+
+        dockview.removeGroup(p1.group);
+        expect(will).toEqual(['remove']);
+        expect(did).toEqual(['remove']);
+    });
+
+    test('addFloatingGroup brackets one "float" transaction', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        will.length = 0;
+        did.length = 0;
+
+        dockview.addFloatingGroup(p1);
+        expect(will).toEqual(['float']);
+        expect(did).toEqual(['float']);
+    });
+
+    test('clear brackets one "clear" transaction', () => {
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        will.length = 0;
+        did.length = 0;
+
+        dockview.clear();
+        expect(will).toEqual(['clear']);
+        expect(did).toEqual(['clear']);
+    });
+
+    test('fromJSON fires a single "load" transaction, not N nested adds', () => {
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        dockview.addPanel({ id: 'p3', component: 'default' });
+        const json = dockview.toJSON();
+        will.length = 0;
+        did.length = 0;
+
+        dockview.fromJSON(json);
+        expect(will).toEqual(['load']);
+        expect(did).toEqual(['load']);
+    });
+
     test('onWillMutateLayout fires before onDidMutateLayout', () => {
         const order: string[] = [];
         dockview.onWillMutateLayout(() => order.push('will'));

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -1,0 +1,90 @@
+import {
+    DockviewComponent,
+    DockviewLayoutMutationKind,
+} from '../../dockview/dockviewComponent';
+import { IContentRenderer } from '../../dockview/types';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * The onWillMutateLayout / onDidMutateLayout transaction boundary. Each
+ * top-level structural mutation brackets once; compound operations (a move
+ * that internally removes the source panel) bracket as a single transaction.
+ */
+describe('layout mutation events', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+    let will: DockviewLayoutMutationKind[];
+    let did: DockviewLayoutMutationKind[];
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(1000, 1000);
+        will = [];
+        did = [];
+        dockview.onWillMutateLayout((e) => will.push(e.kind));
+        dockview.onDidMutateLayout((e) => did.push(e.kind));
+    });
+
+    afterEach(() => dockview.dispose());
+
+    test('addPanel brackets one "add" transaction', () => {
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        expect(will).toEqual(['add']);
+        expect(did).toEqual(['add']);
+    });
+
+    test('removePanel brackets one "remove" transaction', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        will.length = 0;
+        did.length = 0;
+
+        dockview.removePanel(p1);
+        expect(will).toEqual(['remove']);
+        expect(did).toEqual(['remove']);
+    });
+
+    test('a compound move fires once — nested removePanel does not double-fire', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        const p2 = dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        will.length = 0;
+        did.length = 0;
+
+        dockview.moveGroupOrPanel({
+            from: { groupId: p2.group.id, panelId: p2.id },
+            to: { group: p1.group, position: 'center' },
+        });
+
+        // Exactly one 'move' — the source-group teardown inside the move must
+        // not leak its own transaction (depth counter).
+        expect(will).toEqual(['move']);
+        expect(did).toEqual(['move']);
+    });
+
+    test('onWillMutateLayout fires before onDidMutateLayout', () => {
+        const order: string[] = [];
+        dockview.onWillMutateLayout(() => order.push('will'));
+        dockview.onDidMutateLayout(() => order.push('did'));
+
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        expect(order).toEqual(['will', 'did']);
+    });
+});

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -1,4 +1,5 @@
 import {
+    DockviewLayoutMutationEvent,
     DockviewMaximizedGroupChanged,
     FloatingGroupOptions,
     IDockviewComponent,
@@ -729,6 +730,21 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      */
     get onWillDrop(): Event<DockviewWillDropEvent> {
         return this.component.onWillDrop;
+    }
+
+    /**
+     * Fires before each top-level structural layout mutation (add / remove /
+     * move / float / popout / maximize / load / clear). Compound operations
+     * (e.g. a drag) fire once. Pair with `onDidMutateLayout` to bracket a
+     * change — useful for undo/redo, autosave and dirty-tracking.
+     */
+    get onWillMutateLayout(): Event<DockviewLayoutMutationEvent> {
+        return this.component.onWillMutateLayout;
+    }
+
+    /** Fires after each top-level structural layout mutation. See `onWillMutateLayout`. */
+    get onDidMutateLayout(): Event<DockviewLayoutMutationEvent> {
+        return this.component.onDidMutateLayout;
     }
 
     /**

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -273,7 +273,6 @@ export type DockviewLayoutMutationKind =
     | 'move'
     | 'float'
     | 'popout'
-    | 'maximize'
     | 'load'
     | 'clear';
 
@@ -1004,6 +1003,17 @@ export class DockviewComponent
         itemToPopout: DockviewPanel | DockviewGroupPanel,
         options?: DockviewPopoutGroupOptionsInternal
     ): Promise<boolean> {
+        // The transaction brackets the synchronous structural change; the
+        // popout window opens asynchronously after it resolves.
+        return this.mutation('popout', () =>
+            this._doAddPopoutGroup(itemToPopout, options)
+        );
+    }
+
+    private _doAddPopoutGroup(
+        itemToPopout: DockviewPanel | DockviewGroupPanel,
+        options?: DockviewPopoutGroupOptionsInternal
+    ): Promise<boolean> {
         const service = assertModule(
             this._popoutWindowService,
             'PopoutWindow',
@@ -1611,6 +1621,13 @@ export class DockviewComponent
     }
 
     addFloatingGroup(
+        item: DockviewPanel | DockviewGroupPanel,
+        options?: FloatingGroupOptionsInternal
+    ): void {
+        this.mutation('float', () => this._doAddFloatingGroup(item, options));
+    }
+
+    private _doAddFloatingGroup(
         item: DockviewPanel | DockviewGroupPanel,
         options?: FloatingGroupOptionsInternal
     ): void {
@@ -2263,6 +2280,15 @@ export class DockviewComponent
         data: SerializedDockview,
         options?: { reuseExistingPanels: boolean }
     ): void {
+        // One 'load' transaction for the whole deserialization — the many
+        // nested add/remove mutations join it via the depth counter.
+        this.mutation('load', () => this._doFromJSON(data, options));
+    }
+
+    private _doFromJSON(
+        data: SerializedDockview,
+        options?: { reuseExistingPanels: boolean }
+    ): void {
         // Cancel any popout-restoration timers queued by a previous fromJSON
         // that haven't fired yet. The cancel path also disposes orphan groups
         // registered in _groups synchronously but never parented into a popout
@@ -2729,6 +2755,10 @@ export class DockviewComponent
     }
 
     clear(): void {
+        this.mutation('clear', () => this._doClear());
+    }
+
+    private _doClear(): void {
         const groups = Array.from(this._groups.values()).map((_) => _.value);
 
         const hasActiveGroup = !!this.activeGroup;
@@ -3113,7 +3143,7 @@ export class DockviewComponent
               }
             | undefined
     ): void {
-        this.doRemoveGroup(group, options);
+        this.mutation('remove', () => this.doRemoveGroup(group, options));
     }
 
     /**
@@ -3835,6 +3865,10 @@ export class DockviewComponent
     }
 
     moveGroup(options: MoveGroupOptions): void {
+        this.mutation('move', () => this._doMoveGroup(options));
+    }
+
+    private _doMoveGroup(options: MoveGroupOptions): void {
         const from = options.from.group;
         const to = options.to.group;
         const target = options.to.position;

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -266,6 +266,21 @@ export interface DockviewMaximizedGroupChanged {
     isMaximized: boolean;
 }
 
+/** The coarse kind of a structural layout mutation (see `onWillMutateLayout`). */
+export type DockviewLayoutMutationKind =
+    | 'add'
+    | 'remove'
+    | 'move'
+    | 'float'
+    | 'popout'
+    | 'maximize'
+    | 'load'
+    | 'clear';
+
+export interface DockviewLayoutMutationEvent {
+    readonly kind: DockviewLayoutMutationKind;
+}
+
 export interface PopoutGroupChangeSizeEvent {
     width: number;
     height: number;
@@ -285,6 +300,8 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     readonly orientation: Orientation;
     readonly onDidDrop: Event<DockviewDidDropEvent>;
     readonly onWillDrop: Event<DockviewWillDropEvent>;
+    readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent>;
+    readonly onDidMutateLayout: Event<DockviewLayoutMutationEvent>;
     readonly onWillShowOverlay: Event<DockviewWillShowOverlayLocationEvent>;
     readonly onDidRemovePanel: Event<IDockviewPanel>;
     readonly onDidAddPanel: Event<IDockviewPanel>;
@@ -395,6 +412,19 @@ export class DockviewComponent
 
     private readonly _onWillDrop = new Emitter<DockviewWillDropEvent>();
     readonly onWillDrop: Event<DockviewWillDropEvent> = this._onWillDrop.event;
+
+    // Transaction boundary bracketing each top-level structural mutation.
+    // Compound operations (e.g. a drag that relocates a panel) nest via the
+    // depth counter and bracket as a single transaction. See `mutation()`.
+    private _mutationDepth = 0;
+    private readonly _onWillMutateLayout =
+        new Emitter<DockviewLayoutMutationEvent>();
+    readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent> =
+        this._onWillMutateLayout.event;
+    private readonly _onDidMutateLayout =
+        new Emitter<DockviewLayoutMutationEvent>();
+    readonly onDidMutateLayout: Event<DockviewLayoutMutationEvent> =
+        this._onDidMutateLayout.event;
 
     private readonly _onWillShowOverlay =
         new Emitter<DockviewWillShowOverlayLocationEvent>();
@@ -780,6 +810,8 @@ export class DockviewComponent
             this._onDidLayoutFromJSON,
             this._onDidDrop,
             this._onWillDrop,
+            this._onWillMutateLayout,
+            this._onDidMutateLayout,
             this._onDidMovePanel,
             this._onDidMovePanel.event(() => {
                 /**
@@ -2732,6 +2764,12 @@ export class DockviewComponent
     addPanel<T extends object = Parameters>(
         options: AddPanelOptions<T>
     ): DockviewPanel {
+        return this.mutation('add', () => this._doAddPanel(options));
+    }
+
+    private _doAddPanel<T extends object = Parameters>(
+        options: AddPanelOptions<T>
+    ): DockviewPanel {
         if (this.panels.find((_) => _.id === options.id)) {
             throw new Error(
                 `dockview: panel with id ${options.id} already exists`
@@ -2930,6 +2968,19 @@ export class DockviewComponent
     }
 
     removePanel(
+        panel: IDockviewPanel,
+        options: {
+            removeEmptyGroup: boolean;
+            skipDispose?: boolean;
+            skipSetActiveGroup?: boolean;
+        } = {
+            removeEmptyGroup: true,
+        }
+    ): void {
+        this.mutation('remove', () => this._doRemovePanel(panel, options));
+    }
+
+    private _doRemovePanel(
         panel: IDockviewPanel,
         options: {
             removeEmptyGroup: boolean;
@@ -3309,7 +3360,34 @@ export class DockviewComponent
         }
     }
 
+    /**
+     * Bracket a structural mutation with `onWillMutateLayout` /
+     * `onDidMutateLayout`. Re-entrant: nested calls (a compound operation such
+     * as a drag that relocates a panel) join the outermost transaction, so the
+     * events fire exactly once around the whole operation. `kind` reflects the
+     * outermost mutation.
+     */
+    mutation<T>(kind: DockviewLayoutMutationKind, func: () => T): T {
+        const outer = this._mutationDepth === 0;
+        if (outer) {
+            this._onWillMutateLayout.fire({ kind });
+        }
+        this._mutationDepth++;
+        try {
+            return func();
+        } finally {
+            this._mutationDepth--;
+            if (outer) {
+                this._onDidMutateLayout.fire({ kind });
+            }
+        }
+    }
+
     moveGroupOrPanel(options: MoveGroupOrPanelOptions): void {
+        this.mutation('move', () => this._doMoveGroupOrPanel(options));
+    }
+
+    private _doMoveGroupOrPanel(options: MoveGroupOrPanelOptions): void {
         const destinationGroup = options.to.group;
         const sourceGroupId = options.from.groupId;
         const sourceItemId = options.from.panelId;


### PR DESCRIPTION
## Description

Adds a transaction boundary around structural layout mutations — `onWillMutateLayout` / `onDidMutateLayout`, on the component and `DockviewApi`. Each top-level mutation brackets once; compound operations (a drag that internally removes the source panel, a `fromJSON` that adds N panels) bracket as a **single** transaction via a re-entrant depth counter.

```ts
api.onWillMutateLayout(e => { /* e.kind: 'add'|'remove'|'move'|'float'|'popout'|'load'|'clear' */ });
api.onDidMutateLayout(e => { ... });
```

Foundation for **undo/redo** (snapshot `toJSON()` on `onWillMutateLayout`), and equally useful for autosave, dirty-tracking and telemetry.

### How it works
A `mutation(kind, fn)` wrapper (sibling to the existing `movingLock`, but orthogonal — it does not suppress events) wraps each public mutation. Wrapping is **rename-and-wrap**: the method body is unchanged, renamed `_doX`, with a thin public `X` calling `mutation(kind, () => this._doX(...))`. Because internal mutation calls route through the public wrappers, nested operations join the outermost transaction via the depth counter, so the events fire exactly once.

### Coverage
- `addPanel` → `add`, `removePanel`/`removeGroup` → `remove`, `moveGroupOrPanel`/`moveGroup` → `move`
- `addFloatingGroup` → `float`, `addPopoutGroup` → `popout` (brackets the sync structural change; the window opens async after)
- `fromJSON` → `load` (one transaction for the whole load), `clear` → `clear`
- `maximize` is intentionally **not** included — it's a view-state change handled outside the component's structural methods; can be added to the union later (non-breaking).

## Type of change
- [x] New feature (mutation events)
- [x] Refactor / cleanup (rename-and-wrap; no body changes)

## Affected packages
- [x] `dockview-core`

## How to test
`layoutMutation.spec.ts` — add/remove/move/float/clear/removeGroup each bracket once; a compound move fires one `move` (not `move`+`remove`); `fromJSON` fires one `load` (not N adds); will-before-did ordering.

## Checklist
- [x] `yarn test` passes (full `dockview-core` suite: 1052)
- [x] prettier-clean + eslint-clean; typecheck clean
- [x] `npm run gen` run — adds `DockviewLayoutMutationEvent` / `DockviewLayoutMutationKind` exports
- [x] tests added
- [x] No breaking changes (additive events; mutation bodies unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)