### PR TITLE
chore: include dockview-modules in SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,9 @@
 sonar.projectKey=mathuo_dockview
 sonar.organization=dockview
 
-sonar.inclusions=packages/dockview/src/**/*,packages/dockview-core/src/**/*,packages/dockview-vue/src/**/*,packages/dockview-react/src/**/*,packages/dockview-angular/src/**/*
-sonar.exclusions=packages/dockview/docs/**/*,packages/dockview/src/__tests__/**/*,packages/dockview-core/src/__tests__/**/*,packages/dockview-vue/src/__tests__/**/*,packages/dockview-react/src/__tests__/**/*,packages/dockview-angular/src/__tests__/**/*
-sonar.tests=packages/dockview/src/__tests__,packages/dockview-core/src/__tests__,packages/dockview-vue/src/__tests__,packages/dockview-react/src/__tests__,packages/dockview-angular/src/__tests__
+sonar.inclusions=packages/dockview/src/**/*,packages/dockview-core/src/**/*,packages/dockview-vue/src/**/*,packages/dockview-react/src/**/*,packages/dockview-angular/src/**/*,packages/dockview-modules/src/**/*
+sonar.exclusions=packages/dockview/docs/**/*,packages/dockview/src/__tests__/**/*,packages/dockview-core/src/__tests__/**/*,packages/dockview-vue/src/__tests__/**/*,packages/dockview-react/src/__tests__/**/*,packages/dockview-angular/src/__tests__/**/*,packages/dockview-modules/src/__tests__/**/*
+sonar.tests=packages/dockview/src/__tests__,packages/dockview-core/src/__tests__,packages/dockview-vue/src/__tests__,packages/dockview-react/src/__tests__,packages/dockview-angular/src/__tests__,packages/dockview-modules/src/__tests__
 
 sonar.testExecutionReportPaths=test-report.xml
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Summary

`dockview-modules` ships source + tests and is already part of the root `test:cov` run (the root Jest `projects` / `collectCoverageFrom` globs cover `packages/*`), but it was missing from the SonarCloud scope. Add it to `sonar.inclusions`, `sonar.exclusions` (its `__tests__`), and `sonar.tests` so its code is analysed and its coverage counted in the unified report.

## Notes
- All six library/source packages are now in scope: `dockview`, `dockview-core`, `dockview-react`, `dockview-vue`, `dockview-angular`, `dockview-modules`.
- `packages/docs` (the Docusaurus website) is intentionally left out — it has no Jest project / coverage and is not a library to analyse. Happy to add it if you want it scanned too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
