### PR TITLE
feat(dockview-core): keyboard tab-close + focus-the-tab-strip

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/accessibilityDocking.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/accessibilityDocking.spec.ts
@@ -199,6 +199,87 @@ describe('accessibility: tab switching', () => {
 });
 
 /**
+ * Jump focus from panel content into the active group's tab strip
+ * (Ctrl+Shift+\ by default), from where the tablist's own roving-tabindex
+ * arrow navigation takes over.
+ */
+describe('accessibility: focus the tab strip', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+
+    const make = (
+        keyboardNavigation: boolean | { keymap?: Record<string, string> }
+    ): void => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            keyboardNavigation,
+        });
+        dockview.layout(1000, 1000);
+    };
+
+    const threeTabs = (): void => {
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        dockview.addPanel({ id: 'p2', component: 'default', title: 'P2' });
+        dockview.addPanel({ id: 'p3', component: 'default', title: 'P3' });
+    };
+
+    afterEach(() => {
+        dockview.dispose();
+        container.remove();
+    });
+
+    test('Ctrl+Shift+\\ focuses the active group active tab', () => {
+        make(true);
+        threeTabs(); // one group, p3 active
+
+        fireEvent.keyDown(dockview.element, {
+            key: '\\',
+            ctrlKey: true,
+            shiftKey: true,
+        });
+
+        const active = document.activeElement as HTMLElement;
+        expect(active?.getAttribute('role')).toBe('tab');
+        expect(active?.textContent).toContain('P3');
+    });
+
+    test('a rebound focusTabs keymap is honoured (and the default no longer fires)', () => {
+        make({ keymap: { focusTabs: 'alt+t' } });
+        threeTabs();
+
+        fireEvent.keyDown(dockview.element, {
+            key: '\\',
+            ctrlKey: true,
+            shiftKey: true,
+        });
+        expect(
+            (document.activeElement as HTMLElement)?.getAttribute('role')
+        ).not.toBe('tab');
+
+        fireEvent.keyDown(dockview.element, { key: 't', altKey: true });
+        expect((document.activeElement as HTMLElement)?.textContent).toContain(
+            'P3'
+        );
+    });
+
+    test('does nothing when keyboardNavigation is off', () => {
+        make(false);
+        threeTabs();
+
+        fireEvent.keyDown(dockview.element, {
+            key: '\\',
+            ctrlKey: true,
+            shiftKey: true,
+        });
+        expect(
+            (document.activeElement as HTMLElement)?.getAttribute('role')
+        ).not.toBe('tab');
+    });
+});
+
+/**
  * Move focus between groups by keyboard — F6 / Shift+F6 step to the next /
  * previous group in gridview order (wrapping round).
  */

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
@@ -704,6 +704,79 @@ describe('tabs', () => {
         });
     });
 
+    describe('keyboard tab close', () => {
+        function createClosablePanel(id: string): {
+            panel: IDockviewPanel;
+            close: jest.Mock;
+        } {
+            const close = jest.fn();
+            const panel = fromPartial<IDockviewPanel>({
+                id,
+                api: fromPartial({ close }),
+                view: fromPartial<IDockviewPanelModel>({
+                    tab: {
+                        element: document.createElement('div'),
+                        init: jest.fn(),
+                        update: jest.fn(),
+                        dispose: jest.fn(),
+                    },
+                }),
+            });
+            return { panel, close };
+        }
+
+        test.each(['Delete', 'Backspace'])(
+            'pressing %s on a focused tab closes its panel',
+            (key) => {
+                const { tabs } = createTabsForDropTest();
+                const panels = ['p1', 'p2', 'p3'].map((id) =>
+                    createClosablePanel(id)
+                );
+                panels.forEach(({ panel }) => tabs.openPanel(panel));
+
+                fireEvent.keyDown(getTabElements(tabs)[1], { key });
+
+                expect(panels[1].close).toHaveBeenCalledTimes(1);
+                expect(panels[0].close).not.toHaveBeenCalled();
+                expect(panels[2].close).not.toHaveBeenCalled();
+            }
+        );
+
+        test('ignores the key when focus is not on a tab element', () => {
+            const { tabs } = createTabsForDropTest();
+            const { panel, close } = createClosablePanel('p1');
+            tabs.openPanel(panel);
+
+            fireEvent.keyDown((tabs as any)._tabsList, { key: 'Delete' });
+
+            expect(close).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('focusActiveTab', () => {
+        test('moves DOM focus to the tab of the group active panel', () => {
+            const { tabs } = createTabsForDropTest();
+            document.body.appendChild(tabs.element);
+
+            const p1 = createMockPanel('p1');
+            const p2 = createMockPanel('p2');
+            tabs.openPanel(p1);
+            tabs.openPanel(p2);
+            // The group reports p2 as active.
+            (tabs as any).group.activePanel = p2;
+
+            tabs.focusActiveTab();
+
+            expect(document.activeElement).toBe(getTabElements(tabs)[1]);
+            tabs.element.remove();
+        });
+
+        test('does not throw when there are no tabs', () => {
+            const { tabs } = createTabsForDropTest();
+            expect(() => tabs.focusActiveTab()).not.toThrow();
+        });
+    });
+
     describe('direction', () => {
         test('direction setter toggles CSS classes', () => {
             const cut = new Tabs(

--- a/packages/dockview-core/src/dockview/accessibilityService.ts
+++ b/packages/dockview-core/src/dockview/accessibilityService.ts
@@ -36,6 +36,7 @@ const DEFAULT_KEYMAP: DockviewKeybindings = {
     focusGroupUp: 'ctrl+shift+arrowup',
     focusGroupDown: 'ctrl+shift+arrowdown',
     dock: 'ctrl+m',
+    focusTabs: 'ctrl+shift+\\',
 };
 
 /**
@@ -310,10 +311,19 @@ export class AccessibilityService
         } else if (matchesBinding(e, keymap.focusGroupDown)) {
             this._consume(e);
             this._focusGroupInDirection('down');
+        } else if (matchesBinding(e, keymap.focusTabs)) {
+            this._consume(e);
+            this._focusTabs();
         }
     }
 
     // --- navigation (uses the public group API + the adjacentGroup primitive) ---
+
+    private _focusTabs(): void {
+        // Jump from panel content to the active group's tab strip; the
+        // tablist's own roving-tabindex handler takes over from there.
+        this.host.activeGroup?.model.focusActiveTab();
+    }
 
     private _switchTab(reverse: boolean): void {
         const group = this.host.activeGroup;

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -570,6 +570,40 @@ export class Tabs extends CompositeDisposable {
                     this._tabs[index].value.panel.api.setActive()
                 );
                 break;
+            case 'Delete':
+            case 'Backspace':
+                // Close the focused tab (Backspace covers macOS, where the
+                // primary delete key reports as Backspace).
+                event.preventDefault();
+                this._closeTab(index);
+                break;
+        }
+    }
+
+    /**
+     * Close the tab at `index` and move roving focus to a neighbouring tab so
+     * keyboard focus stays in the tablist.
+     */
+    private _closeTab(index: number): void {
+        const tab = this._tabs[index]?.value;
+        if (!tab) {
+            return;
+        }
+        // Resolve the post-close focus target before closing mutates the list:
+        // prefer the next tab, otherwise the previous.
+        const neighbourId = (
+            this._tabs[index + 1]?.value ?? this._tabs[index - 1]?.value
+        )?.panel.id;
+
+        tab.panel.api.close();
+
+        if (neighbourId !== undefined) {
+            const nextIndex = this._tabs.findIndex(
+                (t) => t.value.panel.id === neighbourId
+            );
+            if (nextIndex > -1) {
+                this._focusTab(nextIndex);
+            }
         }
     }
 
@@ -579,6 +613,18 @@ export class Tabs extends CompositeDisposable {
             this._tabs[i].value.element.tabIndex = i === index ? 0 : -1;
         }
         this._tabs[index].value.element.focus();
+    }
+
+    /** Move DOM focus to the active tab — the entry point into the tablist. */
+    focusActiveTab(): void {
+        if (this._tabs.length === 0) {
+            return;
+        }
+        const activeId = this.group.activePanel?.id;
+        const activeIndex = activeId
+            ? this._tabs.findIndex((t) => t.value.panel.id === activeId)
+            : -1;
+        this._focusTab(activeIndex > -1 ? activeIndex : 0);
     }
 
     setActivePanel(panel: IDockviewPanel): void {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -59,6 +59,7 @@ export interface ITabsContainer extends IDisposable {
     getTabId(panelId: string): string | undefined;
     setActive(isGroupActive: boolean): void;
     setActivePanel(panel: IDockviewPanel): void;
+    focusActiveTab(): void;
     isActive(tab: Tab): boolean;
     closePanel(panel: IDockviewPanel): void;
     openPanel(panel: IDockviewPanel, index?: number): void;
@@ -376,6 +377,10 @@ export class TabsContainer
 
     setActivePanel(panel: IDockviewPanel): void {
         this.tabs.setActivePanel(panel);
+    }
+
+    focusActiveTab(): void {
+        this.tabs.focusActiveTab();
     }
 
     openPanel(panel: IDockviewPanel, index: number = this.tabs.size): void {

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1168,6 +1168,10 @@ export class DockviewGroupPanelModel
         this.contentContainer.element.focus();
     }
 
+    focusActiveTab(): void {
+        this.tabsContainer.focusActiveTab();
+    }
+
     set renderContainer(value: OverlayRenderContainer | null) {
         this.panels.forEach((panel) => {
             this.renderContainer.detatch(panel);

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -121,6 +121,8 @@ export interface DockviewKeybindings {
     focusGroupDown: string;
     /** Arm keyboard docking of the active panel. Default `ctrl+m`. */
     dock: string;
+    /** Move focus from panel content to the focused group's tab strip. Default `ctrl+shift+\`. */
+    focusTabs: string;
 }
 
 export interface KeyboardNavigationOptions {


### PR DESCRIPTION
## Summary

Two small keyboard-accessibility additions to round out the tablist keyboard story.

### 1. Delete / Backspace closes a focused tab (free/core)
Extends the always-on WAI-ARIA tablist handler in the tabs component: with a tab focused, `Delete` (or `Backspace`, so the primary macOS delete key works) closes its panel via `panel.api.close()` and moves roving focus to a neighbouring tab so focus stays in the tablist.

### 2. `focusTabs` — jump from content to the tab strip (AccessibilityModule)
A new rebindable keymap action (default **`Ctrl+Shift+\`**) that moves focus from arbitrary panel content into the active group's tab strip; the tablist's existing arrow-key navigation takes over from there. It joins the existing keymap (`Ctrl+]`/`[`, `F6`, `Ctrl+Shift+Arrows`, `Ctrl+M`) and is overridable like the rest.

Path: `AccessibilityService` → `DockviewGroupPanelModel.focusActiveTab()` → `TabsContainer.focusActiveTab()` → `Tabs.focusActiveTab()`.

## Notes
- `Tabs.focusActiveTab()` resolves the active tab from the group's active panel — **not** `selectedIndex`, which only tracks the first-opened tab and isn't updated by `setActivePanel`.
- Delete-to-close mirrors the default tab's close button (no extra lock semantics).

## Tests
- `tabs.spec`: Delete/Backspace closes the focused tab + ignores the key off-tab; `focusActiveTab` focuses the active panel's tab.
- `accessibilityDocking.spec`: `Ctrl+Shift+\` focuses the active group's tab, honours a rebound keymap, and is inert when `keyboardNavigation` is off.
- 1164 core tests pass; `tsc --noEmit` clean; 0 lint errors; gen clean.