### PR TITLE
feat(dockview-core)!: remove the deprecated rootOverlayModel option

### DIFF
--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -96,7 +96,6 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Input() className?: string;
     @Input() orientation?: 'horizontal' | 'vertical';
     @Input() hideBorders?: boolean;
-    @Input() rootOverlayModel?: 'always' | 'never';
     @Input() defaultTabComponent_?: string;
     @Input() tabHeight?: number;
     @Input() disableFloatingGroups?: boolean;

--- a/packages/dockview-core/src/__tests__/dockview/rootDropTargetService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/rootDropTargetService.spec.ts
@@ -1,0 +1,90 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import {
+    IRootDropTargetHost,
+    RootDropTargetService,
+} from '../../dockview/rootDropTargetService';
+import { DroptargetOverlayModel } from '../../dnd/droptarget';
+import { DockviewComponentOptions } from '../../dockview/options';
+
+function createHost(
+    options: Partial<DockviewComponentOptions>
+): IRootDropTargetHost {
+    return fromPartial<IRootDropTargetHost>({
+        id: 'test',
+        element: document.createElement('div'),
+        options: options as DockviewComponentOptions,
+        isGridEmpty: () => true,
+        rootDropTargetOverrideTarget: () => undefined,
+        dispatchUnhandledDragOver: () => false,
+    });
+}
+
+// Reach the (private) backend drop targets to assert the applied overlay model.
+function overlayModels(
+    service: RootDropTargetService
+): (DroptargetOverlayModel | undefined)[] {
+    const s = service as any;
+    return [
+        s._html5Target.options.overlayModel,
+        s._pointerTarget.options.overlayModel,
+    ];
+}
+
+function disabledFlags(service: RootDropTargetService): boolean[] {
+    const s = service as any;
+    return [s._html5Target.disabled, s._pointerTarget.disabled];
+}
+
+describe('RootDropTargetService', () => {
+    test('a `dndEdges` object is applied to both backends at construction', () => {
+        const model: DroptargetOverlayModel = {
+            activationSize: { type: 'pixels', value: 30 },
+            size: { type: 'pixels', value: 40 },
+        };
+
+        const service = new RootDropTargetService(
+            createHost({ dndEdges: model })
+        );
+
+        expect(overlayModels(service)).toEqual([model, model]);
+
+        service.dispose();
+    });
+
+    test('omitting `dndEdges` falls back to the default overlay model', () => {
+        const service = new RootDropTargetService(createHost({}));
+
+        const [html5, pointer] = overlayModels(service);
+        expect(html5).toEqual({
+            activationSize: { type: 'pixels', value: 10 },
+            size: { type: 'pixels', value: 20 },
+        });
+        expect(pointer).toEqual(html5);
+
+        service.dispose();
+    });
+
+    test('setOptions applies a new `dndEdges` overlay model to both backends', () => {
+        const service = new RootDropTargetService(createHost({}));
+
+        const model: DroptargetOverlayModel = {
+            activationSize: { type: 'percentage', value: 25 },
+            size: { type: 'percentage', value: 50 },
+        };
+        service.setOptions({ dndEdges: model });
+
+        expect(overlayModels(service)).toEqual([model, model]);
+
+        service.dispose();
+    });
+
+    test('`dndEdges: false` disables both backends', () => {
+        const service = new RootDropTargetService(createHost({}));
+        expect(disabledFlags(service)).toEqual([false, false]);
+
+        service.setOptions({ dndEdges: false });
+        expect(disabledFlags(service)).toEqual([true, true]);
+
+        service.dispose();
+    });
+});

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -237,10 +237,6 @@ export interface DockviewOptions {
     debug?: boolean;
     // #start dnd
     dndEdges?: false | DroptargetOverlayModel;
-    /**
-     * @deprecated use `dndEdges` instead. To be removed in a future version.
-     * */
-    rootOverlayModel?: DroptargetOverlayModel;
     disableDnd?: boolean;
     /**
      * Selects which drag-and-drop implementation is active.
@@ -444,7 +440,6 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         defaultRenderer: undefined,
         defaultHeaderPosition: undefined,
         debug: undefined,
-        rootOverlayModel: undefined,
         locked: undefined,
         disableDnd: undefined,
         dndStrategy: undefined,

--- a/packages/dockview-core/src/dockview/rootDropTargetService.ts
+++ b/packages/dockview-core/src/dockview/rootDropTargetService.ts
@@ -40,7 +40,7 @@ export interface IRootDropTargetService extends IDisposable {
     readonly onWillShowOverlay: Event<WillShowOverlayEvent>;
     /** Merged stream from both DnD backends. */
     readonly onDrop: Event<DroptargetEvent>;
-    /** Apply changed options (dndEdges, rootOverlayModel). */
+    /** Apply changed options (dndEdges). */
     setOptions(options: Partial<DockviewComponentOptions>): void;
 }
 
@@ -81,7 +81,10 @@ export class RootDropTargetService implements IRootDropTargetService {
         };
 
         const overlayModel =
-            host.options.rootOverlayModel ?? DEFAULT_ROOT_OVERLAY_MODEL;
+            typeof host.options.dndEdges === 'object' &&
+            host.options.dndEdges !== null
+                ? host.options.dndEdges
+                : DEFAULT_ROOT_OVERLAY_MODEL;
 
         this._html5Target = html5Backend.createDropTarget(host.element, {
             className: 'dv-drop-target-edge',
@@ -108,9 +111,8 @@ export class RootDropTargetService implements IRootDropTargetService {
             this._pointerTarget.onDrop
         );
 
-        // Apply remaining initial-state options (dndEdges) now that the
-        // targets exist. rootOverlayModel was already baked into the ctor
-        // args above; setOptions handles dndEdges + late changes.
+        // Apply initial-state options now that the targets exist; setOptions
+        // handles dndEdges (disable + overlay model) and late changes.
         this.setOptions(host.options);
     }
 
@@ -132,10 +134,6 @@ export class RootDropTargetService implements IRootDropTargetService {
                 this._html5Target.setOverlayModel(DEFAULT_ROOT_OVERLAY_MODEL);
                 this._pointerTarget.setOverlayModel(DEFAULT_ROOT_OVERLAY_MODEL);
             }
-        }
-
-        if ('rootOverlayModel' in options) {
-            this.setOptions({ dndEdges: options.dndEdges });
         }
     }
 


### PR DESCRIPTION
## Summary

Removes the deprecated `rootOverlayModel` option. It was superseded by `dndEdges` and was in fact **silently ignored**: `RootDropTargetService.setOptions` re-dispatched `options.dndEdges` (`undefined`) instead of the passed `rootOverlayModel`, so the value was overwritten with the default at construction and on every `updateOptions`. Since master is the v7 (breaking) line, removing the dead alias is cleaner than fixing it.

## ⚠️ Breaking change (v7)

`DockviewOptions.rootOverlayModel` and the Angular `[rootOverlayModel]` input are removed. Use `dndEdges`:

```ts
// before
new DockviewComponent(el, { rootOverlayModel: model });
// after
new DockviewComponent(el, { dndEdges: model });
```

Anyone currently passing `rootOverlayModel` was already not having it honoured, so behaviour for correct (`dndEdges`) configs is unchanged.

## Changes

- Drop `rootOverlayModel` from `DockviewOptions` and `PROPERTY_KEYS_DOCKVIEW`.
- `RootDropTargetService` ctor derives the initial overlay model from `dndEdges`; the buggy `'rootOverlayModel' in options` branch is deleted.
- Remove the dead Angular `[rootOverlayModel]` `@Input` (never forwarded; had a bogus `'always' | 'never'` type).
- New `rootDropTargetService.spec.ts` (the service had zero coverage): a `dndEdges` object reaches both DnD backends at construction and via `setOptions`, the default fallback applies when omitted, and `dndEdges: false` disables both.

## Tests

- 1150 core tests pass (incl. 4 new); `tsc --noEmit` clean; 0 lint errors.