### PR TITLE
fix: watermark overlay persists over layout after fromJSON (blocks clicks)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -4723,6 +4723,70 @@ describe('dockviewComponent', () => {
         ).toBe(1);
     });
 
+    test('that deserializing a populated layout removes the watermark', () => {
+        // Regression: fromJSON rebuilds the grid via gridview.deserialize(),
+        // which does not fire the BaseGrid add events the watermark module
+        // reacts to. The watermark mounted while the dockview was empty must
+        // still be removed once the restored layout has visible grid groups,
+        // otherwise it overlays (and blocks interaction with) the whole layout.
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                switch (options.name) {
+                    case 'default':
+                        return new PanelContentPartTest(
+                            options.id,
+                            options.name
+                        );
+                    default:
+                        throw new Error(`unsupported`);
+                }
+            },
+        });
+
+        // No groups yet → watermark mounted.
+        expect(
+            dockview.element.querySelectorAll('.dv-watermark-container').length
+        ).toBe(1);
+
+        dockview.fromJSON({
+            grid: {
+                orientation: Orientation.HORIZONTAL,
+                root: {
+                    type: 'branch',
+                    data: [
+                        {
+                            type: 'leaf',
+                            data: {
+                                views: ['panel1'],
+                                activeView: 'panel1',
+                                id: '1',
+                            },
+                            size: 100,
+                        },
+                    ],
+                },
+                height: 100,
+                width: 100,
+            },
+            panels: {
+                panel1: {
+                    id: 'panel1',
+                    contentComponent: 'default',
+                    title: 'panel1',
+                },
+            },
+        });
+
+        expect(dockview.groups.length).toBe(1);
+
+        // Restored layout has a visible grid group → watermark removed.
+        expect(
+            dockview.element.querySelectorAll('.dv-watermark-container').length
+        ).toBe(0);
+    });
+
     test('empty', () => {
         const container = document.createElement('div');
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2787,6 +2787,12 @@ export class DockviewComponent
                     this.doSetGroupAndPanelActive(panel);
                 }
             }
+
+            // `gridview.deserialize()` rebuilds the grid without firing the
+            // BaseGrid add events the watermark module reacts to, so the
+            // watermark mounted during `clear()` would otherwise persist over
+            // the restored layout. Re-evaluate now the layout is in place.
+            this._watermarkService?.update();
         } catch (err) {
             console.error(
                 'dockview: failed to deserialize layout. Reverting changes',


### PR DESCRIPTION
## The bug

On a dockview restored via `fromJSON` (e.g. the live demo restoring its saved layout from `localStorage`), a `dv-watermark` overlay covered the entire dockview and intercepted all pointer events — tabs and panels rendered but were unclickable.

## Root cause

`fromJSON` calls `clear()` (→ dockview is momentarily empty → the watermark module mounts the watermark) and then rebuilds the grid via `gridview.deserialize()`. That rebuild does **not** fire the BaseGrid add events the watermark module subscribes to, so the watermark mounted during the empty phase was never re-evaluated and remained as a full-size overlay on top of the restored layout (`hasVisibleGridGroup()` was never re-checked).

This only affected the `fromJSON` path — building a layout with `addPanel`/`addGroup` fires the events normally, which is why a fresh demo (no saved layout) looked fine.

## Fix

Re-evaluate the watermark explicitly at the end of a successful `fromJSON`, once the layout is in place:

```ts
this._watermarkService?.update();
```

## Test

Adds `that deserializing a populated layout removes the watermark` to `dockviewComponent.spec.ts`. Verified it **fails without the fix** (watermark container count `1`, expected `0`) and passes with it. Full `dockview-core` suite green (1073 tests).

## How it was found
Reproduced against a real saved demo layout by injecting it into `localStorage` and driving the demo in a headless browser: before the fix, a `1330×825` `.dv-watermark-container` sat on top of the tabs (`elementFromPoint` over a tab returned `dv-watermark`); after the fix, no watermark and the tab is the topmost element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
