### PR TITLE
fix(build): __esModule + exports maps + sideEffects for v7 packages

### DIFF
--- a/packages/dockview-core/package.json
+++ b/packages/dockview-core/package.json
@@ -45,6 +45,15 @@
     "main": "./dist/package/main.cjs.js",
     "module": "./dist/package/main.esm.mjs",
     "types": "./dist/cjs/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/cjs/index.d.ts",
+            "import": "./dist/package/main.esm.mjs",
+            "require": "./dist/package/main.cjs.js"
+        },
+        "./dist/styles/*": "./dist/styles/*",
+        "./package.json": "./package.json"
+    },
     "sideEffects": [
         "**/*.css",
         "**/*.scss"

--- a/packages/dockview-core/rollup.config.js
+++ b/packages/dockview-core/rollup.config.js
@@ -52,6 +52,9 @@ function createBundle(format, options) {
     const output = {
         file,
         format,
+        // Emit the `__esModule` marker so interop-sensitive consumers (e.g.
+        // SystemJS, legacy AMD loaders) see the named exports.
+        esModule: true,
         sourcemap: isMinified && format === 'umd',
         globals: {},
         banner: [

--- a/packages/dockview-react/package.json
+++ b/packages/dockview-react/package.json
@@ -46,6 +46,15 @@
     "main": "./dist/package/main.cjs.js",
     "module": "./dist/package/main.esm.mjs",
     "types": "./dist/cjs/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/cjs/index.d.ts",
+            "import": "./dist/package/main.esm.mjs",
+            "require": "./dist/package/main.cjs.js"
+        },
+        "./dist/styles/*": "./dist/styles/*",
+        "./package.json": "./package.json"
+    },
     "sideEffects": [
         "**/*.css",
         "**/*.scss"

--- a/packages/dockview-react/rollup.config.js
+++ b/packages/dockview-react/rollup.config.js
@@ -69,6 +69,9 @@ function createBundle(format, options) {
     const output = {
         file,
         format,
+        // Emit the `__esModule` marker so interop-sensitive consumers (e.g.
+        // SystemJS, legacy AMD loaders) see the named exports.
+        esModule: true,
         sourcemap: isMinified && format === 'umd',
         globals: {},
         banner: [

--- a/packages/dockview-react/src/__tests__/dockview/defaultTab.spec.tsx
+++ b/packages/dockview-react/src/__tests__/dockview/defaultTab.spec.tsx
@@ -3,8 +3,10 @@ import { DockviewDefaultTab } from '../../dockview/defaultTab';
 import React, { act } from 'react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { DockviewApi, DockviewPanelApi, TitleEvent } from 'dockview';
-import { Emitter } from 'dockview-core/dist/cjs/events';
-import { Disposable } from 'dockview-core/dist/cjs/lifecycle';
+import {
+    DockviewEmitter as Emitter,
+    DockviewDisposable as Disposable,
+} from 'dockview';
 
 describe('defaultTab', () => {
     test('has close button by default', async () => {

--- a/packages/dockview/package.json
+++ b/packages/dockview/package.json
@@ -53,10 +53,7 @@
         "./dist/styles/*": "./dist/styles/*",
         "./package.json": "./package.json"
     },
-    "sideEffects": [
-        "**/*.css",
-        "**/*.scss"
-    ],
+    "sideEffects": true,
     "files": [
         "dist",
         "README.md"

--- a/packages/dockview/package.json
+++ b/packages/dockview/package.json
@@ -44,6 +44,15 @@
     "main": "./dist/package/main.cjs.js",
     "module": "./dist/package/main.esm.mjs",
     "types": "./dist/cjs/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/cjs/index.d.ts",
+            "import": "./dist/package/main.esm.mjs",
+            "require": "./dist/package/main.cjs.js"
+        },
+        "./dist/styles/*": "./dist/styles/*",
+        "./package.json": "./package.json"
+    },
     "sideEffects": [
         "**/*.css",
         "**/*.scss"

--- a/packages/dockview/rollup.config.js
+++ b/packages/dockview/rollup.config.js
@@ -60,6 +60,9 @@ function createBundle(format, options) {
     const output = {
         file,
         format,
+        // Emit the `__esModule` marker so interop-sensitive consumers (e.g.
+        // SystemJS, legacy AMD loaders) see the named exports.
+        esModule: true,
         sourcemap: isMinified && format === 'umd',
         globals: {},
         banner: [


### PR DESCRIPTION
Follow-up to #1345 — these two commits were pushed to that branch *after* it merged, so they didn't make it into `master`. Re-opening them here.

## Changes
**1. `fix(build)`: emit `__esModule` and add `exports` maps**
- `output.esModule: true` in the `dockview` / `dockview-core` / `dockview-react` rollup configs, so the CJS bundles set `__esModule` and interop-sensitive consumers (SystemJS, legacy AMD loaders) see the named exports. Without it, `import { DockviewReact }` resolves to `undefined`.
- `exports` maps on the three packages so `.` resolves only to the inlined `dist/package` bundle (+ types + `./dist/styles/*`). This makes the tsc `dist/cjs`/`dist/esm` outputs — whose `dockview` build contains a dangling `require('dockview-modules')` (private/unpublished) — unreachable.
- Repointed one `dockview-react` test off the now-blocked `dockview-core/dist/cjs/...` deep import to the public entry.

**2. `fix(dockview)`: `sideEffects: true`**
- `dockview`'s entry runs `registerModules(Modules)` at load — the point of the batteries-included package. With `sideEffects` listing only css/scss, a tree-shaking bundler could resolve a re-exported core symbol straight from `dockview-core` and drop `dockview`'s module, silently skipping registration. `sideEffects: true` keeps the module (and its registration). `dockview-core` stays side-effect-free so unused re-exports are still shaken.

## Verified
- `__esModule` present in all three rebuilt CJS bundles; `exports` maps resolve.
- 78 suites / 1209 tests pass.

Needs a re-published experimental to validate in the docs (see #1346), after which all four framework boilerplates can point uniformly at the published `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)