### PR TITLE
feat(dockview): keyboard 'float' terminal action for keyboard docking

### DIFF
--- a/packages/dockview-core/src/dockview/accessibilityMessages.ts
+++ b/packages/dockview-core/src/dockview/accessibilityMessages.ts
@@ -35,6 +35,8 @@ export interface DockviewMessages {
     moveCancelled(): string;
     /** A move the layout rejected. */
     moveNotAllowed(): string;
+    /** The panel was floated as a terminal move action. */
+    moveFloated(source: string): string;
 }
 
 /** Where a drop position lands, phrased for the *edge prompt*. */
@@ -68,6 +70,7 @@ export const DEFAULT_MESSAGES: DockviewMessages = {
         `${source} ${committedWhere(position, target)}.`,
     moveCancelled: () => `Move cancelled.`,
     moveNotAllowed: () => `That move is not allowed.`,
+    moveFloated: (source) => `${source} floated.`,
 };
 
 /** Merge an app's partial overrides over the English defaults. */

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -926,6 +926,12 @@ export class DockviewComponent
         });
     }
 
+    floatPanel(panel: IDockviewPanel): void {
+        // The accessibility host surface speaks in the public `IDockviewPanel`;
+        // the runtime instance is always a concrete `DockviewPanel`.
+        this.addFloatingGroup(panel as DockviewPanel);
+    }
+
     get contextMenuService(): IContextMenuService | undefined {
         // Owned by ContextMenuModule — undefined when the module is not
         // registered, so callers must `?.`-guard.

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -120,6 +120,8 @@ export interface IAccessibilityHost {
         group: DockviewGroupPanel,
         position: Position
     ): void;
+    /** Float the panel into a new floating group — the keyboard-move "float" terminal action. */
+    floatPanel(panel: IDockviewPanel): void;
 }
 
 export interface IAccessibilityService extends IDisposable {}

--- a/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
+++ b/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
@@ -104,6 +104,46 @@ describe('accessibility: keyboard docking', () => {
         expect(dockview.groups.length).toBe(2);
     });
 
+    test('Ctrl+Shift+F floats the moving panel from the target phase', () => {
+        make(true);
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        dockview.addPanel({ id: 'p2', component: 'default', title: 'P2' });
+        expect(dockview.groups.length).toBe(1); // p1, p2 tabs in one group
+        expect(dockview.floatingGroups.length).toBe(0);
+
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+        expect(region().textContent).toContain('Moving P2');
+
+        // float as a terminal action — no edge phase
+        fireEvent.keyDown(dockview.element, {
+            key: 'f',
+            ctrlKey: true,
+            shiftKey: true,
+        });
+
+        expect(region().textContent).toBe('P2 floated.');
+        expect(dockview.floatingGroups.length).toBe(1);
+    });
+
+    test('float is rebindable', () => {
+        make({ keymap: { float: 'alt+f' } });
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        dockview.addPanel({ id: 'p2', component: 'default', title: 'P2' });
+
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+        // the default binding no longer floats
+        fireEvent.keyDown(dockview.element, {
+            key: 'f',
+            ctrlKey: true,
+            shiftKey: true,
+        });
+        expect(dockview.floatingGroups.length).toBe(0);
+
+        // the rebound key does
+        fireEvent.keyDown(dockview.element, { key: 'f', altKey: true });
+        expect(dockview.floatingGroups.length).toBe(1);
+    });
+
     test('does nothing when keyboardNavigation is off (default)', () => {
         make(false);
         twoGroups();

--- a/packages/dockview-modules/src/keyboardDockingService.ts
+++ b/packages/dockview-modules/src/keyboardDockingService.ts
@@ -45,6 +45,8 @@ interface DockingKeybindings {
     focusGroupDown: string;
     /** Arm keyboard docking of the active panel. Default `ctrl+m`. */
     dock: string;
+    /** Float the moving panel (terminal action during the target phase). Default `ctrl+shift+f`. */
+    float: string;
 }
 
 const DEFAULT_KEYMAP: DockingKeybindings = {
@@ -53,6 +55,7 @@ const DEFAULT_KEYMAP: DockingKeybindings = {
     focusGroupUp: 'ctrl+shift+arrowup',
     focusGroupDown: 'ctrl+shift+arrowdown',
     dock: 'ctrl+m',
+    float: 'ctrl+shift+f',
 };
 
 /**
@@ -67,7 +70,8 @@ const DEFAULT_KEYMAP: DockingKeybindings = {
  *        can be split out); `Enter` selects one.
  *     2. PICK EDGE — arrows choose a split edge (left/right/top/bottom) or the
  *        centre (tab-into); `Enter` commits, `Escape` steps back.
- *   `Escape` from the target phase cancels.
+ *   From the target phase, `Ctrl+Shift+F` floats the panel as a terminal
+ *   action; `Escape` cancels.
  *
  * While a move is in progress it marks the root with
  * {@link KEYBOARD_MOVE_ATTRIBUTE} so the default navigation listener stands
@@ -117,6 +121,7 @@ export class KeyboardDockingService
             focusGroupDown:
                 overrides.focusGroupDown ?? DEFAULT_KEYMAP.focusGroupDown,
             dock: overrides.dock ?? DEFAULT_KEYMAP.dock,
+            float: overrides.float ?? DEFAULT_KEYMAP.float,
         };
     }
 
@@ -241,6 +246,13 @@ export class KeyboardDockingService
         }
 
         if (move.phase === 'target') {
+            // Float is a terminal action from the target phase: pull the moving
+            // panel out into a new floating group instead of docking it.
+            if (matchesBinding(e, this._keymap.float)) {
+                this._consume(e);
+                this._float();
+                return;
+            }
             const n = move.groups.length;
             if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
                 this._consume(e);
@@ -307,6 +319,21 @@ export class KeyboardDockingService
         }
         // The move re-renders the grid; pull focus back into the dock so the
         // keymap keeps working without a click.
+        this._restoreFocus();
+    }
+
+    private _float(): void {
+        const move = this._move!;
+        const source = move.source;
+        const m = this._messages;
+        this._exit();
+        try {
+            this.host.floatPanel(source);
+            this.host.announce(m.moveFloated(this._label(source)));
+        } catch {
+            this.host.announce(m.moveNotAllowed());
+        }
+        // Floating re-renders the grid; pull focus back into the dock.
         this._restoreFocus();
     }
 


### PR DESCRIPTION
## Summary
Keyboard docking (`Ctrl+M`) could only dock a panel into another group — there was no keyboard equivalent of dragging a panel out into a floating group. This adds **`Ctrl+Shift+F`** as a terminal action from the *target* phase of the move: it floats the moving panel, announces the result, and restores focus into the dock.

- `float` keybinding added to the docking keymap (rebindable via `keyboardNavigation.keymap.float`; default `ctrl+shift+f`)
- `IAccessibilityHost.floatPanel(panel)` + implementation on `DockviewComponent` (delegates to `addFloatingGroup`)
- `moveFloated` entry added to the message catalog (overridable via the `messages` option)

Send-to-popout (the other terminal action in the design) is intentionally **deferred** until cross-window keyboard focus lands — a keyboard user shouldn't be sent into a popout window they can't yet navigate into.

## Test
- New cases in `accessibilityDocking.spec.ts`: `Ctrl+Shift+F` floats the moving panel from the target phase; the binding is rebindable.
- `dockview-modules` suite green (101); core `liveRegion` suite green (19); core + modules build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)