### PR TITLE
fix(dockview-core): target inner .dv-dockview for spaced padding reset

### DIFF
--- a/packages/dockview-core/src/theme/_space-mixin.scss
+++ b/packages/dockview-core/src/theme/_space-mixin.scss
@@ -22,13 +22,12 @@
     padding: var(--dv-spacing-padding);
     background-color: var(--dv-group-view-background-color);
 
-    // When the dockview element is embedded inside a shell, the shell wrapper
-    // already carries the outer padding. Suppress it on the inner dockview
-    // element so the layout engine's pixel-exact gridview dimensions don't
-    // overflow the content box and trigger scrollbars.
-    // .dv-shell is only present in shell mode, so this rule is inherently
-    // scoped to shell mode and has no effect on standalone (non-shell) usage.
-    .dv-shell & {
+    // The theme root carries the outer padding above; the inner dockview
+    // element must stay flush so the layout engine's pixel-exact gridview
+    // dimensions don't overflow the content box and trigger scrollbars.
+    // .dv-dockview already has no padding, so this is a defensive zero that
+    // guarantees the inner element never picks up the spaced inset.
+    & .dv-dockview {
         padding: 0;
     }
 


### PR DESCRIPTION
## Problem

The spaced theme mixin (`_space-mixin.scss`) reset the inner element's padding with:

```scss
.dv-shell & {
    padding: 0;
}
```

Because the mixin is `@include`d inside each `.dockview-theme-…-spaced` selector, this compiles to `.dv-shell .dockview-theme-…-spaced` — an **ancestor `.dv-shell` → descendant theme-root** selector. That only matches when the theme class sits on a descendant of `.dv-shell`.

That held when the theme class was applied to both `.dv-shell` and the inner `.dv-dockview`. Since `81050ad4d` ("apply theme class only to the shell element") the theme class lives **only** on the shell, so the rule no longer matches the inner element it was documented to target — in the normal single-dockview case it matches nothing.

## Fix

Target the inner element directly, expressing the rule's documented intent:

```scss
& .dv-dockview {
    padding: 0;
}
```

→ compiles to `.dockview-theme-…-spaced .dv-dockview { padding: 0 }`.

This keeps the inner dockview flush so the layout engine's pixel-exact gridview dimensions don't overflow the content box and trigger scrollbars. `.dv-dockview` already carries no padding (`dockviewComponent.scss` sets only position/background), so the change is **render-identical in normal use** — a defensive zero that also removes the awkward trailing standalone `&`.

## Behavioral notes

- Normal single-dockview usage: no rendered change.
- The only divergence from the previous compiled output is the rare nested spaced-dockview-in-dockview case, where the old selector incidentally stripped the inner component's shell inset; the new rule leaves it intact (closer to intended behavior).

Verified by compiling `theme.scss` with Dart Sass: the new `.dockview-theme-…-spaced .dv-dockview` rule is emitted for every spaced theme and no `.dv-shell .dockview-theme-…` rule remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)