### PR TITLE
chore(v7): audit cleanup — group origin, popout remove event, exports, comments

### DIFF
--- a/MIGRATION-v7.md
+++ b/MIGRATION-v7.md
@@ -148,8 +148,10 @@ interface DockviewActivePanelChangeEvent {
 `panel.id` / `panel.api` read as `undefined` (no error is thrown). Replace
 `panel` with `event.panel`.
 
-> The group-level `dockviewGroupPanelApi.onDidActivePanelChange` is unchanged
-> and continues to emit its existing payload (without `origin`).
+> The group-level `dockviewGroupPanelApi.onDidActivePanelChange` keeps emitting
+> the panel and now additionally carries `origin` (its payload type is
+> `DockviewGroupActivePanelChangeEvent`). This is additive — existing handlers
+> reading `event.panel` keep working.
 
 ## Vue / Angular users
 

--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -39,6 +39,7 @@ DockviewEmitter
 DockviewEvent
 DockviewFrameworkOptions
 DockviewGetTabGroupsOptions
+DockviewGroupActivePanelChangeEvent
 DockviewGroupChangeEvent
 DockviewGroupDropLocation
 DockviewGroupLocation

--- a/packages/dockview-angular/src/lib/dockview/types.ts
+++ b/packages/dockview-angular/src/lib/dockview/types.ts
@@ -45,7 +45,7 @@ export interface DockviewAngularEvents {
     willDrop: DockviewWillDropEvent;
 }
 
-// Re-export commonly used types from dockview-core
+// Re-export commonly used types from dockview
 export {
     DockviewApi,
     DockviewReadyEvent,

--- a/packages/dockview-angular/src/lib/gridview/types.ts
+++ b/packages/dockview-angular/src/lib/gridview/types.ts
@@ -13,5 +13,5 @@ export interface GridviewAngularEvents {
     ready: GridviewAngularReadyEvent;
 }
 
-// Re-export commonly used types from dockview-core
+// Re-export commonly used types from dockview
 export { GridviewApi, GridviewOptions } from 'dockview';

--- a/packages/dockview-angular/src/lib/paneview/types.ts
+++ b/packages/dockview-angular/src/lib/paneview/types.ts
@@ -15,5 +15,5 @@ export interface PaneviewAngularEvents {
     drop: PaneviewDropEvent;
 }
 
-// Re-export commonly used types from dockview-core
+// Re-export commonly used types from dockview
 export { PaneviewApi, PaneviewDropEvent, PaneviewOptions } from 'dockview';

--- a/packages/dockview-angular/src/lib/splitview/types.ts
+++ b/packages/dockview-angular/src/lib/splitview/types.ts
@@ -13,5 +13,5 @@ export interface SplitviewAngularEvents {
     ready: SplitviewAngularReadyEvent;
 }
 
-// Re-export commonly used types from dockview-core
+// Re-export commonly used types from dockview
 export { SplitviewApi, SplitviewOptions } from 'dockview';

--- a/packages/dockview-angular/src/public-api.ts
+++ b/packages/dockview-angular/src/public-api.ts
@@ -2,7 +2,7 @@
  * Public API Surface of dockview-angular
  */
 
-// Re-export everything from dockview-core
+// Re-export everything from dockview (which re-exports dockview-core)
 export * from 'dockview';
 
 // Angular module

--- a/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
@@ -16,8 +16,9 @@ class TestPanel implements IContentRenderer {
 }
 
 /**
- * The popout lifecycle surface: `onDidAddPopoutGroup` (open event carrying the
- * Window handle) and `getPopouts()` (enumeration of the open popout windows).
+ * The popout lifecycle surface: `onDidAddPopoutGroup` (open) /
+ * `onDidRemovePopoutGroup` (close or dock-back), `getPopouts()` (enumeration),
+ * plus teardown and serialize/restore round-tripping.
  */
 describe('popout lifecycle', () => {
     let container: HTMLElement;
@@ -77,5 +78,65 @@ describe('popout lifecycle', () => {
 
         expect(fired.length).toBe(1);
         expect(dockview.api.getPopouts().map((p) => p.id)).toEqual(fired);
+    });
+
+    test('closing the popout window returns the panel, fires onDidRemovePopoutGroup, and clears getPopouts', async () => {
+        const panel = dockview.addPanel({ id: 'p1', component: 'default' });
+        await dockview.addPopoutGroup(panel);
+        expect(dockview.getPopouts().length).toBe(1);
+
+        const popoutId = dockview.getPopouts()[0].id;
+        const popoutWindow = dockview.getPopouts()[0].window;
+
+        const removed: string[] = [];
+        dockview.onDidRemovePopoutGroup((e) => removed.push(e.id));
+
+        // a genuine user close fires `beforeunload`, which drives teardown
+        expect(() => popoutWindow.close()).not.toThrow();
+
+        // the removal is reported once, the popout is no longer enumerable, and
+        // the panel survives in the grid
+        expect(removed).toEqual([popoutId]);
+        expect(dockview.getPopouts()).toEqual([]);
+        expect(dockview.panels.find((p) => p.id === 'p1')).toBeDefined();
+    });
+
+    test('onDidRemovePopoutGroup does not fire on component disposal', async () => {
+        // use a dedicated component so the shared afterEach doesn't double-dispose
+        const localContainer = document.createElement('div');
+        const local = new DockviewComponent(localContainer, {
+            createComponent: () => new TestPanel(),
+        });
+        local.layout(1000, 1000);
+        const panel = local.addPanel({ id: 'p1', component: 'default' });
+        await local.addPopoutGroup(panel);
+
+        const removed: string[] = [];
+        local.onDidRemovePopoutGroup((e) => removed.push(e.id));
+
+        expect(() => local.dispose()).not.toThrow();
+        expect(removed).toEqual([]);
+    });
+
+    test('toJSON captures open popouts and fromJSON round-trips without throwing', async () => {
+        const panel = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        await dockview.addPopoutGroup(panel);
+
+        const json = dockview.toJSON();
+        expect(json.popoutGroups?.length).toBe(1);
+
+        // a fresh component must restore the serialized layout (incl. the popout
+        // descriptor) without throwing
+        const container2 = document.createElement('div');
+        const dockview2 = new DockviewComponent(container2, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview2.layout(1000, 1000);
+
+        expect(() => dockview2.fromJSON(json)).not.toThrow();
+        expect(dockview2.panels.map((p) => p.id).sort()).toEqual(['p1', 'p2']);
+
+        dockview2.dispose();
     });
 });

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -802,6 +802,15 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         return this.component.onDidAddPopoutGroup;
     }
 
+    /**
+     * Fires when a popout group is removed — whether the user closed its window
+     * or it was docked back programmatically. Symmetric with
+     * {@link onDidAddPopoutGroup}; not fired during component disposal.
+     */
+    get onDidRemovePopoutGroup(): Event<PopoutGroup> {
+        return this.component.onDidRemovePopoutGroup;
+    }
+
     get onDidOpenPopoutWindowFail(): Event<void> {
         return this.component.onDidOpenPopoutWindowFail;
     }

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -3,7 +3,7 @@ import { DockviewComponent } from '../dockview/dockviewComponent';
 import { Box } from '../types';
 import { DockviewGroupPanel } from '../dockview/dockviewGroupPanel';
 import {
-    DockviewGroupChangeEvent,
+    DockviewGroupActivePanelChangeEvent,
     DockviewGroupLocation,
     DockviewGroupPanelLocked,
 } from '../dockview/dockviewGroupPanelModel';
@@ -34,7 +34,14 @@ export interface DockviewGroupPanelCollapsedChangeEvent {
 
 export interface DockviewGroupPanelApi extends GridviewPanelApi {
     readonly onDidLocationChange: Event<DockviewGroupPanelFloatingChangeEvent>;
-    readonly onDidActivePanelChange: Event<DockviewGroupChangeEvent>;
+    /**
+     * Fires when the active panel *within this group* changes. Scoped to the
+     * group, in contrast to the component-level
+     * `DockviewApi.onDidActivePanelChange` (which tracks the active panel across
+     * the whole dockview). Both carry an {@link DockviewOrigin} reporting
+     * whether the change came from a user gesture or an API call.
+     */
+    readonly onDidActivePanelChange: Event<DockviewGroupActivePanelChangeEvent>;
     /**
      * Fired when an edge group's collapsed state changes.
      * Never fires for non-edge groups.
@@ -90,7 +97,8 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
     readonly onDidLocationChange: Event<DockviewGroupPanelFloatingChangeEvent> =
         this._onDidLocationChange.event;
 
-    readonly _onDidActivePanelChange = new Emitter<DockviewGroupChangeEvent>();
+    readonly _onDidActivePanelChange =
+        new Emitter<DockviewGroupActivePanelChangeEvent>();
     readonly onDidActivePanelChange = this._onDidActivePanelChange.event;
 
     readonly _onDidCollapsedChange =

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -367,6 +367,7 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     readonly onDidPopoutGroupSizeChange: Event<PopoutGroupChangeSizeEvent>;
     readonly onDidPopoutGroupPositionChange: Event<PopoutGroupChangePositionEvent>;
     readonly onDidAddPopoutGroup: Event<PopoutGroup>;
+    readonly onDidRemovePopoutGroup: Event<PopoutGroup>;
     readonly onDidOpenPopoutWindowFail: Event<void>;
     getPopouts(): PopoutGroup[];
     readonly onDidCreateTabGroup: Event<DockviewTabGroupChangeEvent>;
@@ -552,6 +553,10 @@ export class DockviewComponent
     private readonly _onDidAddPopoutGroup = new Emitter<PopoutGroup>();
     readonly onDidAddPopoutGroup: Event<PopoutGroup> =
         this._onDidAddPopoutGroup.event;
+
+    private readonly _onDidRemovePopoutGroup = new Emitter<PopoutGroup>();
+    readonly onDidRemovePopoutGroup: Event<PopoutGroup> =
+        this._onDidRemovePopoutGroup.event;
 
     private readonly _onDidOpenPopoutWindowFail = new Emitter<void>();
     readonly onDidOpenPopoutWindowFail: Event<void> =
@@ -990,6 +995,23 @@ export class DockviewComponent
         }
         this._moduleRegistry.initialize(this);
 
+        // Surface popout removal symmetrically with `onDidAddPopoutGroup`. The
+        // service is the single point every removal path funnels through — a
+        // genuine window close and an explicit removal alike — and it suppresses
+        // the event during component teardown.
+        const popoutWindowService = this._popoutWindowService;
+        if (popoutWindowService) {
+            this.addDisposables(
+                popoutWindowService.onDidRemove((entry) => {
+                    this._onDidRemovePopoutGroup.fire({
+                        id: entry.popoutGroup.id,
+                        group: entry.popoutGroup,
+                        window: entry.getWindow(),
+                    });
+                })
+            );
+        }
+
         // Purely a developer warning (no functional effect): nudge anyone using
         // the internal `dockview-core` package directly towards `dockview`.
         warnIfUsingCoreDirectly();
@@ -1073,6 +1095,7 @@ export class DockviewComponent
             this._onDidPopoutGroupSizeChange,
             this._onDidPopoutGroupPositionChange,
             this._onDidAddPopoutGroup,
+            this._onDidRemovePopoutGroup,
             this._onDidOpenPopoutWindowFail,
             this._onDidCreateTabGroup,
             this._onDidDestroyTabGroup,

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1,7 +1,7 @@
 import { DockviewApi } from '../api/component.api';
 import { getPanelData, PanelTransfer } from '../dnd/dataTransfer';
 import { Droptarget, Position } from '../dnd/droptarget';
-import { DockviewComponent } from './dockviewComponent';
+import { DockviewComponent, DockviewOrigin } from './dockviewComponent';
 import { addClasses, isAncestor, removeClasses, toggleClass } from '../dom';
 import {
     addDisposableListener,
@@ -87,6 +87,16 @@ export interface GroupPanelViewState extends CoreGroupOptions {
 
 export interface DockviewGroupChangeEvent {
     readonly panel: IDockviewPanel;
+}
+
+/**
+ * Payload for the group-level `onDidActivePanelChange`. Extends
+ * {@link DockviewGroupChangeEvent} with the {@link DockviewOrigin} so it mirrors
+ * the component-level `DockviewActivePanelChangeEvent` — both report whether the
+ * change came from a user gesture or an API call.
+ */
+export interface DockviewGroupActivePanelChangeEvent extends DockviewGroupChangeEvent {
+    readonly origin: DockviewOrigin;
 }
 
 export interface CreateTabGroupOptions extends TabGroupOptions {
@@ -176,7 +186,7 @@ export interface IDockviewGroupPanelModel extends IPanel {
     readonly onWillDrop: Event<DockviewWillDropEvent>;
     readonly onDidAddPanel: Event<DockviewGroupChangeEvent>;
     readonly onDidRemovePanel: Event<DockviewGroupChangeEvent>;
-    readonly onDidActivePanelChange: Event<DockviewGroupChangeEvent>;
+    readonly onDidActivePanelChange: Event<DockviewGroupActivePanelChangeEvent>;
     readonly onMove: Event<GroupMoveEvent>;
     locked: DockviewGroupPanelLocked;
     headerPosition: DockviewHeaderPosition;
@@ -294,8 +304,8 @@ export class DockviewGroupPanelModel
         this._onDidRemovePanel.event;
 
     private readonly _onDidActivePanelChange =
-        new Emitter<DockviewGroupChangeEvent>();
-    readonly onDidActivePanelChange: Event<DockviewGroupChangeEvent> =
+        new Emitter<DockviewGroupActivePanelChangeEvent>();
+    readonly onDidActivePanelChange: Event<DockviewGroupActivePanelChangeEvent> =
         this._onDidActivePanelChange.event;
 
     private readonly _onUnhandledDragOverEvent =
@@ -1621,6 +1631,9 @@ export class DockviewGroupPanelModel
 
             this._onDidActivePanelChange.fire({
                 panel,
+                // `currentOrigin` is always present on the real component;
+                // default to 'user' for minimal test accessors.
+                origin: this.accessor.currentOrigin?.() ?? 'user',
             });
         }
 

--- a/packages/dockview-core/src/dockview/popoutWindowService.ts
+++ b/packages/dockview-core/src/dockview/popoutWindowService.ts
@@ -1,4 +1,5 @@
 import { IDisposable } from '../lifecycle';
+import { Emitter, Event } from '../events';
 import { remove } from '../array';
 import { PopupService } from './components/popupService';
 import { PopoutWindow } from '../popoutWindow';
@@ -40,6 +41,8 @@ export interface IPopoutWindowHost {
 export interface IPopoutWindowService extends IDisposable {
     readonly entries: readonly PopoutGroupEntry[];
 
+    readonly onDidRemove: Event<PopoutGroupEntry>;
+
     add(entry: PopoutGroupEntry): void;
     remove(entry: PopoutGroupEntry): void;
 
@@ -76,6 +79,9 @@ export class PopoutWindowService implements IPopoutWindowService {
     private readonly _restorationCleanups = new Set<() => void>();
     private _restorationPromise: Promise<void> = Promise.resolve();
 
+    private readonly _onDidRemove = new Emitter<PopoutGroupEntry>();
+    readonly onDidRemove = this._onDidRemove.event;
+
     constructor(host: IPopoutWindowHost) {
         this._host = host;
     }
@@ -93,7 +99,12 @@ export class PopoutWindowService implements IPopoutWindowService {
     }
 
     remove(entry: PopoutGroupEntry): void {
-        remove(this._entries, entry);
+        // Fire only on a genuine removal, and not while the host component is
+        // tearing down (consumers don't want popout-removed events during
+        // dispose).
+        if (remove(this._entries, entry) && !this._host.isDisposed) {
+            this._onDidRemove.fire(entry);
+        }
     }
 
     findByGroup(group: DockviewGroupPanel): PopoutGroupEntry | undefined {
@@ -266,6 +277,7 @@ export class PopoutWindowService implements IPopoutWindowService {
     dispose(): void {
         this.cancelPendingRestorations();
         this.disposeAll();
+        this._onDidRemove.dispose();
     }
 }
 

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -51,6 +51,7 @@ export {
     DockviewDidDropEvent,
     DockviewWillDropEvent,
     DockviewGroupChangeEvent,
+    DockviewGroupActivePanelChangeEvent,
     DockviewGroupLocation,
 } from './dockview/dockviewGroupPanelModel';
 export {

--- a/packages/dockview-vue/package.json
+++ b/packages/dockview-vue/package.json
@@ -38,6 +38,15 @@
     "main": "dist/dockview-vue.umd.js",
     "module": "dist/dockview-vue.es.js",
     "types": "dist/types/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/types/index.d.ts",
+            "import": "./dist/dockview-vue.es.js",
+            "require": "./dist/dockview-vue.umd.js"
+        },
+        "./dist/styles/*": "./dist/styles/*",
+        "./package.json": "./package.json"
+    },
     "sideEffects": [
         "**/*.css",
         "**/*.scss"

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -225,8 +225,20 @@ Groups expose events via `group.api`:
 
 ```ts
 // Fires when the active panel within this group changes
-group.api.onDidActivePanelChange((event) => { });
+group.api.onDidActivePanelChange((event) => {
+    // event.panel: IDockviewPanel
+    // event.origin: 'user' | 'api'
+});
 
 // Fires when the group location changes (grid → floating → popout)
 group.api.onDidLocationChange(({ location }) => { });
 ```
+
+:::info
+There are two `onDidActivePanelChange` events that differ in **scope**:
+
+- **`api.onDidActivePanelChange`** (`DockviewActivePanelChangeEvent`) tracks the active panel across the **whole dockview**; `panel` may be `undefined`.
+- **`group.api.onDidActivePanelChange`** (`DockviewGroupActivePanelChangeEvent`) is scoped to a **single group**.
+
+Both carry an `origin` (`'user' | 'api'`) reporting whether the change came from a user gesture or an API call.
+:::


### PR DESCRIPTION
Addresses v7-audit items 5–9.

## 5 — `feat(dockview-core)`: group-level `onDidActivePanelChange` carries `origin`
The component-level event gained `{ panel, origin }` in v7; the group-level one lagged. It now emits `DockviewGroupActivePanelChangeEvent` (`{ panel, origin }`), reading origin from the owning component (defaulting to `'user'` for minimal test accessors). Additive — `event.panel` handlers keep working. Docs (`events.mdx`) + migration note updated; exports snapshot regenerated.

## 9 + 7 — `feat(dockview-core)`: `onDidRemovePopoutGroup` + popout lifecycle tests
- New `onDidRemovePopoutGroup`, symmetric with `onDidAddPopoutGroup`. Fires from the single chokepoint every removal funnels through (`PopoutWindowService.remove()`) — genuine window close **and** explicit dock-back — and is suppressed during component teardown.
- Deepened `popoutLifecycle.spec.ts`: close returns the panel + fires remove once + clears `getPopouts`; disposal does **not** fire it; `toJSON`/`fromJSON` round-trips an open popout without throwing.

## 6 — `chore(dockview-vue)`: add an `exports` map
Explicit entry points mirroring the existing main/module/types resolution + the styles subpath. (Angular already ships an `exports` map via ng-packagr; both confirmed free of the dangling-`dockview-modules` issue.)

## 8 — `docs(dockview-angular)`: fix stale `dockview-core` re-export comments
They re-export from `dockview`; comments corrected.

## Testing
Full suite green: **91 suites / 1344 tests**. `dockview-core` typechecks clean; changed files lint with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)