### PR TITLE
feat(dockview-core): tag layout-mutation origin and complete mutation-boundary coverage

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -52,6 +52,7 @@ DockviewIDisposable
 DockviewKeybindings
 DockviewLayoutMutationEvent
 DockviewLayoutMutationKind
+DockviewLayoutMutationOrigin
 DockviewMaximizedGroupChanged
 DockviewMessages
 DockviewMutableDisposable

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -281,7 +281,10 @@ describe('layout mutation events', () => {
         });
 
         test('a compound api mutation stays "api" through nested teardown', () => {
-            const p1 = dockview.api.addPanel({ id: 'p1', component: 'default' });
+            const p1 = dockview.api.addPanel({
+                id: 'p1',
+                component: 'default',
+            });
             dockview.api.addPanel({
                 id: 'p2',
                 component: 'default',

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -124,6 +124,125 @@ describe('layout mutation events', () => {
         expect(did).toEqual(['load']);
     });
 
+    test('addGroup brackets one "add" transaction', () => {
+        dockview.addGroup();
+        expect(will).toEqual(['add']);
+        expect(did).toEqual(['add']);
+    });
+
+    test('closeAllGroups brackets a single "remove" transaction', () => {
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        will.length = 0;
+        did.length = 0;
+
+        // Multiple panels across multiple groups must collapse into one
+        // transaction, not one-per-panel.
+        dockview.closeAllGroups();
+        expect(will).toEqual(['remove']);
+        expect(did).toEqual(['remove']);
+    });
+
+    test('addEdgeGroup brackets one "add" transaction', () => {
+        dockview.addEdgeGroup('left', { id: 'edge-left' });
+        expect(will).toEqual(['add']);
+        expect(did).toEqual(['add']);
+    });
+
+    test('removeEdgeGroup brackets a single "remove" transaction', () => {
+        dockview.addEdgeGroup('left', { id: 'edge-left' });
+        dockview.addPanel({
+            id: 'p1',
+            component: 'default',
+            position: { referenceGroup: 'edge-left' },
+        });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { referenceGroup: 'edge-left' },
+        });
+        will.length = 0;
+        did.length = 0;
+
+        dockview.removeEdgeGroup('left');
+        expect(will).toEqual(['remove']);
+        expect(did).toEqual(['remove']);
+    });
+
+    describe('tab group mutations', () => {
+        test('createTabGroup brackets one "tab-group" transaction', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            will.length = 0;
+            did.length = 0;
+
+            dockview.api.createTabGroup({ groupId: p1.group.id });
+            expect(will).toEqual(['tab-group']);
+            expect(did).toEqual(['tab-group']);
+        });
+
+        test('addPanelToTabGroup brackets one "tab-group" transaction', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            const tg = dockview.api.createTabGroup({ groupId: p1.group.id });
+            will.length = 0;
+            did.length = 0;
+
+            dockview.api.addPanelToTabGroup({
+                groupId: p1.group.id,
+                tabGroupId: tg.id,
+                panelId: 'p1',
+            });
+            expect(will).toEqual(['tab-group']);
+            expect(did).toEqual(['tab-group']);
+        });
+
+        test('moving a panel between tab groups fires one "tab-group", not two', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            const tg1 = dockview.api.createTabGroup({ groupId: p1.group.id });
+            const tg2 = dockview.api.createTabGroup({ groupId: p1.group.id });
+            dockview.api.addPanelToTabGroup({
+                groupId: p1.group.id,
+                tabGroupId: tg1.id,
+                panelId: 'p1',
+            });
+            will.length = 0;
+            did.length = 0;
+
+            // The destination add internally removes p1 from tg1 first; that
+            // nested removePanelFromTabGroup must not open its own transaction.
+            dockview.api.addPanelToTabGroup({
+                groupId: p1.group.id,
+                tabGroupId: tg2.id,
+                panelId: 'p1',
+            });
+            expect(will).toEqual(['tab-group']);
+            expect(did).toEqual(['tab-group']);
+        });
+
+        test('an "already in this group" no-op fires nothing', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            const tg = dockview.api.createTabGroup({ groupId: p1.group.id });
+            dockview.api.addPanelToTabGroup({
+                groupId: p1.group.id,
+                tabGroupId: tg.id,
+                panelId: 'p1',
+            });
+            will.length = 0;
+            did.length = 0;
+
+            dockview.api.addPanelToTabGroup({
+                groupId: p1.group.id,
+                tabGroupId: tg.id,
+                panelId: 'p1',
+            });
+            expect(will).toEqual([]);
+            expect(did).toEqual([]);
+        });
+    });
+
     test('onWillMutateLayout fires before onDidMutateLayout', () => {
         const order: string[] = [];
         dockview.onWillMutateLayout(() => order.push('will'));
@@ -131,5 +250,57 @@ describe('layout mutation events', () => {
 
         dockview.addPanel({ id: 'p1', component: 'default' });
         expect(order).toEqual(['will', 'did']);
+    });
+
+    describe('mutation origin', () => {
+        let origins: string[];
+
+        beforeEach(() => {
+            origins = [];
+            dockview.onDidMutateLayout((e) => origins.push(e.origin));
+        });
+
+        test('a direct (component) mutation is tagged "user"', () => {
+            // Driving the component directly models the DnD / tab-UI /
+            // keyboard paths that never pass through the DockviewApi.
+            dockview.addPanel({ id: 'p1', component: 'default' });
+            expect(origins).toEqual(['user']);
+        });
+
+        test('a programmatic DockviewApi mutation is tagged "api"', () => {
+            dockview.api.addPanel({ id: 'p1', component: 'default' });
+            expect(origins).toEqual(['api']);
+        });
+
+        test('a programmatic tab-group mutation is tagged "api"', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            origins.length = 0;
+
+            dockview.api.createTabGroup({ groupId: p1.group.id });
+            expect(origins).toEqual(['api']);
+        });
+
+        test('a compound api mutation stays "api" through nested teardown', () => {
+            const p1 = dockview.api.addPanel({ id: 'p1', component: 'default' });
+            dockview.api.addPanel({
+                id: 'p2',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            origins.length = 0;
+
+            // Floating p1 brackets one 'float' transaction whose body removes
+            // the source group (a nested mutation). The outer api origin must
+            // survive — a nested call must not reset it to 'user'.
+            dockview.api.addFloatingGroup(p1);
+            expect(origins).toEqual(['api']);
+        });
+
+        test('origin restores to "user" after an api call completes', () => {
+            dockview.api.addPanel({ id: 'p1', component: 'default' });
+            dockview.addPanel({ id: 'p2', component: 'default' });
+            expect(origins).toEqual(['api', 'user']);
+            expect(dockview.mutationOrigin()).toBe('user');
+        });
     });
 });

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -173,6 +173,55 @@ describe('layout mutation events', () => {
         expect(did).toEqual(['remove']);
     });
 
+    test('maximizeGroup brackets one "maximize" transaction', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        will.length = 0;
+        did.length = 0;
+
+        dockview.maximizeGroup(p1.group);
+        expect(will).toEqual(['maximize']);
+        expect(did).toEqual(['maximize']);
+    });
+
+    test('exitMaximizedGroup brackets one "maximize" transaction', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        dockview.maximizeGroup(p1.group);
+        will.length = 0;
+        did.length = 0;
+
+        dockview.exitMaximizedGroup();
+        expect(will).toEqual(['maximize']);
+        expect(did).toEqual(['maximize']);
+    });
+
+    test('maximize state survives a toJSON/fromJSON round-trip', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        dockview.maximizeGroup(p1.group);
+        expect(dockview.hasMaximizedGroup()).toBe(true);
+
+        const json = dockview.toJSON();
+        dockview.fromJSON(json);
+
+        // Confirms the seam fires on a restorable state — undo/redo via
+        // fromJSON can put the maximize back.
+        expect(dockview.hasMaximizedGroup()).toBe(true);
+    });
+
     describe('tab group mutations', () => {
         test('createTabGroup brackets one "tab-group" transaction', () => {
             const p1 = dockview.addPanel({ id: 'p1', component: 'default' });

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -891,14 +891,18 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
     addPanel<T extends object = Parameters>(
         options: AddPanelOptions<T>
     ): IDockviewPanel {
-        return this.component.addPanel(options);
+        return this.component.withMutationOrigin('api', () =>
+            this.component.addPanel(options)
+        );
     }
 
     /**
      * Remove a panel given the panel object.
      */
     removePanel(panel: IDockviewPanel): void {
-        this.component.removePanel(panel);
+        this.component.withMutationOrigin('api', () =>
+            this.component.removePanel(panel)
+        );
     }
 
     /**
@@ -912,14 +916,18 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      * Close all groups and panels.
      */
     closeAllGroups(): void {
-        return this.component.closeAllGroups();
+        return this.component.withMutationOrigin('api', () =>
+            this.component.closeAllGroups()
+        );
     }
 
     /**
      * Remove a group and any panels within the group.
      */
     removeGroup(group: IDockviewGroupPanel): void {
-        this.component.removeGroup(<DockviewGroupPanel>group);
+        this.component.withMutationOrigin('api', () =>
+            this.component.removeGroup(<DockviewGroupPanel>group)
+        );
     }
 
     /**
@@ -936,7 +944,9 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         item: IDockviewPanel | DockviewGroupPanel,
         options?: FloatingGroupOptions
     ): void {
-        return this.component.addFloatingGroup(item, options);
+        return this.component.withMutationOrigin('api', () =>
+            this.component.addFloatingGroup(item, options)
+        );
     }
 
     /**
@@ -946,7 +956,9 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         data: SerializedDockview,
         options?: { reuseExistingPanels: boolean }
     ): void {
-        this.component.fromJSON(data, options);
+        this.component.withMutationOrigin('api', () =>
+            this.component.fromJSON(data, options)
+        );
     }
 
     /**
@@ -960,7 +972,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      * Reset the component back to an empty and default state.
      */
     clear(): void {
-        this.component.clear();
+        this.component.withMutationOrigin('api', () => this.component.clear());
     }
 
     /**
@@ -1005,7 +1017,9 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
             onWillClose?: (event: { id: string; window: Window }) => void;
         }
     ): Promise<boolean> {
-        return this.component.addPopoutGroup(item, options);
+        return this.component.withMutationOrigin('api', () =>
+            this.component.addPopoutGroup(item, options)
+        );
     }
 
     /**
@@ -1072,16 +1086,20 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         componentParams?: Record<string, unknown>;
     }): ITabGroup {
         const model = this._getGroupModel(options.groupId);
-        return model.createTabGroup({
-            label: options.label,
-            color: options.color,
-            componentParams: options.componentParams,
-        });
+        return this.component.withMutationOrigin('api', () =>
+            model.createTabGroup({
+                label: options.label,
+                color: options.color,
+                componentParams: options.componentParams,
+            })
+        );
     }
 
     dissolveTabGroup(options: { groupId: string; tabGroupId: string }): void {
         const model = this._getGroupModel(options.groupId);
-        model.dissolveTabGroup(options.tabGroupId);
+        this.component.withMutationOrigin('api', () =>
+            model.dissolveTabGroup(options.tabGroupId)
+        );
     }
 
     addPanelToTabGroup(options: {
@@ -1091,10 +1109,12 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         index?: number;
     }): void {
         const model = this._getGroupModel(options.groupId);
-        model.addPanelToTabGroup(
-            options.tabGroupId,
-            options.panelId,
-            options.index
+        this.component.withMutationOrigin('api', () =>
+            model.addPanelToTabGroup(
+                options.tabGroupId,
+                options.panelId,
+                options.index
+            )
         );
     }
 
@@ -1103,7 +1123,9 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         panelId: string;
     }): void {
         const model = this._getGroupModel(options.groupId);
-        model.removePanelFromTabGroup(options.panelId);
+        this.component.withMutationOrigin('api', () =>
+            model.removePanelFromTabGroup(options.panelId)
+        );
     }
 
     getTabGroups(options: DockviewGetTabGroupsOptions): readonly ITabGroup[] {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -278,6 +278,7 @@ export type DockviewLayoutMutationKind =
     | 'move'
     | 'float'
     | 'popout'
+    | 'maximize'
     | 'tab-group'
     | 'load'
     | 'clear';
@@ -4018,6 +4019,19 @@ export class DockviewComponent
 
     moveGroup(options: MoveGroupOptions): void {
         this.mutation('move', () => this._doMoveGroup(options));
+    }
+
+    // Bracket maximize/restore as a 'maximize' transaction. The maximized node
+    // is serialized by the gridview (`SerializedGridview.maximizedNode`), so
+    // the state round-trips through toJSON/fromJSON and is restorable on undo.
+    // When the exit is a side-effect of another bracketed operation (e.g. a
+    // move that activates a different group) the depth counter folds it in.
+    override maximizeGroup(panel: DockviewGroupPanel): void {
+        this.mutation('maximize', () => super.maximizeGroup(panel));
+    }
+
+    override exitMaximizedGroup(): void {
+        this.mutation('maximize', () => super.exitMaximizedGroup());
     }
 
     private _doMoveGroup(options: MoveGroupOptions): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -278,11 +278,22 @@ export type DockviewLayoutMutationKind =
     | 'move'
     | 'float'
     | 'popout'
+    | 'tab-group'
     | 'load'
     | 'clear';
 
+/**
+ * Who caused a layout mutation: `'user'` for mutations driven by direct
+ * interaction (drag-and-drop, tab UI, keyboard docking) and `'api'` for those
+ * entered through a {@link DockviewApi} method called by application code.
+ * Lets consumers (e.g. an undo stack) treat the app's own programmatic changes
+ * differently from end-user gestures.
+ */
+export type DockviewLayoutMutationOrigin = 'user' | 'api';
+
 export interface DockviewLayoutMutationEvent {
     readonly kind: DockviewLayoutMutationKind;
+    readonly origin: DockviewLayoutMutationOrigin;
 }
 
 export interface PopoutGroupChangeSizeEvent {
@@ -306,6 +317,11 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     readonly onWillDrop: Event<DockviewWillDropEvent>;
     readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent>;
     readonly onDidMutateLayout: Event<DockviewLayoutMutationEvent>;
+    mutationOrigin(): DockviewLayoutMutationOrigin;
+    withMutationOrigin<T>(
+        origin: DockviewLayoutMutationOrigin,
+        func: () => T
+    ): T;
     readonly onWillShowOverlay: Event<DockviewWillShowOverlayLocationEvent>;
     readonly onDidRemovePanel: Event<IDockviewPanel>;
     readonly onDidAddPanel: Event<IDockviewPanel>;
@@ -423,6 +439,10 @@ export class DockviewComponent
     // Compound operations (e.g. a drag that relocates a panel) nest via the
     // depth counter and bracket as a single transaction. See `mutation()`.
     private _mutationDepth = 0;
+    // Current mutation origin. Defaults to `'user'`; the DockviewApi boundary
+    // flips it to `'api'` for the duration of a programmatic call via
+    // `withMutationOrigin`. Nested mutations inherit the outer origin.
+    private _mutationOrigin: DockviewLayoutMutationOrigin = 'user';
     private readonly _onWillMutateLayout =
         new Emitter<DockviewLayoutMutationEvent>();
     readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent> =
@@ -2147,27 +2167,29 @@ export class DockviewComponent
             );
         }
 
-        const group = this.createGroup({ id: options.id });
-        group.model.location = { type: 'edge', position };
-        group.model.headerPosition = position;
+        return this.mutation('add', () => {
+            const group = this.createGroup({ id: options.id });
+            group.model.location = { type: 'edge', position };
+            group.model.headerPosition = position;
 
-        // Collapse when the group becomes empty
-        const autoCollapseDisposable = group.model.onDidRemovePanel(() => {
-            if (group.model.isEmpty) {
-                this.setEdgeGroupCollapsed(group, true);
-            }
+            // Collapse when the group becomes empty
+            const autoCollapseDisposable = group.model.onDidRemovePanel(() => {
+                if (group.model.isEmpty) {
+                    this.setEdgeGroupCollapsed(group, true);
+                }
+            });
+
+            service.add(position, group, autoCollapseDisposable);
+            this._onDidAddGroup.fire(group);
+
+            this._shellManager!.addEdgeView(
+                position,
+                options,
+                group as IEdgeGroupHost
+            );
+
+            return group.api;
         });
-
-        service.add(position, group, autoCollapseDisposable);
-        this._onDidAddGroup.fire(group);
-
-        this._shellManager!.addEdgeView(
-            position,
-            options,
-            group as IEdgeGroupHost
-        );
-
-        return group.api;
     }
 
     getEdgeGroup(
@@ -2200,22 +2222,26 @@ export class DockviewComponent
             );
         }
 
-        // Remove panels inside the group first
-        for (const panel of [...group.panels]) {
-            this.removePanel(panel, {
-                removeEmptyGroup: false,
-                skipDispose: false,
-            });
-        }
+        // One transaction — the per-panel removals below nest via the depth
+        // counter, so consumers see a single edge-group removal.
+        this.mutation('remove', () => {
+            // Remove panels inside the group first
+            for (const panel of [...group.panels]) {
+                this.removePanel(panel, {
+                    removeEmptyGroup: false,
+                    skipDispose: false,
+                });
+            }
 
-        // Remove from the shell splitview
-        this._shellManager!.removeEdgeView(position);
+            // Remove from the shell splitview
+            this._shellManager!.removeEdgeView(position);
 
-        // Clean up service-tracked state + group itself
-        service.remove(position);
-        group.dispose();
-        this._groups.delete(group.id);
-        this._onDidRemoveGroup.fire(group);
+            // Clean up service-tracked state + group itself
+            service.remove(position);
+            group.dispose();
+            this._groups.delete(group.id);
+            this._onDidRemoveGroup.fire(group);
+        });
     }
 
     setEdgeGroupCollapsed(group: DockviewGroupPanel, collapsed: boolean): void {
@@ -2867,11 +2893,15 @@ export class DockviewComponent
     }
 
     closeAllGroups(): void {
-        for (const entry of this._groups.entries()) {
-            const [_, group] = entry;
+        // One transaction — the per-panel removals inside nest via the depth
+        // counter, so consumers (undo, announcements) see a single mutation.
+        this.mutation('remove', () => {
+            for (const entry of this._groups.entries()) {
+                const [_, group] = entry;
 
-            group.value.model.closeAllPanels();
-        }
+                group.value.model.closeAllPanels();
+            }
+        });
     }
 
     addPanel<T extends object = Parameters>(
@@ -3133,6 +3163,10 @@ export class DockviewComponent
     }
 
     addGroup(options?: AddGroupOptions): DockviewGroupPanel {
+        return this.mutation('add', () => this._doAddGroup(options));
+    }
+
+    private _doAddGroup(options?: AddGroupOptions): DockviewGroupPanel {
         if (options) {
             let referenceGroup: DockviewGroupPanel | undefined;
 
@@ -3482,8 +3516,9 @@ export class DockviewComponent
      */
     mutation<T>(kind: DockviewLayoutMutationKind, func: () => T): T {
         const outer = this._mutationDepth === 0;
+        const origin = this._mutationOrigin;
         if (outer) {
-            this._onWillMutateLayout.fire({ kind });
+            this._onWillMutateLayout.fire({ kind, origin });
         }
         this._mutationDepth++;
         try {
@@ -3491,8 +3526,42 @@ export class DockviewComponent
         } finally {
             this._mutationDepth--;
             if (outer) {
-                this._onDidMutateLayout.fire({ kind });
+                this._onDidMutateLayout.fire({ kind, origin });
             }
+        }
+    }
+
+    /**
+     * The origin of the mutation currently in progress (`'user'` by default).
+     * Read inside a `mutation()`'s lifetime to learn whether the change was
+     * driven by application code (via the {@link DockviewApi}) or a user
+     * gesture.
+     */
+    mutationOrigin(): DockviewLayoutMutationOrigin {
+        return this._mutationOrigin;
+    }
+
+    /**
+     * Run `func` with the mutation origin set to `origin`, restoring the
+     * previous value afterwards. Used by the DockviewApi boundary to tag
+     * programmatic mutations as `'api'`; nested mutations inherit the
+     * outermost origin (a re-entrant call does not overwrite it).
+     */
+    withMutationOrigin<T>(
+        origin: DockviewLayoutMutationOrigin,
+        func: () => T
+    ): T {
+        // Only the outermost caller sets the origin — a nested mutation keeps
+        // whatever the enclosing operation established.
+        if (this._mutationDepth > 0) {
+            return func();
+        }
+        const previous = this._mutationOrigin;
+        this._mutationOrigin = origin;
+        try {
+            return func();
+        } finally {
+            this._mutationOrigin = previous;
         }
     }
 

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -688,7 +688,26 @@ export class DockviewGroupPanelModel
         });
     }
 
+    /**
+     * Bracket a tab-group mutation as a layout transaction. `accessor` is
+     * always a full {@link DockviewComponent} in production; the optional-call
+     * fallback keeps partial test doubles (which omit `mutation`) working.
+     * When nested inside a larger operation (a drag-driven move, fromJSON
+     * restore) the component's depth counter folds it into the outer one.
+     */
+    private _bracketTabGroupMutation<T>(func: () => T): T {
+        return this.accessor.mutation
+            ? this.accessor.mutation('tab-group', func)
+            : func();
+    }
+
     createTabGroup(options?: CreateTabGroupOptions): ITabGroup {
+        return this._bracketTabGroupMutation(() =>
+            this._doCreateTabGroup(options)
+        );
+    }
+
+    private _doCreateTabGroup(options?: CreateTabGroupOptions): ITabGroup {
         const id = options?.id ?? `tg-${this.id}-${this._tabGroupIdCounter++}`;
         const tabGroup = new TabGroup(id, {
             label: options?.label,
@@ -731,15 +750,17 @@ export class DockviewGroupPanelModel
             return;
         }
 
-        // Remove all panels from the group (they stay in the flat panel list)
-        const panelIds = [...tabGroup.panelIds];
-        for (const panelId of panelIds) {
-            tabGroup.removePanel(panelId);
-            this._panelToTabGroup.delete(panelId);
-            this._onDidRemovePanelFromTabGroup.fire({ tabGroup, panelId });
-        }
+        this._bracketTabGroupMutation(() => {
+            // Remove all panels from the group (they stay in the flat panel list)
+            const panelIds = [...tabGroup.panelIds];
+            for (const panelId of panelIds) {
+                tabGroup.removePanel(panelId);
+                this._panelToTabGroup.delete(panelId);
+                this._onDidRemovePanelFromTabGroup.fire({ tabGroup, panelId });
+            }
 
-        tabGroup.dispose();
+            tabGroup.dispose();
+        });
     }
 
     addPanelToTabGroup(
@@ -759,21 +780,24 @@ export class DockviewGroupPanelModel
 
         // Remove from any existing group first
         const existingGroup = this.getTabGroupForPanel(panelId);
-        if (existingGroup) {
-            if (existingGroup.id === tabGroupId) {
-                return; // already in this group
-            }
-            this.removePanelFromTabGroup(panelId);
+        if (existingGroup && existingGroup.id === tabGroupId) {
+            return; // already in this group — no mutation
         }
 
-        tabGroup.addPanel(panelId, index);
-        this._panelToTabGroup.set(panelId, tabGroup);
+        this._bracketTabGroupMutation(() => {
+            if (existingGroup) {
+                this.removePanelFromTabGroup(panelId);
+            }
 
-        // Enforce contiguity: move the panel in the flat _panels array
-        // to the correct global position matching its group-local index
-        this._enforceContiguity(tabGroup, panelId);
+            tabGroup.addPanel(panelId, index);
+            this._panelToTabGroup.set(panelId, tabGroup);
 
-        this._onDidAddPanelToTabGroup.fire({ tabGroup, panelId });
+            // Enforce contiguity: move the panel in the flat _panels array
+            // to the correct global position matching its group-local index
+            this._enforceContiguity(tabGroup, panelId);
+
+            this._onDidAddPanelToTabGroup.fire({ tabGroup, panelId });
+        });
     }
 
     /**
@@ -968,14 +992,16 @@ export class DockviewGroupPanelModel
             return;
         }
 
-        tabGroup.removePanel(panelId);
-        this._panelToTabGroup.delete(panelId);
-        this._onDidRemovePanelFromTabGroup.fire({ tabGroup, panelId });
+        this._bracketTabGroupMutation(() => {
+            tabGroup.removePanel(panelId);
+            this._panelToTabGroup.delete(panelId);
+            this._onDidRemovePanelFromTabGroup.fire({ tabGroup, panelId });
 
-        // Auto-destroy empty groups
-        if (tabGroup.isEmpty) {
-            tabGroup.dispose();
-        }
+            // Auto-destroy empty groups
+            if (tabGroup.isEmpty) {
+                tabGroup.dispose();
+            }
+        });
     }
 
     getTabGroups(): readonly ITabGroup[] {

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -70,6 +70,27 @@ api.onDidLayoutFromJSON(() => { });
 api.onDidMaximizedGroupChange((event: DockviewMaximizedGroupChanged) => { });
 ```
 
+### Mutation boundary
+
+`onWillMutateLayout` and `onDidMutateLayout` bracket each top-level structural change to the layout. Unlike `onDidLayoutChange` — which is coalesced and only fires _after_ a change — these provide an explicit before/after pair, so you can capture a snapshot of the layout _before_ the mutation runs. This makes them the right hook for autosave, dirty-tracking and undo/redo.
+
+```ts
+// Fires immediately before a structural mutation
+api.onWillMutateLayout((event: DockviewLayoutMutationEvent) => {
+    // event.kind: 'add' | 'remove' | 'move' | 'float' | 'popout'
+    //           | 'tab-group' | 'load' | 'clear'
+    // event.origin: 'user' | 'api'
+    const snapshot = api.toJSON(); // pre-image, before the change applies
+});
+
+// Fires immediately after the same mutation settles
+api.onDidMutateLayout((event: DockviewLayoutMutationEvent) => { });
+```
+
+A compound operation brackets as a **single** transaction: dragging a panel to a new group, or restoring a whole layout via `fromJSON`, fires exactly one before/after pair rather than one per internal step.
+
+`event.origin` distinguishes _who_ caused the change — `'user'` for direct interaction (drag-and-drop, tab UI), `'api'` for a programmatic `DockviewApi` call made by your own code — so consumers such as an undo stack can choose to ignore the app's own programmatic mutations.
+
 ## Drag & Drop
 
 These events let you intercept and customize drag and drop behaviour.


### PR DESCRIPTION
## Summary

Extends the `onWillMutateLayout` / `onDidMutateLayout` transaction boundary so consumers can tell **who** caused a layout change, and so **every** structural mutation actually fires the boundary. Both are additive — existing consumers ignore the new field, and no public behaviour changes.

### Mutation origin
- `DockviewLayoutMutationEvent` gains `origin: 'user' | 'api'`.
- The component defaults to `'user'`; a new `withMutationOrigin('api', fn)` wrapper (used by the `DockviewApi` mutation methods) tags programmatic changes as `'api'`. Nested mutations inherit the outermost origin.
- Adds a public `mutationOrigin()` reader.

### Boundary-coverage audit
Every discrete structural transition now brackets the seam. Newly covered entry points that previously fired nothing:
- `addGroup` → `'add'`
- `closeAllGroups` and `removeEdgeGroup` → a single `'remove'` (per-panel removals nest via the depth counter)
- `addEdgeGroup` → `'add'`
- `maximizeGroup` / `exitMaximizedGroup` → new `'maximize'` kind (the gridview serializes the maximized node, so it round-trips through `toJSON`/`fromJSON` and is restorable)
- The four `DockviewGroupPanelModel` tab-group operations → new `'tab-group'` kind, bracketed at the model layer so both the `DockviewApi` path and the user chip-drag path are covered

When driven by a larger operation (a drag-move, `fromJSON` restore) nested mutations fold into the enclosing transaction via the depth counter.

**Out of scope (follow-ups):** geometry changes (sash resize, float/popout move+resize) are coalescable and handled separately; user-initiated popout window-close relocation is unbracketed and tracked for the cross-window work.

## Why
A reliable pre/post transaction boundary with an origin tag is the foundation for layout-change consumers (autosave, dirty-tracking, undo/redo) — none of which can be built correctly on the coalesced, post-hoc `onDidLayoutChange` ping. This PR makes the boundary complete and origin-aware.

## Testing
- 24 tests in `layoutMutation.spec.ts` covering origin (`user`/`api`), every bracketed kind, tab-group nesting (moving a panel between tab groups fires one transaction, not two), maximize round-trip, and no-op suppression.
- Full `dockview-core` suite green (1135).
- `tsc --noEmit` clean; ESLint 0 errors on changed files; `format` + `gen` applied.

## Docs
Adds a "Mutation boundary" section to the events reference (`packages/docs/docs/core/events.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)