### PR TITLE
fix(dockview-core): accessible name for the default tab close button

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/tab/defaultTab.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/tab/defaultTab.spec.ts
@@ -117,6 +117,41 @@ describe('defaultTab', () => {
         expect(api.close).not.toHaveBeenCalled();
     });
 
+    test('that close button exposes an accessible name and hides the glyph', () => {
+        const cut = new DefaultTab();
+
+        const onDidTitleChange = new Emitter<TitleEvent>();
+        const api = fromPartial<DockviewPanelApi>({
+            onDidTitleChange: onDidTitleChange.event,
+            close: jest.fn(),
+        });
+        const containerApi = fromPartial<DockviewApi>({});
+
+        const action = cut.element.querySelector(
+            '.dv-default-tab-action'
+        ) as HTMLElement;
+
+        // role is set at construction, before init
+        expect(action.getAttribute('role')).toBe('button');
+        // the decorative glyph is hidden from assistive technology
+        expect(action.querySelector('svg')!.getAttribute('aria-hidden')).toBe(
+            'true'
+        );
+
+        cut.init({
+            api,
+            containerApi,
+            params: {},
+            title: 'title_abc',
+        });
+
+        // the accessible name is qualified with the panel title
+        expect(action.getAttribute('aria-label')).toBe('Close title_abc');
+
+        onDidTitleChange.fire({ title: 'title_def' });
+        expect(action.getAttribute('aria-label')).toBe('Close title_def');
+    });
+
     test('that close button is visible by default', () => {
         const cut = new DefaultTab();
 

--- a/packages/dockview-core/src/dockview/components/tab/defaultTab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/defaultTab.ts
@@ -24,7 +24,15 @@ export class DefaultTab extends CompositeDisposable implements ITabRenderer {
 
         this.action = document.createElement('div');
         this.action.className = 'dv-default-tab-action';
-        this.action.appendChild(createCloseButton());
+        // Expose the close affordance to assistive technology: a named button
+        // role so screen readers announce it, with the decorative glyph hidden.
+        // Keyboard users close the focused tab via the tab strip's Delete
+        // binding; this element is operated by pointer / AT.
+        this.action.setAttribute('role', 'button');
+        this.action.setAttribute('aria-label', 'Close');
+        const closeIcon = createCloseButton();
+        closeIcon.setAttribute('aria-hidden', 'true');
+        this.action.appendChild(closeIcon);
 
         this._element.appendChild(this._content);
         this._element.appendChild(this.action);
@@ -60,5 +68,11 @@ export class DefaultTab extends CompositeDisposable implements ITabRenderer {
         if (this._content.textContent !== this._title) {
             this._content.textContent = this._title ?? '';
         }
+        // Qualify the close button with the panel title when available so the
+        // announced name disambiguates it from sibling tabs' close buttons.
+        this.action.setAttribute(
+            'aria-label',
+            this._title ? `Close ${this._title}` : 'Close'
+        );
     }
 }


### PR DESCRIPTION
## Summary
The default tab close affordance was a bare `<div>` wrapping a decorative SVG — no role, no accessible name — so assistive technology announced nothing and the glyph leaked into the accessibility tree (WCAG 4.1.2, Name/Role/Value).

This adds:
- `role="button"` on the close element
- an `aria-label` qualified with the panel title (`Close <title>`), updated on title change
- `aria-hidden="true"` on the decorative SVG

Keyboard close continues to use the tab strip's `Delete` binding; this element is operated by pointer / AT.

## Test
- New `defaultTab.spec.ts` case asserting the role, hidden glyph, and title-qualified label (incl. live update on title change).
- Tab + titlebar suites green (240 tests), no snapshot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)