### PR TITLE
feat(dockview-core): expose spatial group navigation and geometry

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -97,6 +97,7 @@ GridviewOptions
 GridviewPanel
 GridviewPanelApi
 GroupDragEvent
+GroupNavigationDirection
 GroupPanelPartInitParameters
 GroupviewPanelState
 HeaderPartInitParameters

--- a/packages/dockview-core/src/__tests__/dockview/spatialNavigation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/spatialNavigation.spec.ts
@@ -1,0 +1,138 @@
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
+import { IContentRenderer } from '../../dockview/types';
+import { mockGetBoundingClientRect } from '../__test_utils__/utils';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * Spatial group navigation — `adjacentGroupInDirection` and the
+ * `group.api.boundingBox` geometry accessor. DOM rects are zero in jsdom, so
+ * each group's rect is mocked to lay out a deterministic grid.
+ */
+describe('spatial group navigation', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(1000, 1000);
+    });
+
+    afterEach(() => dockview.dispose());
+
+    function mockRect(
+        group: DockviewGroupPanel,
+        box: { left: number; top: number; width: number; height: number }
+    ) {
+        jest.spyOn(group.element, 'getBoundingClientRect').mockImplementation(
+            () => mockGetBoundingClientRect(box)
+        );
+    }
+
+    /** Four groups laid out as a 2x2 grid (mocked geometry). */
+    function build2x2() {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        const p2 = dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right', referencePanel: 'p1' },
+        });
+        const p3 = dockview.addPanel({
+            id: 'p3',
+            component: 'default',
+            position: { direction: 'below', referencePanel: 'p1' },
+        });
+        const p4 = dockview.addPanel({
+            id: 'p4',
+            component: 'default',
+            position: { direction: 'below', referencePanel: 'p2' },
+        });
+
+        mockRect(p1.group, { left: 0, top: 0, width: 100, height: 100 });
+        mockRect(p2.group, { left: 100, top: 0, width: 100, height: 100 });
+        mockRect(p3.group, { left: 0, top: 100, width: 100, height: 100 });
+        mockRect(p4.group, { left: 100, top: 100, width: 100, height: 100 });
+
+        return {
+            topLeft: p1.group,
+            topRight: p2.group,
+            bottomLeft: p3.group,
+            bottomRight: p4.group,
+        };
+    }
+
+    test('finds the nearest grid group in each direction', () => {
+        const { topLeft, topRight, bottomLeft, bottomRight } = build2x2();
+
+        expect(dockview.adjacentGroupInDirection(topLeft, 'right')).toBe(
+            topRight
+        );
+        expect(dockview.adjacentGroupInDirection(topLeft, 'down')).toBe(
+            bottomLeft
+        );
+        expect(dockview.adjacentGroupInDirection(topRight, 'left')).toBe(
+            topLeft
+        );
+        expect(dockview.adjacentGroupInDirection(bottomRight, 'up')).toBe(
+            topRight
+        );
+    });
+
+    test('returns undefined at an edge', () => {
+        const { topLeft } = build2x2();
+
+        expect(
+            dockview.adjacentGroupInDirection(topLeft, 'left')
+        ).toBeUndefined();
+        expect(
+            dockview.adjacentGroupInDirection(topLeft, 'up')
+        ).toBeUndefined();
+    });
+
+    test('the DockviewApi surface delegates to the component', () => {
+        const { topLeft, topRight } = build2x2();
+
+        expect(dockview.api.adjacentGroupInDirection(topLeft, 'right')).toBe(
+            topRight
+        );
+    });
+
+    test('group.api.boundingBox is relative to the dock root', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+
+        jest.spyOn(
+            dockview.element,
+            'getBoundingClientRect'
+        ).mockImplementation(() =>
+            mockGetBoundingClientRect({
+                left: 10,
+                top: 20,
+                width: 1000,
+                height: 1000,
+            })
+        );
+        mockRect(p1.group, { left: 60, top: 70, width: 100, height: 100 });
+
+        expect(p1.group.api.boundingBox).toEqual({
+            left: 50,
+            top: 50,
+            width: 100,
+            height: 100,
+        });
+    });
+});

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -2,6 +2,7 @@ import {
     DockviewLayoutMutationEvent,
     DockviewMaximizedGroupChanged,
     FloatingGroupOptions,
+    GroupNavigationDirection,
     IDockviewComponent,
     MovePanelEvent,
     PopoutGroupChangePositionEvent,
@@ -846,6 +847,23 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      */
     get groups(): DockviewGroupPanel[] {
         return this.component.groups;
+    }
+
+    /**
+     * The nearest grid group in a spatial direction from `group`, comparing
+     * group centre points — e.g. the group visually to the left. Floating and
+     * popout groups are ignored. Returns `undefined` when there is no group in
+     * that direction. Pair with `group.api.boundingBox` to build your own
+     * spatial navigation.
+     */
+    adjacentGroupInDirection(
+        group: IDockviewGroupPanel,
+        direction: GroupNavigationDirection
+    ): IDockviewGroupPanel | undefined {
+        return this.component.adjacentGroupInDirection(
+            <DockviewGroupPanel>group,
+            direction
+        );
     }
 
     /**

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -1,5 +1,6 @@
 import { Position, positionToDirection } from '../dnd/droptarget';
 import { DockviewComponent } from '../dockview/dockviewComponent';
+import { Box } from '../types';
 import { DockviewGroupPanel } from '../dockview/dockviewGroupPanel';
 import {
     DockviewGroupChangeEvent,
@@ -102,6 +103,26 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             throw new Error(NOT_INITIALIZED_MESSAGE);
         }
         return this._group.model.location;
+    }
+
+    /**
+     * The group's bounding box relative to the top-left of the dockview root,
+     * in pixels. Covers grid and floating groups; returns `undefined` for a
+     * popout group (it lives in a separate window). Reflects the live rendered
+     * geometry, so it is only meaningful once the layout has been sized.
+     */
+    get boundingBox(): Box | undefined {
+        if (!this._group || this._group.model.location.type === 'popout') {
+            return undefined;
+        }
+        const root = this.accessor.element.getBoundingClientRect();
+        const rect = this._group.element.getBoundingClientRect();
+        return {
+            left: rect.left - root.left,
+            top: rect.top - root.top,
+            width: rect.width,
+            height: rect.height,
+        };
     }
 
     get locked(): DockviewGroupPanelLocked {

--- a/packages/dockview-core/src/dockview/accessibilityService.ts
+++ b/packages/dockview-core/src/dockview/accessibilityService.ts
@@ -343,44 +343,15 @@ export class AccessibilityService
         direction: 'left' | 'right' | 'up' | 'down'
     ): void {
         const current = this.host.activeGroup;
-        if (!current || current.api.location.type !== 'grid') {
+        if (!current) {
             return;
         }
-        const from = current.element.getBoundingClientRect();
-        const fromX = from.left + from.width / 2;
-        const fromY = from.top + from.height / 2;
-
-        let best: DockviewGroupPanel | undefined;
-        let bestDistance = Number.POSITIVE_INFINITY;
-        for (const group of this.host.groups) {
-            if (group === current || group.api.location.type !== 'grid') {
-                continue;
-            }
-            const rect = group.element.getBoundingClientRect();
-            const dx = rect.left + rect.width / 2 - fromX;
-            const dy = rect.top + rect.height / 2 - fromY;
-            // require the candidate to sit predominantly in the asked-for
-            // direction (dominant axis), so 'left' ignores a group that's
-            // mostly above/below.
-            const inDirection =
-                direction === 'left'
-                    ? dx < 0 && Math.abs(dx) >= Math.abs(dy)
-                    : direction === 'right'
-                      ? dx > 0 && Math.abs(dx) >= Math.abs(dy)
-                      : direction === 'up'
-                        ? dy < 0 && Math.abs(dy) >= Math.abs(dx)
-                        : dy > 0 && Math.abs(dy) >= Math.abs(dx);
-            if (!inDirection) {
-                continue;
-            }
-            const distance = dx * dx + dy * dy;
-            if (distance < bestDistance) {
-                bestDistance = distance;
-                best = group;
-            }
-        }
-
-        this._focusGroup(best);
+        // Geometry lives on the host as the shared `adjacentGroupInDirection`
+        // primitive (also public on the api), so mouse and keyboard navigation
+        // agree on what "the group to the left" is.
+        this._focusGroup(
+            this.host.adjacentGroupInDirection(current, direction)
+        );
     }
 
     private _focusGroup(target: DockviewGroupPanel | undefined): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -297,6 +297,9 @@ export interface PopoutGroupChangePositionEvent {
     group: DockviewGroupPanel;
 }
 
+/** A spatial (visual) direction for group-to-group navigation. */
+export type GroupNavigationDirection = 'left' | 'right' | 'up' | 'down';
+
 export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     readonly activePanel: IDockviewPanel | undefined;
     readonly totalPanels: number;
@@ -344,6 +347,10 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     // lifecycle
     addGroup(options?: AddGroupOptions): DockviewGroupPanel;
     closeAllGroups(): void;
+    adjacentGroupInDirection(
+        group: DockviewGroupPanel,
+        direction: GroupNavigationDirection
+    ): DockviewGroupPanel | undefined;
     // events
     moveToNext(options?: MovementOptions): void;
     moveToPrevious(options?: MovementOptions): void;
@@ -733,6 +740,55 @@ export class DockviewComponent
                 : this.gridview.next(location)
             )?.view
         );
+    }
+
+    /**
+     * The nearest grid group in a spatial direction from `group`, by
+     * comparing group centre points. Floating and popout groups sit outside
+     * the grid's geometry and are ignored. Returns `undefined` when there is
+     * no group in that direction.
+     */
+    adjacentGroupInDirection(
+        group: DockviewGroupPanel,
+        direction: GroupNavigationDirection
+    ): DockviewGroupPanel | undefined {
+        if (group.api.location.type !== 'grid') {
+            return undefined;
+        }
+        const from = group.element.getBoundingClientRect();
+        const fromX = from.left + from.width / 2;
+        const fromY = from.top + from.height / 2;
+
+        let best: DockviewGroupPanel | undefined;
+        let bestDistance = Number.POSITIVE_INFINITY;
+        for (const candidate of this.groups) {
+            if (candidate === group || candidate.api.location.type !== 'grid') {
+                continue;
+            }
+            const rect = candidate.element.getBoundingClientRect();
+            const dx = rect.left + rect.width / 2 - fromX;
+            const dy = rect.top + rect.height / 2 - fromY;
+            // Require the candidate to sit predominantly in the asked-for
+            // direction (dominant axis), so 'left' ignores a group that's
+            // mostly above/below.
+            const inDirection =
+                direction === 'left'
+                    ? dx < 0 && Math.abs(dx) >= Math.abs(dy)
+                    : direction === 'right'
+                      ? dx > 0 && Math.abs(dx) >= Math.abs(dy)
+                      : direction === 'up'
+                        ? dy < 0 && Math.abs(dy) >= Math.abs(dx)
+                        : dy > 0 && Math.abs(dy) >= Math.abs(dx);
+            if (!inDirection) {
+                continue;
+            }
+            const distance = dx * dx + dy * dy;
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                best = candidate;
+            }
+        }
+        return best;
     }
 
     showDropPreview(

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -15,7 +15,10 @@ import { ITabGroup } from './tabGroup';
 import { TabGroupColorPalette } from './tabGroupAccent';
 import { PopupService } from './components/popupService';
 import { DockviewComponentOptions } from './options';
-import { DockviewLayoutMutationEvent } from './dockviewComponent';
+import {
+    DockviewLayoutMutationEvent,
+    GroupNavigationDirection,
+} from './dockviewComponent';
 import { DockviewWillDropEvent } from './dockviewGroupPanelModel';
 import {
     GroupDragEvent,
@@ -101,6 +104,11 @@ export interface IAccessibilityHost {
     adjacentGroup(
         group: DockviewGroupPanel,
         reverse: boolean
+    ): DockviewGroupPanel | undefined;
+    /** The nearest grid group in a spatial direction — drives Alt+Arrow nav. */
+    adjacentGroupInDirection(
+        group: DockviewGroupPanel,
+        direction: GroupNavigationDirection
     ): DockviewGroupPanel | undefined;
     /** Fires before / after a structural layout change — used to restore focus on close. */
     readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent>;

--- a/packages/docs/docs/advanced/keyboard.mdx
+++ b/packages/docs/docs/advanced/keyboard.mdx
@@ -35,6 +35,26 @@ api.moveToNext();
 api.moveToNext({ includePanel: true });
 ```
 
+## Spatial Navigation
+
+`moveToNext` / `moveToPrevious` cycle through groups in list order. To navigate by *visual* direction instead, `adjacentGroupInDirection` returns the nearest grid group to the left, right, above, or below a given group (by comparing their centre points). Floating and popout groups are ignored, and it returns `undefined` when there is no group in that direction.
+
+```ts
+const left = api.adjacentGroupInDirection(api.activeGroup, 'left');
+if (left) {
+    left.focus();
+}
+```
+
+Each group also exposes its rendered geometry, relative to the top-left of the dockview root, via `group.api.boundingBox` (`undefined` for popout groups). Combined with `api.groups`, this lets you build a custom spatial map or overview:
+
+```ts
+const layout = api.groups.map((group) => ({
+    group,
+    box: group.api.boundingBox,
+}));
+```
+
 ## Live Example
 
 <MultiFrameworkContainer


### PR DESCRIPTION
## Summary

Surfaces the **directional group navigation** that already existed privately inside the accessibility service as **public API**, and adds a **group geometry accessor**. The keyboard spatial nav is refactored to consume the shared primitive so mouse-built and keyboard navigation agree on what "the group to the left" is.

- **`api.adjacentGroupInDirection(group, 'left' | 'right' | 'up' | 'down')`** — the nearest grid group in a visual direction, by comparing group centre points. Floating/popout groups are ignored; returns `undefined` at an edge. For building custom spatial navigation (e.g. "focus the panel to the left").
- **`group.api.boundingBox`** — the group's rendered rect relative to the dockview root (`undefined` for popout groups, which live in a separate window). Combined with `api.groups`, lets you build an overview / minimap or layout-aware UI.

```ts
const left = api.adjacentGroupInDirection(api.activeGroup, 'left');
left?.focus();

const layout = api.groups.map((g) => ({ group: g, box: g.api.boundingBox }));
```

## Refactor (dedupe)
The accessibility service's `_focusGroupInDirection` previously implemented this geometry itself. It now calls the shared `adjacentGroupInDirection` on the host contract (`IAccessibilityHost`) — same behaviour, one implementation, and the existing `focusGroupLeft/Right/Up/Down` keybindings keep working.

## Notes / scope
- **Grid-only** for directional results, and **grid + floating** for `boundingBox`; **popout deferred** (separate document → cross-window geometry is future work).
- DOM-rect based, so values are meaningful once the layout has been sized.

## Testing
- New `spatialNavigation.spec.ts` (geometry mocked, as in the overlay tests): finds the correct neighbour in each direction over a 2x2 grid; returns `undefined` at an edge; the api delegates; `boundingBox` is relative to the dock root.
- Existing accessibility suite green (42) — the dedupe is behaviour-preserving.
- Full `dockview-core` suite green (1123); `tsc --noEmit` clean; ESLint 0 errors; `format` + `gen` applied.

## Docs
Adds a "Spatial Navigation" section to the keyboard docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)