### PR TITLE
fix(dockview-angular): ship bundled CSS under dist/styles

### DIFF
--- a/packages/dockview-angular/scripts/copy-css.js
+++ b/packages/dockview-angular/scripts/copy-css.js
@@ -2,7 +2,9 @@ const fs = require('fs');
 const path = require('path');
 
 const sourceCssDir = path.resolve(__dirname, '../../dockview-core/dist/styles');
-const targetDir = path.resolve(__dirname, '../dist');
+// Match the other framework packages (dockview-react / dockview-vue) and the
+// documented import path: styles live under `dist/styles`, not the dist root.
+const targetDir = path.resolve(__dirname, '../dist/styles');
 
 if (!fs.existsSync(targetDir)) {
     fs.mkdirSync(targetDir, { recursive: true });
@@ -17,7 +19,7 @@ if (fs.existsSync(sourceCssDir)) {
             const sourcePath = path.join(sourceCssDir, file);
             const targetPath = path.join(targetDir, file);
             fs.copyFileSync(sourcePath, targetPath);
-            console.log(`Copied ${file} to dist/`);
+            console.log(`Copied ${file} to dist/styles/`);
         }
     });
 } else {


### PR DESCRIPTION
## Symptom
The Angular example renders **unstyled** — `dockview-angular/dist/styles/dockview.css` returns 404.

## Root cause
Commit `27966f2b7` (the v7 package realignment) switched the Angular example's CSS import to the per-framework convention:
```diff
- import 'dockview-core/dist/styles/dockview.css';
+ import 'dockview-angular/dist/styles/dockview.css';
```
But `dockview-angular`'s `copy-css.js` copies the stylesheet to the **dist root** (`dist/dockview.css`), not `dist/styles/` — unlike `dockview-react` / `dockview-vue`, which copy to `dist/styles`. So the new import path 404s.

This is why the **deployed** docs still work: `dockview.dev` was built before `27966f2b7`, so its Angular example still imports `dockview-core/dist/styles/dockview.css` (a path that exists) on 6.6.1. The breakage only appears once the docs are rebuilt from current master.

## Fix
Point `copy-css.js`'s target at `../dist/styles`, matching the other framework packages and the import path used throughout the templates/sandboxes. One line.

## Verified
Running the script now produces `packages/dockview-angular/dist/styles/dockview.css`. Takes effect on the next publish, after which the Angular examples are styled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)