### PR TITLE
feat(dockview-core): add popout group open event and enumeration

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -188,6 +188,7 @@ PaneviewPanel
 PaneviewPanelApi
 PaneviewUnhandledDragOverEvent
 Parameters
+PopoutGroup
 PopoutGroupChangePositionEvent
 PopoutGroupChangeSizeEvent
 Position

--- a/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
@@ -1,0 +1,81 @@
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { IContentRenderer } from '../../dockview/types';
+import { setupMockWindow } from '../__mocks__/mockWindow';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * The popout lifecycle surface: `onDidAddPopoutGroup` (open event carrying the
+ * Window handle) and `getPopouts()` (enumeration of the open popout windows).
+ */
+describe('popout lifecycle', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+
+    beforeEach(() => {
+        window.open = () => setupMockWindow();
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(1000, 1000);
+    });
+
+    afterEach(() => dockview.dispose());
+
+    test('onDidAddPopoutGroup fires with the group and window on open', async () => {
+        const panel = dockview.addPanel({ id: 'p1', component: 'default' });
+        const events: { id: string; hasGroup: boolean; hasWindow: boolean }[] =
+            [];
+        dockview.onDidAddPopoutGroup((e) =>
+            events.push({
+                id: e.id,
+                hasGroup: !!e.group,
+                hasWindow: !!e.window,
+            })
+        );
+
+        await dockview.addPopoutGroup(panel);
+
+        expect(events.length).toBe(1);
+        expect(events[0].hasGroup).toBe(true);
+        expect(events[0].hasWindow).toBe(true);
+        // the event id matches the now-enumerable popout
+        expect(events[0].id).toBe(dockview.getPopouts()[0].id);
+    });
+
+    test('getPopouts enumerates the open popout windows', async () => {
+        expect(dockview.getPopouts()).toEqual([]);
+
+        const panel = dockview.addPanel({ id: 'p1', component: 'default' });
+        await dockview.addPopoutGroup(panel);
+
+        const popouts = dockview.getPopouts();
+        expect(popouts.length).toBe(1);
+        expect(typeof popouts[0].id).toBe('string');
+        expect(popouts[0].group).toBeDefined();
+        expect(popouts[0].window).toBeDefined();
+    });
+
+    test('the DockviewApi surface delegates to the component', async () => {
+        const fired: string[] = [];
+        dockview.api.onDidAddPopoutGroup((e) => fired.push(e.id));
+
+        const panel = dockview.addPanel({ id: 'p1', component: 'default' });
+        await dockview.addPopoutGroup(panel);
+
+        expect(fired.length).toBe(1);
+        expect(dockview.api.getPopouts().map((p) => p.id)).toEqual(fired);
+    });
+});

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -4,6 +4,7 @@ import {
     FloatingGroupOptions,
     IDockviewComponent,
     MovePanelEvent,
+    PopoutGroup,
     PopoutGroupChangePositionEvent,
     PopoutGroupChangeSizeEvent,
     SerializedDockview,
@@ -788,8 +789,22 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         return this.component.onDidPopoutGroupPositionChange;
     }
 
+    /**
+     * Fires when a popout group successfully opens in its own window, carrying
+     * the live `Window` handle. Use it to route focus or attach per-document
+     * listeners. Enumerate the current popouts at any time with `getPopouts()`.
+     */
+    get onDidAddPopoutGroup(): Event<PopoutGroup> {
+        return this.component.onDidAddPopoutGroup;
+    }
+
     get onDidOpenPopoutWindowFail(): Event<void> {
         return this.component.onDidOpenPopoutWindowFail;
+    }
+
+    /** Enumerate the popout groups currently open in their own windows. */
+    getPopouts(): PopoutGroup[] {
+        return this.component.getPopouts();
     }
 
     /**

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -297,6 +297,17 @@ export interface PopoutGroupChangePositionEvent {
     group: DockviewGroupPanel;
 }
 
+/**
+ * A popout group currently open in its own window. `window` is the live
+ * `Window` handle of the popout, so consumers can route focus, attach
+ * per-document listeners, or place the window.
+ */
+export interface PopoutGroup {
+    readonly id: string;
+    readonly group: DockviewGroupPanel;
+    readonly window: Window;
+}
+
 export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     readonly activePanel: IDockviewPanel | undefined;
     readonly totalPanels: number;
@@ -321,7 +332,9 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     readonly onDidMaximizedGroupChange: Event<DockviewMaximizedGroupChanged>;
     readonly onDidPopoutGroupSizeChange: Event<PopoutGroupChangeSizeEvent>;
     readonly onDidPopoutGroupPositionChange: Event<PopoutGroupChangePositionEvent>;
+    readonly onDidAddPopoutGroup: Event<PopoutGroup>;
     readonly onDidOpenPopoutWindowFail: Event<void>;
+    getPopouts(): PopoutGroup[];
     readonly onDidCreateTabGroup: Event<DockviewTabGroupChangeEvent>;
     readonly onDidDestroyTabGroup: Event<DockviewTabGroupChangeEvent>;
     readonly onDidAddPanelToTabGroup: Event<DockviewTabGroupPanelChangeEvent>;
@@ -458,6 +471,10 @@ export class DockviewComponent
         new Emitter<PopoutGroupChangePositionEvent>();
     readonly onDidPopoutGroupPositionChange: Event<PopoutGroupChangePositionEvent> =
         this._onDidPopoutGroupPositionChange.event;
+
+    private readonly _onDidAddPopoutGroup = new Emitter<PopoutGroup>();
+    readonly onDidAddPopoutGroup: Event<PopoutGroup> =
+        this._onDidAddPopoutGroup.event;
 
     private readonly _onDidOpenPopoutWindowFail = new Emitter<void>();
     readonly onDidOpenPopoutWindowFail: Event<void> =
@@ -899,6 +916,7 @@ export class DockviewComponent
             this._onDidMaximizedGroupChange,
             this._onDidPopoutGroupSizeChange,
             this._onDidPopoutGroupPositionChange,
+            this._onDidAddPopoutGroup,
             this._onDidOpenPopoutWindowFail,
             this._onDidCreateTabGroup,
             this._onDidDestroyTabGroup,
@@ -1090,6 +1108,17 @@ export class DockviewComponent
         // popout window opens asynchronously after it resolves.
         return this.mutation('popout', () =>
             this._doAddPopoutGroup(itemToPopout, options)
+        );
+    }
+
+    /** Enumerate the popout groups currently open in their own windows. */
+    getPopouts(): PopoutGroup[] {
+        return (
+            this._popoutWindowService?.entries.map((entry) => ({
+                id: entry.popoutGroup.id,
+                group: entry.popoutGroup,
+                window: entry.getWindow(),
+            })) ?? []
         );
     }
 
@@ -1465,6 +1494,12 @@ export class DockviewComponent
                 );
 
                 service.add(value);
+
+                this._onDidAddPopoutGroup.fire({
+                    id: value.popoutGroup.id,
+                    group: value.popoutGroup,
+                    window: value.getWindow(),
+                });
 
                 return true;
             })

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -108,6 +108,13 @@ api.onUnhandledDragOverEvent((event: DockviewDndOverlayEvent) => {
 These events fire in response to popout window activity.
 
 ```ts
+// Fires when a popout group opens in its own window, carrying the live Window
+// handle. Use it to route focus or attach listeners to the popout's document.
+api.onDidAddPopoutGroup((event: PopoutGroup) => {
+    // event.id, event.group, event.window
+    event.window.focus();
+});
+
 // Fires when a popout window is resized
 api.onDidPopoutGroupSizeChange((event: PopoutGroupChangeSizeEvent) => { });
 
@@ -118,6 +125,14 @@ api.onDidPopoutGroupPositionChange((event: PopoutGroupChangePositionEvent) => { 
 api.onDidOpenPopoutWindowFail(() => {
     console.warn('popup was blocked by the browser');
 });
+```
+
+Enumerate the popout groups currently open at any time:
+
+```ts
+for (const popout of api.getPopouts()) {
+    // popout.id, popout.group, popout.window
+}
 ```
 
 > See [Popout Windows](/docs/core/groups/popoutGroups) for more.


### PR DESCRIPTION
## Summary

Surfaces the popout-window lifecycle so applications can react when a popout opens and enumerate the windows that are currently open. Today the only way to learn about a popout is the per-call `onDidOpen` callback passed to `addPopoutGroup` — there's no component/api-level event and no way to enumerate. Both additions are free, additive, and change no existing behaviour.

- **`onDidAddPopoutGroup`** — fires when a popout group successfully opens in its own window, carrying `{ id, group, window }` with the **live `Window` handle**. Lets consumers route focus, attach per-document listeners, or place the window.
- **`getPopouts()`** — enumerates the popout groups currently open (`PopoutGroup[]`).

Exposed on both `DockviewComponent` and `DockviewApi`.

## Why
A service-level popout-open event carrying the `Window` is the missing primitive for multi-window coordination — focus routing across documents, attaching listeners inside a popout, and window placement all need it. It's broadly useful on its own and unblocks future cross-window work.

## Scope note
This PR covers the **open** half of the lifecycle plus enumeration. A symmetric `onDidRemovePopoutGroup` is intentionally deferred: a popout can close via several paths (programmatic `removeGroup`, a group dragged out, and a user closing the OS window), and the user-window-close teardown doesn't currently route through a single removal choke point. A reliable close event wants that traced and verified in a real multi-window context, so it's left for the cross-window follow-up. Consumers can observe removals via the existing `onDidRemoveGroup` in the meantime, and `getPopouts()` always reflects current state.

## Testing
- New `popoutLifecycle.spec.ts`: `onDidAddPopoutGroup` fires with group + window on open; `getPopouts()` enumerates open popouts; the `DockviewApi` surface delegates correctly.
- Full `dockview-core` suite green (1122).
- `tsc --noEmit` clean; ESLint 0 errors; `format` + `gen` applied.

## Docs
Adds `onDidAddPopoutGroup` and `getPopouts()` to the Popout Window events reference (`packages/docs/docs/core/events.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)