### PR TITLE
fix(dockview-core): tab group indicator placement for bottom/right header positions

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/tabGroupIndicator.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/tabGroupIndicator.spec.ts
@@ -1,0 +1,105 @@
+import { WrapTabGroupIndicator } from '../../dockview/components/titlebar/tabGroupIndicator';
+import { mockGetBoundingClientRect } from '../__test_utils__/utils';
+
+/**
+ * The Chrome-style wrap indicator must sit on the edge of the tab strip that is
+ * adjacent to the content — i.e. it flips with the header position: bottom edge
+ * for a top header, top edge for a bottom header, left edge for a left header,
+ * right edge for a right header. These tests assert the generated SVG path's
+ * anchored edge flips with `headerPosition`.
+ */
+describe('WrapTabGroupIndicator header-position geometry', () => {
+    const ACTIVE_ID = 'p1';
+    const CROSS_SIZE = 20;
+    const MAIN_SIZE = 200;
+
+    function buildPath(
+        headerPosition: 'top' | 'bottom' | 'left' | 'right',
+        direction: 'horizontal' | 'vertical'
+    ): string {
+        const tabElement = document.createElement('div');
+        jest.spyOn(tabElement, 'getBoundingClientRect').mockImplementation(() =>
+            mockGetBoundingClientRect({
+                left: 50,
+                top: 50,
+                width: 30,
+                height: 30,
+            })
+        );
+
+        const ctx = {
+            getTabMap: () =>
+                new Map([
+                    [
+                        ACTIVE_ID,
+                        {
+                            value: { element: tabElement },
+                            disposable: { dispose: jest.fn() },
+                        },
+                    ],
+                ]),
+            getChipElement: () => undefined,
+            getDirection: () => direction,
+            getHeaderPosition: () => headerPosition,
+            // a palette that always resolves a concrete colour, so the path renders
+            getColorPalette: () => ({ resolveValue: () => '#ff0000' }),
+        };
+
+        const indicator = new WrapTabGroupIndicator(ctx as any);
+        const underline = document.createElement('div');
+        const tg = { id: 'tg', color: 'red', panelIds: [ACTIVE_ID] };
+        const containerRect = mockGetBoundingClientRect({
+            left: 0,
+            top: 0,
+            width: MAIN_SIZE,
+            height: CROSS_SIZE,
+        });
+
+        (indicator as any).applyShape(
+            underline,
+            tg,
+            /* groupStart */ 0,
+            /* groupSpan */ MAIN_SIZE,
+            /* containerCrossSize */ CROSS_SIZE,
+            ACTIVE_ID,
+            containerRect,
+            /* isVertical */ direction === 'vertical'
+        );
+
+        return underline.querySelector('path')?.getAttribute('d') ?? '';
+    }
+
+    function startCoord(d: string, axis: 'x' | 'y'): number {
+        // horizontal paths start `M 0,<y>`; vertical paths start `M <x>,0`
+        const m = d.match(/^M\s+([\d.]+),([\d.]+)/);
+        expect(m).not.toBeNull();
+        return axis === 'x' ? Number(m![1]) : Number(m![2]);
+    }
+
+    test('horizontal: a top header anchors near the bottom edge, a bottom header near the top', () => {
+        const top = buildPath('top', 'horizontal');
+        const bottom = buildPath('bottom', 'horizontal');
+
+        // wrap shape, not the straight-line fallback
+        expect(top).toContain('Q');
+        expect(top).not.toEqual(bottom);
+
+        // top header → anchored near the bottom edge (large y); bottom → near top (small y)
+        expect(startCoord(top, 'y')).toBeGreaterThan(startCoord(bottom, 'y'));
+        expect(startCoord(bottom, 'y')).toBeLessThan(CROSS_SIZE / 2);
+        expect(startCoord(top, 'y')).toBeGreaterThan(CROSS_SIZE / 2);
+    });
+
+    test('vertical: a left header anchors near the left edge, a right header near the right', () => {
+        const left = buildPath('left', 'vertical');
+        const right = buildPath('right', 'vertical');
+
+        expect(left).toContain('Q');
+        expect(left).not.toEqual(right);
+
+        // left header → anchored near the left edge (small x); right → near right (large x)
+        expect(startCoord(right, 'x')).toBeGreaterThan(startCoord(left, 'x'));
+        expect(startCoord(left, 'x')).toBeLessThan(CROSS_SIZE / 2);
+        expect(startCoord(right, 'x')).toBeGreaterThan(CROSS_SIZE / 2);
+    });
+});

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
@@ -1,5 +1,5 @@
 import { IValueDisposable } from '../../../lifecycle';
-import { DockviewHeaderDirection } from '../../options';
+import { DockviewHeaderDirection, DockviewHeaderPosition } from '../../options';
 import { Tab } from '../tab/tab';
 import { ITabGroup } from '../../tabGroup';
 import {
@@ -14,6 +14,7 @@ export interface TabGroupIndicatorContext {
     getTabMap(): Map<string, IValueDisposable<Tab>>;
     getChipElement(groupId: string): HTMLElement | undefined;
     getDirection(): DockviewHeaderDirection;
+    getHeaderPosition(): DockviewHeaderPosition;
     getColorPalette(): TabGroupColorPalette | undefined;
 }
 
@@ -410,6 +411,7 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
 
         const r = 6; // corner radius
         const half = t / 2;
+        const headerPosition = this._ctx.getHeaderPosition();
 
         if (isVertical) {
             const svgW = crossSize;
@@ -419,20 +421,23 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
             underline.style.width = `${svgW}px`;
             underline.style.height = `${svgH}px`;
 
-            const xLeft = half;
-            const xRight = svgW - half;
+            // right header: indicator on the left edge (invert x sides)
+            const isRightHeader = headerPosition === 'right';
+            const xNear = isRightHeader ? svgW - half : half;
+            const xFar = isRightHeader ? half : svgW - half;
+            const cd = isRightHeader ? -1 : 1; // curve direction
 
             const d = [
-                `M ${xLeft},0`,
-                `L ${xLeft},${aStart - r}`,
-                `Q ${xLeft},${aStart} ${xLeft + r},${aStart}`,
-                `L ${xRight - r},${aStart}`,
-                `Q ${xRight},${aStart} ${xRight},${aStart + r}`,
-                `L ${xRight},${aEnd - r}`,
-                `Q ${xRight},${aEnd} ${xRight - r},${aEnd}`,
-                `L ${xLeft + r},${aEnd}`,
-                `Q ${xLeft},${aEnd} ${xLeft},${aEnd + r}`,
-                `L ${xLeft},${svgH}`,
+                `M ${xNear},0`,
+                `L ${xNear},${aStart - r}`,
+                `Q ${xNear},${aStart} ${xNear + cd * r},${aStart}`,
+                `L ${xFar - cd * r},${aStart}`,
+                `Q ${xFar},${aStart} ${xFar},${aStart + r}`,
+                `L ${xFar},${aEnd - r}`,
+                `Q ${xFar},${aEnd} ${xFar - cd * r},${aEnd}`,
+                `L ${xNear + cd * r},${aEnd}`,
+                `Q ${xNear},${aEnd} ${xNear},${aEnd + r}`,
+                `L ${xNear},${svgH}`,
             ].join(' ');
 
             path.setAttribute('d', d);
@@ -444,20 +449,23 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
             underline.style.width = `${svgW}px`;
             underline.style.height = `${svgH}px`;
 
-            const yBot = svgH - half;
-            const yTop = half;
+            // bottom header: indicator on the top edge (invert y sides)
+            const isBottomHeader = headerPosition === 'bottom';
+            const yNear = isBottomHeader ? half : svgH - half;
+            const yFar = isBottomHeader ? svgH - half : half;
+            const cd = isBottomHeader ? 1 : -1; // curve direction
 
             const d = [
-                `M 0,${yBot}`,
-                `L ${aStart - r},${yBot}`,
-                `Q ${aStart},${yBot} ${aStart},${yBot - r}`,
-                `L ${aStart},${yTop + r}`,
-                `Q ${aStart},${yTop} ${aStart + r},${yTop}`,
-                `L ${aEnd - r},${yTop}`,
-                `Q ${aEnd},${yTop} ${aEnd},${yTop + r}`,
-                `L ${aEnd},${yBot - r}`,
-                `Q ${aEnd},${yBot} ${aEnd + r},${yBot}`,
-                `L ${svgW},${yBot}`,
+                `M 0,${yNear}`,
+                `L ${aStart - r},${yNear}`,
+                `Q ${aStart},${yNear} ${aStart},${yNear + cd * r}`,
+                `L ${aStart},${yFar - cd * r}`,
+                `Q ${aStart},${yFar} ${aStart + r},${yFar}`,
+                `L ${aEnd - r},${yFar}`,
+                `Q ${aEnd},${yFar} ${aEnd},${yFar - cd * r}`,
+                `L ${aEnd},${yNear + cd * r}`,
+                `Q ${aEnd},${yNear} ${aEnd + r},${yNear}`,
+                `L ${svgW},${yNear}`,
             ].join(' ');
 
             path.setAttribute('d', d);

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -358,6 +358,7 @@ export class TabGroupManager {
                 getChipElement: (id) =>
                     this._chipRenderers.get(id)?.chip.element,
                 getDirection: () => this._ctx.getDirection(),
+                getHeaderPosition: () => this._ctx.group.model.headerPosition,
                 getColorPalette: () => this._ctx.accessor.tabGroupColorPalette,
             });
         }

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -1135,10 +1135,23 @@
 
 // Header-bottom: flip the active-tab indicator from bottom (content side when
 // tabs are on top) to top (content side when tabs are on bottom).
-.dv-groupview-header-bottom {
-    .dv-tabs-container > .dv-tab::after {
-        top: 0px;
-        bottom: auto;
+//
+// The per-theme active-marker rules compile with the theme-class prefix
+// (`.dockview-theme-x .dv-groupview.dv-active-group … .dv-active-tab::after`,
+// specificity 0,7,1). This override therefore mirrors that selector chain —
+// adding the header-bottom class on the (same) group element — to reach equal
+// specificity, then wins on source order because it is declared after every
+// theme mixin. A shorter selector loses the cascade and the flip silently
+// does nothing.
+.dv-groupview.dv-groupview-header-bottom {
+    &.dv-active-group,
+    &.dv-inactive-group {
+        > .dv-tabs-and-actions-container
+            .dv-tabs-container
+            > .dv-tab.dv-active-tab::after {
+            top: 0px;
+            bottom: auto;
+        }
     }
 }
 

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -1133,16 +1133,10 @@
     }
 }
 
-// Header-bottom: flip the active-tab indicator from bottom (content side when
-// tabs are on top) to top (content side when tabs are on bottom).
-//
-// The per-theme active-marker rules compile with the theme-class prefix
-// (`.dockview-theme-x .dv-groupview.dv-active-group … .dv-active-tab::after`,
-// specificity 0,7,1). This override therefore mirrors that selector chain —
-// adding the header-bottom class on the (same) group element — to reach equal
-// specificity, then wins on source order because it is declared after every
-// theme mixin. A shorter selector loses the cascade and the flip silently
-// does nothing.
+// When the header is at the bottom, the active-tab marker sits on the tab's
+// top edge — the side nearest the content. (For a top header it sits on the
+// bottom edge; this overrides that.) The selector matches the full per-theme
+// active-marker chain so it still applies inside a theme.
 .dv-groupview.dv-groupview-header-bottom {
     &.dv-active-group,
     &.dv-inactive-group {

--- a/packages/dockview-core/src/theme.scss
+++ b/packages/dockview-core/src/theme.scss
@@ -265,7 +265,7 @@
                         &::after {
                             position: absolute;
                             left: 0px;
-                            top: 0px;
+                            bottom: 0px;
                             content: '';
                             width: 100%;
                             height: 1px;
@@ -485,7 +485,7 @@
                         &::after {
                             position: absolute;
                             left: 0px;
-                            top: 0px;
+                            bottom: 0px;
                             content: '';
                             width: 100%;
                             height: 2px;
@@ -504,7 +504,7 @@
                         &::after {
                             position: absolute;
                             left: 0px;
-                            top: 0px;
+                            bottom: 0px;
                             content: '';
                             width: 100%;
                             height: 2px;
@@ -1132,3 +1132,13 @@
         bottom: 0;
     }
 }
+
+// Header-bottom: flip the active-tab indicator from bottom (content side when
+// tabs are on top) to top (content side when tabs are on bottom).
+.dv-groupview-header-bottom {
+    .dv-tabs-container > .dv-tab::after {
+        top: 0px;
+        bottom: auto;
+    }
+}
+

--- a/packages/docs/templates/dockview/tab-groups/react/src/app.tsx
+++ b/packages/docs/templates/dockview/tab-groups/react/src/app.tsx
@@ -6,6 +6,7 @@ import {
     GetTabContextMenuItemsParams,
     GetTabGroupChipContextMenuItemsParams,
     themeAbyss,
+    DockviewHeaderPosition,
 } from 'dockview-react';
 import React from 'react';
 import {
@@ -27,6 +28,18 @@ const components = {
 
 export default () => {
     const [api, setApi] = React.useState<DockviewApi>();
+    const [headerPosition, setHeaderPosition] =
+        React.useState<DockviewHeaderPosition>('top');
+
+    const onHeaderPositionChange = (
+        position: DockviewHeaderPosition
+    ) => {
+        setHeaderPosition(position);
+        if (!api) return;
+        for (const group of api.groups) {
+            group.api.setHeaderPosition(position);
+        }
+    };
 
     const onReady = (event: DockviewReadyEvent) => {
         setApi(event.api);
@@ -154,18 +167,33 @@ export default () => {
     );
 
     return (
-        <div style={{ width: '100%', height: '100%' }}>
-            <DockviewReact
-                className={'dockview-theme-abyss'}
-                onReady={onReady}
-                components={components}
-                theme={{ ...themeAbyss, tabAnimation: 'smooth' }}
-                disableFloatingGroups={true}
-                getTabContextMenuItems={getTabContextMenuItems}
-                getTabGroupChipContextMenuItems={
-                    getTabGroupChipContextMenuItems
-                }
-            />
+        <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '4px 8px' }}>
+                <span style={{ fontSize: '12px', color: 'var(--dv-paneview-header-border-color, #888)' }}>Tab position:</span>
+                {(['top', 'bottom'] as DockviewHeaderPosition[]).map((pos) => (
+                    <button
+                        key={pos}
+                        onClick={() => onHeaderPositionChange(pos)}
+                        disabled={headerPosition === pos}
+                    >
+                        {pos}
+                    </button>
+                ))}
+            </div>
+            <div style={{ flex: 1, minHeight: 0 }}>
+                <DockviewReact
+                    className={'dockview-theme-abyss'}
+                    onReady={onReady}
+                    components={components}
+                    theme={{ ...themeAbyss, tabAnimation: 'smooth', tabGroupIndicator: 'wrap' }}
+                    disableFloatingGroups={true}
+                    getTabContextMenuItems={getTabContextMenuItems}
+                    getTabGroupChipContextMenuItems={
+                        getTabGroupChipContextMenuItems
+                    }
+                />
+            </div>
         </div>
     );
 };
+


### PR DESCRIPTION
Builds on @KyDenZ's work in #1229 (tab-group indicator placement for bottom header position), brought up to date with master and completed.

## Summary
When tabs are at the **bottom** (or **right**), the Chrome-style tab-group wrap indicator and the active-tab marker now render on the content-adjacent edge, matching the top/left behaviour.

- **SVG wrap indicator** (`tabGroupIndicator.ts`): the path now flips its anchored edge with the header position — bottom headers anchor to the top edge, right headers to the left edge (the `near/far` + curve-direction refactor handles all four positions). *(from #1229)*
- **Active-tab `::after` marker** (`theme.scss`): flips to the top edge for bottom headers.

## Completeness fixes on top of #1229
- **The `::after` override now actually takes effect.** As originally written it was defeated by the per-theme active-marker rules: those compile with the theme-class prefix (`.dockview-theme-x …::after`, specificity `0,7,1`) while the override was only `0,3,1`, so the marker never flipped in a themed context. The override now mirrors the themed selector chain (the `header-bottom` class sits on the same `.dv-groupview` element), reaching equal specificity and winning on source order. Verified against the compiled CSS.
- **Regression tests added** (`tabGroupIndicator.spec.ts`): assert the generated SVG path's anchored edge flips with `headerPosition` for both axes (top↔bottom, left↔right) — the geometry was previously untested.

## Notes
- The change also harmonises a few themes whose active marker was inconsistently on the top edge, so the default (top-header) marker is now uniformly content-adjacent (bottom edge) across themes.
- The tab-groups sandbox gains a header-position selector for manual testing. *(from #1229)*

## Testing
- Full `dockview-core` suite green (1148); new indicator geometry tests pass; SCSS compiles; ESLint clean.

Closes #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)