### PR TITLE
feat(dockview-core): L5 announcements — assertive region, more events, pluggable announcer

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -7,6 +7,7 @@ AddPanelOptions
 AddPanelPositionOptions
 AddPaneviewComponentOptions
 AddSplitviewComponentOptions
+AnnouncementEvent
 BaseComponentOptions
 BaseGrid
 BaseGridOptions

--- a/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
@@ -2,6 +2,7 @@ import { DockviewComponent } from '../../dockview/dockviewComponent';
 import { IContentRenderer } from '../../dockview/types';
 import { ILiveRegionService } from '../../dockview/liveRegionService';
 import { AnnouncementEvent } from '../../dockview/options';
+import { setupMockWindow } from '../__mocks__/mockWindow';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');
@@ -216,6 +217,42 @@ describe('LiveRegion announcer', () => {
 
         p.api.group.api.maximize();
         expect(region().textContent).toBe('Vue agrandi');
+    });
+
+    test('announces a panel floating', () => {
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        const p2 = dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'P2',
+        });
+        dockview.addFloatingGroup(p2);
+        expect(region().textContent).toBe('P2 floated');
+    });
+
+    test('a normal grid split does not spuriously announce float/dock', () => {
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'P2',
+            position: { direction: 'right' },
+        });
+        // the only announcement is the open — group creation's initial
+        // `-> grid` transition must not read as a dock
+        expect(region().textContent).toBe('P2 opened');
+    });
+
+    test('announces a panel popping out to a new window', async () => {
+        window.open = () => setupMockWindow();
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        const p2 = dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'P2',
+        });
+        await dockview.addPopoutGroup(p2);
+        expect(region().textContent).toBe('P2 opened in a new window');
     });
 
     test('a custom announcer receives events; the DOM regions stay empty', () => {

--- a/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
@@ -1,6 +1,7 @@
 import { DockviewComponent } from '../../dockview/dockviewComponent';
 import { IContentRenderer } from '../../dockview/types';
 import { ILiveRegionService } from '../../dockview/liveRegionService';
+import { AnnouncementEvent } from '../../dockview/options';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');
@@ -160,5 +161,51 @@ describe('LiveRegion announcer', () => {
 
         dockview.removePanel(p1);
         expect(region().textContent).toBe('Orders closed'); // default kept
+    });
+
+    const assertiveRegion = (): HTMLElement =>
+        container.querySelector('.dv-live-region-assertive') as HTMLElement;
+
+    test('creates a separate assertive (alert) region', () => {
+        const r = assertiveRegion();
+        expect(r).toBeTruthy();
+        expect(r.getAttribute('role')).toBe('alert');
+        expect(r.getAttribute('aria-live')).toBe('assertive');
+    });
+
+    test('routes by politeness — assertive vs polite region', () => {
+        service().announce('routine');
+        expect(region().textContent).toBe('routine');
+        expect(assertiveRegion().textContent).toBe('');
+
+        service().announce('not allowed', 'assertive');
+        expect(assertiveRegion().textContent).toBe('not allowed');
+        expect(region().textContent).toBe('routine'); // polite untouched
+    });
+
+    test('a custom announcer receives events; the DOM regions stay empty', () => {
+        const events: AnnouncementEvent[] = [];
+        const c2 = document.createElement('div');
+        const dv2 = new DockviewComponent(c2, {
+            createComponent: () => new TestPanel(),
+            announcer: (e) => events.push(e),
+        });
+        dv2.layout(800, 600);
+        const svc = (
+            dv2 as unknown as {
+                _moduleRegistry: {
+                    services: { liveRegionService: ILiveRegionService };
+                };
+            }
+        )._moduleRegistry.services.liveRegionService;
+
+        svc.announce('hi', 'assertive');
+
+        expect(events).toEqual([{ message: 'hi', politeness: 'assertive' }]);
+        expect(c2.querySelector('.dv-live-region')?.textContent).toBe('');
+        expect(c2.querySelector('.dv-live-region-assertive')?.textContent).toBe(
+            ''
+        );
+        dv2.dispose();
     });
 });

--- a/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
@@ -183,6 +183,41 @@ describe('LiveRegion announcer', () => {
         expect(region().textContent).toBe('routine'); // polite untouched
     });
 
+    test('announces maximize and restore (via the active panel)', () => {
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'Orders' });
+        const p2 = dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'Chart',
+            position: { direction: 'right' },
+        });
+
+        p2.api.group.api.maximize();
+        expect(region().textContent).toBe('Chart maximized');
+
+        p2.api.group.api.exitMaximized();
+        expect(region().textContent).toBe('Chart restored');
+    });
+
+    test('maximize announcement is localisable via getAnnouncement', () => {
+        dockview.dispose();
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            getAnnouncement: ({ kind, panel }) =>
+                kind === 'maximize' ? `${panel.title} agrandi` : undefined,
+        });
+        dockview.layout(800, 600);
+        const p = dockview.addPanel({
+            id: 'p1',
+            component: 'default',
+            title: 'Vue',
+        });
+
+        p.api.group.api.maximize();
+        expect(region().textContent).toBe('Vue agrandi');
+    });
+
     test('a custom announcer receives events; the DOM regions stay empty', () => {
         const events: AnnouncementEvent[] = [];
         const c2 = document.createElement('div');

--- a/packages/dockview-core/src/dockview/liveRegionService.ts
+++ b/packages/dockview-core/src/dockview/liveRegionService.ts
@@ -4,8 +4,9 @@ import { IDockviewPanel } from './dockviewPanel';
 import {
     DockviewLayoutMutationEvent,
     DockviewLayoutMutationKind,
+    DockviewMaximizedGroupChanged,
 } from './dockviewComponent';
-import { DockviewComponentOptions } from './options';
+import { DockviewComponentOptions, LiveRegionEvent } from './options';
 import { defineModule } from './modules';
 
 /**
@@ -21,6 +22,7 @@ export interface ILiveRegionHost {
     readonly onDidRemovePanel: Event<IDockviewPanel>;
     readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent>;
     readonly onDidMutateLayout: Event<DockviewLayoutMutationEvent>;
+    readonly onDidMaximizedGroupChange: Event<DockviewMaximizedGroupChanged>;
 }
 
 export interface ILiveRegionService extends IDisposable {
@@ -94,10 +96,8 @@ export class LiveRegionService
         this.addDisposables(
             { dispose: () => this._polite.remove() },
             { dispose: () => this._assertive.remove() },
-            host.onDidAddPanel((panel) => this._announcePanel(panel, 'open')),
-            host.onDidRemovePanel((panel) =>
-                this._announcePanel(panel, 'close')
-            ),
+            host.onDidAddPanel((panel) => this._announce(panel, 'open')),
+            host.onDidRemovePanel((panel) => this._announce(panel, 'close')),
             // Bracket bulk transactions so a fromJSON / clear doesn't announce
             // every nested add/remove.
             host.onWillMutateLayout((e) => {
@@ -108,6 +108,15 @@ export class LiveRegionService
             host.onDidMutateLayout((e) => {
                 if (isBulk(e.kind)) {
                     this._suppressDepth = Math.max(0, this._suppressDepth - 1);
+                }
+            }),
+            host.onDidMaximizedGroupChange((e) => {
+                const panel = e.group.activePanel;
+                if (panel) {
+                    this._announce(
+                        panel,
+                        e.isMaximized ? 'maximize' : 'restore'
+                    );
                 }
             })
         );
@@ -139,9 +148,9 @@ export class LiveRegionService
         region.textContent = message;
     }
 
-    private _announcePanel(
+    private _announce(
         panel: IDockviewPanel,
-        kind: 'open' | 'close'
+        kind: LiveRegionEvent['kind']
     ): void {
         // The app may localise/override the message, suppress it (null / ''),
         // or fall through to the default (undefined).
@@ -154,9 +163,15 @@ export class LiveRegionService
 
     private _defaultMessage(
         panel: IDockviewPanel,
-        kind: 'open' | 'close'
+        kind: LiveRegionEvent['kind']
     ): string {
-        return `${panel.title ?? panel.id} ${kind === 'open' ? 'opened' : 'closed'}`;
+        const verb = {
+            open: 'opened',
+            close: 'closed',
+            maximize: 'maximized',
+            restore: 'restored',
+        }[kind];
+        return `${panel.title ?? panel.id} ${verb}`;
     }
 }
 

--- a/packages/dockview-core/src/dockview/liveRegionService.ts
+++ b/packages/dockview-core/src/dockview/liveRegionService.ts
@@ -36,11 +36,16 @@ export interface ILiveRegionService extends IDisposable {
 const isBulk = (kind: DockviewLayoutMutationKind): boolean =>
     kind === 'load' || kind === 'clear';
 
-function createLiveRegion(): HTMLElement {
+function createLiveRegion(politeness: 'polite' | 'assertive'): HTMLElement {
     const el = document.createElement('div');
-    el.className = 'dv-live-region';
-    el.setAttribute('role', 'status');
-    el.setAttribute('aria-live', 'polite');
+    el.className =
+        politeness === 'assertive'
+            ? 'dv-live-region-assertive'
+            : 'dv-live-region';
+    // assertive interrupts the SR (errors / cancellations); polite waits for a
+    // pause (routine status). `alert` implies assertive, `status` implies polite.
+    el.setAttribute('role', politeness === 'assertive' ? 'alert' : 'status');
+    el.setAttribute('aria-live', politeness);
     el.setAttribute('aria-atomic', 'true');
     // Visually hidden but kept in the accessibility tree (never display:none /
     // visibility:hidden, which would drop it from AT). Standard clip pattern.
@@ -60,28 +65,35 @@ function createLiveRegion(): HTMLElement {
 }
 
 /**
- * Narrates layout state changes to screen readers via a visually-hidden
- * `aria-live` region. Free / core (WCAG 4.1.3). Phase 1: open / close
- * announcements + the `announce()` sink; the bulk load/clear burst is
- * suppressed via the mutation-transaction events.
+ * Narrates layout state changes to screen readers via visually-hidden
+ * `aria-live` regions. Free / core (WCAG 4.1.3). Announces panel open/close +
+ * the shared `announce()` sink (the pro module narrates docking here too).
+ * Two regions: a **polite** one for routine status and an **assertive** one
+ * for errors/cancellations. The bulk load/clear burst is suppressed via the
+ * mutation-transaction events, and an app can take over delivery entirely with
+ * the `announcer` option.
  */
 export class LiveRegionService
     extends CompositeDisposable
     implements ILiveRegionService
 {
     private readonly _host: ILiveRegionHost;
-    private readonly _region: HTMLElement;
+    private readonly _polite: HTMLElement;
+    private readonly _assertive: HTMLElement;
     private _suppressDepth = 0;
 
     constructor(host: ILiveRegionHost) {
         super();
 
         this._host = host;
-        this._region = createLiveRegion();
-        host.element.appendChild(this._region);
+        this._polite = createLiveRegion('polite');
+        this._assertive = createLiveRegion('assertive');
+        host.element.appendChild(this._polite);
+        host.element.appendChild(this._assertive);
 
         this.addDisposables(
-            { dispose: () => this._region.remove() },
+            { dispose: () => this._polite.remove() },
+            { dispose: () => this._assertive.remove() },
             host.onDidAddPanel((panel) => this._announcePanel(panel, 'open')),
             host.onDidRemovePanel((panel) =>
                 this._announcePanel(panel, 'close')
@@ -103,7 +115,7 @@ export class LiveRegionService
 
     announce(
         message: string,
-        _politeness: 'polite' | 'assertive' = 'polite'
+        politeness: 'polite' | 'assertive' = 'polite'
     ): void {
         // Opt-out (read live so `updateOptions({ announcements })` applies).
         if (
@@ -113,9 +125,18 @@ export class LiveRegionService
         ) {
             return;
         }
+        // Apps can route announcements into their own SR system instead of the
+        // built-in regions (e.g. a shared app-wide live region).
+        const announcer = this._host.options.announcer;
+        if (announcer) {
+            announcer({ message, politeness });
+            return;
+        }
         // Clearing first forces SRs to re-announce an identical message.
-        this._region.textContent = '';
-        this._region.textContent = message;
+        const region =
+            politeness === 'assertive' ? this._assertive : this._polite;
+        region.textContent = '';
+        region.textContent = message;
     }
 
     private _announcePanel(

--- a/packages/dockview-core/src/dockview/liveRegionService.ts
+++ b/packages/dockview-core/src/dockview/liveRegionService.ts
@@ -1,6 +1,7 @@
 import { CompositeDisposable, IDisposable } from '../lifecycle';
 import { Event } from '../events';
 import { IDockviewPanel } from './dockviewPanel';
+import { DockviewGroupPanel } from './dockviewGroupPanel';
 import {
     DockviewLayoutMutationEvent,
     DockviewLayoutMutationKind,
@@ -23,6 +24,8 @@ export interface ILiveRegionHost {
     readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent>;
     readonly onDidMutateLayout: Event<DockviewLayoutMutationEvent>;
     readonly onDidMaximizedGroupChange: Event<DockviewMaximizedGroupChanged>;
+    readonly onDidAddGroup: Event<DockviewGroupPanel>;
+    readonly onDidRemoveGroup: Event<DockviewGroupPanel>;
 }
 
 export interface ILiveRegionService extends IDisposable {
@@ -83,6 +86,7 @@ export class LiveRegionService
     private readonly _polite: HTMLElement;
     private readonly _assertive: HTMLElement;
     private _suppressDepth = 0;
+    private readonly _locationSubs = new Map<string, IDisposable>();
 
     constructor(host: ILiveRegionHost) {
         super();
@@ -118,8 +122,45 @@ export class LiveRegionService
                         e.isMaximized ? 'maximize' : 'restore'
                     );
                 }
-            })
+            }),
+            // Narrate a group floating / docking back / popping out. A group is
+            // born in the grid then transitions, so track each group's previous
+            // location and ignore the no-op initial `-> grid`.
+            host.onDidAddGroup((group) => this._trackLocation(group)),
+            host.onDidRemoveGroup((group) => {
+                this._locationSubs.get(group.id)?.dispose();
+                this._locationSubs.delete(group.id);
+            }),
+            {
+                dispose: () => {
+                    this._locationSubs.forEach((sub) => sub.dispose());
+                    this._locationSubs.clear();
+                },
+            }
         );
+    }
+
+    private _trackLocation(group: DockviewGroupPanel): void {
+        let prev = group.api.location.type;
+        const sub = group.api.onDidLocationChange((e) => {
+            const next = e.location.type;
+            if (next === prev) {
+                return;
+            }
+            prev = next;
+            const panel = group.activePanel;
+            if (!panel) {
+                return;
+            }
+            const kind =
+                next === 'floating'
+                    ? 'float'
+                    : next === 'popout'
+                      ? 'popout'
+                      : 'dock';
+            this._announce(panel, kind);
+        });
+        this._locationSubs.set(group.id, sub);
     }
 
     announce(
@@ -165,13 +206,23 @@ export class LiveRegionService
         panel: IDockviewPanel,
         kind: LiveRegionEvent['kind']
     ): string {
-        const verb = {
-            open: 'opened',
-            close: 'closed',
-            maximize: 'maximized',
-            restore: 'restored',
-        }[kind];
-        return `${panel.title ?? panel.id} ${verb}`;
+        const name = panel.title ?? panel.id;
+        switch (kind) {
+            case 'open':
+                return `${name} opened`;
+            case 'close':
+                return `${name} closed`;
+            case 'maximize':
+                return `${name} maximized`;
+            case 'restore':
+                return `${name} restored`;
+            case 'float':
+                return `${name} floated`;
+            case 'dock':
+                return `${name} docked`;
+            case 'popout':
+                return `${name} opened in a new window`;
+        }
     }
 }
 

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -67,11 +67,20 @@ export interface DropOverlayModelParams {
 /** A layout change to be announced — see the `getAnnouncement` option. */
 export interface LiveRegionEvent {
     /**
-     * What changed: a panel was added (`'open'`) or removed (`'close'`), or a
-     * group was maximized (`'maximize'`) / restored (`'restore'`). `panel` is
-     * the affected panel — for group events, the group's active panel.
+     * What changed: a panel was added (`'open'`) or removed (`'close'`); a
+     * group was maximized (`'maximize'`) / restored (`'restore'`); or a group
+     * moved to a floating window (`'float'`), back into the grid (`'dock'`), or
+     * out to a popout window (`'popout'`). `panel` is the affected panel — for
+     * group events, the group's active panel.
      */
-    kind: 'open' | 'close' | 'maximize' | 'restore';
+    kind:
+        | 'open'
+        | 'close'
+        | 'maximize'
+        | 'restore'
+        | 'float'
+        | 'dock'
+        | 'popout';
     panel: IDockviewPanel;
 }
 

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -66,8 +66,12 @@ export interface DropOverlayModelParams {
 
 /** A layout change to be announced — see the `getAnnouncement` option. */
 export interface LiveRegionEvent {
-    /** `'open'` when a panel was added, `'close'` when it was removed. */
-    kind: 'open' | 'close';
+    /**
+     * What changed: a panel was added (`'open'`) or removed (`'close'`), or a
+     * group was maximized (`'maximize'`) / restored (`'restore'`). `panel` is
+     * the affected panel — for group events, the group's active panel.
+     */
+    kind: 'open' | 'close' | 'maximize' | 'restore';
     panel: IDockviewPanel;
 }
 

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -71,6 +71,14 @@ export interface LiveRegionEvent {
     panel: IDockviewPanel;
 }
 
+/** A resolved announcement handed to a custom `announcer`. */
+export interface AnnouncementEvent {
+    /** The (already localised) text to announce. */
+    message: string;
+    /** `'assertive'` interrupts the screen reader; `'polite'` waits for a pause. */
+    politeness: 'polite' | 'assertive';
+}
+
 /**
  * Key bindings for {@link DockviewComponentOptions.keyboardNavigation}. Each
  * value is a string of `+`-separated parts, modifiers first, e.g. `'ctrl+]'`,
@@ -289,6 +297,13 @@ export interface DockviewOptions {
      */
     getAnnouncement?: (event: LiveRegionEvent) => string | null | undefined;
     /**
+     * Route announcements to your own screen-reader infrastructure instead of
+     * the built-in `aria-live` regions (e.g. an app-wide live region). When
+     * set, dockview hands you each {@link AnnouncementEvent} and writes nothing
+     * to its own regions. `getAnnouncement` (localisation) still applies first.
+     */
+    announcer?: (event: AnnouncementEvent) => void;
+    /**
      * Operate the dock with the keyboard. `true` enables the default bindings;
      * pass an object to override individual ones via `keymap`. Off by default
      * (opt-in while the feature matures). Enables:
@@ -389,6 +404,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         dropOverlayModel: undefined,
         announcements: undefined,
         getAnnouncement: undefined,
+        announcer: undefined,
         keyboardNavigation: undefined,
         tabGroupColors: undefined,
         tabGroupAccent: undefined,


### PR DESCRIPTION
Layer-5 (screen-reader announcements) for the LiveRegion module. Builds on the open/close announcer already on master.

## What's added
- **Assertive region.** A second visually-hidden region (`role="alert"`, `aria-live="assertive"`) alongside the polite one; `announce(message, politeness)` now routes errors/cancellations to it so they interrupt the screen reader instead of queuing behind routine status.
- **More events announced.** Maximize/restore (via `onDidMaximizedGroupChange`) and float/dock/popout (via per-group `onDidLocationChange`, tracking each group's previous location so a normal grid split never misreads as a "dock"). All via the group's active panel.
- **Pluggable `announcer`.** New option to route every `AnnouncementEvent` to the app's own screen-reader infrastructure; when set, dockview writes nothing to its own regions.
- All messages flow through the existing `getAnnouncement` localisation hook. `LiveRegionEvent.kind` now covers `open | close | maximize | restore | float | dock | popout`.

## Tests
18 LiveRegion tests (+8); 1094 total. All jsdom-testable (announcements are DOM text), incl. popout via the mock window.

## Deferred (tracked)
- **Message catalog / full i18n set** — intentionally after the L4 PR (#1321) merges, so the catalog can also cover the docking-narration strings that live in the AccessibilityService there, in one place.
- **Debounce/coalesce** — optional; no high-frequency announcement source exists yet (active-change deliberately not announced, as focus already surfaces it).
- **Per-window regions** for popouts — folded with the deferred popout cross-window focus work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)