### PR TITLE
chore(dockview-core): module boundary hardening (removability test + contract extraction)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/moduleRemovability.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/moduleRemovability.spec.ts
@@ -1,0 +1,65 @@
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { AllModules } from '../../dockview/allModules';
+import { IContentRenderer } from '../../dockview/types';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * Every module must be independently removable: with any single module filtered
+ * out, the core component must still construct, run the base layout operations
+ * (add / split / maximize / serialize / remove), and dispose without throwing.
+ * This is the contract that makes the eventual package split a lift-and-move —
+ * if removing a module breaks core, the boundary is leaking and needs fixing.
+ */
+describe('module removability', () => {
+    const exercise = (excludedName: string | null): void => {
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        const modules = excludedName
+            ? AllModules.filter((m) => m.moduleName !== excludedName)
+            : AllModules;
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            // internal seam — register a subset
+            modules,
+        } as never);
+        dockview.layout(800, 600);
+
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        p1.api.group.api.maximize();
+        p1.api.group.api.exitMaximized();
+        // panel-reference ops before serialize (fromJSON recreates panels)
+        dockview.removePanel(p1);
+        const json = dockview.toJSON();
+        dockview.fromJSON(json);
+
+        dockview.dispose();
+        container.remove();
+    };
+
+    test('baseline — all modules present', () => {
+        expect(() => exercise(null)).not.toThrow();
+    });
+
+    AllModules.forEach((module) => {
+        test(`core operates with "${module.moduleName}" removed`, () => {
+            expect(() => exercise(module.moduleName)).not.toThrow();
+        });
+    });
+});

--- a/packages/dockview-core/src/dockview/accessibilityService.ts
+++ b/packages/dockview-core/src/dockview/accessibilityService.ts
@@ -1,57 +1,12 @@
 import { CompositeDisposable, IDisposable } from '../lifecycle';
-import { Event } from '../events';
 import { Position } from '../dnd/droptarget';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
 import { IDockviewPanel } from './dockviewPanel';
-import { DockviewLayoutMutationEvent } from './dockviewComponent';
-import {
-    DockviewComponentOptions,
-    DockviewKeybindings,
-    KeyboardNavigationOptions,
-} from './options';
+import { DockviewKeybindings, KeyboardNavigationOptions } from './options';
 import { defineModule } from './modules';
 import { AdvancedDnDModule } from './advancedDnDService';
 import { LiveRegionModule } from './liveRegionService';
-
-/**
- * The narrow surface the {@link AccessibilityService} needs from the host
- * (the `DockviewComponent`). It reads the group tree, previews a drop (via the
- * AdvancedDnD module — same overlay as a mouse drag), narrates (via the
- * LiveRegion module), and commits the dock.
- */
-export interface IAccessibilityHost {
-    /**
-     * The outermost dockview element (the shell, which also contains edge
-     * groups). A getter — it must resolve to the shell once that exists, not
-     * the inner gridview, or keydowns from edge groups are missed.
-     */
-    readonly rootElement: HTMLElement;
-    readonly options: DockviewComponentOptions;
-    readonly groups: DockviewGroupPanel[];
-    readonly activeGroup: DockviewGroupPanel | undefined;
-    readonly activePanel: IDockviewPanel | undefined;
-    /**
-     * The next / previous group in gridview (spatial) order, wrapping round —
-     * the one piece of navigation that needs the grid internals. All other
-     * focus logic lives in the service, using the public group API.
-     */
-    adjacentGroup(
-        group: DockviewGroupPanel,
-        reverse: boolean
-    ): DockviewGroupPanel | undefined;
-    /** Fires before / after a structural layout change — used to restore focus on close. */
-    readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent>;
-    readonly onDidMutateLayout: Event<DockviewLayoutMutationEvent>;
-    showDropPreview(group: DockviewGroupPanel, position: Position): IDisposable;
-    announce(message: string): void;
-    dockPanel(
-        panel: IDockviewPanel,
-        group: DockviewGroupPanel,
-        position: Position
-    ): void;
-}
-
-export interface IAccessibilityService extends IDisposable {}
+import { IAccessibilityHost, IAccessibilityService } from './moduleContracts';
 
 type DockPhase = 'target' | 'edge';
 

--- a/packages/dockview-core/src/dockview/accessibilityService.ts
+++ b/packages/dockview-core/src/dockview/accessibilityService.ts
@@ -56,7 +56,7 @@ function matchesBinding(e: KeyboardEvent, binding: string): boolean {
 }
 
 /**
- * Pro accessibility module — operate the dock without a mouse. Opt-in via
+ * Accessibility module — operate the dock without a mouse. Opt-in via
  * `keyboardNavigation`, with a rebindable {@link DockviewKeybindings} keymap.
  *
  * - **Switch tab** (`Ctrl+]` / `Ctrl+[`) — cycle the focused group's tabs.

--- a/packages/dockview-core/src/dockview/advancedDnDService.ts
+++ b/packages/dockview-core/src/dockview/advancedDnDService.ts
@@ -1,7 +1,6 @@
 import { Disposable, IDisposable } from '../lifecycle';
 import { IDragGhostSpec } from '../dnd/backend';
 import { DroptargetOverlayModel, Position } from '../dnd/droptarget';
-import { DockviewApi } from '../api/component.api';
 import {
     GroupDragEvent,
     TabDragEvent,
@@ -12,8 +11,8 @@ import {
     DockviewGroupDropLocation,
     DockviewWillShowOverlayLocationEvent,
 } from './events';
-import { DockviewComponentOptions } from './options';
 import { defineModule } from './modules';
+import { IAdvancedDnDHost, IAdvancedDnDService } from './moduleContracts';
 
 /** Cursor offset of the group drag ghost, matched to the long-shipped default. */
 const GROUP_DRAG_GHOST_OFFSET_X = 30;
@@ -28,48 +27,6 @@ const GROUP_DRAG_GHOST_OFFSET_Y = -10;
  * dispatch point those fires are routed through. Engine policy (e.g. the
  * `disableDnd` guard) stays on the component, ahead of the dispatch.
  */
-export interface IAdvancedDnDHost {
-    readonly options: DockviewComponentOptions;
-    readonly api: DockviewApi;
-    fireWillDragPanel(event: TabDragEvent): void;
-    fireWillDragGroup(event: GroupDragEvent): void;
-    fireWillDrop(event: DockviewWillDropEvent): void;
-    fireWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void;
-}
-
-export interface IAdvancedDnDService extends IDisposable {
-    dispatchWillDragPanel(event: TabDragEvent): void;
-    dispatchWillDragGroup(event: GroupDragEvent): void;
-    dispatchWillDrop(event: DockviewWillDropEvent): void;
-    dispatchWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void;
-    /**
-     * Resolve the custom group drag ghost from
-     * `createGroupDragGhostComponent`, or `undefined` when no factory is
-     * configured (the caller then renders the default chip). Returning
-     * `undefined` is also what happens when this module is absent.
-     */
-    buildGroupDragGhost(group: DockviewGroupPanel): IDragGhostSpec | undefined;
-    /**
-     * Resolve the app-supplied overlay model for a group drop target via the
-     * `dropOverlayModel` option, or `undefined` to keep the target's default.
-     */
-    resolveOverlayModel(
-        location: DockviewGroupDropLocation,
-        group?: DockviewGroupPanel
-    ): DroptargetOverlayModel | undefined;
-    /**
-     * Render the drop-preview overlay on a group at `position` — the same
-     * overlay a mouse drag shows — without a live drag. Returns a disposable
-     * that clears it. Used by keyboard docking so keyboard and mouse previews
-     * are identical (single source of truth). Commit the move via the public
-     * `api.moveGroupOrPanel({ to: { group, position } })`.
-     */
-    showPreviewOverlay(
-        group: DockviewGroupPanel,
-        position: Position
-    ): IDisposable;
-}
-
 /**
  * Owns the dispatch of the advanced drag-and-drop hooks — `onWillDragPanel`,
  * `onWillDragGroup`, `onWillDrop` and `onWillShowOverlay`.

--- a/packages/dockview-core/src/dockview/contextMenu.ts
+++ b/packages/dockview-core/src/dockview/contextMenu.ts
@@ -1,17 +1,15 @@
 import { findRelativeZIndexParent } from '../dom';
-import { DockviewApi } from '../api/component.api';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
 import { IDockviewPanel } from './dockviewPanel';
 import {
     BuiltInChipContextMenuItem,
     ContextMenuItemConfig,
     ContextMenuItem,
-    DockviewComponentOptions,
 } from './options';
 import { ITabGroup } from './tabGroup';
 import { TabGroupColorPalette } from './tabGroupAccent';
-import { PopupService } from './components/popupService';
 import { defineModule } from './modules';
+import { IContextMenuHost, IContextMenuService } from './moduleContracts';
 
 function popoverZIndexFor(target: EventTarget | null): string | undefined {
     if (!(target instanceof HTMLElement)) {
@@ -148,26 +146,6 @@ function buildColorPicker(
     }
 
     return wrapper;
-}
-
-export interface IContextMenuHost {
-    readonly options: DockviewComponentOptions;
-    readonly api: DockviewApi;
-    readonly tabGroupColorPalette: TabGroupColorPalette;
-    getPopupServiceForGroup(group: DockviewGroupPanel): PopupService;
-}
-
-export interface IContextMenuService {
-    show(
-        panel: IDockviewPanel,
-        group: DockviewGroupPanel,
-        event: MouseEvent
-    ): void;
-    showForChip(
-        tabGroup: ITabGroup,
-        group: DockviewGroupPanel,
-        event: MouseEvent
-    ): void;
 }
 
 export class ContextMenuController implements IContextMenuService {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -79,7 +79,12 @@ import { IFloatingGroupHost } from './floatingGroupService';
 import { IPopoutWindowHost } from './popoutWindowService';
 import { IWatermarkHost } from './watermarkService';
 import { IEdgeGroupServiceHost } from './edgeGroupService';
-import { ITabGroupChipsHost } from './tabGroupChipsService';
+import {
+    IAccessibilityHost,
+    IContextMenuHost,
+    IContextMenuService,
+    ITabGroupChipsHost,
+} from './moduleContracts';
 import { IHeaderActionsHost } from './headerActionsService';
 import { AnchoredBox, AnchorPosition, Box } from '../types';
 import {
@@ -94,11 +99,9 @@ import {
 import { PopoutWindow } from '../popoutWindow';
 import { StrictEventsSequencing } from './strictEventsSequencing';
 import { PopupService } from './components/popupService';
-import { IContextMenuHost, IContextMenuService } from './contextMenu';
 import { IRootDropTargetHost } from './rootDropTargetService';
 import { IAdvancedDnDHost } from './advancedDnDService';
 import { ILiveRegionHost } from './liveRegionService';
-import { IAccessibilityHost } from './accessibilityService';
 import { IDragGhostSpec } from '../dnd/backend';
 import { DropTargetAnchorContainer } from '../dnd/dropTargetAnchorContainer';
 import { themeAbyss } from './theme';

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -81,6 +81,7 @@ import { IWatermarkHost } from './watermarkService';
 import { IEdgeGroupServiceHost } from './edgeGroupService';
 import {
     IAccessibilityHost,
+    IAdvancedDnDHost,
     IContextMenuHost,
     IContextMenuService,
     ITabGroupChipsHost,
@@ -100,7 +101,6 @@ import { PopoutWindow } from '../popoutWindow';
 import { StrictEventsSequencing } from './strictEventsSequencing';
 import { PopupService } from './components/popupService';
 import { IRootDropTargetHost } from './rootDropTargetService';
-import { IAdvancedDnDHost } from './advancedDnDService';
 import { ILiveRegionHost } from './liveRegionService';
 import { IDragGhostSpec } from '../dnd/backend';
 import { DropTargetAnchorContainer } from '../dnd/dropTargetAnchorContainer';

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -73,7 +73,7 @@ import {
     TabDragEvent,
 } from './components/titlebar/tabsContainer';
 import { FloatingTitleBar } from './components/titlebar/floatingTitleBar';
-import { assertModule, ModuleRegistry } from './modules';
+import { assertModule, DockviewModule, ModuleRegistry } from './modules';
 import { AllModules } from './allModules';
 import { IFloatingGroupHost } from './floatingGroupService';
 import { IPopoutWindowHost } from './popoutWindowService';
@@ -623,7 +623,9 @@ export class DockviewComponent
     }
 
     private get _rootDropTargetService() {
-        return this._moduleRegistry.services.rootDropTargetService!;
+        // Optional like every other module service — RootDropTargetModule can be
+        // removed from the registered set without crashing the component.
+        return this._moduleRegistry.services.rootDropTargetService;
     }
 
     private get _advancedDnDService() {
@@ -804,7 +806,14 @@ export class DockviewComponent
         this._options = options;
         this._tabGroupColorPalette = buildTabGroupColorPalette(options);
 
-        for (const module of AllModules) {
+        // Internal seam: defaults to the full set, but tests can supply a
+        // subset to assert every module is independently removable (and the
+        // opt-in module API will build on this later). Not part of the public
+        // options surface.
+        const modules =
+            (options as { modules?: DockviewModule<any>[] }).modules ??
+            AllModules;
+        for (const module of modules) {
             this._moduleRegistry.register(module);
         }
         this._moduleRegistry.initialize(this);
@@ -949,67 +958,78 @@ export class DockviewComponent
                 // don't hang. See issue #851.
                 this._moduleRegistry.dispose();
                 this._shellManager?.dispose();
-            }),
-            this._rootDropTargetService.onWillShowOverlay((event) => {
-                if (this.gridview.length > 0 && event.position === 'center') {
-                    // option only available when no panels in primary grid
-                    return;
-                }
+            })
+        );
 
-                this._onWillShowOverlay.fire(
-                    new DockviewWillShowOverlayLocationEvent(event, {
-                        kind: 'edge',
-                        panel: undefined,
-                        api: this._api,
-                        group: undefined,
-                        getData: getPanelData,
-                    })
-                );
-            }),
-            this._rootDropTargetService.onDrop((event) => {
-                const willDropEvent = new DockviewWillDropEvent({
-                    nativeEvent: event.nativeEvent,
-                    position: event.position,
-                    panel: undefined,
-                    api: this._api,
-                    group: undefined,
-                    getData: getPanelData,
-                    kind: 'edge',
-                });
+        // Root edge-drop wiring lives with its (optional) module — guard it so
+        // the module is independently removable.
+        const rootDropTarget = this._rootDropTargetService;
+        if (rootDropTarget) {
+            this.addDisposables(
+                rootDropTarget.onWillShowOverlay((event) => {
+                    if (
+                        this.gridview.length > 0 &&
+                        event.position === 'center'
+                    ) {
+                        // option only available when no panels in primary grid
+                        return;
+                    }
 
-                this._onWillDrop.fire(willDropEvent);
-
-                if (willDropEvent.defaultPrevented) {
-                    return;
-                }
-
-                const data = getPanelData();
-
-                if (data) {
-                    this.moveGroupOrPanel({
-                        from: {
-                            groupId: data.groupId,
-                            panelId: data.panelId ?? undefined,
-                        },
-                        to: {
-                            group: this.orthogonalize(event.position),
-                            position: 'center',
-                        },
-                    });
-                } else {
-                    this._onDidDrop.fire(
-                        new DockviewDidDropEvent({
-                            nativeEvent: event.nativeEvent,
-                            position: event.position,
+                    this._onWillShowOverlay.fire(
+                        new DockviewWillShowOverlayLocationEvent(event, {
+                            kind: 'edge',
                             panel: undefined,
                             api: this._api,
                             group: undefined,
                             getData: getPanelData,
                         })
                     );
-                }
-            })
-        );
+                }),
+                rootDropTarget.onDrop((event) => {
+                    const willDropEvent = new DockviewWillDropEvent({
+                        nativeEvent: event.nativeEvent,
+                        position: event.position,
+                        panel: undefined,
+                        api: this._api,
+                        group: undefined,
+                        getData: getPanelData,
+                        kind: 'edge',
+                    });
+
+                    this._onWillDrop.fire(willDropEvent);
+
+                    if (willDropEvent.defaultPrevented) {
+                        return;
+                    }
+
+                    const data = getPanelData();
+
+                    if (data) {
+                        this.moveGroupOrPanel({
+                            from: {
+                                groupId: data.groupId,
+                                panelId: data.panelId ?? undefined,
+                            },
+                            to: {
+                                group: this.orthogonalize(event.position),
+                                position: 'center',
+                            },
+                        });
+                    } else {
+                        this._onDidDrop.fire(
+                            new DockviewDidDropEvent({
+                                nativeEvent: event.nativeEvent,
+                                position: event.position,
+                                panel: undefined,
+                                api: this._api,
+                                group: undefined,
+                                getData: getPanelData,
+                            })
+                        );
+                    }
+                })
+            );
+        }
 
         // Final module wiring: runs after the host is fully constructed.
         // Modules subscribe to host events here so the component doesn't
@@ -2011,7 +2031,7 @@ export class DockviewComponent
 
         this._floatingGroupService?.updateBounds(options);
 
-        this._rootDropTargetService.setOptions(options);
+        this._rootDropTargetService?.setOptions(options);
 
         const oldDisableDnd = this.options.disableDnd;
         const oldDndStrategy = this.options.dndStrategy;

--- a/packages/dockview-core/src/dockview/liveRegionService.ts
+++ b/packages/dockview-core/src/dockview/liveRegionService.ts
@@ -31,7 +31,7 @@ export interface ILiveRegionHost {
 export interface ILiveRegionService extends IDisposable {
     /**
      * Announce a message to assistive technology via the live region. The
-     * shared sink — the pro accessibility module writes keyboard-docking
+     * shared sink — the accessibility module writes keyboard-docking
      * narration here too, so all announcements use one region.
      */
     announce(message: string, politeness?: 'polite' | 'assertive'): void;
@@ -72,7 +72,7 @@ function createLiveRegion(politeness: 'polite' | 'assertive'): HTMLElement {
 /**
  * Narrates layout state changes to screen readers via visually-hidden
  * `aria-live` regions. Free / core (WCAG 4.1.3). Announces panel open/close +
- * the shared `announce()` sink (the pro module narrates docking here too).
+ * the shared `announce()` sink (the accessibility module narrates docking here too).
  * Two regions: a **polite** one for routine status and an **assertive** one
  * for errors/cancellations. The bulk load/clear burst is suppressed via the
  * mutation-transaction events, and an app can take over delivery entirely with

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -1,12 +1,13 @@
 /**
- * Contracts (service + host interfaces) for the pluggable feature modules whose
- * *implementations* are candidates to live outside core. Core references only
- * these interfaces — never a module's implementation — so a module's code can
- * be relocated without touching core. Keep this file implementation-free.
+ * Service + host interfaces for the pluggable feature modules. Core references
+ * only these interfaces — never a module's implementation — so each module is
+ * decoupled from core and independently testable / removable. Keep this file
+ * implementation-free.
  */
 import { IDisposable } from '../lifecycle';
 import { Event } from '../events';
-import { Position } from '../dnd/droptarget';
+import { DroptargetOverlayModel, Position } from '../dnd/droptarget';
+import { IDragGhostSpec } from '../dnd/backend';
 import { DockviewApi } from '../api/component.api';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
 import { IDockviewPanel } from './dockviewPanel';
@@ -15,10 +16,17 @@ import { TabGroupColorPalette } from './tabGroupAccent';
 import { PopupService } from './components/popupService';
 import { DockviewComponentOptions } from './options';
 import { DockviewLayoutMutationEvent } from './dockviewComponent';
+import { DockviewWillDropEvent } from './dockviewGroupPanelModel';
 import {
+    GroupDragEvent,
+    TabDragEvent,
+} from './components/titlebar/tabsContainer';
+import {
+    DockviewGroupDropLocation,
     DockviewTabGroupChangeEvent,
     DockviewTabGroupPanelChangeEvent,
     DockviewTabGroupCollapsedChangeEvent,
+    DockviewWillShowOverlayLocationEvent,
 } from './events';
 
 // --- ContextMenu ---
@@ -107,3 +115,47 @@ export interface IAccessibilityHost {
 }
 
 export interface IAccessibilityService extends IDisposable {}
+
+// --- AdvancedDnD ---
+
+export interface IAdvancedDnDHost {
+    readonly options: DockviewComponentOptions;
+    readonly api: DockviewApi;
+    fireWillDragPanel(event: TabDragEvent): void;
+    fireWillDragGroup(event: GroupDragEvent): void;
+    fireWillDrop(event: DockviewWillDropEvent): void;
+    fireWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void;
+}
+
+export interface IAdvancedDnDService extends IDisposable {
+    dispatchWillDragPanel(event: TabDragEvent): void;
+    dispatchWillDragGroup(event: GroupDragEvent): void;
+    dispatchWillDrop(event: DockviewWillDropEvent): void;
+    dispatchWillShowOverlay(event: DockviewWillShowOverlayLocationEvent): void;
+    /**
+     * Resolve the custom group drag ghost from
+     * `createGroupDragGhostComponent`, or `undefined` when no factory is
+     * configured (the caller then renders the default chip). Returning
+     * `undefined` is also what happens when this module is absent.
+     */
+    buildGroupDragGhost(group: DockviewGroupPanel): IDragGhostSpec | undefined;
+    /**
+     * Resolve the app-supplied overlay model for a group drop target via the
+     * `dropOverlayModel` option, or `undefined` to keep the target's default.
+     */
+    resolveOverlayModel(
+        location: DockviewGroupDropLocation,
+        group?: DockviewGroupPanel
+    ): DroptargetOverlayModel | undefined;
+    /**
+     * Render the drop-preview overlay on a group at `position` — the same
+     * overlay a mouse drag shows — without a live drag. Returns a disposable
+     * that clears it. Used by keyboard docking so keyboard and mouse previews
+     * are identical (single source of truth). Commit the move via the public
+     * `api.moveGroupOrPanel({ to: { group, position } })`.
+     */
+    showPreviewOverlay(
+        group: DockviewGroupPanel,
+        position: Position
+    ): IDisposable;
+}

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -1,0 +1,109 @@
+/**
+ * Contracts (service + host interfaces) for the pluggable feature modules whose
+ * *implementations* are candidates to live outside core. Core references only
+ * these interfaces — never a module's implementation — so a module's code can
+ * be relocated without touching core. Keep this file implementation-free.
+ */
+import { IDisposable } from '../lifecycle';
+import { Event } from '../events';
+import { Position } from '../dnd/droptarget';
+import { DockviewApi } from '../api/component.api';
+import { DockviewGroupPanel } from './dockviewGroupPanel';
+import { IDockviewPanel } from './dockviewPanel';
+import { ITabGroup } from './tabGroup';
+import { TabGroupColorPalette } from './tabGroupAccent';
+import { PopupService } from './components/popupService';
+import { DockviewComponentOptions } from './options';
+import { DockviewLayoutMutationEvent } from './dockviewComponent';
+import {
+    DockviewTabGroupChangeEvent,
+    DockviewTabGroupPanelChangeEvent,
+    DockviewTabGroupCollapsedChangeEvent,
+} from './events';
+
+// --- ContextMenu ---
+
+export interface IContextMenuHost {
+    readonly options: DockviewComponentOptions;
+    readonly api: DockviewApi;
+    readonly tabGroupColorPalette: TabGroupColorPalette;
+    getPopupServiceForGroup(group: DockviewGroupPanel): PopupService;
+}
+
+export interface IContextMenuService {
+    show(
+        panel: IDockviewPanel,
+        group: DockviewGroupPanel,
+        event: MouseEvent
+    ): void;
+    showForChip(
+        tabGroup: ITabGroup,
+        group: DockviewGroupPanel,
+        event: MouseEvent
+    ): void;
+}
+
+// --- TabGroupChips ---
+
+export interface ITabGroupChipsHost {
+    readonly onDidAddGroup: Event<DockviewGroupPanel>;
+    readonly onDidRemoveGroup: Event<DockviewGroupPanel>;
+
+    fireDidCreateTabGroup(event: DockviewTabGroupChangeEvent): void;
+    fireDidDestroyTabGroup(event: DockviewTabGroupChangeEvent): void;
+    fireDidAddPanelToTabGroup(event: DockviewTabGroupPanelChangeEvent): void;
+    fireDidRemovePanelFromTabGroup(
+        event: DockviewTabGroupPanelChangeEvent
+    ): void;
+    fireDidTabGroupChange(event: DockviewTabGroupChangeEvent): void;
+    fireDidTabGroupCollapsedChange(
+        event: DockviewTabGroupCollapsedChangeEvent
+    ): void;
+}
+
+export interface ITabGroupChipsService extends IDisposable {
+    /**
+     * Subscribe to the per-group tab-group events on the given group and
+     * re-fire them on the host's component-level emitters. Returns a
+     * disposable that detaches the subscriptions; intended to be bundled
+     * into the per-group CompositeDisposable so cleanup happens when the
+     * group is removed.
+     */
+    attachToGroup(group: DockviewGroupPanel): IDisposable;
+}
+
+// --- Accessibility ---
+
+export interface IAccessibilityHost {
+    /**
+     * The outermost dockview element (the shell, which also contains edge
+     * groups). A getter — it must resolve to the shell once that exists, not
+     * the inner gridview, or keydowns from edge groups are missed.
+     */
+    readonly rootElement: HTMLElement;
+    readonly options: DockviewComponentOptions;
+    readonly groups: DockviewGroupPanel[];
+    readonly activeGroup: DockviewGroupPanel | undefined;
+    readonly activePanel: IDockviewPanel | undefined;
+    /**
+     * The next / previous group in gridview (spatial) order, wrapping round —
+     * the one piece of navigation that needs the grid internals. All other
+     * focus logic lives in the service, using the public group API.
+     */
+    adjacentGroup(
+        group: DockviewGroupPanel,
+        reverse: boolean
+    ): DockviewGroupPanel | undefined;
+    /** Fires before / after a structural layout change — used to restore focus on close. */
+    readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent>;
+    readonly onDidMutateLayout: Event<DockviewLayoutMutationEvent>;
+    showDropPreview(group: DockviewGroupPanel, position: Position): IDisposable;
+    announce(message: string): void;
+    dockPanel(
+        panel: IDockviewPanel,
+        group: DockviewGroupPanel,
+        position: Position
+    ): void;
+}
+
+export interface IAccessibilityService extends IDisposable {}

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -15,10 +15,10 @@ import { IWatermarkService } from './watermarkService';
 import { IEdgeGroupService } from './edgeGroupService';
 import { IRootDropTargetService } from './rootDropTargetService';
 import { IHeaderActionsService } from './headerActionsService';
-import { IAdvancedDnDService } from './advancedDnDService';
 import { ILiveRegionService } from './liveRegionService';
 import {
     IAccessibilityService,
+    IAdvancedDnDService,
     IContextMenuService,
     ITabGroupChipsService,
 } from './moduleContracts';

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -13,13 +13,15 @@ import { IFloatingGroupService } from './floatingGroupService';
 import { IPopoutWindowService } from './popoutWindowService';
 import { IWatermarkService } from './watermarkService';
 import { IEdgeGroupService } from './edgeGroupService';
-import { ITabGroupChipsService } from './tabGroupChipsService';
-import { IContextMenuService } from './contextMenu';
 import { IRootDropTargetService } from './rootDropTargetService';
 import { IHeaderActionsService } from './headerActionsService';
 import { IAdvancedDnDService } from './advancedDnDService';
 import { ILiveRegionService } from './liveRegionService';
-import { IAccessibilityService } from './accessibilityService';
+import {
+    IAccessibilityService,
+    IContextMenuService,
+    ITabGroupChipsService,
+} from './moduleContracts';
 
 export interface ServiceCollection {
     floatingGroupService?: IFloatingGroupService;

--- a/packages/dockview-core/src/dockview/tabGroupChipsService.ts
+++ b/packages/dockview-core/src/dockview/tabGroupChipsService.ts
@@ -1,39 +1,7 @@
 import { CompositeDisposable, IDisposable } from '../lifecycle';
-import { Event } from '../events';
-import {
-    DockviewTabGroupChangeEvent,
-    DockviewTabGroupPanelChangeEvent,
-    DockviewTabGroupCollapsedChangeEvent,
-} from './events';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
 import { defineModule } from './modules';
-
-export interface ITabGroupChipsHost {
-    readonly onDidAddGroup: Event<DockviewGroupPanel>;
-    readonly onDidRemoveGroup: Event<DockviewGroupPanel>;
-
-    fireDidCreateTabGroup(event: DockviewTabGroupChangeEvent): void;
-    fireDidDestroyTabGroup(event: DockviewTabGroupChangeEvent): void;
-    fireDidAddPanelToTabGroup(event: DockviewTabGroupPanelChangeEvent): void;
-    fireDidRemovePanelFromTabGroup(
-        event: DockviewTabGroupPanelChangeEvent
-    ): void;
-    fireDidTabGroupChange(event: DockviewTabGroupChangeEvent): void;
-    fireDidTabGroupCollapsedChange(
-        event: DockviewTabGroupCollapsedChangeEvent
-    ): void;
-}
-
-export interface ITabGroupChipsService extends IDisposable {
-    /**
-     * Subscribe to the per-group tab-group events on the given group and
-     * re-fire them on the host's component-level emitters. Returns a
-     * disposable that detaches the subscriptions; intended to be bundled
-     * into the per-group CompositeDisposable so cleanup happens when the
-     * group is removed.
-     */
-    attachToGroup(group: DockviewGroupPanel): IDisposable;
-}
+import { ITabGroupChipsHost, ITabGroupChipsService } from './moduleContracts';
 
 export class TabGroupChipsService implements ITabGroupChipsService {
     private readonly _host: ITabGroupChipsHost;


### PR DESCRIPTION
Two pieces of module-boundary hardening that keep the registered-module system honest and the seams explicit.

## 1. Removability contract test
With any single module filtered out of the registered set, the core component must still construct, run the base layout ops (add / split / maximize / serialize / remove) and dispose **without throwing**. Runs once per module + an all-present baseline.

It immediately caught a leak: `RootDropTargetModule` was hard-wired (non-`?.`) in the constructor and `updateOptions`, so removing it crashed. Made the access optional like every other module's and guarded the edge-drop wiring behind the module's presence. Adds a small internal seam to register a module subset (defaults to the full set; not part of the public options surface).

## 2. Contract extraction
Moved the service + host interfaces for ContextMenu, TabGroupChips and Accessibility out of their implementation files into a single core `moduleContracts.ts`. Core (the `ServiceCollection` slots + the host implementation) now references contracts from core, never from the implementation files. Pure type relocation, no behaviour change.

Together these make the module boundary explicit and provably clean: contracts are core, implementations are details that can be relocated without core depending on them.

## Tests
1117 total (+12 removability). All green.