### PR TITLE
feat(dockview-core): report user-vs-api origin on active panel change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,12 @@ NX handles build ordering automatically via `dependsOn: ["^build"]`. The depende
 -   Serialization provides snapshot-based state persistence
 -   APIs provide reactive interfaces with event subscriptions
 
+### Coding Conventions
+
+-   When fixing a bug, write a failing test that reproduces it first, then make it pass.
+-   Code comments describe the current state of the code, not its history. Don't reference the fix, PR, or what changed unless that context is critical to understanding the code as it stands.
+-   Keep comments brief and concise.
+
 ## Release Management
 
 ### Creating Release Notes

--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -26,6 +26,7 @@ DefaultDockviewDeserialzier
 DefaultTab
 Direction
 DistributeSizing
+DockviewActivePanelChangeEvent
 DockviewApi
 DockviewComponent
 DockviewComponentOptions
@@ -52,11 +53,11 @@ DockviewIDisposable
 DockviewKeybindings
 DockviewLayoutMutationEvent
 DockviewLayoutMutationKind
-DockviewLayoutMutationOrigin
 DockviewMaximizedGroupChanged
 DockviewMessages
 DockviewMutableDisposable
 DockviewOptions
+DockviewOrigin
 DockviewPanel
 DockviewPanelApi
 DockviewPanelMoveParams

--- a/packages/dockview-core/src/__tests__/dockview/activePanelOrigin.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/activePanelOrigin.spec.ts
@@ -1,0 +1,105 @@
+import {
+    DockviewActivePanelChangeEvent,
+    DockviewComponent,
+    DockviewOrigin,
+} from '../../dockview/dockviewComponent';
+import { IContentRenderer } from '../../dockview/types';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * `onDidActivePanelChange` carries a {@link DockviewOrigin} so consumers can
+ * tell a user gesture (`'user'`) from a programmatic `setActive` (`'api'`).
+ * The component sink defaults to `'user'`; the DockviewApi / panel-api boundary
+ * flips it to `'api'`, and an outer `withOrigin('user')` (used by gesture call
+ * sites that route through the panel api) wins over that.
+ */
+describe('active panel change origin', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+    let origins: DockviewOrigin[];
+    let events: DockviewActivePanelChangeEvent[];
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(1000, 1000);
+        origins = [];
+        events = [];
+        dockview.onDidActivePanelChange((e) => {
+            origins.push(e.origin);
+            events.push(e);
+        });
+    });
+
+    afterEach(() => dockview.dispose());
+
+    test('activation from a programmatic api mutation is tagged "api"', () => {
+        dockview.api.addPanel({ id: 'p1', component: 'default' });
+        expect(origins).toEqual(['api']);
+    });
+
+    test('activation from a direct (component) mutation is tagged "user"', () => {
+        // Driving the component directly models the DnD / tab-UI paths that
+        // never pass through the DockviewApi.
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        expect(origins).toEqual(['user']);
+    });
+
+    test('a programmatic panel.api.setActive() is tagged "api"', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        origins.length = 0;
+
+        p1.api.setActive();
+        expect(origins).toEqual(['api']);
+    });
+
+    test('a direct component setActivePanel is tagged "user"', () => {
+        // Models the main tab-click path (group.model.openPanel), which never
+        // passes through the panel api's `'api'` stamp.
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        origins.length = 0;
+
+        dockview.setActivePanel(p1);
+        expect(origins).toEqual(['user']);
+    });
+
+    test('an outer withOrigin("user") wins over the panel-api "api" stamp', () => {
+        // This is exactly what gesture call sites (tab overflow, keyboard
+        // activation) do: wrap the setActive call so it reports "user" even
+        // though it routes through the panel api.
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        origins.length = 0;
+
+        dockview.withOrigin('user', () => p1.api.setActive());
+        expect(origins).toEqual(['user']);
+    });
+
+    test('the event payload carries both the panel and the origin', () => {
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        events.length = 0;
+
+        p1.api.setActive();
+
+        expect(events.length).toBe(1);
+        expect(events[0].panel).toBe(p1);
+        expect(events[0].origin).toBe('api');
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
@@ -15,6 +15,7 @@ import { DockviewPanelApi } from '../../../../api/dockviewPanelApi';
 describe('tabsContainer', () => {
     test('that an external event does not render a drop target and calls through to the group mode', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
             options: {},
@@ -73,6 +74,7 @@ describe('tabsContainer', () => {
 
     test('that a drag over event from another tab should render a drop target', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             id: 'testcomponentid',
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -148,6 +150,7 @@ describe('tabsContainer', () => {
 
     test('that dropping over the empty space should render a drop target', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             id: 'testcomponentid',
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -219,6 +222,7 @@ describe('tabsContainer', () => {
         'that dropping over the empty space does not render a drop target when group is locked=%p (regression #990)',
         (lockedValue) => {
             const accessor = fromPartial<DockviewComponent>({
+                withOrigin: (_origin: any, fn: () => any) => fn(),
                 id: 'testcomponentid',
                 onDidAddPanel: jest.fn(),
                 onDidRemovePanel: jest.fn(),
@@ -287,6 +291,7 @@ describe('tabsContainer', () => {
 
     test('that dropping the first tab should render a drop target', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             id: 'testcomponentid',
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -356,6 +361,7 @@ describe('tabsContainer', () => {
 
     test('that dropping a tab from another component should not render a drop target', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             id: 'testcomponentid',
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -430,6 +436,7 @@ describe('tabsContainer', () => {
 
     test('left actions', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             id: 'testcomponentid',
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -497,6 +504,7 @@ describe('tabsContainer', () => {
 
     test('right actions', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             id: 'testcomponentid',
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -564,6 +572,7 @@ describe('tabsContainer', () => {
 
     test('that a tab will become floating when clicked if not floating and shift is selected', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             options: {},
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -623,6 +632,7 @@ describe('tabsContainer', () => {
 
     test('that an edge group cannot be floated via shift+click', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             options: {},
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -672,6 +682,7 @@ describe('tabsContainer', () => {
 
     test('that a tab that is already floating cannot be floated again', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             options: {},
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -726,6 +737,7 @@ describe('tabsContainer', () => {
 
     test('that selecting a tab with shift down will move that tab into a new floating group', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             options: {},
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -785,6 +797,7 @@ describe('tabsContainer', () => {
 
     test('pre header actions', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             options: {},
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -855,6 +868,7 @@ describe('tabsContainer', () => {
 
     test('left header actions', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             options: {},
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -925,6 +939,7 @@ describe('tabsContainer', () => {
 
     test('right header actions', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             options: {},
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
@@ -996,6 +1011,7 @@ describe('tabsContainer', () => {
     test('class dv-single-tab is present when only one tab exists`', () => {
         const cut = new TabsContainer(
             fromPartial<DockviewComponent>({
+                withOrigin: (_origin: any, fn: () => any) => fn(),
                 options: {},
                 onDidOptionsChange: jest
                     .fn()
@@ -1030,6 +1046,7 @@ describe('tabsContainer', () => {
     describe('updateDragAndDropState', () => {
         test('that updateDragAndDropState calls updateDragAndDropState on tabs and voidContainer', () => {
             const accessor = fromPartial<DockviewComponent>({
+                withOrigin: (_origin: any, fn: () => any) => fn(),
                 onDidAddPanel: jest.fn(),
                 onDidRemovePanel: jest.fn(),
                 options: {},
@@ -1071,6 +1088,7 @@ describe('tabsContainer', () => {
             };
 
             const accessor = fromPartial<DockviewComponent>({
+                withOrigin: (_origin: any, fn: () => any) => fn(),
                 onDidAddPanel: jest.fn(),
                 onDidRemovePanel: jest.fn(),
                 options: {},
@@ -1212,6 +1230,7 @@ describe('tabsContainer', () => {
             };
 
             const accessor = fromPartial<DockviewComponent>({
+                withOrigin: (_origin: any, fn: () => any) => fn(),
                 onDidAddPanel: jest.fn(),
                 onDidRemovePanel: jest.fn(),
                 options: {},
@@ -1343,6 +1362,7 @@ describe('tabsContainer', () => {
             };
 
             const accessor = fromPartial<DockviewComponent>({
+                withOrigin: (_origin: any, fn: () => any) => fn(),
                 onDidAddPanel: jest.fn(),
                 onDidRemovePanel: jest.fn(),
                 options: {},
@@ -1466,6 +1486,7 @@ describe('tabsContainer', () => {
 
     test('direction setter toggles CSS classes', () => {
         const accessor = fromPartial<DockviewComponent>({
+            withOrigin: (_origin: any, fn: () => any) => fn(),
             onDidAddPanel: jest.fn(),
             onDidRemovePanel: jest.fn(),
             options: {},

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -2799,7 +2799,7 @@ describe('dockviewComponent', () => {
             dockview.onDidRemovePanel((panel) => {
                 events.push({ type: 'REMOVE_PANEL', panel });
             }),
-            dockview.onDidActivePanelChange((panel) => {
+            dockview.onDidActivePanelChange(({ panel }) => {
                 events.push({ type: 'ACTIVE_PANEL', panel });
             }),
             dockview.onDidMovePanel(({ panel }) => {
@@ -3691,7 +3691,7 @@ describe('dockviewComponent', () => {
                 removePanel.push(panel);
             }),
             dockview.onDidActivePanelChange((event) => {
-                activePanel.push(event);
+                activePanel.push(event.panel);
             }),
             dockview.onDidMovePanel((event) => {
                 movedPanels.push(event.panel);

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -352,7 +352,7 @@ describe('layout mutation events', () => {
             dockview.api.addPanel({ id: 'p1', component: 'default' });
             dockview.addPanel({ id: 'p2', component: 'default' });
             expect(origins).toEqual(['api', 'user']);
-            expect(dockview.mutationOrigin()).toBe('user');
+            expect(dockview.currentOrigin()).toBe('user');
         });
     });
 });

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -1,4 +1,5 @@
 import {
+    DockviewActivePanelChangeEvent,
     DockviewLayoutMutationEvent,
     DockviewMaximizedGroupChanged,
     FloatingGroupOptions,
@@ -679,9 +680,11 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
     }
 
     /**
-     * Invoked when the active panel changes. May be undefined if no panel is active.
+     * Invoked when the active panel changes. The event carries the active
+     * `panel` (may be undefined if no panel is active) and the
+     * {@link DockviewOrigin} (`'user'` vs `'api'`) of the change.
      */
-    get onDidActivePanelChange(): Event<IDockviewPanel | undefined> {
+    get onDidActivePanelChange(): Event<DockviewActivePanelChangeEvent> {
         return this.component.onDidActivePanelChange;
     }
 
@@ -924,7 +927,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
     addPanel<T extends object = Parameters>(
         options: AddPanelOptions<T>
     ): IDockviewPanel {
-        return this.component.withMutationOrigin('api', () =>
+        return this.component.withOrigin('api', () =>
             this.component.addPanel(options)
         );
     }
@@ -933,7 +936,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      * Remove a panel given the panel object.
      */
     removePanel(panel: IDockviewPanel): void {
-        this.component.withMutationOrigin('api', () =>
+        this.component.withOrigin('api', () =>
             this.component.removePanel(panel)
         );
     }
@@ -949,7 +952,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      * Close all groups and panels.
      */
     closeAllGroups(): void {
-        return this.component.withMutationOrigin('api', () =>
+        return this.component.withOrigin('api', () =>
             this.component.closeAllGroups()
         );
     }
@@ -958,7 +961,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      * Remove a group and any panels within the group.
      */
     removeGroup(group: IDockviewGroupPanel): void {
-        this.component.withMutationOrigin('api', () =>
+        this.component.withOrigin('api', () =>
             this.component.removeGroup(<DockviewGroupPanel>group)
         );
     }
@@ -977,7 +980,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         item: IDockviewPanel | DockviewGroupPanel,
         options?: FloatingGroupOptions
     ): void {
-        return this.component.withMutationOrigin('api', () =>
+        return this.component.withOrigin('api', () =>
             this.component.addFloatingGroup(item, options)
         );
     }
@@ -989,7 +992,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         data: SerializedDockview,
         options?: { reuseExistingPanels: boolean }
     ): void {
-        this.component.withMutationOrigin('api', () =>
+        this.component.withOrigin('api', () =>
             this.component.fromJSON(data, options)
         );
     }
@@ -1005,7 +1008,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      * Reset the component back to an empty and default state.
      */
     clear(): void {
-        this.component.withMutationOrigin('api', () => this.component.clear());
+        this.component.withOrigin('api', () => this.component.clear());
     }
 
     /**
@@ -1050,7 +1053,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
             onWillClose?: (event: { id: string; window: Window }) => void;
         }
     ): Promise<boolean> {
-        return this.component.withMutationOrigin('api', () =>
+        return this.component.withOrigin('api', () =>
             this.component.addPopoutGroup(item, options)
         );
     }
@@ -1119,7 +1122,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         componentParams?: Record<string, unknown>;
     }): ITabGroup {
         const model = this._getGroupModel(options.groupId);
-        return this.component.withMutationOrigin('api', () =>
+        return this.component.withOrigin('api', () =>
             model.createTabGroup({
                 label: options.label,
                 color: options.color,
@@ -1130,7 +1133,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
 
     dissolveTabGroup(options: { groupId: string; tabGroupId: string }): void {
         const model = this._getGroupModel(options.groupId);
-        this.component.withMutationOrigin('api', () =>
+        this.component.withOrigin('api', () =>
             model.dissolveTabGroup(options.tabGroupId)
         );
     }
@@ -1142,7 +1145,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         index?: number;
     }): void {
         const model = this._getGroupModel(options.groupId);
-        this.component.withMutationOrigin('api', () =>
+        this.component.withOrigin('api', () =>
             model.addPanelToTabGroup(
                 options.tabGroupId,
                 options.panelId,
@@ -1156,7 +1159,7 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         panelId: string;
     }): void {
         const model = this._getGroupModel(options.groupId);
-        this.component.withMutationOrigin('api', () =>
+        this.component.withOrigin('api', () =>
             model.removePanelFromTabGroup(options.panelId)
         );
     }

--- a/packages/dockview-core/src/api/dockviewPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewPanelApi.ts
@@ -159,6 +159,14 @@ export class DockviewPanelApiImpl
         return this.group.api.getWindow();
     }
 
+    override setActive(): void {
+        // A bare `panel.api.setActive()` from application code is a
+        // programmatic activation. Tag it `'api'` so `onDidActivePanelChange`
+        // reports the correct origin; user-gesture call sites that route
+        // through here wrap the call in `withOrigin('user')` first, which wins.
+        this.accessor.withOrigin('api', () => super.setActive());
+    }
+
     moveTo(options: DockviewPanelMoveParams): void {
         this.accessor.moveGroupOrPanel({
             from: { groupId: this._group.id, panelId: this.panel.id },

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -566,7 +566,9 @@ export class Tabs extends CompositeDisposable {
             case ' ':
                 // Manual activation of the focused tab.
                 event.preventDefault();
-                this._tabs[index].value.panel.api.setActive();
+                this.accessor.withOrigin('user', () =>
+                    this._tabs[index].value.panel.api.setActive()
+                );
                 break;
         }
     }

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -509,7 +509,9 @@ export class TabsContainer
                                 const panel = this.group.panels.find(
                                     (p) => p.id === firstPanelId
                                 );
-                                panel?.api.setActive();
+                                this.accessor.withOrigin('user', () =>
+                                    panel?.api.setActive()
+                                );
                             }
                         });
 
@@ -554,7 +556,9 @@ export class TabsContainer
                             tg.expand();
                         }
                         tab.element.scrollIntoView();
-                        tab.panel.api.setActive();
+                        this.accessor.withOrigin('user', () =>
+                            tab.panel.api.setActive()
+                        );
                     });
                     wrapper.appendChild(child);
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -284,17 +284,28 @@ export type DockviewLayoutMutationKind =
     | 'clear';
 
 /**
- * Who caused a layout mutation: `'user'` for mutations driven by direct
- * interaction (drag-and-drop, tab UI, keyboard docking) and `'api'` for those
- * entered through a {@link DockviewApi} method called by application code.
- * Lets consumers (e.g. an undo stack) treat the app's own programmatic changes
- * differently from end-user gestures.
+ * Who caused an operation: `'user'` for changes driven by direct interaction
+ * (drag-and-drop, tab UI, keyboard docking) and `'api'` for those entered
+ * through a {@link DockviewApi} method called by application code. Lets
+ * consumers (e.g. an undo stack, or a context-sync listener) treat the app's
+ * own programmatic changes differently from end-user gestures.
  */
-export type DockviewLayoutMutationOrigin = 'user' | 'api';
+export type DockviewOrigin = 'user' | 'api';
 
 export interface DockviewLayoutMutationEvent {
     readonly kind: DockviewLayoutMutationKind;
-    readonly origin: DockviewLayoutMutationOrigin;
+    readonly origin: DockviewOrigin;
+}
+
+/**
+ * Fired by `onDidActivePanelChange` when the active panel changes. Carries the
+ * {@link DockviewOrigin} so consumers can distinguish a user clicking a tab
+ * from a programmatic `setActive` call (e.g. to avoid feedback loops when
+ * syncing context off the active panel).
+ */
+export interface DockviewActivePanelChangeEvent {
+    readonly panel: IDockviewPanel | undefined;
+    readonly origin: DockviewOrigin;
 }
 
 export interface PopoutGroupChangeSizeEvent {
@@ -332,16 +343,13 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     readonly onWillDrop: Event<DockviewWillDropEvent>;
     readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent>;
     readonly onDidMutateLayout: Event<DockviewLayoutMutationEvent>;
-    mutationOrigin(): DockviewLayoutMutationOrigin;
-    withMutationOrigin<T>(
-        origin: DockviewLayoutMutationOrigin,
-        func: () => T
-    ): T;
+    currentOrigin(): DockviewOrigin;
+    withOrigin<T>(origin: DockviewOrigin, func: () => T): T;
     readonly onWillShowOverlay: Event<DockviewWillShowOverlayLocationEvent>;
     readonly onDidRemovePanel: Event<IDockviewPanel>;
     readonly onDidAddPanel: Event<IDockviewPanel>;
     readonly onDidLayoutFromJSON: Event<void>;
-    readonly onDidActivePanelChange: Event<IDockviewPanel | undefined>;
+    readonly onDidActivePanelChange: Event<DockviewActivePanelChangeEvent>;
     readonly onWillDragPanel: Event<TabDragEvent>;
     readonly onWillDragGroup: Event<GroupDragEvent>;
     readonly onDidRemoveGroup: Event<DockviewGroupPanel>;
@@ -460,10 +468,13 @@ export class DockviewComponent
     // Compound operations (e.g. a drag that relocates a panel) nest via the
     // depth counter and bracket as a single transaction. See `mutation()`.
     private _mutationDepth = 0;
-    // Current mutation origin. Defaults to `'user'`; the DockviewApi boundary
+    // Current operation origin. Defaults to `'user'`; the DockviewApi boundary
     // flips it to `'api'` for the duration of a programmatic call via
-    // `withMutationOrigin`. Nested mutations inherit the outer origin.
-    private _mutationOrigin: DockviewLayoutMutationOrigin = 'user';
+    // `withOrigin`. Nested operations inherit the outermost origin (tracked by
+    // `_originDepth`, independent of mutation bracketing so it also covers
+    // active-panel changes that are not structural mutations).
+    private _origin: DockviewOrigin = 'user';
+    private _originDepth = 0;
     private readonly _onWillMutateLayout =
         new Emitter<DockviewLayoutMutationEvent>();
     readonly onWillMutateLayout: Event<DockviewLayoutMutationEvent> =
@@ -511,10 +522,9 @@ export class DockviewComponent
     private readonly _onDidLayoutFromJSON = new Emitter<void>();
     readonly onDidLayoutFromJSON: Event<void> = this._onDidLayoutFromJSON.event;
 
-    private readonly _onDidActivePanelChange = new Emitter<
-        IDockviewPanel | undefined
-    >({ replay: true });
-    readonly onDidActivePanelChange: Event<IDockviewPanel | undefined> =
+    private readonly _onDidActivePanelChange =
+        new Emitter<DockviewActivePanelChangeEvent>({ replay: true });
+    readonly onDidActivePanelChange: Event<DockviewActivePanelChangeEvent> =
         this._onDidActivePanelChange.event;
 
     private readonly _onDidMovePanel = new Emitter<MovePanelEvent>();
@@ -3594,7 +3604,7 @@ export class DockviewComponent
 
         if (!options?.skipActive) {
             if (this.activePanel !== activePanel) {
-                this._onDidActivePanelChange.fire(this.activePanel);
+                this.fireActivePanelChange(this.activePanel);
             }
         }
 
@@ -3642,7 +3652,7 @@ export class DockviewComponent
      */
     mutation<T>(kind: DockviewLayoutMutationKind, func: () => T): T {
         const outer = this._mutationDepth === 0;
-        const origin = this._mutationOrigin;
+        const origin = this._origin;
         if (outer) {
             this._onWillMutateLayout.fire({ kind, origin });
         }
@@ -3658,37 +3668,44 @@ export class DockviewComponent
     }
 
     /**
-     * The origin of the mutation currently in progress (`'user'` by default).
-     * Read inside a `mutation()`'s lifetime to learn whether the change was
-     * driven by application code (via the {@link DockviewApi}) or a user
-     * gesture.
+     * The origin of the operation currently in progress (`'user'` by default).
+     * Read inside a `mutation()` or active-panel change to learn whether the
+     * change was driven by application code (via the {@link DockviewApi}) or a
+     * user gesture.
      */
-    mutationOrigin(): DockviewLayoutMutationOrigin {
-        return this._mutationOrigin;
+    currentOrigin(): DockviewOrigin {
+        return this._origin;
     }
 
     /**
-     * Run `func` with the mutation origin set to `origin`, restoring the
+     * Run `func` with the operation origin set to `origin`, restoring the
      * previous value afterwards. Used by the DockviewApi boundary to tag
-     * programmatic mutations as `'api'`; nested mutations inherit the
-     * outermost origin (a re-entrant call does not overwrite it).
+     * programmatic operations as `'api'`, and by user-gesture handlers to tag
+     * `'user'`. Only the outermost caller sets the origin — a nested call (or a
+     * call made while a mutation is already in flight) keeps whatever the
+     * enclosing operation established, so the trigger always wins.
      */
-    withMutationOrigin<T>(
-        origin: DockviewLayoutMutationOrigin,
-        func: () => T
-    ): T {
-        // Only the outermost caller sets the origin — a nested mutation keeps
-        // whatever the enclosing operation established.
-        if (this._mutationDepth > 0) {
+    withOrigin<T>(origin: DockviewOrigin, func: () => T): T {
+        if (this._originDepth > 0 || this._mutationDepth > 0) {
             return func();
         }
-        const previous = this._mutationOrigin;
-        this._mutationOrigin = origin;
+        const previous = this._origin;
+        this._origin = origin;
+        this._originDepth++;
         try {
             return func();
         } finally {
-            this._mutationOrigin = previous;
+            this._originDepth--;
+            this._origin = previous;
         }
+    }
+
+    /**
+     * Fire `onDidActivePanelChange` with the panel and the current operation
+     * {@link DockviewOrigin}. Callers keep their own dedupe guards.
+     */
+    private fireActivePanelChange(panel: IDockviewPanel | undefined): void {
+        this._onDidActivePanelChange.fire({ panel, origin: this._origin });
     }
 
     moveGroupOrPanel(options: MoveGroupOrPanelOptions): void {
@@ -4419,9 +4436,9 @@ export class DockviewComponent
 
         if (
             !this._moving &&
-            activePanel !== this._onDidActivePanelChange.value
+            activePanel !== this._onDidActivePanelChange.value?.panel
         ) {
-            this._onDidActivePanelChange.fire(activePanel);
+            this.fireActivePanelChange(activePanel);
         }
     }
 
@@ -4440,9 +4457,9 @@ export class DockviewComponent
 
         if (
             !this._moving &&
-            activePanel !== this._onDidActivePanelChange.value
+            activePanel !== this._onDidActivePanelChange.value?.panel
         ) {
-            this._onDidActivePanelChange.fire(activePanel);
+            this.fireActivePanelChange(activePanel);
         }
     }
 
@@ -4543,8 +4560,11 @@ export class DockviewComponent
                         return;
                     }
 
-                    if (this._onDidActivePanelChange.value !== event.panel) {
-                        this._onDidActivePanelChange.fire(event.panel);
+                    if (
+                        this._onDidActivePanelChange.value?.panel !==
+                        event.panel
+                    ) {
+                        this.fireActivePanelChange(event.panel);
                     }
                 }),
                 Event.any(

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -28,8 +28,13 @@ api.onDidAddPanel((panel: IDockviewPanel) => { });
 // Fires when a panel is removed (including when panels move between groups)
 api.onDidRemovePanel((panel: IDockviewPanel) => { });
 
-// Fires when the active panel changes. May be undefined if no panel is active.
-api.onDidActivePanelChange((panel: IDockviewPanel | undefined) => { });
+// Fires when the active panel changes. `panel` may be undefined if no panel is
+// active. `origin` is 'user' for a user gesture (e.g. clicking a tab) or 'api'
+// for a programmatic `setActive` call.
+api.onDidActivePanelChange((event: DockviewActivePanelChangeEvent) => {
+    // event.panel: IDockviewPanel | undefined
+    // event.origin: 'user' | 'api'
+});
 
 // Fires when a panel moves from one group to another
 api.onDidMovePanel((event: MovePanelEvent) => { });

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -442,8 +442,8 @@ const DockviewDemo = (props: {
                 addLogLine(`Panel Added ${event.id}`);
             }),
             api.onDidActivePanelChange((event) => {
-                setActivePanel(event?.id);
-                addLogLine(`Panel Activated ${event?.id}`);
+                setActivePanel(event.panel?.id);
+                addLogLine(`Panel Activated ${event.panel?.id}`);
             }),
             api.onDidRemovePanel((event) => {
                 setPanels((_) => {

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/eventLogPanel.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/eventLogPanel.tsx
@@ -49,7 +49,7 @@ export const EventLogPanel: React.FC<{ api: DockviewApi }> = ({ api }) => {
                 add(`Panel removed: ${e.id}`, 'panel')
             ),
             api.onDidActivePanelChange((e) =>
-                add(`Active panel: ${e?.id ?? 'none'}`, 'panel')
+                add(`Active panel: ${e.panel?.id ?? 'none'}`, 'panel')
             ),
             api.onDidMovePanel((e) =>
                 add(`Panel moved: ${e.panel.id}`, 'panel')

--- a/packages/docs/templates/dockview/demo-dockview/angular/src/index.ts
+++ b/packages/docs/templates/dockview/demo-dockview/angular/src/index.ts
@@ -275,8 +275,8 @@ export class AppComponent implements OnDestroy {
                 this.groupCount = this.api!.groups.length;
                 this.cd.markForCheck();
             }),
-            this.api.onDidActivePanelChange((panel) => {
-                this.activePanelId = panel?.id ?? '';
+            this.api.onDidActivePanelChange((event) => {
+                this.activePanelId = event.panel?.id ?? '';
                 this.cd.markForCheck();
             })
         );

--- a/packages/docs/templates/dockview/demo-dockview/react/src/app.tsx
+++ b/packages/docs/templates/dockview/demo-dockview/react/src/app.tsx
@@ -164,8 +164,8 @@ const DockviewDemo = (props: { theme?: string }) => {
                 addLogLine(`Panel Added ${event.id}`);
             }),
             api.onDidActivePanelChange((event) => {
-                setActivePanel(event?.id);
-                addLogLine(`Panel Activated ${event?.id}`);
+                setActivePanel(event.panel?.id);
+                addLogLine(`Panel Activated ${event.panel?.id}`);
             }),
             api.onDidRemovePanel((event) => {
                 setPanels((_) => {


### PR DESCRIPTION
## Summary

`onDidActivePanelChange` now reports **who** caused the change, so consumers can distinguish a user gesture (e.g. clicking a tab) from a programmatic `setActive` — useful for cross-panel context-linking recipes that must ignore their own programmatic activations to avoid feedback loops.

This is the active-change counterpart to the layout-mutation **origin** added in #1328 — the same operation-origin mechanism, applied to active-panel changes.

## ⚠️ Breaking change (v7)

`DockviewApi.onDidActivePanelChange` payload changes from `IDockviewPanel | undefined` to:

```ts
interface DockviewActivePanelChangeEvent {
    panel: IDockviewPanel | undefined;
    origin: 'user' | 'api'; // DockviewOrigin
}
```

Migration:
```ts
// before
api.onDidActivePanelChange((panel) => use(panel?.id));
// after
api.onDidActivePanelChange(({ panel }) => use(panel?.id));
```

The group-level `group.api.onDidActivePanelChange` is unchanged.

## Implementation

- Generalised the mutation-origin context into one shared operation origin: `withMutationOrigin`→`withOrigin`, `mutationOrigin`→`currentOrigin`, `DockviewLayoutMutationOrigin`→`DockviewOrigin` (clean rename, no aliases — they were one day old and internal-only).
- Default origin is `'user'`; the panel-api boundary (`DockviewPanelApiImpl.setActive`) stamps `'api'`. Outermost-wins guard means user-gesture call sites that route through the panel api (tab overflow, keyboard activation) wrap in `withOrigin('user')`.
- The main tab-click path (`group.model.openPanel`) needs no annotation — it defaults to `'user'`.

## Tests

- New `activePanelOrigin.spec.ts` (6 tests) covering api / user / mutation-side-effect / outermost-wins / payload shape.
- All 1152 core tests pass; `tsc --noEmit` clean; 0 lint errors.

## Docs

- `events.mdx` updated; demo + source templates migrated to the new payload.