### PR TITLE
fix(v7): externalize dockview-react bundle + complete the v7 migration guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ yarn-error.log
 # NX
 .nx/cache
 .nx/workspace-data
+
+# Vite writes a transient bundled config next to vite.config.ts
+*.timestamp-*.mjs

--- a/MIGRATION-v7.md
+++ b/MIGRATION-v7.md
@@ -91,6 +91,66 @@ package — use `dockview`** (or a framework package — `dockview-react` / `-vu
 `console.warn` is emitted when a component is constructed on bare `dockview-core`
 steering you to `dockview`.
 
+## Removed and changed APIs (breaking)
+
+These affect every consumer regardless of framework.
+
+### `rootOverlayModel` removed
+
+The `rootOverlayModel` option has been removed. It was a single static overlay
+model applied to the root drop target. Drop-overlay shaping is now driven by:
+
+- **`dropOverlayModel`** — a callback that shapes the overlay per drop target
+  (`(params: DropOverlayModelParams) => DroptargetOverlayModel | undefined`).
+  Return `undefined` to keep the default for that target.
+- **`dndEdges`** — configures the outer-layout edge overlay (the case
+  `rootOverlayModel` previously covered for edge drops). `dropOverlayModel` does
+  **not** dispatch the `'edge'` target.
+
+```diff
+- new DockviewComponent(el, {
+-     rootOverlayModel: { size: { value: 100, type: 'pixels' } },
+- });
++ new DockviewComponent(el, {
++     dropOverlayModel: (params) => ({ size: { value: 100, type: 'pixels' } }),
++ });
+```
+
+If you were using `rootOverlayModel` purely to size the outer edge overlay, use
+`dndEdges` instead.
+
+### `onDidActivePanelChange` payload changed
+
+`onDidActivePanelChange` now emits an event object instead of the panel
+directly, so it can also report whether the change came from a user interaction
+or an API call.
+
+```diff
+- api.onDidActivePanelChange((panel) => {
+-     console.log(panel?.id);
+- });
++ api.onDidActivePanelChange((event) => {
++     console.log(event.panel?.id);
++     console.log(event.origin); // 'user' | 'api'
++ });
+```
+
+The event shape is:
+
+```ts
+interface DockviewActivePanelChangeEvent {
+    readonly panel: IDockviewPanel | undefined;
+    readonly origin: 'user' | 'api';
+}
+```
+
+**Symptom if you don't migrate:** the handler argument is now an object, so
+`panel.id` / `panel.api` read as `undefined` (no error is thrown). Replace
+`panel` with `event.panel`.
+
+> The group-level `dockviewGroupPanelApi.onDidActivePanelChange` is unchanged
+> and continues to emit its existing payload (without `origin`).
+
 ## Vue / Angular users
 
 No source changes required — keep installing `dockview-vue` / `dockview-angular`

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -436,8 +436,20 @@ let _hasWarnedUsingCoreDirectly = false;
  * `markDockviewPackageLoaded()` on import; if that marker is absent the consumer
  * is using `dockview-core` directly, so emit a one-time console warning
  * steering them to `dockview`.
+ *
+ * Suppressed in production builds: it is a development-time nudge and most
+ * bundlers inline `process.env.NODE_ENV` so the branch is dropped entirely. The
+ * `typeof process` guard keeps this safe in plain browser/UMD contexts where
+ * `process` is undefined.
  */
 function warnIfUsingCoreDirectly(): void {
+    if (
+        typeof process !== 'undefined' &&
+        process.env &&
+        process.env.NODE_ENV === 'production'
+    ) {
+        return;
+    }
     if (_hasWarnedUsingCoreDirectly || isDockviewPackageLoaded()) {
         return;
     }

--- a/packages/dockview-modules/src/__tests__/moduleRemovability.spec.ts
+++ b/packages/dockview-modules/src/__tests__/moduleRemovability.spec.ts
@@ -1,0 +1,117 @@
+import {
+    DockviewComponent,
+    DockviewModule,
+    IContentRenderer,
+    clearRegisteredModules,
+    registerModules,
+} from 'dockview-core';
+import { Modules } from '..';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * Companion to dockview-core's own `module removability` spec, which proves the
+ * built-in (core) modules are each independently removable. This proves the
+ * same for the *extracted* modules in this package: with any one of them
+ * absent, the core component must still construct, run the base layout
+ * operations (add / split / maximize / serialize / remove) and dispose without
+ * throwing. That is the contract that keeps the package boundary a
+ * lift-and-move — if removing a module breaks core, the boundary is leaking.
+ *
+ * Modules are wired through the process-global registry exactly how `dockview`
+ * ships them (`registerModules(Modules)`); the component is then constructed
+ * with no explicit `modules` option so it picks up the full realistic stack:
+ * core built-ins + whatever is registered here.
+ *
+ * `register()` recursively pulls in a module's `dependsOn`, so dropping a
+ * depended-on module while a dependent is still present would silently re-add
+ * it. To remove a module *genuinely* we also drop its (transitive) dependents.
+ */
+describe('extracted module removability', () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        container.remove();
+        // restore the baseline global registration for any later test
+        clearRegisteredModules();
+        registerModules(Modules);
+    });
+
+    const transitiveDependents = (
+        target: DockviewModule<any>
+    ): Set<DockviewModule<any>> => {
+        const dependents = new Set<DockviewModule<any>>();
+        let changed = true;
+        while (changed) {
+            changed = false;
+            for (const m of Modules) {
+                if (m === target || dependents.has(m)) {
+                    continue;
+                }
+                const deps = m.dependsOn ?? [];
+                if (
+                    deps.includes(target) ||
+                    deps.some((d) => dependents.has(d))
+                ) {
+                    dependents.add(m);
+                    changed = true;
+                }
+            }
+        }
+        return dependents;
+    };
+
+    const exercise = (excluded: DockviewModule<any> | null): void => {
+        const drop = excluded
+            ? new Set([excluded, ...transitiveDependents(excluded)])
+            : new Set<DockviewModule<any>>();
+        clearRegisteredModules();
+        registerModules(Modules.filter((m) => !drop.has(m)));
+
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(800, 600);
+
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        p1.api.group.api.maximize();
+        p1.api.group.api.exitMaximized();
+        // panel-reference ops before serialize (fromJSON recreates panels)
+        dockview.removePanel(p1);
+        const json = dockview.toJSON();
+        dockview.fromJSON(json);
+
+        dockview.dispose();
+    };
+
+    test('baseline — all extracted modules present', () => {
+        expect(() => exercise(null)).not.toThrow();
+    });
+
+    Modules.forEach((module) => {
+        test(`core operates with "${module.moduleName}" removed`, () => {
+            expect(() => exercise(module)).not.toThrow();
+        });
+    });
+});

--- a/packages/dockview-react/rollup.config.js
+++ b/packages/dockview-react/rollup.config.js
@@ -48,7 +48,23 @@ function createBundle(format, options) {
     const input = getInput(options);
     const file = outputFile(format, isMinified, withStyles);
 
-    const external = [];
+    const isUMD = format === 'umd';
+
+    // dockview (and its transitive dockview-core) are published packages:
+    // externalize them in the package builds so a consumer ends up with a
+    // single shared instance (one module registry, one DockviewComponent
+    // identity), but inline them in the UMD bundle so the CDN build is
+    // self-contained.
+    const external = isUMD
+        ? ['react', 'react-dom']
+        : [
+              'react',
+              'react-dom',
+              'dockview',
+              /^dockview\//,
+              'dockview-core',
+              /^dockview-core\//,
+          ];
 
     const output = {
         file,
@@ -67,10 +83,12 @@ function createBundle(format, options) {
 
     const plugins = [
         nodeResolve({
-            include: [
-                'node_modules/dockview/**',
-                'node_modules/dockview-core/**',
-            ],
+            include: isUMD
+                ? [
+                      'node_modules/dockview/**',
+                      'node_modules/dockview-core/**',
+                  ]
+                : [],
         }),
         typescript({
             tsconfig: 'tsconfig.esm.json',
@@ -89,11 +107,6 @@ function createBundle(format, options) {
 
     if (format === 'umd') {
         output['name'] = name;
-    }
-
-    external.push('react', 'react-dom');
-
-    if (format === 'umd') {
         output.globals['react'] = 'React';
         output.globals['react-dom'] = 'ReactDOM';
     }


### PR DESCRIPTION
Three v7-finishing changes surfaced while reviewing the `v6.6.1..HEAD` diff for release readiness.

## 1. `fix(dockview-react)`: externalize `dockview` in the npm package builds
The `dockview-react` rollup config was inherited verbatim from the pre-v7 React-bindings package, which inlined its dependency. After the rename it still baked a private copy of `dockview` (and transitively `dockview-core`) into the cjs/esm package builds instead of requiring the declared `dockview` dependency.

That meant duplicate code and — when a consumer also imported `dockview`/`dockview-core` directly — a **second `dockview-core` instance** with its own module registry and `DockviewComponent` identity, breaking `instanceof` and the shared registry across the boundary.

Fix: branch `external` / `nodeResolve.include` on `isUMD`, mirroring the `dockview` package. Package builds now externalize `dockview` + `dockview-core`; only the self-contained UMD/CDN bundle inlines them.

**Verified from the rebuilt artifacts:**
- `dockview-react` package bundle → `require('dockview')` (no inlined `DockviewComponent`, ~38K)
- `dockview` package bundle → `require('dockview-core')`
- `dockview-core` → leaf
- UMD bundle → fully inlined, self-contained (992K)
- Re-export surface intact: all 295 of `dockview-core`'s type+value exports flow through `dockview` and into `dockview-react` (+25 React-only); 0 dropped.

## 2. `feat(dockview-core)`: suppress the core-direct-usage warning in production
The one-time "do not use dockview-core directly" `console.warn` fired unconditionally, including in production for legitimate bare-`dockview-core` consumers. Now gated behind `process.env.NODE_ENV === 'production'` with a `typeof process` guard for plain browser/UMD safety.

## 3. `docs(migration)`: document the removed and changed APIs
The v7 migration guide covered the package rename but omitted the other two breaking changes:
- `rootOverlayModel` removed → `dropOverlayModel` (per-target) + `dndEdges` (outer edge).
- `onDidActivePanelChange` now emits `{ panel, origin }` instead of the panel directly.

Added a "Removed and changed APIs" section with before/after diffs and failure symptoms.

## Testing
- `dockview-core` + `dockview-modules`: 1160 tests pass; `dockview-core` typechecks clean.
- `nx run dockview-react:build:bundle` (+7 dependent tasks) succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)