### PR TITLE
test(dockview-modules): keyboard docking shows/clears the drop preview

### DIFF
--- a/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
+++ b/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
@@ -104,6 +104,32 @@ describe('accessibility: keyboard docking', () => {
         expect(dockview.groups.length).toBe(2);
     });
 
+    test('renders the drop preview during the move and clears it on cancel', () => {
+        make(true);
+        twoGroups();
+        expect(container.querySelector('.dv-drop-target')).toBeNull();
+
+        // The move reuses the same drop-preview overlay a mouse drag shows, so
+        // keyboard and pointer previews stay a single source of truth.
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+        expect(container.querySelector('.dv-drop-target')).not.toBeNull();
+
+        fireEvent.keyDown(dockview.element, { key: 'Escape' });
+        expect(container.querySelector('.dv-drop-target')).toBeNull();
+    });
+
+    test('clears the drop preview after committing a move', () => {
+        make(true);
+        twoGroups();
+
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+        fireEvent.keyDown(dockview.element, { key: 'ArrowRight' }); // target the other group
+        fireEvent.keyDown(dockview.element, { key: 'Enter' }); // → edge phase
+        fireEvent.keyDown(dockview.element, { key: 'Enter' }); // commit (tab-into)
+
+        expect(container.querySelector('.dv-drop-target')).toBeNull();
+    });
+
     test('Ctrl+Shift+F floats the moving panel from the target phase', () => {
         make(true);
         dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });


### PR DESCRIPTION
## Summary
Keyboard move mode reuses the same `.dv-drop-target` overlay a mouse drag shows, but nothing asserted it actually renders when the move arms and is cleared on **cancel** and on **commit**. These tests lock the keyboard↔overlay wiring and its teardown against regression.

This rounds out the jsdom-testable a11y coverage gaps from the audit. (Cross-window/popout focus remains the one large gap and needs a real-browser harness — out of scope for jsdom.)

## Test
- 2 new cases in `accessibilityDocking.spec.ts`; suite green (35). Formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)