### PR TITLE
feat(dockview-core): i18n message catalog for accessibility strings

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -53,6 +53,7 @@ DockviewKeybindings
 DockviewLayoutMutationEvent
 DockviewLayoutMutationKind
 DockviewMaximizedGroupChanged
+DockviewMessages
 DockviewMutableDisposable
 DockviewOptions
 DockviewPanel

--- a/packages/dockview-core/src/__tests__/dockview/accessibilityDocking.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/accessibilityDocking.spec.ts
@@ -695,3 +695,47 @@ describe('accessibility: floating group Tab containment', () => {
         expect(document.activeElement).toBe(last); // not wrapped
     });
 });
+
+/**
+ * L5 i18n — the keyboard-docking narration flows through the same `messages`
+ * catalog as the announcements, so a translator owns every string.
+ */
+describe('accessibility: docking narration i18n', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+
+    afterEach(() => {
+        dockview.dispose();
+        container.remove();
+    });
+
+    test('the messages catalog localises docking narration', () => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            keyboardNavigation: true,
+            messages: {
+                movePickTarget: (source) => `Deplacement ${source}.`,
+                moveCancelled: () => 'Annule.',
+            },
+        });
+        dockview.layout(1000, 1000);
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'P2',
+            position: { direction: 'right' },
+        });
+        const region = container.querySelector(
+            '.dv-live-region'
+        ) as HTMLElement;
+
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+        expect(region.textContent).toBe('Deplacement P2.');
+
+        fireEvent.keyDown(dockview.element, { key: 'Escape' });
+        expect(region.textContent).toBe('Annule.');
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
@@ -255,6 +255,29 @@ describe('LiveRegion announcer', () => {
         expect(region().textContent).toBe('P2 opened in a new window');
     });
 
+    test('the messages catalog localises announcement strings', () => {
+        dockview.dispose();
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            messages: {
+                panelOpened: (t) => `${t} ouvert`,
+                groupFloated: (t) => `${t} flottant`,
+            },
+        });
+        dockview.layout(800, 600);
+
+        const p = dockview.addPanel({
+            id: 'p1',
+            component: 'default',
+            title: 'Vue',
+        });
+        expect(region().textContent).toBe('Vue ouvert');
+
+        dockview.addFloatingGroup(p);
+        expect(region().textContent).toBe('Vue flottant');
+    });
+
     test('a custom announcer receives events; the DOM regions stay empty', () => {
         const events: AnnouncementEvent[] = [];
         const c2 = document.createElement('div');

--- a/packages/dockview-core/src/dockview/accessibilityMessages.ts
+++ b/packages/dockview-core/src/dockview/accessibilityMessages.ts
@@ -1,0 +1,78 @@
+import { Position } from '../dnd/droptarget';
+
+/**
+ * The full set of localisable strings dockview speaks to assistive technology:
+ * the LiveRegion announcements and the keyboard-docking narration. Each entry
+ * returns the complete sentence so a translator owns wording *and* word order.
+ *
+ * Override any subset via the `messages` option; unset entries keep the
+ * English defaults below. For fine-grained, per-event announcement overrides
+ * (with access to the panel) use `getAnnouncement`, which takes precedence.
+ */
+export interface DockviewMessages {
+    // --- LiveRegion announcements (the affected panel's title) ---
+    panelOpened(title: string): string;
+    panelClosed(title: string): string;
+    groupMaximized(title: string): string;
+    groupRestored(title: string): string;
+    groupFloated(title: string): string;
+    groupDocked(title: string): string;
+    groupPoppedOut(title: string): string;
+
+    // --- keyboard-docking narration ---
+    /** Target phase: which group is highlighted, and how to proceed. */
+    movePickTarget(
+        source: string,
+        target: string,
+        current: number,
+        total: number
+    ): string;
+    /** Edge phase: which drop position is selected, and how to proceed. */
+    movePickEdge(position: Position, target: string): string;
+    /** A move committed. */
+    moveCommitted(source: string, target: string, position: Position): string;
+    /** A move cancelled with Escape. */
+    moveCancelled(): string;
+    /** A move the layout rejected. */
+    moveNotAllowed(): string;
+}
+
+/** Where a drop position lands, phrased for the *edge prompt*. */
+function edgeWhere(position: Position, target: string): string {
+    return position === 'center'
+        ? `Tab into ${target}`
+        : `Split ${position} of ${target}`;
+}
+
+/** Where a drop position landed, phrased for the *commit* sentence. */
+function committedWhere(position: Position, target: string): string {
+    return position === 'center'
+        ? `docked into ${target}`
+        : `split ${position} of ${target}`;
+}
+
+export const DEFAULT_MESSAGES: DockviewMessages = {
+    panelOpened: (title) => `${title} opened`,
+    panelClosed: (title) => `${title} closed`,
+    groupMaximized: (title) => `${title} maximized`,
+    groupRestored: (title) => `${title} restored`,
+    groupFloated: (title) => `${title} floated`,
+    groupDocked: (title) => `${title} docked`,
+    groupPoppedOut: (title) => `${title} opened in a new window`,
+
+    movePickTarget: (source, target, current, total) =>
+        `Moving ${source}. Target ${target}, ${current} of ${total}. Enter to choose where, Escape to cancel.`,
+    movePickEdge: (position, target) =>
+        `${edgeWhere(position, target)}. Arrows to change, Enter to confirm, Escape to go back.`,
+    moveCommitted: (source, target, position) =>
+        `${source} ${committedWhere(position, target)}.`,
+    moveCancelled: () => `Move cancelled.`,
+    moveNotAllowed: () => `That move is not allowed.`,
+};
+
+/** Merge an app's partial overrides over the English defaults. */
+export function resolveMessages(
+    overrides?: Partial<DockviewMessages>
+): DockviewMessages {
+    return overrides ? { ...DEFAULT_MESSAGES, ...overrides } : DEFAULT_MESSAGES;
+}

--- a/packages/dockview-core/src/dockview/accessibilityService.ts
+++ b/packages/dockview-core/src/dockview/accessibilityService.ts
@@ -9,6 +9,7 @@ import {
     DockviewKeybindings,
     KeyboardNavigationOptions,
 } from './options';
+import { resolveMessages } from './accessibilityMessages';
 import { defineModule } from './modules';
 import { AdvancedDnDModule } from './advancedDnDService';
 import { LiveRegionModule } from './liveRegionService';
@@ -472,7 +473,7 @@ export class AccessibilityService
                 this._render();
             } else {
                 this._exit();
-                this.host.announce('Move cancelled.');
+                this.host.announce(this._messages.moveCancelled());
                 this._restoreFocus();
             }
             return;
@@ -517,6 +518,10 @@ export class AccessibilityService
         }
     }
 
+    private get _messages() {
+        return resolveMessages(this.host.options.messages);
+    }
+
     private _render(): void {
         const move = this._move!;
         const group = move.groups[move.groupIndex];
@@ -524,16 +529,18 @@ export class AccessibilityService
         this._preview = this.host.showDropPreview(group, move.position);
 
         const name = group.activePanel?.title ?? group.id;
+        const m = this._messages;
         if (move.phase === 'target') {
             this.host.announce(
-                `Moving ${this._label(move.source)}. Target ${name}, ${
-                    move.groupIndex + 1
-                } of ${move.groups.length}. Enter to choose where, Escape to cancel.`
+                m.movePickTarget(
+                    this._label(move.source),
+                    name,
+                    move.groupIndex + 1,
+                    move.groups.length
+                )
             );
         } else {
-            this.host.announce(
-                `${this._describe(move.position)} ${name}. Arrows to change, Enter to confirm, Escape to go back.`
-            );
+            this.host.announce(m.movePickEdge(move.position, name));
         }
     }
 
@@ -543,26 +550,19 @@ export class AccessibilityService
         const position = move.position;
         const source = move.source;
         const name = group.activePanel?.title ?? group.id;
+        const m = this._messages;
         this._exit();
         try {
             this.host.dockPanel(source, group, position);
             this.host.announce(
-                `${this._label(source)} ${
-                    position === 'center'
-                        ? `docked into ${name}`
-                        : `split ${position} of ${name}`
-                }.`
+                m.moveCommitted(this._label(source), name, position)
             );
         } catch {
-            this.host.announce('That move is not allowed.');
+            this.host.announce(m.moveNotAllowed());
         }
         // The move re-renders the grid; pull focus back into the dock so the
         // keymap keeps working without a click.
         this._restoreFocus();
-    }
-
-    private _describe(position: Position): string {
-        return position === 'center' ? 'Tab into' : `Split ${position} of`;
     }
 
     private _exit(): void {

--- a/packages/dockview-core/src/dockview/liveRegionService.ts
+++ b/packages/dockview-core/src/dockview/liveRegionService.ts
@@ -8,6 +8,7 @@ import {
     DockviewMaximizedGroupChanged,
 } from './dockviewComponent';
 import { DockviewComponentOptions, LiveRegionEvent } from './options';
+import { resolveMessages } from './accessibilityMessages';
 import { defineModule } from './modules';
 
 /**
@@ -206,22 +207,23 @@ export class LiveRegionService
         panel: IDockviewPanel,
         kind: LiveRegionEvent['kind']
     ): string {
+        const m = resolveMessages(this._host.options.messages);
         const name = panel.title ?? panel.id;
         switch (kind) {
             case 'open':
-                return `${name} opened`;
+                return m.panelOpened(name);
             case 'close':
-                return `${name} closed`;
+                return m.panelClosed(name);
             case 'maximize':
-                return `${name} maximized`;
+                return m.groupMaximized(name);
             case 'restore':
-                return `${name} restored`;
+                return m.groupRestored(name);
             case 'float':
-                return `${name} floated`;
+                return m.groupFloated(name);
             case 'dock':
-                return `${name} docked`;
+                return m.groupDocked(name);
             case 'popout':
-                return `${name} opened in a new window`;
+                return m.groupPoppedOut(name);
         }
     }
 }

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -4,6 +4,8 @@ import { IGridView } from '../gridview/gridview';
 import { IContentRenderer, ITabRenderer, IWatermarkRenderer } from './types';
 import { Parameters } from '../panel/types';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
+import { DockviewMessages } from './accessibilityMessages';
+export type { DockviewMessages } from './accessibilityMessages';
 import { PanelTransfer } from '../dnd/dataTransfer';
 import { IDisposable } from '../lifecycle';
 import { DroptargetOverlayModel, Position } from '../dnd/droptarget';
@@ -317,6 +319,14 @@ export interface DockviewOptions {
      */
     announcer?: (event: AnnouncementEvent) => void;
     /**
+     * Translate / override the strings dockview speaks to assistive technology
+     * — both the LiveRegion announcements and the keyboard-docking narration.
+     * Provide any subset of {@link DockviewMessages}; unset entries keep the
+     * English defaults. (`getAnnouncement` still applies first, per-event, for
+     * announcements.)
+     */
+    messages?: Partial<DockviewMessages>;
+    /**
      * Operate the dock with the keyboard. `true` enables the default bindings;
      * pass an object to override individual ones via `keymap`. Off by default
      * (opt-in while the feature matures). Enables:
@@ -418,6 +428,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         announcements: undefined,
         getAnnouncement: undefined,
         announcer: undefined,
+        messages: undefined,
         keyboardNavigation: undefined,
         tabGroupColors: undefined,
         tabGroupAccent: undefined,


### PR DESCRIPTION
Completes the a11y pack's internationalisation: one place to translate every string dockview speaks to assistive technology.

## What changed
- New **`DockviewMessages`** catalog (`messages` option) covering both the **LiveRegion announcements** (open/close/maximize/float/dock/popout) and the **keyboard-docking narration** (pick-target / pick-edge prompts, commit, cancel, not-allowed). Each entry returns the complete sentence, so translators control wording *and* word order.
- `LiveRegionService` and `AccessibilityService` resolve their strings from the catalog (`{ ...defaults, ...options.messages }`). Defaults are byte-identical to the previous hardcoded strings.
- `getAnnouncement` still applies first, per-event, for announcements (fine-grained dynamic override); `messages` is the static translation surface.

## Why
Previously announcements were localisable via `getAnnouncement`, but the **docking narration was hardcoded English with no override**. This closes that gap and gives one coherent i18n surface for the whole pack.

## Tests
46 a11y tests (+2 catalog-override: one announcement, one docking-narration); 1107 total. Existing string assertions pass unchanged (defaults identical).