### PR TITLE
fix: keep dockview-modules & docs in version lockstep (v7 CI fix)

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -44,10 +44,12 @@
     "release": {
         "projects": [
             "dockview-core",
+            "dockview-modules",
             "dockview",
             "dockview-vue",
             "dockview-react",
-            "dockview-angular"
+            "dockview-angular",
+            "dockview-docs"
         ],
         "projectsRelationship": "fixed",
         "version": {
@@ -68,5 +70,6 @@
         }
     },
     "defaultBase": "master",
-    "useInferencePlugins": false
+    "useInferencePlugins": false,
+    "analytics": false
 }

--- a/packages/dockview-modules/package.json
+++ b/packages/dockview-modules/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-modules",
-    "version": "6.6.1",
+    "version": "7.0.0",
     "private": true,
     "description": "Separable feature modules for dockview",
     "keywords": [
@@ -43,6 +43,6 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'"
     },
     "dependencies": {
-        "dockview-core": "^6.6.1"
+        "dockview-core": "^7.0.0"
     }
 }

--- a/packages/dockview/package.json
+++ b/packages/dockview/package.json
@@ -77,6 +77,6 @@
         "dockview-core": "^7.0.0"
     },
     "devDependencies": {
-        "dockview-modules": "^6.6.1"
+        "dockview-modules": "^7.0.0"
     }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-docs",
-    "version": "6.0.1",
+    "version": "7.0.0",
     "private": true,
     "scripts": {
         "build": "npm run build-templates && docusaurus build",
@@ -36,8 +36,8 @@
         "ag-grid-community": "^35.3.0",
         "ag-grid-react": "^35.3.0",
         "clsx": "^2.1.1",
-        "dockview": "^6.0.1",
-        "dockview-react": "^6.0.1",
+        "dockview": "^7.0.0",
+        "dockview-react": "^7.0.0",
         "prism-react-renderer": "^2.4.1",
         "react-dnd": "^16.0.1",
         "source-map-loader": "^5.0.0"


### PR DESCRIPTION
## Why CI went red on master

The v7.0.0 release (`nx release`) only versions the packages listed in `nx.json` → `release.projects` (the 5 public packages). The **private** `dockview-modules` and `dockview-docs` packages weren't in that list, so they stayed at `6.x` with stale `^6` internal dependency ranges. Once `dockview-core`/`dockview` became `7.0.0`, those ranges no longer matched the workspace packages, so a fresh `yarn install` (as CI does) resolved the **old published 6.x** copies from npm instead of symlinking the workspace — and the `dockview-modules` build failed against a `dockview-core` that predates the v7 module exports (`defineModule`, `IDragGhostSpec`, the module contracts, …).

## Fix

- Realign `dockview-modules` and `dockview-docs` to `7.0.0` and bump their internal deps to `^7.0.0` (`dockview-modules` → `dockview-core`; `dockview` → `dockview-modules`; `dockview-docs` → `dockview` / `dockview-react`).
- Add both to `nx.json` → `release.projects` so future releases bump them in lockstep and rewrite their internal ranges automatically. Both remain `private: true`, so `nx release publish` **skips** them — versioned, never published.
- Also disable nx analytics (`analytics: false`).

## Verification
- `yarn install` resolves cleanly (no more "Couldn't find package dockview-modules@^6.6.1").
- `npx nx run-many -t build --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular --skip-nx-cache` (the CI build command) passes, including the `dockview-modules` dependency build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
