### PR TITLE
test(docs): build example templates against a specific (experimental) version

### DIFF
--- a/packages/docs/scripts/buildTemplates.mjs
+++ b/packages/docs/scripts/buildTemplates.mjs
@@ -12,8 +12,14 @@ const { version } = JSON.parse(
     )
 );
 
-const DOCKVIEW_VERSION = version;
+// Defaults to the published `dockview` version, but can be overridden via the
+// DOCKVIEW_VERSION env var to build the live examples against a specific
+// (e.g. experimental/prerelease) build for testing — without committing a
+// version that would break the normal docs build.
+const DOCKVIEW_VERSION = process.env.DOCKVIEW_VERSION || version;
 const USE_LOCAL_CDN = argv.slice(2).includes('--local');
+
+console.log(`[buildTemplates] using dockview version: ${DOCKVIEW_VERSION}`);
 
 const local = 'http://localhost:1111';
 

--- a/packages/docs/static/example-runner/dockview-react-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-react-boilerplate/systemjs.config.js
@@ -46,13 +46,20 @@
             app: {
                 defaultExtension: 'tsx',
             },
+            // dockview-core and dockview-react are imported directly by example
+            // code via ES named imports, so they must use the tsc `dist/cjs`
+            // build, which sets `__esModule` (SystemJS 0.21 only exposes named
+            // exports from a CJS module when that flag is present). `dockview`
+            // is consumed only via `require()` from dockview-react, so it can
+            // use the inlined `dist/package` bundle — which avoids the dangling
+            // `require('dockview-modules')` present in its tsc `dist/cjs` build.
             'dockview-core': {
                 main: './dist/cjs/index.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },
             dockview: {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },


### PR DESCRIPTION
Adds the ability to build the docs example templates against a published experimental/prerelease build, for testing v7 before release.

## Changes
- **`buildTemplates.mjs`** — honours a `DOCKVIEW_VERSION` env var (defaulting to the published `dockview` version), so the live-example SystemJS CDN map can target any version:
  ```sh
  DOCKVIEW_VERSION=0.0.0-experimental-079903f15-20260618 npm run build-templates
  ```
  Non-destructive: with no env var, behaviour is unchanged. Also logs the resolved version.

- **`dockview-react-boilerplate/systemjs.config.js`** — points the package entries at the correct published files for v7:
  - `dockview-core` / `dockview-react` → tsc `dist/cjs` (sets `__esModule`, which SystemJS 0.21 requires to expose named exports — otherwise `import { DockviewReact }` resolves to `undefined`).
  - `dockview` → inlined `dist/package` bundle, avoiding the dangling `require('dockview-modules')` present in its tsc `dist/cjs` build (`dockview-modules` is private/unpublished).

## Notes
- The boilerplate split is an **interim workaround** for the currently-published experimental package. Once a build carrying the `__esModule` + `exports`-map fixes (see the companion packaging PR #1345) is published, all four framework boilerplates can be simplified to point uniformly at the published `main`.
- This may break the examples for the default released line (6.6.1) since it assumes v7 package semantics — acceptable while preparing v7.

## Verified
- React examples render against `0.0.0-experimental-079903f15-20260618` end-to-end via the docs dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)