### PR TITLE
feat: split keyboard support into default navigation + optional docking module

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -138,6 +138,7 @@ IGroupHeaderProps
 IGroupPanelBaseProps
 IGroupPanelInitParameters
 IHeaderActionsRenderer
+IKeyboardDockingService
 INodeDescriptor
 IPanePart
 IPanel

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -124,6 +124,12 @@ export interface IAccessibilityHost {
 
 export interface IAccessibilityService extends IDisposable {}
 
+/**
+ * Marker for the advanced keyboard docking service (spatial group focus +
+ * keyboard move mode). Self-driven; the component never calls into it.
+ */
+export interface IKeyboardDockingService extends IDisposable {}
+
 // --- AdvancedDnD ---
 
 export interface IAdvancedDnDHost {

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -21,6 +21,7 @@ import {
     IAccessibilityService,
     IAdvancedDnDService,
     IContextMenuService,
+    IKeyboardDockingService,
     ITabGroupChipsService,
 } from './moduleContracts';
 
@@ -36,6 +37,7 @@ export interface ServiceCollection {
     advancedDnDService?: IAdvancedDnDService;
     liveRegionService?: ILiveRegionService;
     accessibilityService?: IAccessibilityService;
+    keyboardDockingService?: IKeyboardDockingService;
 }
 
 export interface DockviewModule<THost = unknown> {

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -98,9 +98,9 @@ export interface AnnouncementEvent {
 /**
  * Key bindings for {@link DockviewComponentOptions.keyboardNavigation}. Each
  * value is a string of `+`-separated parts, modifiers first, e.g. `'ctrl+]'`,
- * `'shift+f6'`, `'ctrl+m'`. Recognised modifiers: `ctrl`, `shift`, `alt`,
- * `meta` (alias `cmd`). The final part is the `KeyboardEvent.key` to match,
- * case-insensitively (`'m'`, `']'`, `'f6'`, `'arrowleft'`).
+ * `'shift+f6'`. Recognised modifiers: `ctrl`, `shift`, `alt`, `meta` (alias
+ * `cmd`). The final part is the `KeyboardEvent.key` to match, case-insensitively
+ * (`']'`, `'f6'`, `'arrowleft'`).
  */
 export interface DockviewKeybindings {
     /** Switch to the next tab in the focused group. Default `ctrl+]`. */
@@ -111,16 +111,6 @@ export interface DockviewKeybindings {
     focusNextGroup: string;
     /** Move focus to the previous group. Default `shift+f6`. */
     focusPrevGroup: string;
-    /** Move focus to the group spatially to the left. Default `ctrl+shift+arrowleft`. */
-    focusGroupLeft: string;
-    /** Move focus to the group spatially to the right. Default `ctrl+shift+arrowright`. */
-    focusGroupRight: string;
-    /** Move focus to the group spatially above. Default `ctrl+shift+arrowup`. */
-    focusGroupUp: string;
-    /** Move focus to the group spatially below. Default `ctrl+shift+arrowdown`. */
-    focusGroupDown: string;
-    /** Arm keyboard docking of the active panel. Default `ctrl+m`. */
-    dock: string;
     /** Move focus from panel content to the focused group's tab strip. Default `ctrl+shift+\`. */
     focusTabs: string;
 }

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -195,6 +195,7 @@ export {
     IAdvancedDnDService,
     IContextMenuHost,
     IContextMenuService,
+    IKeyboardDockingService,
     ITabGroupChipsHost,
     ITabGroupChipsService,
 } from './dockview/moduleContracts';

--- a/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
+++ b/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
@@ -1,6 +1,12 @@
 import { fireEvent } from '@testing-library/dom';
 import { DockviewComponent } from 'dockview-core';
+import { registerModules } from 'dockview-core';
 import { IContentRenderer } from 'dockview-core';
+import { KeyboardDockingModule } from '../keyboardDockingService';
+
+// Advanced keyboard docking (spatial focus + Ctrl+M move mode) is not part of
+// the default `Modules` bundle, so register it explicitly for these tests.
+registerModules([KeyboardDockingModule]);
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');
@@ -818,5 +824,49 @@ describe('accessibility: docking narration i18n', () => {
 
         fireEvent.keyDown(dockview.element, { key: 'Escape' });
         expect(region.textContent).toBe('Annule.');
+    });
+});
+
+/**
+ * While a keyboard move is armed, the default navigation keys must stand down
+ * so the move isn't double-handled (the docking module owns the keys then).
+ */
+describe('accessibility: move-mode takes precedence over navigation', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+
+    afterEach(() => {
+        dockview.dispose();
+        container.remove();
+    });
+
+    test('a navigation key (Ctrl+]) does not switch tabs while move mode is armed', () => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            keyboardNavigation: true,
+        });
+        dockview.layout(1000, 1000);
+        // two tabs in one group; p2 is active
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'P2',
+        });
+        expect(dockview.activePanel?.id).toBe('p2');
+
+        // arm keyboard docking
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+
+        // a free nav key now must be ignored (no tab switch)
+        fireEvent.keyDown(dockview.element, { key: ']', ctrlKey: true });
+        expect(dockview.activePanel?.id).toBe('p2');
+
+        // cancelling restores normal navigation (Ctrl+] now switches tabs)
+        fireEvent.keyDown(dockview.element, { key: 'Escape' });
+        fireEvent.keyDown(dockview.element, { key: ']', ctrlKey: true });
+        expect(dockview.activePanel?.id).toBe('p1');
     });
 });

--- a/packages/dockview-modules/src/accessibilityService.ts
+++ b/packages/dockview-modules/src/accessibilityService.ts
@@ -2,95 +2,50 @@ import {
     DockviewCompositeDisposable as CompositeDisposable,
     DockviewIDisposable as IDisposable,
 } from 'dockview-core';
-import { Position } from 'dockview-core';
 import { DockviewGroupPanel } from 'dockview-core';
-import { IDockviewPanel } from 'dockview-core';
 import { DockviewKeybindings, KeyboardNavigationOptions } from 'dockview-core';
-import { resolveMessages } from 'dockview-core';
 import { defineModule } from 'dockview-core';
-import { AdvancedDnDModule } from './advancedDnDService';
-import { LiveRegionModule } from 'dockview-core';
 import { IAccessibilityHost, IAccessibilityService } from 'dockview-core';
-
-type DockPhase = 'target' | 'edge';
-
-interface MoveState {
-    readonly source: IDockviewPanel;
-    readonly groups: DockviewGroupPanel[];
-    groupIndex: number;
-    phase: DockPhase;
-    position: Position;
-}
-
-const EDGE_FROM_KEY: Record<string, Position> = {
-    ArrowLeft: 'left',
-    ArrowRight: 'right',
-    ArrowUp: 'top',
-    ArrowDown: 'bottom',
-};
+import {
+    KEYBOARD_MOVE_ATTRIBUTE,
+    matchesBinding,
+    readKeyboardNavigation,
+} from './keyboardShared';
 
 const DEFAULT_KEYMAP: DockviewKeybindings = {
     nextTab: 'ctrl+]',
     prevTab: 'ctrl+[',
     focusNextGroup: 'f6',
     focusPrevGroup: 'shift+f6',
-    focusGroupLeft: 'ctrl+shift+arrowleft',
-    focusGroupRight: 'ctrl+shift+arrowright',
-    focusGroupUp: 'ctrl+shift+arrowup',
-    focusGroupDown: 'ctrl+shift+arrowdown',
-    dock: 'ctrl+m',
     focusTabs: 'ctrl+shift+\\',
 };
 
 /**
- * Does `e` match a binding string like `'ctrl+]'` / `'shift+f6'`? Modifiers
- * are matched exactly (a binding without `shift` will not fire while Shift is
- * held), and the final part is compared to `KeyboardEvent.key`, lower-cased.
- */
-function matchesBinding(e: KeyboardEvent, binding: string): boolean {
-    const parts = binding.toLowerCase().split('+');
-    const key = parts[parts.length - 1];
-    const mods = parts.slice(0, -1);
-    return (
-        e.ctrlKey === mods.includes('ctrl') &&
-        e.shiftKey === mods.includes('shift') &&
-        e.altKey === mods.includes('alt') &&
-        e.metaKey === (mods.includes('meta') || mods.includes('cmd')) &&
-        e.key.toLowerCase() === key
-    );
-}
-
-/**
- * Accessibility module — operate the dock without a mouse. Opt-in via
- * `keyboardNavigation`, with a rebindable {@link DockviewKeybindings} keymap.
+ * Keyboard navigation & focus management — operate the dock without a mouse.
+ * Opt-in via `keyboardNavigation`, with a rebindable {@link DockviewKeybindings}
+ * keymap.
  *
  * - **Switch tab** (`Ctrl+]` / `Ctrl+[`) — cycle the focused group's tabs.
- * - **Focus group** (`F6` / `Shift+F6` sequential, `Ctrl+Shift+Arrows`
- *   spatial) — move focus between groups.
- * - **Keyboard docking** (`Ctrl+M`) — arms a two-phase move of the active
- *   panel with a live drop preview + screen-reader narration:
- *     1. PICK TARGET — arrows cycle the groups (incl. the panel's own, so a tab
- *        can be split out); `Enter` selects one.
- *     2. PICK EDGE — arrows choose a split edge (left/right/top/bottom) or the
- *        centre (tab-into); `Enter` commits, `Escape` steps back.
- *   `Escape` from the target phase cancels.
- * - **Focus restore on close** (L4) — when removing a panel/group pulls focus
- *   out of the dock, focus returns to the neighbour the layout just activated
- *   instead of being stranded on `<body>`.
- * - **Floating `Esc`** (L4) — `Esc` inside a floating group returns focus to
- *   the control that had it before entering the float (polite: bubble phase,
+ * - **Focus group** (`F6` / `Shift+F6`) — move focus to the next / previous
+ *   group in sequence.
+ * - **Focus the tab strip** (`Ctrl+Shift+\`) — jump focus from panel content to
+ *   the active group's tab strip (the strip's roving-tabindex takes over).
+ * - **Focus restore on close** — when removing a panel/group pulls focus out of
+ *   the dock, focus returns to the neighbour the layout just activated instead
+ *   of being stranded on `<body>`.
+ * - **Floating `Esc`** — `Esc` inside a floating group returns focus to the
+ *   control that had it before entering the float (polite: bubble phase,
  *   respects `defaultPrevented`, so panel content keeps `Esc`).
- * - **Floating Tab-containment** (L4) — Tab wraps within the floating group so
- *   focus doesn't leak to the grid behind it.
+ * - **Floating Tab-containment** — Tab wraps within the floating group so focus
+ *   doesn't leak to the grid behind it.
  *
- * Cross-window (popout) focus is a later phase.
+ * Stands down while an advanced keyboard move is in progress (see
+ * {@link KEYBOARD_MOVE_ATTRIBUTE}) so the docking module owns the keys then.
  */
 export class AccessibilityService
     extends CompositeDisposable
     implements IAccessibilityService
 {
-    private _move: MoveState | null = null;
-    private _preview: IDisposable | undefined;
     private _focusWasInside = false;
     private _lastNonFloatFocus: HTMLElement | undefined;
 
@@ -100,7 +55,6 @@ export class AccessibilityService
         // Listen on the document (capture) rather than the dockview element:
         // edge groups live in the shell *outside* the gridview, and the shell
         // is created after this service, so a fixed element would miss them.
-        // Capture also lets move-mode keys beat the free tab-strip navigation.
         const doc = host.rootElement.ownerDocument;
         const onKeyDown = (e: KeyboardEvent): void => this._onKeyDown(e);
         doc.addEventListener('keydown', onKeyDown, true);
@@ -126,7 +80,6 @@ export class AccessibilityService
         doc.addEventListener('keydown', onEscape, false);
 
         this.addDisposables(
-            { dispose: () => this._clearPreview() },
             {
                 dispose: () =>
                     doc.removeEventListener('keydown', onKeyDown, true),
@@ -139,10 +92,10 @@ export class AccessibilityService
                 dispose: () =>
                     doc.removeEventListener('keydown', onEscape, false),
             },
-            // L4 focus management — when a close pulls focus out of the dock,
-            // return it to the neighbour the component just activated rather
-            // than leaving it stranded on <body>. Snapshot before the teardown
-            // (focus still on the closing panel), restore after.
+            // When a close pulls focus out of the dock, return it to the
+            // neighbour the component just activated rather than leaving it
+            // stranded on <body>. Snapshot before the teardown (focus still on
+            // the closing panel), restore after.
             host.onWillMutateLayout((e) => {
                 if (e.kind === 'remove' && this._nav) {
                     this._focusWasInside = this._isFocusInside();
@@ -161,6 +114,10 @@ export class AccessibilityService
         );
     }
 
+    private get _moveActive(): boolean {
+        return this.host.rootElement.hasAttribute(KEYBOARD_MOVE_ATTRIBUTE);
+    }
+
     private _isFocusInside(): boolean {
         const active = this.host.rootElement.ownerDocument.activeElement;
         return active instanceof Node && this.host.rootElement.contains(active);
@@ -169,7 +126,7 @@ export class AccessibilityService
     private _onFloatingEscape(e: KeyboardEvent): void {
         if (
             !this._nav ||
-            this._move ||
+            this._moveActive ||
             e.defaultPrevented ||
             e.key !== 'Escape'
         ) {
@@ -256,11 +213,7 @@ export class AccessibilityService
     }
 
     private get _nav(): KeyboardNavigationOptions | undefined {
-        const opt = this.host.options.keyboardNavigation;
-        if (!opt) {
-            return undefined;
-        }
-        return opt === true ? {} : opt;
+        return readKeyboardNavigation(this.host.options);
     }
 
     private get _keymap(): DockviewKeybindings {
@@ -271,8 +224,8 @@ export class AccessibilityService
         if (!this._nav) {
             return;
         }
-        if (this._move) {
-            this._onMoveKey(e);
+        // Stand down while the docking module is driving a keyboard move.
+        if (this._moveActive) {
             return;
         }
         // Only act on events originating inside *this* dockview.
@@ -288,9 +241,7 @@ export class AccessibilityService
             return;
         }
         const keymap = this._keymap;
-        if (matchesBinding(e, keymap.dock)) {
-            this._enterMoveMode(e);
-        } else if (matchesBinding(e, keymap.nextTab)) {
+        if (matchesBinding(e, keymap.nextTab)) {
             this._consume(e);
             this._switchTab(false);
         } else if (matchesBinding(e, keymap.prevTab)) {
@@ -302,18 +253,6 @@ export class AccessibilityService
         } else if (matchesBinding(e, keymap.focusPrevGroup)) {
             this._consume(e);
             this._cycleGroup(true);
-        } else if (matchesBinding(e, keymap.focusGroupLeft)) {
-            this._consume(e);
-            this._focusGroupInDirection('left');
-        } else if (matchesBinding(e, keymap.focusGroupRight)) {
-            this._consume(e);
-            this._focusGroupInDirection('right');
-        } else if (matchesBinding(e, keymap.focusGroupUp)) {
-            this._consume(e);
-            this._focusGroupInDirection('up');
-        } else if (matchesBinding(e, keymap.focusGroupDown)) {
-            this._consume(e);
-            this._focusGroupInDirection('down');
         } else if (matchesBinding(e, keymap.focusTabs)) {
             this._consume(e);
             this._focusTabs();
@@ -352,21 +291,6 @@ export class AccessibilityService
         this._focusGroup(target);
     }
 
-    private _focusGroupInDirection(
-        direction: 'left' | 'right' | 'up' | 'down'
-    ): void {
-        const current = this.host.activeGroup;
-        if (!current) {
-            return;
-        }
-        // Geometry lives on the host as the shared `adjacentGroupInDirection`
-        // primitive (also public on the api), so mouse and keyboard navigation
-        // agree on what "the group to the left" is.
-        this._focusGroup(
-            this.host.adjacentGroupInDirection(current, direction)
-        );
-    }
-
     private _focusGroup(target: DockviewGroupPanel | undefined): void {
         if (!target) {
             return;
@@ -380,147 +304,9 @@ export class AccessibilityService
         this.host.activeGroup?.model.focusContent();
     }
 
-    private _enterMoveMode(e: KeyboardEvent): void {
-        const source = this.host.activePanel;
-        const groups = this.host.groups;
-        if (!source || groups.length === 0) {
-            return;
-        }
-        e.preventDefault();
-        e.stopPropagation();
-        // Start on the panel's own group so a single group of tabs can still
-        // split a tab out via the edge phase.
-        const groupIndex = Math.max(0, groups.indexOf(source.group));
-        this._move = {
-            source,
-            groups,
-            groupIndex,
-            phase: 'target',
-            position: 'center',
-        };
-        this._render();
-    }
-
-    private _onMoveKey(e: KeyboardEvent): void {
-        const move = this._move!;
-
-        if (e.key === 'Escape') {
-            this._consume(e);
-            if (move.phase === 'edge') {
-                move.phase = 'target';
-                move.position = 'center';
-                this._render();
-            } else {
-                this._exit();
-                this.host.announce(this._messages.moveCancelled());
-                this._restoreFocus();
-            }
-            return;
-        }
-
-        if (e.key === 'Enter') {
-            this._consume(e);
-            if (move.phase === 'target') {
-                move.phase = 'edge';
-                move.position = 'center';
-                this._render();
-            } else {
-                this._commit();
-            }
-            return;
-        }
-
-        if (move.phase === 'target') {
-            const n = move.groups.length;
-            if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-                this._consume(e);
-                move.groupIndex = (move.groupIndex + 1) % n;
-                this._render();
-            } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-                this._consume(e);
-                move.groupIndex = (move.groupIndex - 1 + n) % n;
-                this._render();
-            }
-            return;
-        }
-
-        // edge phase
-        const edge = EDGE_FROM_KEY[e.key];
-        if (edge) {
-            this._consume(e);
-            move.position = edge;
-            this._render();
-        } else if (e.key === ' ' || e.key === 'c' || e.key === 'C') {
-            this._consume(e);
-            move.position = 'center';
-            this._render();
-        }
-    }
-
-    private get _messages() {
-        return resolveMessages(this.host.options.messages);
-    }
-
-    private _render(): void {
-        const move = this._move!;
-        const group = move.groups[move.groupIndex];
-        this._clearPreview();
-        this._preview = this.host.showDropPreview(group, move.position);
-
-        const name = group.activePanel?.title ?? group.id;
-        const m = this._messages;
-        if (move.phase === 'target') {
-            this.host.announce(
-                m.movePickTarget(
-                    this._label(move.source),
-                    name,
-                    move.groupIndex + 1,
-                    move.groups.length
-                )
-            );
-        } else {
-            this.host.announce(m.movePickEdge(move.position, name));
-        }
-    }
-
-    private _commit(): void {
-        const move = this._move!;
-        const group = move.groups[move.groupIndex];
-        const position = move.position;
-        const source = move.source;
-        const name = group.activePanel?.title ?? group.id;
-        const m = this._messages;
-        this._exit();
-        try {
-            this.host.dockPanel(source, group, position);
-            this.host.announce(
-                m.moveCommitted(this._label(source), name, position)
-            );
-        } catch {
-            this.host.announce(m.moveNotAllowed());
-        }
-        // The move re-renders the grid; pull focus back into the dock so the
-        // keymap keeps working without a click.
-        this._restoreFocus();
-    }
-
-    private _exit(): void {
-        this._clearPreview();
-        this._move = null;
-    }
-
-    private _clearPreview(): void {
-        this._preview?.dispose();
-        this._preview = undefined;
-    }
-
     private _consume(e: KeyboardEvent): void {
         e.preventDefault();
         e.stopPropagation();
-    }
-
-    private _label(panel: IDockviewPanel): string {
-        return panel.title ?? panel.id;
     }
 }
 
@@ -531,5 +317,4 @@ export const AccessibilityModule = defineModule<
     name: 'Accessibility',
     serviceKey: 'accessibilityService',
     create: (host) => new AccessibilityService(host),
-    dependsOn: [AdvancedDnDModule, LiveRegionModule],
 });

--- a/packages/dockview-modules/src/index.ts
+++ b/packages/dockview-modules/src/index.ts
@@ -14,6 +14,12 @@ export {
     AccessibilityService,
     AccessibilityModule,
 } from './accessibilityService';
+// Advanced keyboard docking is an optional module — exported for explicit
+// registration, but not part of the default `Modules` bundle below.
+export {
+    KeyboardDockingService,
+    KeyboardDockingModule,
+} from './keyboardDockingService';
 
 /**
  * The set of modules provided by this package. `dockview` registers these via

--- a/packages/dockview-modules/src/keyboardDockingService.ts
+++ b/packages/dockview-modules/src/keyboardDockingService.ts
@@ -1,0 +1,342 @@
+import {
+    DockviewCompositeDisposable as CompositeDisposable,
+    DockviewIDisposable as IDisposable,
+} from 'dockview-core';
+import { Position } from 'dockview-core';
+import { DockviewGroupPanel } from 'dockview-core';
+import { IDockviewPanel } from 'dockview-core';
+import { resolveMessages } from 'dockview-core';
+import { defineModule } from 'dockview-core';
+import { AdvancedDnDModule } from './advancedDnDService';
+import { LiveRegionModule } from 'dockview-core';
+import { IAccessibilityHost, IKeyboardDockingService } from 'dockview-core';
+import {
+    KEYBOARD_MOVE_ATTRIBUTE,
+    matchesBinding,
+    readKeyboardNavigation,
+} from './keyboardShared';
+
+type DockPhase = 'target' | 'edge';
+
+interface MoveState {
+    readonly source: IDockviewPanel;
+    readonly groups: DockviewGroupPanel[];
+    groupIndex: number;
+    phase: DockPhase;
+    position: Position;
+}
+
+const EDGE_FROM_KEY: Record<string, Position> = {
+    ArrowLeft: 'left',
+    ArrowRight: 'right',
+    ArrowUp: 'top',
+    ArrowDown: 'bottom',
+};
+
+/** Bindings owned by this module (kept separate from the default navigation keymap). */
+interface DockingKeybindings {
+    /** Move focus to the group spatially to the left. Default `ctrl+shift+arrowleft`. */
+    focusGroupLeft: string;
+    /** Move focus to the group spatially to the right. Default `ctrl+shift+arrowright`. */
+    focusGroupRight: string;
+    /** Move focus to the group spatially above. Default `ctrl+shift+arrowup`. */
+    focusGroupUp: string;
+    /** Move focus to the group spatially below. Default `ctrl+shift+arrowdown`. */
+    focusGroupDown: string;
+    /** Arm keyboard docking of the active panel. Default `ctrl+m`. */
+    dock: string;
+}
+
+const DEFAULT_KEYMAP: DockingKeybindings = {
+    focusGroupLeft: 'ctrl+shift+arrowleft',
+    focusGroupRight: 'ctrl+shift+arrowright',
+    focusGroupUp: 'ctrl+shift+arrowup',
+    focusGroupDown: 'ctrl+shift+arrowdown',
+    dock: 'ctrl+m',
+};
+
+/**
+ * Advanced keyboard control — drive the layout itself without a mouse. Opt-in
+ * via `keyboardNavigation` (shared with the default navigation module).
+ *
+ * - **Spatial group focus** (`Ctrl+Shift+Arrows`) — move focus to the visually
+ *   adjacent group via the `adjacentGroupInDirection` geometry primitive.
+ * - **Keyboard docking** (`Ctrl+M`) — arms a two-phase move of the active panel
+ *   with a live drop preview + screen-reader narration:
+ *     1. PICK TARGET — arrows cycle the groups (incl. the panel's own, so a tab
+ *        can be split out); `Enter` selects one.
+ *     2. PICK EDGE — arrows choose a split edge (left/right/top/bottom) or the
+ *        centre (tab-into); `Enter` commits, `Escape` steps back.
+ *   `Escape` from the target phase cancels.
+ *
+ * While a move is in progress it marks the root with
+ * {@link KEYBOARD_MOVE_ATTRIBUTE} so the default navigation listener stands
+ * down and the move keys aren't double-handled.
+ */
+export class KeyboardDockingService
+    extends CompositeDisposable
+    implements IKeyboardDockingService
+{
+    private _move: MoveState | null = null;
+    private _preview: IDisposable | undefined;
+
+    constructor(private readonly host: IAccessibilityHost) {
+        super();
+
+        // Capture phase, on the document — matches the navigation listener so
+        // edge groups (outside the gridview) are covered.
+        const doc = host.rootElement.ownerDocument;
+        const onKeyDown = (e: KeyboardEvent): void => this._onKeyDown(e);
+        doc.addEventListener('keydown', onKeyDown, true);
+
+        this.addDisposables(
+            { dispose: () => this._exit() },
+            {
+                dispose: () =>
+                    doc.removeEventListener('keydown', onKeyDown, true),
+            }
+        );
+    }
+
+    private get _enabled(): boolean {
+        return !!readKeyboardNavigation(this.host.options);
+    }
+
+    private get _keymap(): DockingKeybindings {
+        // The public `keyboardNavigation.keymap` carries the default-navigation
+        // bindings; this module's bindings are read from the same object when
+        // present (so a consumer can rebind them too).
+        const overrides = (readKeyboardNavigation(this.host.options)?.keymap ??
+            {}) as Record<string, string>;
+        return {
+            focusGroupLeft:
+                overrides.focusGroupLeft ?? DEFAULT_KEYMAP.focusGroupLeft,
+            focusGroupRight:
+                overrides.focusGroupRight ?? DEFAULT_KEYMAP.focusGroupRight,
+            focusGroupUp: overrides.focusGroupUp ?? DEFAULT_KEYMAP.focusGroupUp,
+            focusGroupDown:
+                overrides.focusGroupDown ?? DEFAULT_KEYMAP.focusGroupDown,
+            dock: overrides.dock ?? DEFAULT_KEYMAP.dock,
+        };
+    }
+
+    private get _messages() {
+        return resolveMessages(this.host.options.messages);
+    }
+
+    private _onKeyDown(e: KeyboardEvent): void {
+        if (!this._enabled) {
+            return;
+        }
+        if (this._move) {
+            this._onMoveKey(e);
+            return;
+        }
+        // Only act on events originating inside *this* dockview.
+        if (
+            !(e.target instanceof Node) ||
+            !this.host.rootElement.contains(e.target)
+        ) {
+            return;
+        }
+        const keymap = this._keymap;
+        if (matchesBinding(e, keymap.dock)) {
+            this._enterMoveMode(e);
+        } else if (matchesBinding(e, keymap.focusGroupLeft)) {
+            this._consume(e);
+            this._focusGroupInDirection('left');
+        } else if (matchesBinding(e, keymap.focusGroupRight)) {
+            this._consume(e);
+            this._focusGroupInDirection('right');
+        } else if (matchesBinding(e, keymap.focusGroupUp)) {
+            this._consume(e);
+            this._focusGroupInDirection('up');
+        } else if (matchesBinding(e, keymap.focusGroupDown)) {
+            this._consume(e);
+            this._focusGroupInDirection('down');
+        }
+    }
+
+    // --- spatial focus ---
+
+    private _focusGroupInDirection(
+        direction: 'left' | 'right' | 'up' | 'down'
+    ): void {
+        const current = this.host.activeGroup;
+        if (!current) {
+            return;
+        }
+        // Geometry lives on the host as the shared `adjacentGroupInDirection`
+        // primitive (also public on the api), so mouse and keyboard navigation
+        // agree on what "the group to the left" is.
+        this._focusGroup(
+            this.host.adjacentGroupInDirection(current, direction)
+        );
+    }
+
+    private _focusGroup(target: DockviewGroupPanel | undefined): void {
+        if (!target) {
+            return;
+        }
+        target.api.setActive();
+        target.model.focusContent();
+    }
+
+    private _restoreFocus(): void {
+        this.host.activeGroup?.model.focusContent();
+    }
+
+    // --- keyboard docking (move mode) ---
+
+    private _enterMoveMode(e: KeyboardEvent): void {
+        const source = this.host.activePanel;
+        const groups = this.host.groups;
+        if (!source || groups.length === 0) {
+            return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        // Start on the panel's own group so a single group of tabs can still
+        // split a tab out via the edge phase.
+        const groupIndex = Math.max(0, groups.indexOf(source.group));
+        this._move = {
+            source,
+            groups,
+            groupIndex,
+            phase: 'target',
+            position: 'center',
+        };
+        // Signal the navigation module to stand down while the move runs.
+        this.host.rootElement.setAttribute(KEYBOARD_MOVE_ATTRIBUTE, '');
+        this._render();
+    }
+
+    private _onMoveKey(e: KeyboardEvent): void {
+        const move = this._move!;
+
+        if (e.key === 'Escape') {
+            this._consume(e);
+            if (move.phase === 'edge') {
+                move.phase = 'target';
+                move.position = 'center';
+                this._render();
+            } else {
+                this._exit();
+                this.host.announce(this._messages.moveCancelled());
+                this._restoreFocus();
+            }
+            return;
+        }
+
+        if (e.key === 'Enter') {
+            this._consume(e);
+            if (move.phase === 'target') {
+                move.phase = 'edge';
+                move.position = 'center';
+                this._render();
+            } else {
+                this._commit();
+            }
+            return;
+        }
+
+        if (move.phase === 'target') {
+            const n = move.groups.length;
+            if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+                this._consume(e);
+                move.groupIndex = (move.groupIndex + 1) % n;
+                this._render();
+            } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+                this._consume(e);
+                move.groupIndex = (move.groupIndex - 1 + n) % n;
+                this._render();
+            }
+            return;
+        }
+
+        // edge phase
+        const edge = EDGE_FROM_KEY[e.key];
+        if (edge) {
+            this._consume(e);
+            move.position = edge;
+            this._render();
+        } else if (e.key === ' ' || e.key === 'c' || e.key === 'C') {
+            this._consume(e);
+            move.position = 'center';
+            this._render();
+        }
+    }
+
+    private _render(): void {
+        const move = this._move!;
+        const group = move.groups[move.groupIndex];
+        this._clearPreview();
+        this._preview = this.host.showDropPreview(group, move.position);
+
+        const name = group.activePanel?.title ?? group.id;
+        const m = this._messages;
+        if (move.phase === 'target') {
+            this.host.announce(
+                m.movePickTarget(
+                    this._label(move.source),
+                    name,
+                    move.groupIndex + 1,
+                    move.groups.length
+                )
+            );
+        } else {
+            this.host.announce(m.movePickEdge(move.position, name));
+        }
+    }
+
+    private _commit(): void {
+        const move = this._move!;
+        const group = move.groups[move.groupIndex];
+        const position = move.position;
+        const source = move.source;
+        const name = group.activePanel?.title ?? group.id;
+        const m = this._messages;
+        this._exit();
+        try {
+            this.host.dockPanel(source, group, position);
+            this.host.announce(
+                m.moveCommitted(this._label(source), name, position)
+            );
+        } catch {
+            this.host.announce(m.moveNotAllowed());
+        }
+        // The move re-renders the grid; pull focus back into the dock so the
+        // keymap keeps working without a click.
+        this._restoreFocus();
+    }
+
+    private _exit(): void {
+        this._clearPreview();
+        this._move = null;
+        this.host.rootElement.removeAttribute(KEYBOARD_MOVE_ATTRIBUTE);
+    }
+
+    private _clearPreview(): void {
+        this._preview?.dispose();
+        this._preview = undefined;
+    }
+
+    private _consume(e: KeyboardEvent): void {
+        e.preventDefault();
+        e.stopPropagation();
+    }
+
+    private _label(panel: IDockviewPanel): string {
+        return panel.title ?? panel.id;
+    }
+}
+
+export const KeyboardDockingModule = defineModule<
+    'keyboardDockingService',
+    IAccessibilityHost
+>({
+    name: 'KeyboardDocking',
+    serviceKey: 'keyboardDockingService',
+    create: (host) => new KeyboardDockingService(host),
+    dependsOn: [AdvancedDnDModule, LiveRegionModule],
+});

--- a/packages/dockview-modules/src/keyboardShared.ts
+++ b/packages/dockview-modules/src/keyboardShared.ts
@@ -1,0 +1,44 @@
+import {
+    DockviewComponentOptions,
+    KeyboardNavigationOptions,
+} from 'dockview-core';
+
+/**
+ * Marks (on the dockview root element) that a keyboard move is in progress, so
+ * the default navigation listener stands down while the advanced docking module
+ * drives the keys. A neutral DOM signal keeps the two listeners coordinated
+ * without either service holding a reference to the other.
+ */
+export const KEYBOARD_MOVE_ATTRIBUTE = 'data-dv-kbd-moving';
+
+/**
+ * Does `e` match a binding string like `'ctrl+]'` / `'shift+f6'`? Modifiers are
+ * matched exactly (a binding without `shift` will not fire while Shift is held),
+ * and the final part is compared to `KeyboardEvent.key`, lower-cased.
+ */
+export function matchesBinding(e: KeyboardEvent, binding: string): boolean {
+    const parts = binding.toLowerCase().split('+');
+    const key = parts[parts.length - 1];
+    const mods = parts.slice(0, -1);
+    return (
+        e.ctrlKey === mods.includes('ctrl') &&
+        e.shiftKey === mods.includes('shift') &&
+        e.altKey === mods.includes('alt') &&
+        e.metaKey === (mods.includes('meta') || mods.includes('cmd')) &&
+        e.key.toLowerCase() === key
+    );
+}
+
+/**
+ * Resolve the `keyboardNavigation` opt-in to its options object, or `undefined`
+ * when keyboard support is off. Both keyboard modules read the same opt-in.
+ */
+export function readKeyboardNavigation(
+    options: DockviewComponentOptions
+): KeyboardNavigationOptions | undefined {
+    const opt = options.keyboardNavigation;
+    if (!opt) {
+        return undefined;
+    }
+    return opt === true ? {} : opt;
+}

--- a/packages/docs/docs/advanced/accessibility.mdx
+++ b/packages/docs/docs/advanced/accessibility.mdx
@@ -32,11 +32,6 @@ This wires up the following default bindings:
 | Switch to the previous tab in the focused group | `Ctrl+[` | `prevTab` |
 | Move focus to the next group | `F6` | `focusNextGroup` |
 | Move focus to the previous group | `Shift+F6` | `focusPrevGroup` |
-| Move focus to the group on the left | `Ctrl+Shift+←` | `focusGroupLeft` |
-| Move focus to the group on the right | `Ctrl+Shift+→` | `focusGroupRight` |
-| Move focus to the group above | `Ctrl+Shift+↑` | `focusGroupUp` |
-| Move focus to the group below | `Ctrl+Shift+↓` | `focusGroupDown` |
-| Arm keyboard docking of the active panel | `Ctrl+M` | `dock` |
 | Move focus from panel content to the tab strip | `Ctrl+Shift+\` | `focusTabs` |
 
 ### Rebinding keys
@@ -50,7 +45,6 @@ const options = {
         keymap: {
             nextTab: 'ctrl+tab',
             prevTab: 'ctrl+shift+tab',
-            dock: 'ctrl+shift+m',
         },
     },
 };
@@ -59,17 +53,10 @@ const options = {
 Each binding is a string of `+`-separated parts, modifiers first. Recognised
 modifiers are `ctrl`, `shift`, `alt`, and `meta` (alias `cmd`); the final part
 is the [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
-to match, case-insensitively — e.g. `'ctrl+]'`, `'shift+f6'`, `'ctrl+m'`,
-`'ctrl+shift+arrowleft'`.
+to match, case-insensitively — e.g. `'ctrl+]'`, `'shift+f6'`, `'ctrl+tab'`.
 
-:::info
-`Ctrl+M` arms **keyboard docking**: it enters a two-phase mode where you pick a
-target group and then an edge, letting you re-dock the active panel without a
-mouse.
-:::
-
-For *programmatic* focus movement (building your own shortcut handlers), see
-[Keyboard](/docs/advanced/keyboard).
+For *programmatic* focus movement (building your own shortcut handlers, e.g.
+moving focus by spatial direction), see [Keyboard](/docs/advanced/keyboard).
 
 ## Screen-reader announcements
 

--- a/packages/docs/docs/overview/migrating-to-v7.mdx
+++ b/packages/docs/docs/overview/migrating-to-v7.mdx
@@ -92,7 +92,7 @@ set of [feature modules](/docs/core/modules) is no longer part of bare
 - **advanced drag-and-drop** (`onWillDragPanel` / `onWillDragGroup` /
   `onWillDrop` hooks, custom drag ghost / [drop overlay](/docs/core/dnd/overlay))
 - **[keyboard accessibility](/docs/advanced/accessibility)** (keyboard
-  navigation / docking / screen-reader announcements)
+  navigation / focus management / screen-reader announcements)
 
 These now live in the `dockview` package, which registers them automatically.
 **`dockview-core` is an internal package — use `dockview`** (or a framework

--- a/packages/docs/docs/overview/whats-new-v7.mdx
+++ b/packages/docs/docs/overview/whats-new-v7.mdx
@@ -31,12 +31,13 @@ package is batteries-included (it registers them all), while bare `dockview-core
 ships without them. Authors can register modules explicitly with
 `registerModules` / `defineModule`.
 
-### Accessibility pack
+### Keyboard navigation & announcements
 
 A new [`keyboardNavigation`](/docs/advanced/accessibility#keyboard-navigation)
-option enables a fully rebindable keymap: tab switching, F6 / spatial group
-focus, and `Ctrl+M` keyboard docking. Layout changes can also be narrated to
-screen readers via a built-in live region, with hooks
+option enables a rebindable keymap for moving around the dock — tab switching,
+F6 group cycling, and jumping to the tab strip — alongside focus management
+(focus restore on close, floating-group focus containment). Layout changes can
+also be narrated to screen readers via a built-in live region, with hooks
 ([`announcements`](/docs/advanced/accessibility#screen-reader-announcements),
 `getAnnouncement`, `announcer`) and an i18n `messages` catalog.
 

--- a/packages/docs/src/generated/api.output.json
+++ b/packages/docs/src/generated/api.output.json
@@ -2331,7 +2331,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "DockviewOrigin",
-                                "target": 10591
+                                "target": 10589
                             },
                             {
                                 "kind": "text",
@@ -2388,7 +2388,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewOrigin",
-                            "target": 10591
+                            "target": 10589
                         },
                         {
                             "kind": "text",
@@ -3094,7 +3094,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "onDidAddPopoutGroup",
-                                "target": 5986
+                                "target": 5985
                             },
                             {
                                 "kind": "text",
@@ -3127,7 +3127,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "onDidAddPopoutGroup",
-                            "target": 5986
+                            "target": 5985
                         },
                         {
                             "kind": "text",
@@ -7755,7 +7755,7 @@
                                     "kind": "inline-tag",
                                     "tag": "@link",
                                     "text": "DockviewApi",
-                                    "target": 5954
+                                    "target": 5953
                                 },
                                 {
                                     "kind": "text",
@@ -7800,7 +7800,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewApi",
-                            "target": 5954
+                            "target": 5953
                         },
                         {
                             "kind": "text",
@@ -30066,7 +30066,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewOrigin",
-                            "target": 10591
+                            "target": 10589
                         },
                         {
                             "kind": "text",
@@ -30782,136 +30782,6 @@
         "kind": "interface",
         "name": "DockviewKeybindings",
         "children": [
-            {
-                "name": "dock",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {},
-                "comment": {
-                    "summary": [
-                        {
-                            "kind": "text",
-                            "text": "Arm keyboard docking of the active panel. Default "
-                        },
-                        {
-                            "kind": "code",
-                            "text": "`ctrl+m`"
-                        },
-                        {
-                            "kind": "text",
-                            "text": "."
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "focusGroupDown",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {},
-                "comment": {
-                    "summary": [
-                        {
-                            "kind": "text",
-                            "text": "Move focus to the group spatially below. Default "
-                        },
-                        {
-                            "kind": "code",
-                            "text": "`ctrl+shift+arrowdown`"
-                        },
-                        {
-                            "kind": "text",
-                            "text": "."
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "focusGroupLeft",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {},
-                "comment": {
-                    "summary": [
-                        {
-                            "kind": "text",
-                            "text": "Move focus to the group spatially to the left. Default "
-                        },
-                        {
-                            "kind": "code",
-                            "text": "`ctrl+shift+arrowleft`"
-                        },
-                        {
-                            "kind": "text",
-                            "text": "."
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "focusGroupRight",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {},
-                "comment": {
-                    "summary": [
-                        {
-                            "kind": "text",
-                            "text": "Move focus to the group spatially to the right. Default "
-                        },
-                        {
-                            "kind": "code",
-                            "text": "`ctrl+shift+arrowright`"
-                        },
-                        {
-                            "kind": "text",
-                            "text": "."
-                        }
-                    ]
-                }
-            },
-            {
-                "name": "focusGroupUp",
-                "code": "string",
-                "kind": "property",
-                "type": {
-                    "type": "intrinsic",
-                    "value": "string"
-                },
-                "flags": {},
-                "comment": {
-                    "summary": [
-                        {
-                            "kind": "text",
-                            "text": "Move focus to the group spatially above. Default "
-                        },
-                        {
-                            "kind": "code",
-                            "text": "`ctrl+shift+arrowup`"
-                        },
-                        {
-                            "kind": "text",
-                            "text": "."
-                        }
-                    ]
-                }
-            },
             {
                 "name": "focusNextGroup",
                 "code": "string",
@@ -31813,7 +31683,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "AnnouncementEvent",
-                            "target": 8471
+                            "target": 8470
                         },
                         {
                             "kind": "text",
@@ -32208,7 +32078,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DroptargetOverlayModel",
-                            "target": 10597
+                            "target": 10595
                         },
                         {
                             "kind": "text",
@@ -32876,7 +32746,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewMessages",
-                            "target": 8678
+                            "target": 8672
                         },
                         {
                             "kind": "text",
@@ -35088,7 +34958,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewOptions.floatingGroupDragHandle",
-                            "target": 8764
+                            "target": 8758
                         },
                         {
                             "kind": "text",
@@ -44960,6 +44830,33 @@
             "IDisposable"
         ]
     },
+    "IKeyboardDockingService": {
+        "kind": "interface",
+        "name": "IKeyboardDockingService",
+        "children": [
+            {
+                "name": "dispose",
+                "code": "(): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "dispose",
+                        "typeParameters": [],
+                        "parameters": [],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            }
+        ],
+        "extends": [
+            "IDisposable"
+        ]
+    },
     "INodeDescriptor": {
         "kind": "interface",
         "name": "INodeDescriptor",
@@ -49158,7 +49055,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewKeybindings",
-                            "target": 8661
+                            "target": 8660
                         },
                         {
                             "kind": "text",
@@ -52899,6 +52796,19 @@
                 }
             },
             {
+                "name": "keyboardDockingService",
+                "code": "IKeyboardDockingService",
+                "kind": "property",
+                "type": {
+                    "type": "reference",
+                    "value": "IKeyboardDockingService",
+                    "source": "dockview-core"
+                },
+                "flags": {
+                    "isOptional": true
+                }
+            },
+            {
                 "name": "liveRegionService",
                 "code": "ILiveRegionService",
                 "kind": "property",
@@ -54816,7 +54726,7 @@
                     "kind": "inline-tag",
                     "tag": "@link",
                     "text": "DockviewApi",
-                    "target": 5954
+                    "target": 5953
                 },
                 {
                     "kind": "text",


### PR DESCRIPTION
Splits the single keyboard accessibility module into a default-navigation module (batteries-included) and an optional, separately-registered docking module.

## Motivation
`AccessibilityService` bundled everyday keyboard navigation/focus together with advanced layout control. The default navigation should ship by default; the advanced layout-editing piece is opt-in.

## dockview-modules
- **`AccessibilityModule`** (default — stays in the `Modules` bundle `dockview` registers): tab switching (`Ctrl+]`/`Ctrl+[`), F6 group cycling, focus-the-tab-strip (`Ctrl+Shift+\`), and focus management (Esc-from-float, float Tab-trap, focus-restore-on-close). No `dependsOn`.
- **`KeyboardDockingModule`** (new — `export`ed for explicit registration, **not** in the default bundle): spatial group focus (`Ctrl+Shift+Arrows`) and the `Ctrl+M` keyboard move/dock state machine (two-phase target→edge, live drop preview + screen-reader narration). `dependsOn` `AdvancedDnD` + `LiveRegion`.
- Shared opt-in/keymap helpers in `keyboardShared.ts`.

### Coordination
Both modules attach a capture-phase document `keydown` listener. They coordinate via a neutral `data-dv-kbd-moving` attribute set on the dock root while a move is armed — the navigation listener stands down then, so move keys aren't double-handled. A new test asserts a navigation key (`Ctrl+]`) is inert while move mode is active.

## dockview-core
- `DockviewKeybindings` now covers the default-navigation bindings only (`nextTab`, `prevTab`, `focusNextGroup`, `focusPrevGroup`, `focusTabs`); the docking/spatial bindings live in the docking module's own keymap.
- New `IKeyboardDockingService` contract + `keyboardDockingService` service slot.

## docs
`accessibility.mdx`, `whats-new-v7.mdx`, `migrating-to-v7.mdx` updated to describe the default navigation surface; API reference (`api.output.json`) + exports snapshot regenerated.

## Verification
- Full suite green: **91 suites / 1345 tests** (incl. the new precedence test; docking tests register `KeyboardDockingModule` explicitly).
- `dockview-core` + `dockview-modules` typecheck clean; changed files lint with 0 errors.
- `packages/docs` builds clean, including `/docs/api/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)