### PR TITLE
docs: v7 feature docs + migration guide

### DIFF
--- a/MIGRATION-v7.md
+++ b/MIGRATION-v7.md
@@ -1,170 +1,18 @@
 # Migrating to v7
 
-v7 realigns the package names so that `dockview` is the framework-agnostic
-JavaScript package and each framework has a matching `dockview-<framework>`
-package.
+The v7 migration guide now lives in the documentation site and is the canonical
+reference:
 
-| Package | v6 | v7 |
-|---|---|---|
-| `dockview-core` | Vanilla core (public) | Vanilla core — **internal implementation detail** |
-| `dockview` | **React bindings** | Vanilla JS / TypeScript (re-export of `dockview-core`) — **recommended for vanilla** |
-| `dockview-react` | Re-export of `dockview` | **React bindings** |
-| `dockview-vue` | Vue bindings | Vue bindings (now consumes `dockview`) |
-| `dockview-angular` | Angular bindings | Angular bindings (now consumes `dockview`) |
+👉 **https://dockview.dev/docs/overview/migrating-to-v7**
 
-## React users — action required (breaking)
+In short, v7 realigns the package names:
 
-The React bindings moved from `dockview` to `dockview-react`. In v7 the
-`dockview` package is the vanilla JavaScript library (a re-export of
-`dockview-core`), so it no longer exports the React components.
+- `dockview` is now the framework-agnostic JavaScript package (a re-export of
+  `dockview-core`).
+- The **React bindings moved to `dockview-react`** — React users must install
+  and import from `dockview-react`.
+- `dockview-vue` / `dockview-angular` are unchanged for consumers.
 
-**Symptoms if you don't migrate** (the React names are simply gone — core names
-like `DockviewComponent` still resolve from `dockview`):
-
-- TypeScript: `error TS2305: Module '"dockview"' has no exported member 'DockviewReact'`
-- Runtime (JS): React throws *"Element type is invalid … got: undefined"* when
-  rendering `<DockviewReact />`, because the import resolves to `undefined`.
-
-The fix is to install and import from `dockview-react`:
-
-```diff
-- npm install dockview
-+ npm install dockview-react
-```
-
-```diff
-- import { DockviewReact } from 'dockview';
-+ import { DockviewReact } from 'dockview-react';
-```
-
-```diff
-- @import 'dockview/dist/styles/dockview.css';
-+ @import 'dockview-react/dist/styles/dockview.css';
-```
-
-A one-shot codemod for a source tree:
-
-```sh
-# update imports
-grep -rl "from 'dockview'" src | xargs sed -i '' "s/from 'dockview'/from 'dockview-react'/g"
-```
-
-## Vanilla JavaScript / TypeScript users — recommended
-
-`dockview-core` is now considered an internal implementation detail. Install the
-`dockview` package instead — it re-exports the entire core API.
-
-```diff
-- npm install dockview-core
-+ npm install dockview
-```
-
-```diff
-- import { DockviewComponent } from 'dockview-core';
-+ import { DockviewComponent } from 'dockview';
-```
-
-```diff
-- import 'dockview-core/dist/styles/dockview.css';
-+ import 'dockview/dist/styles/dockview.css';
-```
-
-`dockview-core` continues to be published and will keep working, but new code
-should depend on `dockview`.
-
-### `dockview-core` no longer bundles every feature (behaviour change)
-
-In v6, `dockview-core` shipped with all built-in features registered. In v7 a
-set of feature modules is no longer part of bare `dockview-core`:
-
-- **tab group chips** (chip rendering + the `onDid*TabGroup` events)
-- **context menus** (the built-in tab / chip right-click menus)
-- **advanced drag-and-drop** (`onWillDragPanel` / `onWillDragGroup` /
-  `onWillDrop` hooks, custom drag ghost / drop overlay)
-- **keyboard accessibility** (keyboard navigation / docking / live-region
-  announcements)
-
-These now live in the `dockview` package. **`dockview-core` is an internal
-package — use `dockview`** (or a framework package — `dockview-react` / `-vue` /
-`-angular`, which all consume `dockview`). Nothing throws if you stay on bare
-`dockview-core` — the affected features simply do nothing — so a one-time
-`console.warn` is emitted when a component is constructed on bare `dockview-core`
-steering you to `dockview`.
-
-## Removed and changed APIs (breaking)
-
-These affect every consumer regardless of framework.
-
-### `rootOverlayModel` removed
-
-The `rootOverlayModel` option has been removed. It was a single static overlay
-model applied to the root drop target. Drop-overlay shaping is now driven by:
-
-- **`dropOverlayModel`** — a callback that shapes the overlay per drop target
-  (`(params: DropOverlayModelParams) => DroptargetOverlayModel | undefined`).
-  Return `undefined` to keep the default for that target.
-- **`dndEdges`** — configures the outer-layout edge overlay (the case
-  `rootOverlayModel` previously covered for edge drops). `dropOverlayModel` does
-  **not** dispatch the `'edge'` target.
-
-```diff
-- new DockviewComponent(el, {
--     rootOverlayModel: { size: { value: 100, type: 'pixels' } },
-- });
-+ new DockviewComponent(el, {
-+     dropOverlayModel: (params) => ({ size: { value: 100, type: 'pixels' } }),
-+ });
-```
-
-If you were using `rootOverlayModel` purely to size the outer edge overlay, use
-`dndEdges` instead.
-
-### `onDidActivePanelChange` payload changed
-
-`onDidActivePanelChange` now emits an event object instead of the panel
-directly, so it can also report whether the change came from a user interaction
-or an API call.
-
-```diff
-- api.onDidActivePanelChange((panel) => {
--     console.log(panel?.id);
-- });
-+ api.onDidActivePanelChange((event) => {
-+     console.log(event.panel?.id);
-+     console.log(event.origin); // 'user' | 'api'
-+ });
-```
-
-The event shape is:
-
-```ts
-interface DockviewActivePanelChangeEvent {
-    readonly panel: IDockviewPanel | undefined;
-    readonly origin: 'user' | 'api';
-}
-```
-
-**Symptom if you don't migrate:** the handler argument is now an object, so
-`panel.id` / `panel.api` read as `undefined` (no error is thrown). Replace
-`panel` with `event.panel`.
-
-> The group-level `dockviewGroupPanelApi.onDidActivePanelChange` is unchanged
-> and continues to emit its existing payload (without `origin`).
-
-## Vue / Angular users
-
-No source changes required — keep installing `dockview-vue` / `dockview-angular`
-and importing from them. Internally these now depend on `dockview` rather than
-`dockview-core`; this is transparent to consumers.
-
-## CDN / UMD users
-
-The React global moved from the `dockview` UMD bundle to the `dockview-react`
-bundle:
-
-```diff
-- https://cdn.jsdelivr.net/npm/dockview@7/dist/dockview.js
-+ https://cdn.jsdelivr.net/npm/dockview-react@7/dist/dockview-react.js
-```
-
-The `dockview` UMD bundle now contains the vanilla API only.
+There are also two breaking API changes (the removal of `rootOverlayModel` and a
+new `onDidActivePanelChange` payload). See the guide above for full details and
+codemods.

--- a/packages/docs/docs/advanced/accessibility.mdx
+++ b/packages/docs/docs/advanced/accessibility.mdx
@@ -1,0 +1,127 @@
+---
+title: Accessibility
+description: Keyboard navigation and screen-reader announcements in Dockview.
+---
+
+# Accessibility
+
+Dockview ships an accessibility pack — keyboard navigation and screen-reader
+announcements — as part of the [`dockview` package](/docs/core/modules). It is a
+module, so it is included in `dockview` and the framework packages, but **not**
+in bare `dockview-core`.
+
+The options below are set the same way as any other Dockview option — via the
+options argument for vanilla (`createDockview(element, { ... })`) or via the
+component props/inputs for React, Vue, and Angular.
+
+## Keyboard navigation
+
+Set `keyboardNavigation` to `true` to enable the built-in keymap:
+
+```ts
+const options = {
+    keyboardNavigation: true,
+};
+```
+
+This wires up the following default bindings:
+
+| Action | Default | Binding key |
+|---|---|---|
+| Switch to the next tab in the focused group | `Ctrl+]` | `nextTab` |
+| Switch to the previous tab in the focused group | `Ctrl+[` | `prevTab` |
+| Move focus to the next group | `F6` | `focusNextGroup` |
+| Move focus to the previous group | `Shift+F6` | `focusPrevGroup` |
+| Move focus to the group on the left | `Ctrl+Shift+←` | `focusGroupLeft` |
+| Move focus to the group on the right | `Ctrl+Shift+→` | `focusGroupRight` |
+| Move focus to the group above | `Ctrl+Shift+↑` | `focusGroupUp` |
+| Move focus to the group below | `Ctrl+Shift+↓` | `focusGroupDown` |
+| Arm keyboard docking of the active panel | `Ctrl+M` | `dock` |
+| Move focus from panel content to the tab strip | `Ctrl+Shift+\` | `focusTabs` |
+
+### Rebinding keys
+
+Pass an object instead of `true` to override individual bindings. Unset keys
+keep their defaults:
+
+```ts
+const options = {
+    keyboardNavigation: {
+        keymap: {
+            nextTab: 'ctrl+tab',
+            prevTab: 'ctrl+shift+tab',
+            dock: 'ctrl+shift+m',
+        },
+    },
+};
+```
+
+Each binding is a string of `+`-separated parts, modifiers first. Recognised
+modifiers are `ctrl`, `shift`, `alt`, and `meta` (alias `cmd`); the final part
+is the [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
+to match, case-insensitively — e.g. `'ctrl+]'`, `'shift+f6'`, `'ctrl+m'`,
+`'ctrl+shift+arrowleft'`.
+
+:::info
+`Ctrl+M` arms **keyboard docking**: it enters a two-phase mode where you pick a
+target group and then an edge, letting you re-dock the active panel without a
+mouse.
+:::
+
+For *programmatic* focus movement (building your own shortcut handlers), see
+[Keyboard](/docs/advanced/keyboard).
+
+## Screen-reader announcements
+
+Dockview narrates layout changes — panels opening/closing, groups floating,
+docking, popping out, maximizing/restoring — through a visually-hidden ARIA live
+region. This is on by default. Opt out with:
+
+```ts
+const options = {
+    announcements: false,
+};
+```
+
+### Localising and overriding announcements
+
+`getAnnouncement` runs per event and lets you override or localise the spoken
+string. Return a string to use it, `null` / `''` to suppress that announcement,
+or `undefined` to fall through to the default:
+
+```ts
+const options = {
+    getAnnouncement: (event) => {
+        if (event.kind === 'maximize') {
+            return 'Panel maximised';
+        }
+        return undefined; // keep the default
+    },
+};
+```
+
+For full translations, provide a `messages` catalog. Each entry is a function
+that builds the string from the relevant context (e.g. the panel title); supply
+any subset — unset entries keep the English defaults:
+
+```ts
+const options = {
+    messages: {
+        panelOpened: (title) => `${title} ouvert`,
+        panelClosed: (title) => `${title} fermé`,
+        groupMaximized: (title) => `${title} agrandi`,
+    },
+};
+```
+
+### Routing to your own announcer
+
+If your app already manages a screen-reader live region, route Dockview's
+announcements to it with `announcer` instead of using the built-in region.
+`getAnnouncement` (localisation) still applies first:
+
+```ts
+const options = {
+    announcer: (event) => myLiveRegion.announce(event.message),
+};
+```

--- a/packages/docs/docs/advanced/keyboard.mdx
+++ b/packages/docs/docs/advanced/keyboard.mdx
@@ -8,6 +8,13 @@ import DockviewKeyboard from '@site/sandboxes/keyboard-dockview/src/app';
 
 # Keyboard Navigation
 
+:::tip
+Looking for built-in keyboard shortcuts? Dockview ships a rebindable keymap
+(tab switching, F6 / spatial group focus, `Ctrl+M` docking) behind the
+`keyboardNavigation` option — see [Accessibility](/docs/advanced/accessibility).
+This page covers the **programmatic** focus API for building your own handlers.
+:::
+
 ## Programmatic Focus Navigation
 
 `DockviewApi` provides two methods for moving focus between panels and groups programmatically, useful for building keyboard shortcut handlers:

--- a/packages/docs/docs/core/dnd/overlay.mdx
+++ b/packages/docs/docs/core/dnd/overlay.mdx
@@ -1,0 +1,60 @@
+---
+title: Drop overlay
+sidebar_position: 5
+description: Shape the drag-and-drop overlay per target with the dropOverlayModel option.
+---
+
+# Drop overlay
+
+When you drag a panel or group over Dockview, a highlighted overlay previews
+where it will land. The `dropOverlayModel` option lets you shape that overlay
+**per drop target** — its size, the activation threshold, and the small-element
+boundaries.
+
+:::info
+`dropOverlayModel` replaces the v6 `rootOverlayModel` option. Where
+`rootOverlayModel` was a single static model, `dropOverlayModel` is a callback
+invoked per target. See [Migrating to v7](/docs/overview/migrating-to-v7#rootoverlaymodel-removed).
+:::
+
+## Usage
+
+`dropOverlayModel` is a callback that receives the target and returns a
+`DroptargetOverlayModel`, or `undefined` to keep the default for that target:
+
+```ts
+const options = {
+    dropOverlayModel: (params) => {
+        // params.location: which drop target ('tab' | 'header_space' | 'content')
+        // params.group: the group the target belongs to, where known
+        if (params.location === 'content') {
+            return {
+                size: { value: 100, type: 'pixels' },
+            };
+        }
+        return undefined; // default overlay for other targets
+    },
+};
+```
+
+The returned model accepts:
+
+| Field | Description |
+|---|---|
+| `size` | The size of the highlighted overlay region. |
+| `activationSize` | How close the pointer must be to a target before it activates. |
+| `smallWidthBoundary` | Width (px) below which the overlay switches to a thin-border indicator instead of a half-width highlight. Set `0` to always show the half-width overlay. |
+| `smallHeightBoundary` | Height (px) below which the overlay switches to a thin-border indicator instead of a half-height highlight. Set `0` to always show the half-height overlay. |
+
+## The outer edge overlay
+
+`dropOverlayModel` does **not** dispatch the `'edge'` target — the overlay shown
+when dragging to the outer edges of the whole layout. That is configured
+separately via the `dndEdges` option. If you were using `rootOverlayModel`
+purely to size the outer edge overlay, use `dndEdges` instead.
+
+:::warning
+Advanced drag-and-drop, including `dropOverlayModel`, is part of the
+[`dockview` package](/docs/core/modules) and is not active on bare
+`dockview-core`.
+:::

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -141,6 +141,12 @@ api.onDidAddPopoutGroup((event: PopoutGroup) => {
     event.window.focus();
 });
 
+// Fires when a popout group is removed — the user closed its window or it was
+// docked back programmatically. Not fired during component disposal.
+api.onDidRemovePopoutGroup((event: PopoutGroup) => {
+    // event.id, event.group
+});
+
 // Fires when a popout window is resized
 api.onDidPopoutGroupSizeChange((event: PopoutGroupChangeSizeEvent) => { });
 

--- a/packages/docs/docs/core/groups/floatingGroups.mdx
+++ b/packages/docs/docs/core/groups/floatingGroups.mdx
@@ -12,8 +12,8 @@ This section describes floating groups.
 Floating groups **cannot** be maximized. Calling maximize function on groups in these states will have no effect.
 :::
 
-Dockview has built-in support for floating groups. Each floating container can contain a single group with many panels
-and you can have as many floating containers as needed. You cannot dock multiple groups together in the same floating container.
+Dockview has built-in support for floating groups. Each floating container hosts its own nested layout, so you can dock multiple groups
+together inside a single floating container, and you can have as many floating containers as needed.
 
 ## Options
 

--- a/packages/docs/docs/core/groups/popoutGroups.mdx
+++ b/packages/docs/docs/core/groups/popoutGroups.mdx
@@ -14,8 +14,14 @@ Popout groups **cannot** be maximized. Calling maximize function on groups in th
 <DocRef declaration="DockviewApi" methods={['addPopoutGroup']} />
 
 Dockview has built-in support for opening groups in new Windows.
-Each popout window can contain a single group with many panels and you can have as many popout
-windows as needed. You cannot dock multiple groups together in the same window.
+Each popout window hosts its own nested layout, so you can dock multiple groups
+together inside a single popout window, and you can have as many popout windows
+as needed.
+
+The popout lifecycle is observable: `onDidAddPopoutGroup` /
+`onDidRemovePopoutGroup` fire as windows open and close (or dock back), and
+`api.getPopouts()` enumerates the open popout windows — see
+[Events](/docs/core/events#popout-window).
 
 Popout windows require your website to have a blank `.html` page that can be used, by default this is set to `/popout.html` but
 can be configured to match requirements.

--- a/packages/docs/docs/core/modules.mdx
+++ b/packages/docs/docs/core/modules.mdx
@@ -1,0 +1,76 @@
+---
+title: Modules
+sidebar_position: 4
+description: How Dockview's separable feature modules work, and the difference between the dockview and dockview-core packages.
+---
+
+# Modules
+
+In v7 a set of separable features is delivered as **modules**. This is mostly
+transparent — it determines which package you should depend on.
+
+## `dockview` vs `dockview-core`
+
+| Package | Modules | Use it when |
+|---|---|---|
+| **`dockview`** | All built-in modules registered (batteries-included) | You're building a vanilla JS/TS app — **recommended** |
+| **`dockview-core`** | None — bare implementation | Advanced: you want the smallest core and will opt features in yourself |
+
+The framework packages (`dockview-react`, `dockview-vue`, `dockview-angular`)
+all depend on `dockview`, so they get the full feature set automatically.
+
+The following features are modules and are included in `dockview` but **not** in
+bare `dockview-core`:
+
+- **tab group chips** — chip rendering and the `onDid*TabGroup` events
+- **context menus** — the built-in tab / chip right-click menus
+- **advanced drag-and-drop** — the `onWillDragPanel` / `onWillDragGroup` /
+  `onWillDrop` hooks, custom drag ghosts, and the
+  [`dropOverlayModel`](/docs/core/dnd/overlay) overlay shaping
+- **accessibility** — [keyboard navigation, docking, and screen-reader
+  announcements](/docs/advanced/accessibility)
+
+:::info
+If you construct a component on bare `dockview-core`, the affected features
+simply do nothing (nothing throws), and a one-time `console.warn` nudges you
+toward `dockview`. Use `dockview` (or a framework package) to get the full
+feature set.
+:::
+
+```ts
+// Recommended — everything works out of the box
+import { createDockview } from 'dockview';
+
+// Advanced — bare core, the modules above are inactive
+import { createDockview } from 'dockview-core';
+```
+
+## Authoring a module (advanced)
+
+`dockview` exposes a small module API for advanced integrations — for example to
+provide your own implementation of one of the built-in service contracts. A
+module fills a known service slot and may hook into the host lifecycle:
+
+```ts
+import { registerModules, defineModule } from 'dockview';
+
+const MyContextMenuModule = defineModule({
+    name: 'MyContextMenu',
+    serviceKey: 'contextMenuService',
+    create: (host) => new MyContextMenuService(host),
+});
+
+// register globally, before constructing any component
+registerModules([MyContextMenuModule]);
+```
+
+The service contracts a module can implement (`IContextMenuService`,
+`IAdvancedDnDService`, `IAccessibilityService`, `ITabGroupChipsService`) and the
+matching host interfaces are exported from `dockview`. The related helpers
+`getRegisteredModules` and `clearRegisteredModules` are also available.
+
+:::warning
+This is a low-level, evolving surface intended for advanced/internal use. Most
+applications never need it — depend on `dockview` and use the documented
+options and events instead.
+:::

--- a/packages/docs/docs/overview/migrating-to-v7.mdx
+++ b/packages/docs/docs/overview/migrating-to-v7.mdx
@@ -1,0 +1,184 @@
+---
+title: Migrating to v7
+sidebar_position: 5
+description: How to upgrade from Dockview v6 to v7 — the package realignment and the breaking API changes.
+---
+
+# Migrating to v7
+
+v7 realigns the package names so that **`dockview` is the framework-agnostic
+JavaScript package** and each framework has a matching `dockview-<framework>`
+package. There are also two small breaking API changes that affect every
+consumer.
+
+| Package | v6 | v7 |
+|---|---|---|
+| `dockview-core` | Vanilla core (public) | Vanilla core — **internal implementation detail** |
+| `dockview` | **React bindings** | Vanilla JS / TypeScript (re-export of `dockview-core`) — **recommended for vanilla** |
+| `dockview-react` | Re-export of `dockview` | **React bindings** |
+| `dockview-vue` | Vue bindings | Vue bindings (now consume `dockview`) |
+| `dockview-angular` | Angular bindings | Angular bindings (now consume `dockview`) |
+
+## React users — action required
+
+The React bindings **moved from `dockview` to `dockview-react`**. In v7 the
+`dockview` package is the vanilla JavaScript library (a re-export of
+`dockview-core`), so it no longer exports the React components.
+
+:::warning Symptoms if you don't migrate
+The React names are simply gone — core names like `DockviewComponent` still
+resolve from `dockview`, but the React components do not:
+
+- **TypeScript:** `error TS2305: Module '"dockview"' has no exported member 'DockviewReact'`
+- **Runtime (JS):** React throws *"Element type is invalid … got: undefined"* when
+  rendering `<DockviewReact />`, because the import resolves to `undefined`.
+:::
+
+Install and import from `dockview-react`:
+
+```diff
+- npm install dockview
++ npm install dockview-react
+```
+
+```diff
+- import { DockviewReact } from 'dockview';
++ import { DockviewReact } from 'dockview-react';
+```
+
+```diff
+- @import 'dockview/dist/styles/dockview.css';
++ @import 'dockview-react/dist/styles/dockview.css';
+```
+
+A one-shot codemod for a source tree:
+
+```sh
+grep -rl "from 'dockview'" src | xargs sed -i '' "s/from 'dockview'/from 'dockview-react'/g"
+```
+
+## Vanilla JavaScript / TypeScript users — recommended
+
+`dockview-core` is now considered an internal implementation detail. Install the
+`dockview` package instead — it re-exports the entire core API.
+
+```diff
+- npm install dockview-core
++ npm install dockview
+```
+
+```diff
+- import { DockviewComponent } from 'dockview-core';
++ import { DockviewComponent } from 'dockview';
+```
+
+```diff
+- import 'dockview-core/dist/styles/dockview.css';
++ import 'dockview/dist/styles/dockview.css';
+```
+
+`dockview-core` continues to be published and will keep working, but new code
+should depend on `dockview`.
+
+### `dockview-core` no longer bundles every feature
+
+In v6, `dockview-core` shipped with all built-in features registered. In v7 a
+set of [feature modules](/docs/core/modules) is no longer part of bare
+`dockview-core`:
+
+- **tab group chips** (chip rendering + the `onDid*TabGroup` events)
+- **context menus** (the built-in tab / chip right-click menus)
+- **advanced drag-and-drop** (`onWillDragPanel` / `onWillDragGroup` /
+  `onWillDrop` hooks, custom drag ghost / [drop overlay](/docs/core/dnd/overlay))
+- **[keyboard accessibility](/docs/advanced/accessibility)** (keyboard
+  navigation / docking / screen-reader announcements)
+
+These now live in the `dockview` package, which registers them automatically.
+**`dockview-core` is an internal package — use `dockview`** (or a framework
+package — `dockview-react` / `-vue` / `-angular`, which all consume `dockview`).
+Nothing throws if you stay on bare `dockview-core` — the affected features
+simply do nothing — so a one-time `console.warn` is emitted when a component is
+constructed on bare `dockview-core` steering you to `dockview`. See
+[Modules](/docs/core/modules) for how to opt features back in on bare core.
+
+## Removed and changed APIs
+
+These affect every consumer regardless of framework.
+
+### `rootOverlayModel` removed
+
+The `rootOverlayModel` option has been removed. It was a single static overlay
+model applied to the root drop target. Drop-overlay shaping is now driven by
+[`dropOverlayModel`](/docs/core/dnd/overlay) and `dndEdges`:
+
+```diff
+- new DockviewComponent(el, {
+-     rootOverlayModel: { size: { value: 100, type: 'pixels' } },
+- });
++ new DockviewComponent(el, {
++     dropOverlayModel: (params) => ({ size: { value: 100, type: 'pixels' } }),
++ });
+```
+
+`dropOverlayModel` shapes the overlay **per drop target**; return `undefined` to
+keep the default for that target. It does **not** dispatch the `'edge'` target —
+if you used `rootOverlayModel` purely to size the outer edge overlay, use
+`dndEdges` instead.
+
+### `onDidActivePanelChange` payload changed
+
+`onDidActivePanelChange` now emits an event object instead of the panel
+directly, so it can also report whether the change came from a user interaction
+or an API call.
+
+```diff
+- api.onDidActivePanelChange((panel) => {
+-     console.log(panel?.id);
+- });
++ api.onDidActivePanelChange((event) => {
++     console.log(event.panel?.id);
++     console.log(event.origin); // 'user' | 'api'
++ });
+```
+
+The event shape is:
+
+```ts
+interface DockviewActivePanelChangeEvent {
+    readonly panel: IDockviewPanel | undefined;
+    readonly origin: 'user' | 'api';
+}
+```
+
+:::warning Symptom if you don't migrate
+The handler argument is now an object, so `panel.id` / `panel.api` read as
+`undefined` (no error is thrown). Replace `panel` with `event.panel`.
+:::
+
+The group-level `group.api.onDidActivePanelChange` is scoped to a single group;
+it keeps emitting the panel and additionally carries `origin` (its payload type
+is `DockviewGroupActivePanelChangeEvent`). This is additive — handlers reading
+`event.panel` keep working.
+
+## Vue / Angular users
+
+No source changes required — keep installing `dockview-vue` / `dockview-angular`
+and importing from them. Internally these now depend on `dockview` rather than
+`dockview-core`; this is transparent to consumers.
+
+## CDN / UMD users
+
+The React global moved from the `dockview` UMD bundle to the `dockview-react`
+bundle:
+
+```diff
+- https://cdn.jsdelivr.net/npm/dockview@7/dist/dockview.js
++ https://cdn.jsdelivr.net/npm/dockview-react@7/dist/dockview-react.js
+```
+
+The `dockview` UMD bundle now contains the vanilla API only.
+
+---
+
+See [What's new in v7](/docs/overview/whats-new-v7) for the full list of new
+features in this release.

--- a/packages/docs/docs/overview/whats-new-v7.mdx
+++ b/packages/docs/docs/overview/whats-new-v7.mdx
@@ -1,0 +1,87 @@
+---
+title: What's new in v7
+sidebar_position: 4
+description: Highlights and breaking changes in Dockview 7.0 — package realignment, the module system, the accessibility pack, and more.
+---
+
+Dockview 7.0 realigns the package names so the ecosystem is consistent
+(`dockview` for vanilla, `dockview-<framework>` for each framework), introduces
+a [module system](/docs/core/modules), and ships a new
+[accessibility pack](/docs/advanced/accessibility) covering keyboard navigation
+and screen-reader announcements.
+
+This page covers the headline additions. For the upgrade steps and the
+[breaking changes](#breaking-changes), see [Migrating to v7](/docs/overview/migrating-to-v7).
+
+## Highlights
+
+### Package realignment
+
+`dockview` is now the **framework-agnostic** JavaScript package (a re-export of
+`dockview-core`), and the **React bindings moved to `dockview-react`**. Every
+framework package (`dockview-react` / `-vue` / `-angular`) consumes `dockview`.
+React users must switch their imports — see
+[Migrating to v7](/docs/overview/migrating-to-v7#react-users--action-required).
+
+### Module system
+
+Separable features — tab group chips, context menus, advanced drag-and-drop, and
+the accessibility pack — are now [modules](/docs/core/modules). The `dockview`
+package is batteries-included (it registers them all), while bare `dockview-core`
+ships without them. Authors can register modules explicitly with
+`registerModules` / `defineModule`.
+
+### Accessibility pack
+
+A new [`keyboardNavigation`](/docs/advanced/accessibility#keyboard-navigation)
+option enables a fully rebindable keymap: tab switching, F6 / spatial group
+focus, and `Ctrl+M` keyboard docking. Layout changes can also be narrated to
+screen readers via a built-in live region, with hooks
+([`announcements`](/docs/advanced/accessibility#screen-reader-announcements),
+`getAnnouncement`, `announcer`) and an i18n `messages` catalog.
+
+### Per-target drop overlays
+
+The new [`dropOverlayModel`](/docs/core/dnd/overlay) callback shapes the
+drag-and-drop overlay per target (size, activation threshold, small-element
+boundaries), replacing the removed static `rootOverlayModel`.
+
+### Popout lifecycle events
+
+`onDidAddPopoutGroup` and `onDidRemovePopoutGroup` fire as popout windows open
+and close (or dock back), and `getPopouts()` enumerates the open popout windows.
+See [Events](/docs/core/events) and [Popout Groups](/docs/core/groups/popoutGroups).
+
+### Floating groups & popout windows as nested layouts
+
+Floating groups and popout windows now host their own nested grid, so a single
+floating window or popout can hold a full splitview layout of groups rather than
+a single group. See [Floating Groups](/docs/core/groups/floatingGroups) and
+[Popout Groups](/docs/core/groups/popoutGroups).
+
+### Layout-mutation transaction events
+
+`onWillMutateLayout` / `onDidMutateLayout` bracket structural changes
+(add / remove / move / float / popout / maximize / load / clear) as a single
+transaction, each tagged with a `'user'` or `'api'` origin. See
+[Events](/docs/core/events).
+
+### Active-panel origin
+
+`onDidActivePanelChange` now reports whether the active panel changed from a user
+gesture or an API call via `event.origin`. This is a
+[breaking payload change](#breaking-changes).
+
+## Breaking changes
+
+v7's breaking changes are covered in full, with codemods, in
+[Migrating to v7](/docs/overview/migrating-to-v7):
+
+- **Package realignment** — React bindings moved from `dockview` to
+  `dockview-react`; `dockview` is now vanilla core.
+- **`rootOverlayModel` removed** — use [`dropOverlayModel`](/docs/core/dnd/overlay)
+  / `dndEdges` instead.
+- **`onDidActivePanelChange` payload** — now emits `{ panel, origin }` instead of
+  the panel directly.
+- **`dockview-core` no longer bundles every feature** — use `dockview` (or a
+  framework package), or register [modules](/docs/core/modules) explicitly.


### PR DESCRIPTION
Adds the missing v7 documentation: new feature pages, updates to existing pages, and a first-class migration guide.

## New pages
- **`overview/migrating-to-v7.mdx`** — canonical v7 migration guide (ported + expanded from the root `MIGRATION-v7.md`, which is now a pointer): package realignment table, React action-required (install/import `dockview-react`, symptoms, codemod), vanilla recommendation + the "`dockview-core` no longer bundles every feature" behaviour, removed `rootOverlayModel`, changed `onDidActivePanelChange` payload, Vue/Angular, CDN.
- **`overview/whats-new-v7.mdx`** — v7 highlights (mirrors `whats-new-v6`).
- **`core/modules.mdx`** — the module system: `dockview` (batteries-included) vs `dockview-core` (bare), and the `registerModules`/`defineModule` authoring API.
- **`advanced/accessibility.mdx`** — the `keyboardNavigation` option + rebindable keymap (full default-bindings table) and screen-reader announcements (`announcements` / `getAnnouncement` / `announcer` / i18n `messages`).
- **`core/dnd/overlay.mdx`** — `dropOverlayModel` per-target overlay shaping (the `rootOverlayModel` replacement).

## Updates to existing pages
- **`core/events.mdx`** — document `onDidRemovePopoutGroup`.
- **`core/groups/popoutGroups.mdx` + `floatingGroups.mdx`** — correct the now-stale "can only contain a single group" claim (v7 floating/popout windows host nested layouts and can hold multiple groups); add a popout lifecycle-events note.
- **`advanced/keyboard.mdx`** — cross-link to the new accessibility page.

## Verification
`cd packages/docs && yarn build` succeeds — MDX compiles and **all internal links resolve** under `onBrokenLinks: 'throw'`.

## Notes
- Decisions: code snippets only (no new live sandboxes this round); migration docs page is canonical; separate what's-new + migration pages.
- A couple of pages reference APIs added in PR #1349 (`onDidRemovePopoutGroup`, the group-level `onDidActivePanelChange` `origin`) — this docs PR assumes #1349 lands for v7.
- The untracked commercial drafts (`overview/features.mdx`, `enterprise-*`, `v7.md`) were deliberately **excluded** from this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)