### PR TITLE
docs: treat dockview-core as internal; point users at dockview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ See per-package `AGENTS.md` files under `packages/` for package-specific guidanc
 NX handles build ordering automatically via `dependsOn: ["^build"]`. The dependency chain is:
 
     dockview-core → dockview → dockview-react
-    dockview-core → dockview-vue
-    dockview-core → dockview-angular
+    dockview-core → dockview → dockview-vue
+    dockview-core → dockview → dockview-angular
 
 ### CSS Flow
 
@@ -55,9 +55,9 @@ NX handles build ordering automatically via `dependsOn: ["^build"]`. The depende
 
 ### Monorepo Structure
 
--   **packages/dockview-core** - Core layout engine (TypeScript, framework-agnostic, zero dependencies)
--   **packages/dockview-react** - Canonical React bindings package — what docs, READMEs, and examples point users at (`npm install dockview-react`). Re-exports the implementation from `packages/dockview`.
--   **packages/dockview** - Legacy alias kept for backwards compatibility. Still holds the actual React source; `dockview-react` re-exports from it.
+-   **packages/dockview-core** - Internal core layout engine (TypeScript, framework-agnostic, zero dependencies). Not a documented install target — consumers use `dockview` or a framework binding.
+-   **packages/dockview** - Canonical vanilla JavaScript / TypeScript package (`npm install dockview`). Batteries-included: re-exports the core API and registers the separable feature modules. No `react` peer dependency.
+-   **packages/dockview-react** - Canonical React bindings package — what docs, READMEs, and examples point users at (`npm install dockview-react`). Holds the actual React source and depends on `dockview`.
 -   **packages/dockview-vue** - Vue 3 bindings and components
 -   **packages/dockview-angular** - Angular bindings and components
 -   **packages/docs** - Documentation website (Docusaurus v3)

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 
 ---
 
-[![npm version](https://badge.fury.io/js/dockview-core.svg)](https://www.npmjs.com/package/dockview-core)
-[![npm](https://img.shields.io/npm/dm/dockview-core)](https://www.npmjs.com/package/dockview-core)
+[![npm version](https://badge.fury.io/js/dockview.svg)](https://www.npmjs.com/package/dockview)
+[![npm](https://img.shields.io/npm/dm/dockview)](https://www.npmjs.com/package/dockview)
 [![CI Build](https://github.com/mathuo/dockview/workflows/CI/badge.svg)](https://github.com/mathuo/dockview/actions?query=workflow%3ACI)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=mathuo_dockview&metric=coverage)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mathuo_dockview&metric=alert_status)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
-[![Bundle Phobia](https://badgen.net/bundlephobia/minzip/dockview-core)](https://bundlephobia.com/result?p=dockview-core)
+[![Bundle Phobia](https://badgen.net/bundlephobia/minzip/dockview)](https://bundlephobia.com/result?p=dockview)
 
 ##
 
@@ -40,7 +40,7 @@ Please see the website: https://dockview.dev
 
 | Package | Description | Version |
 | --- | --- | --- |
-| [`dockview-core`](https://www.npmjs.com/package/dockview-core) | Core layout engine — zero dependencies, vanilla TypeScript | [![npm version](https://badge.fury.io/js/dockview-core.svg)](https://www.npmjs.com/package/dockview-core) |
+| [`dockview`](https://www.npmjs.com/package/dockview) | Vanilla JavaScript / TypeScript — zero dependencies, full feature set out of the box | [![npm version](https://badge.fury.io/js/dockview.svg)](https://www.npmjs.com/package/dockview) |
 | [`dockview-react`](https://www.npmjs.com/package/dockview-react) | React bindings (peer: `react` ≥16.8) | [![npm version](https://badge.fury.io/js/dockview-react.svg)](https://www.npmjs.com/package/dockview-react) |
 | [`dockview-vue`](https://www.npmjs.com/package/dockview-vue) | Vue 3 bindings (peer: `vue` ≥3.4) | [![npm version](https://badge.fury.io/js/dockview-vue.svg)](https://www.npmjs.com/package/dockview-vue) |
 | [`dockview-angular`](https://www.npmjs.com/package/dockview-angular) | Angular bindings (peer: `@angular/core` ≥21) | [![npm version](https://badge.fury.io/js/dockview-angular.svg)](https://www.npmjs.com/package/dockview-angular) |
@@ -48,10 +48,10 @@ Please see the website: https://dockview.dev
 ## Installation
 
 ```bash
+npm install dockview          # Vanilla JavaScript / TypeScript
 npm install dockview-react    # React
 npm install dockview-vue      # Vue
 npm install dockview-angular  # Angular
-npm install dockview-core     # Vanilla TypeScript
 ```
 
 ## Quick Start (React)
@@ -100,9 +100,9 @@ yarn format     # Run Prettier
 Build order is managed automatically by NX:
 
 ```
-dockview-core → dockview-react
-dockview-core → dockview-vue
-dockview-core → dockview-angular
+dockview-core → dockview → dockview-react
+dockview-core → dockview → dockview-vue
+dockview-core → dockview → dockview-angular
 ```
 
 ## Contributing

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23,9 +23,8 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 
 | Package | Framework | Install |
 |---|---|---|
-| dockview-core | Vanilla TypeScript | `npm install dockview-core` |
+| dockview | Vanilla JavaScript / TypeScript | `npm install dockview` |
 | dockview-react | React | `npm install dockview-react` |
-| dockview | React (legacy alias) | `npm install dockview` |
 | dockview-vue | Vue 3 | `npm install dockview-vue` |
 | dockview-angular | Angular | `npm install dockview-angular` |
 
@@ -34,19 +33,19 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 Install:
 
 ```
-npm install dockview-core
+npm install dockview
 ```
 
 Import the stylesheet:
 
 ```css
-@import 'dockview-core/dist/styles/dockview.css';
+@import 'dockview/dist/styles/dockview.css';
 ```
 
 Create a dockview instance:
 
 ```ts
-import { DockviewComponent } from 'dockview-core';
+import { DockviewComponent } from 'dockview';
 
 const element = document.getElementById('app');
 
@@ -144,7 +143,7 @@ Use the component in a Vue SFC:
 
 <script setup lang="ts">
 import { DockviewVue } from 'dockview-vue';
-import type { DockviewReadyEvent } from 'dockview-core';
+import type { DockviewReadyEvent } from 'dockview-vue';
 
 function onReady(event: DockviewReadyEvent) {
     event.api.addPanel({
@@ -174,7 +173,7 @@ Use the component:
 ```typescript
 import { Component } from '@angular/core';
 import { DockviewModule } from 'dockview-angular';
-import { DockviewReadyEvent } from 'dockview-core';
+import { DockviewReadyEvent } from 'dockview-angular';
 
 @Component({
     selector: 'app-root',

--- a/llms.txt
+++ b/llms.txt
@@ -22,9 +22,8 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 
 | Package | Framework | Install |
 |---|---|---|
-| dockview-core | Vanilla TypeScript | `npm install dockview-core` |
+| dockview | Vanilla JavaScript / TypeScript | `npm install dockview` |
 | dockview-react | React | `npm install dockview-react` |
-| dockview | React (legacy alias) | `npm install dockview` |
 | dockview-vue | Vue 3 | `npm install dockview-vue` |
 | dockview-angular | Angular | `npm install dockview-angular` |
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -7,17 +7,18 @@ This mono-repository has a number of packages containing the code for the dockvi
 -   Contains the core logic for the dockview library.
 -   Written entirely in vanilla JavaScript/TypeScript.
 
-## dockview-react
-
--   Depends on `dockview-core` (via the `dockview` package).
--   Exports a `React` wrapper.
--   Published as [dockview-react](https://www.npmjs.com/package/dockview-react) on npm — the canonical install name.
-
 ## dockview
 
--   Legacy alias of `dockview-react`, kept for backwards compatibility.
--   Still holds the underlying React source that `dockview-react` re-exports.
+-   The batteries-included vanilla JavaScript / TypeScript package — re-exports the core API and registers the separable feature modules so consumers get the full feature set out of the box.
+-   The package framework-agnostic consumers should install (`npm install dockview`).
+-   Has no `react` peer dependency; framework bindings live in the `dockview-<framework>` packages.
 -   Published as [dockview](https://www.npmjs.com/package/dockview) on npm.
+
+## dockview-react
+
+-   The React bindings package — holds the actual React source (`DockviewReact`, hooks, portal bridge).
+-   Depends on `dockview`; peer dependency on `react`.
+-   Published as [dockview-react](https://www.npmjs.com/package/dockview-react) on npm — the canonical install name for React.
 
 ## docs
 

--- a/packages/dockview-angular/README.md
+++ b/packages/dockview-angular/README.md
@@ -57,7 +57,7 @@ Use the component in your Angular template:
 ```typescript
 import { Component } from '@angular/core';
 import { DockviewModule } from 'dockview-angular';
-import { DockviewReadyEvent } from 'dockview-core';
+import { DockviewReadyEvent } from 'dockview-angular';
 
 @Component({
     selector: 'app-root',

--- a/packages/dockview-core/README.md
+++ b/packages/dockview-core/README.md
@@ -20,6 +20,13 @@
 
 Please see the website: https://dockview.dev
 
+> **`dockview-core` is an internal package.** Install
+> **[`dockview`](https://www.npmjs.com/package/dockview)** instead — the vanilla
+> JavaScript / TypeScript package that ships the full feature set out of the box. Using a
+> framework? Install the bindings: [`dockview-react`](https://www.npmjs.com/package/dockview-react),
+> [`dockview-vue`](https://www.npmjs.com/package/dockview-vue) or
+> [`dockview-angular`](https://www.npmjs.com/package/dockview-angular).
+
 ## Features
 
 -   Serialization / deserialization with full layout management

--- a/packages/dockview-vue/README.md
+++ b/packages/dockview-vue/README.md
@@ -67,7 +67,7 @@ Use the component in a Vue SFC:
 
 <script setup lang="ts">
 import { DockviewVue } from 'dockview-vue';
-import type { DockviewReadyEvent } from 'dockview-core';
+import type { DockviewReadyEvent } from 'dockview-vue';
 
 function onReady(event: DockviewReadyEvent) {
     event.api.addPanel({

--- a/packages/docs/docs/advanced/accessibility.mdx
+++ b/packages/docs/docs/advanced/accessibility.mdx
@@ -6,9 +6,8 @@ description: Keyboard navigation and screen-reader announcements in Dockview.
 # Accessibility
 
 Dockview ships an accessibility pack — keyboard navigation and screen-reader
-announcements — as part of the [`dockview` package](/docs/core/modules). It is a
-module, so it is included in `dockview` and the framework packages, but **not**
-in bare `dockview-core`.
+announcements — included out of the box in the `dockview` package and the
+framework packages.
 
 The options below are set the same way as any other Dockview option — via the
 options argument for vanilla (`createDockview(element, { ... })`) or via the

--- a/packages/docs/docs/core/dnd/overlay.mdx
+++ b/packages/docs/docs/core/dnd/overlay.mdx
@@ -52,9 +52,3 @@ The returned model accepts:
 when dragging to the outer edges of the whole layout. That is configured
 separately via the `dndEdges` option. If you were using `rootOverlayModel`
 purely to size the outer edge overlay, use `dndEdges` instead.
-
-:::warning
-Advanced drag-and-drop, including `dropOverlayModel`, is part of the
-[`dockview` package](/docs/core/modules) and is not active on bare
-`dockview-core`.
-:::

--- a/packages/docs/docs/core/modules.mdx
+++ b/packages/docs/docs/core/modules.mdx
@@ -1,26 +1,17 @@
 ---
 title: Modules
 sidebar_position: 4
-description: How Dockview's separable feature modules work, and the difference between the dockview and dockview-core packages.
+description: How Dockview's separable feature modules work and how to author your own.
 ---
 
 # Modules
 
 In v7 a set of separable features is delivered as **modules**. This is mostly
-transparent — it determines which package you should depend on.
+transparent: the `dockview` package and the framework packages
+(`dockview-react`, `dockview-vue`, `dockview-angular`) register every built-in
+module for you, so the full feature set works out of the box.
 
-## `dockview` vs `dockview-core`
-
-| Package | Modules | Use it when |
-|---|---|---|
-| **`dockview`** | All built-in modules registered (batteries-included) | You're building a vanilla JS/TS app — **recommended** |
-| **`dockview-core`** | None — bare implementation | Advanced: you want the smallest core and will opt features in yourself |
-
-The framework packages (`dockview-react`, `dockview-vue`, `dockview-angular`)
-all depend on `dockview`, so they get the full feature set automatically.
-
-The following features are modules and are included in `dockview` but **not** in
-bare `dockview-core`:
+The following features are delivered as modules and are all included by default:
 
 - **tab group chips** — chip rendering and the `onDid*TabGroup` events
 - **context menus** — the built-in tab / chip right-click menus
@@ -30,19 +21,8 @@ bare `dockview-core`:
 - **accessibility** — [keyboard navigation, docking, and screen-reader
   announcements](/docs/advanced/accessibility)
 
-:::info
-If you construct a component on bare `dockview-core`, the affected features
-simply do nothing (nothing throws), and a one-time `console.warn` nudges you
-toward `dockview`. Use `dockview` (or a framework package) to get the full
-feature set.
-:::
-
 ```ts
-// Recommended — everything works out of the box
 import { createDockview } from 'dockview';
-
-// Advanced — bare core, the modules above are inactive
-import { createDockview } from 'dockview-core';
 ```
 
 ## Authoring a module (advanced)

--- a/packages/docs/docs/core/theming.mdx
+++ b/packages/docs/docs/core/theming.mdx
@@ -71,10 +71,6 @@ const {className} = themeAbyss;
 
 <ThemeTable/>
 
-:::info
-The source code for all themes can be found [here](https://github.com/mathuo/dockview/blob/master/packages/dockview-core/src/theme.scss) and the compiled CSS [here](https://github.com/mathuo/dockview/blob/master/packages/dockview-core/dist/styles/dockview.css).
-:::
-
 ## Build your own theme
 
 You can define your own `DockviewTheme` object and pass it to the `theme` property. At minimum you need to provide a `name` and a `className`. The class name should match a CSS class where you define your theme variables.


### PR DESCRIPTION
## Summary

Aligns documentation with the v7 package model: **`dockview` is the recommended vanilla JS/TS package** (batteries-included), and **`dockview-core` is an internal implementation detail** that consumers shouldn't install or import directly.

## Changes
- Drop `dockview-core` from user-facing surfaces: install tables, quick-starts, `llms.txt` / `llms-full.txt`, and the docs feature pages (`modules`, `accessibility`, `overlay`, `theming`).
- Fix package descriptions in the root `README.md`, `packages/README.md`, and `AGENTS.md` — `dockview` re-exports core **and** registers the feature modules (it is not a thin re-export).
- `dockview-core`'s own README now redirects readers to `dockview`.
- Vue/Angular README type imports come from their own package rather than `dockview-core`.

`dockview-core` is intentionally retained where it is correct: the v7 migration guides (to explain the rename), the contributor build-dependency graph, and `dockview-core`'s own npm page.

## Notes
No source/behaviour changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
