### PR TITLE
feat(dockview-core): add a floating-group drag position transform hook

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -78,6 +78,7 @@ DroptargetOverlayModel
 EdgeGroupOptions
 EdgeGroupPosition
 ExpansionEvent
+FloatingGroupDragContext
 FloatingGroupOptions
 FocusEvent
 GetTabContextMenuItemsParams

--- a/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
@@ -861,4 +861,150 @@ describe('overlay', () => {
             overlay.dispose();
         });
     });
+
+    describe('drag position transform', () => {
+        function setupDraggableOverlay(options: {
+            transformDragPosition?: Parameters<
+                typeof Overlay
+            >[0]['transformDragPosition'];
+            getSiblingBoxes?: () => readonly {
+                left: number;
+                top: number;
+                width: number;
+                height: number;
+            }[];
+        }) {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            document.body.appendChild(container);
+            container.appendChild(content);
+
+            const overlay = new Overlay({
+                height: 100,
+                width: 100,
+                left: 50,
+                top: 50,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content,
+                ...options,
+            });
+
+            jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 0,
+                        top: 0,
+                        width: 400,
+                        height: 400,
+                    })
+            );
+            jest.spyOn(
+                overlay.element,
+                'getBoundingClientRect'
+            ).mockImplementation(() =>
+                mockGetBoundingClientRect({
+                    left: 50,
+                    top: 50,
+                    width: 100,
+                    height: 100,
+                })
+            );
+
+            const dragTarget = document.createElement('div');
+            container.appendChild(dragTarget);
+            overlay.setupDrag(dragTarget);
+
+            const drag = (clientX: number, clientY: number) => {
+                const down = new MouseEvent('pointerdown', {
+                    clientX: 60,
+                    clientY: 60,
+                    bubbles: true,
+                }) as any;
+                down.pointerId = 1;
+                dragTarget.dispatchEvent(down);
+
+                const move = new MouseEvent('pointermove', {
+                    clientX,
+                    clientY,
+                    bubbles: true,
+                }) as any;
+                move.pointerId = 1;
+                window.dispatchEvent(move);
+            };
+
+            return { overlay, drag };
+        }
+
+        test('receives the proposed box, container and sibling boxes', () => {
+            const calls: any[] = [];
+            const siblings = [{ left: 0, top: 0, width: 10, height: 10 }];
+            const { overlay, drag } = setupDraggableOverlay({
+                getSiblingBoxes: () => siblings,
+                transformDragPosition: (ctx) => {
+                    calls.push(ctx);
+                },
+            });
+
+            drag(200, 200);
+
+            expect(calls.length).toBeGreaterThan(0);
+            expect(calls[0].proposed).toMatchObject({
+                width: 100,
+                height: 100,
+            });
+            expect(calls[0].container).toEqual({ width: 400, height: 400 });
+            expect(calls[0].others).toEqual(siblings);
+
+            overlay.dispose();
+        });
+
+        test('a returned position is applied (pin to top-left)', () => {
+            const { overlay, drag } = setupDraggableOverlay({
+                transformDragPosition: () => ({ top: 0, left: 0 }),
+            });
+            const spy = jest.spyOn(overlay, 'setBounds');
+
+            drag(300, 300);
+
+            // top <= bottom and left <= right at (0,0), so it anchors top-left.
+            expect(spy).toHaveBeenLastCalledWith({ top: 0, left: 0 });
+
+            overlay.dispose();
+        });
+
+        test('runs before the container clamp (out-of-bounds is still clamped in)', () => {
+            const { overlay, drag } = setupDraggableOverlay({
+                // Ask for a position far outside the 400x400 container.
+                transformDragPosition: () => ({ top: 100000, left: 100000 }),
+            });
+            const spy = jest.spyOn(overlay, 'setBounds');
+
+            drag(200, 200);
+
+            // The raw 100000 must never reach setBounds — it's clamped to the
+            // container range first (every applied offset stays near the
+            // 400x400 container, nowhere near the requested 100000).
+            const bounds = spy.mock.calls.at(-1)![0] as Record<string, number>;
+            for (const value of Object.values(bounds)) {
+                expect(Math.abs(value)).toBeLessThan(1000);
+            }
+
+            overlay.dispose();
+        });
+
+        test('no transform → sibling boxes are never gathered', () => {
+            const getSiblingBoxes = jest.fn(() => []);
+            const { overlay, drag } = setupDraggableOverlay({
+                getSiblingBoxes,
+            });
+
+            drag(200, 200);
+
+            expect(getSiblingBoxes).not.toHaveBeenCalled();
+
+            overlay.dispose();
+        });
+    });
 });

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -607,6 +607,30 @@ export class DockviewComponent
         );
     }
 
+    /**
+     * Boxes of the floating groups other than `exclude`, in coordinates
+     * relative to the floating overlay container. Supplied to a
+     * `transformFloatingGroupDrag` callback as `context.others` so it can
+     * align the dragged float against its siblings.
+     */
+    private _gatherFloatingGroupBoxes(
+        exclude: DockviewGroupPanel
+    ): readonly Box[] {
+        const container = this._floatingOverlayHost ?? this.gridview.element;
+        const containerRect = container.getBoundingClientRect();
+        return this.floatingGroups
+            .filter((floating) => floating.group !== exclude)
+            .map((floating) => {
+                const rect = floating.overlay.element.getBoundingClientRect();
+                return {
+                    left: rect.left - containerRect.left,
+                    top: rect.top - containerRect.top,
+                    width: rect.width,
+                    height: rect.height,
+                };
+            });
+    }
+
     private get _floatingGroupService() {
         return this._moduleRegistry.services.floatingGroupService;
     }
@@ -1932,6 +1956,16 @@ export class DockviewComponent
                     : (this.options.floatingGroupBounds
                           ?.minimumHeightWithinViewport ??
                       DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE),
+            transformDragPosition: this.options.transformFloatingGroupDrag
+                ? (context) =>
+                      this.options.transformFloatingGroupDrag!({
+                          group: anchorGroup,
+                          proposed: context.proposed,
+                          container: context.container,
+                          others: context.others,
+                      })
+                : undefined,
+            getSiblingBoxes: () => this._gatherFloatingGroupBoxes(anchorGroup),
         });
 
         const dragHandle =

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -8,6 +8,7 @@ import { DockviewMessages } from './accessibilityMessages';
 export type { DockviewMessages } from './accessibilityMessages';
 import { PanelTransfer } from '../dnd/dataTransfer';
 import { IDisposable } from '../lifecycle';
+import { Box } from '../types';
 import { DroptargetOverlayModel, Position } from '../dnd/droptarget';
 import { GroupOptions } from './dockviewGroupPanelModel';
 import { DockviewGroupDropLocation } from './events';
@@ -170,6 +171,24 @@ export type DockviewHeaderDirection = 'horizontal' | 'vertical';
 
 export type DockviewDndStrategy = 'auto' | 'pointer' | 'html5';
 
+/**
+ * Context handed to {@link DockviewOptions.transformFloatingGroupDrag} on each
+ * pointer-move frame while a floating group is being dragged.
+ */
+export interface FloatingGroupDragContext {
+    /** The floating group being dragged. */
+    readonly group: DockviewGroupPanel;
+    /** Proposed top-left + size this frame, in container pixels (pre-clamp). */
+    readonly proposed: Box;
+    /** Size of the container the floating group is dragged within. */
+    readonly container: { width: number; height: number };
+    /**
+     * Bounds of the other floating groups (relative to the same container),
+     * snapshotted at drag start.
+     */
+    readonly others: readonly Box[];
+}
+
 export interface DockviewOptions {
     /**
      * Disable the auto-resizing which is controlled through a `ResizeObserver`.
@@ -185,6 +204,20 @@ export interface DockviewOptions {
               minimumHeightWithinViewport?: number;
               minimumWidthWithinViewport?: number;
           };
+    /**
+     * Adjust a floating group's position while it is being dragged. Runs on
+     * each pointer-move frame with the proposed top-left (before the container
+     * clamp) and returns an adjusted top-left, or nothing to leave it
+     * unchanged. Use it for snapping, alignment, or custom bounds. Move only —
+     * resizing a floating group is unaffected.
+     *
+     * `context.others` holds the bounds of the other floating groups (relative
+     * to the same container), snapshotted at drag start, so the callback can
+     * align the dragged group against its siblings.
+     */
+    transformFloatingGroupDrag?: (
+        context: FloatingGroupDragContext
+    ) => { top: number; left: number } | void;
     /**
      * Selects which element moves a floating group when dragged.
      *
@@ -404,6 +437,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         singleTabMode: undefined,
         disableFloatingGroups: undefined,
         floatingGroupBounds: undefined,
+        transformFloatingGroupDrag: undefined,
         floatingGroupDragHandle: undefined,
         popoutUrl: undefined,
         nonce: undefined,

--- a/packages/dockview-core/src/overlay/overlay.ts
+++ b/packages/dockview-core/src/overlay/overlay.ts
@@ -10,7 +10,20 @@ import {
     MutableDisposable,
 } from '../lifecycle';
 import { clamp } from '../math';
-import { AnchoredBox } from '../types';
+import { AnchoredBox, Box } from '../types';
+
+/**
+ * Context handed to {@link OverlayOptions.transformDragPosition} each
+ * pointer-move frame while a floating overlay is being dragged.
+ */
+export interface OverlayDragContext {
+    /** Proposed top-left + size this frame, in container pixels (pre-clamp). */
+    readonly proposed: Box;
+    /** Size of the container the overlay is dragged within. */
+    readonly container: { width: number; height: number };
+    /** Bounds of the sibling overlays, snapshotted at drag start. */
+    readonly others: readonly Box[];
+}
 
 class AriaLevelTracker {
     private _orderedList: HTMLElement[] = [];
@@ -104,6 +117,19 @@ export class Overlay extends CompositeDisposable {
             header?: HTMLElement;
             minimumInViewportWidth?: number;
             minimumInViewportHeight?: number;
+            /**
+             * Adjust the proposed top-left each drag frame (before the
+             * container clamp). Return an adjusted position or nothing to leave
+             * it unchanged. Used to implement snapping / custom bounds.
+             */
+            transformDragPosition?: (
+                context: OverlayDragContext
+            ) => { top: number; left: number } | void;
+            /**
+             * Snapshot the sibling overlays' boxes at drag start, supplied to
+             * `transformDragPosition` as `context.others`.
+             */
+            getSiblingBoxes?: () => readonly Box[];
         }
     ) {
         super();
@@ -305,6 +331,11 @@ export class Overlay extends CompositeDisposable {
             let hasMoved = false;
             this._dragCancelled = false;
 
+            // Snapshot once per drag — siblings don't move while this one drags.
+            const siblingBoxes = this.options.transformDragPosition
+                ? (this.options.getSiblingBoxes?.() ?? [])
+                : [];
+
             const iframes = disableIframePointEvents();
 
             if (
@@ -380,43 +411,54 @@ export class Overlay extends CompositeDisposable {
                         this.getMinimumHeight(overlayRect.height)
                     );
 
-                    const top = clamp(
-                        y - offset.y,
-                        -yOffset,
-                        Math.max(
-                            0,
-                            containerRect.height - overlayRect.height + yOffset
-                        )
+                    let proposedTop = y - offset.y;
+                    let proposedLeft = x - offset.x;
+
+                    // Let a consumer nudge the proposed position (snapping,
+                    // custom bounds) before the container clamp below.
+                    if (this.options.transformDragPosition) {
+                        const adjusted = this.options.transformDragPosition({
+                            proposed: {
+                                top: proposedTop,
+                                left: proposedLeft,
+                                width: overlayRect.width,
+                                height: overlayRect.height,
+                            },
+                            container: {
+                                width: containerRect.width,
+                                height: containerRect.height,
+                            },
+                            others: siblingBoxes,
+                        });
+                        if (adjusted) {
+                            proposedTop = adjusted.top;
+                            proposedLeft = adjusted.left;
+                        }
+                    }
+
+                    const maxTop = Math.max(
+                        0,
+                        containerRect.height - overlayRect.height + yOffset
                     );
+                    const maxLeft = Math.max(
+                        0,
+                        containerRect.width - overlayRect.width + xOffset
+                    );
+
+                    const top = clamp(proposedTop, -yOffset, maxTop);
 
                     const bottom = clamp(
-                        offset.y -
-                            y +
-                            containerRect.height -
-                            overlayRect.height,
+                        containerRect.height - overlayRect.height - proposedTop,
                         -yOffset,
-                        Math.max(
-                            0,
-                            containerRect.height - overlayRect.height + yOffset
-                        )
+                        maxTop
                     );
 
-                    const left = clamp(
-                        x - offset.x,
-                        -xOffset,
-                        Math.max(
-                            0,
-                            containerRect.width - overlayRect.width + xOffset
-                        )
-                    );
+                    const left = clamp(proposedLeft, -xOffset, maxLeft);
 
                     const right = clamp(
-                        offset.x - x + containerRect.width - overlayRect.width,
+                        containerRect.width - overlayRect.width - proposedLeft,
                         -xOffset,
-                        Math.max(
-                            0,
-                            containerRect.width - overlayRect.width + xOffset
-                        )
+                        maxLeft
                     );
 
                     const bounds: any = {};

--- a/packages/docs/docs/core/groups/floatingGroups.mdx
+++ b/packages/docs/docs/core/groups/floatingGroups.mdx
@@ -41,6 +41,25 @@ You can control the bounding box of floating groups through the optional `floati
 -   `{minimumHeightWithinViewport?: number, minimumWidthWithinViewport?: number}` sets the respective dimension minimums that must appears within the docks viewport
 -   If no options are provided the defaults of `100px` minimum height and width within the viewport are set.
 
+### Customising drag behaviour
+
+`transformFloatingGroupDrag` lets you adjust a floating group's position while it is being dragged — for snapping to a grid, aligning to other floating groups, or constraining a group to a region. It runs on every pointer-move frame with the proposed top-left (before dockview's container clamp) and returns an adjusted top-left, or nothing to leave it unchanged. It affects moving only — resizing is unaffected.
+
+```ts
+const api = createDockview(element, {
+    // …
+    transformFloatingGroupDrag: ({ group, proposed, container, others }) => {
+        // Snap the proposed position to a 20px grid
+        return {
+            top: Math.round(proposed.top / 20) * 20,
+            left: Math.round(proposed.left / 20) * 20,
+        };
+    },
+});
+```
+
+`context.others` holds the bounds of the other floating groups (relative to the same container), snapshotted at drag start, so you can align the dragged group against its siblings.
+
 
 ## API
 


### PR DESCRIPTION
## Summary

Adds `transformFloatingGroupDrag` — a per-frame hook that lets an application adjust a floating group's position while it is being dragged. Useful for grid snapping, aligning to other floating groups, or constraining a group to a region. Additive and a no-op when unset, so default float dragging is unchanged.

```ts
createDockview(element, {
  transformFloatingGroupDrag: ({ group, proposed, container, others }) => {
    // snap to a 20px grid
    return {
      top: Math.round(proposed.top / 20) * 20,
      left: Math.round(proposed.left / 20) * 20,
    };
  },
});
```

## Contract
- Runs on **every pointer-move frame** with the proposed top-left, **before** dockview's container clamp — so snapping can pull the group toward another edge and the result is still clamped into the container afterwards.
- Returns an adjusted `{ top, left }`, or nothing to leave the position unchanged.
- **Move only** — resizing a floating group is unaffected.
- `context.others` carries the other floating groups' boxes (relative to the same container), **snapshotted at drag start**, so the callback can align against siblings.
- Resolved-pixel coordinates in/out — the callback never sees the internal anchored-box representation; core re-derives the nearest-edge anchor on the returned value.

## Implementation
- `overlay/overlay.ts` — the drag loop computes the proposed top-left, calls the hook, then runs the existing clamp + nearest-edge anchor. Sibling boxes are snapshotted once per drag.
- `dockview/dockviewComponent.ts` — wires the public option into the `Overlay`, injecting the dragged `group` and gathering sibling boxes (relative to the floating overlay container).
- `dockview/options.ts` — the `transformFloatingGroupDrag` option + `FloatingGroupDragContext` type.

## Testing
- New Overlay tests: the hook receives `proposed` / `container` / `others`; a returned position is applied; it runs **before** the clamp (an out-of-bounds return is still clamped in); and sibling boxes are not gathered when no hook is set.
- Full `dockview-core` suite green (1123) — the drag-loop refactor is behaviour-preserving.
- `tsc --noEmit` clean; ESLint 0 errors; `format` + `gen` applied.

## Docs
Documents the option with a snapping example on the Floating Groups page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)