### PR TITLE
feat(dockview-core): cross-window accessibility for popout windows

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -65,13 +65,16 @@
                 dockview.layout(el.clientWidth, el.clientHeight);
 
                 // Test-facing handle.
+                const panels = {};
                 window.__dv = {
-                    addPanel: (id) =>
-                        dockview.addPanel({
+                    addPanel: (id) => {
+                        panels[id] = dockview.addPanel({
                             id,
                             component: 'default',
                             title: id,
-                        }),
+                        });
+                    },
+                    closePanel: (id) => panels[id] && panels[id].api.close(),
                     popoutActiveGroup: () =>
                         dockview.addPopoutGroup(dockview.activeGroup),
                     groupCount: () => dockview.groups.length,

--- a/e2e/tests/keyboard-docking.spec.ts
+++ b/e2e/tests/keyboard-docking.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Cross-window keyboard docking: the keyboard services attach their listeners to
+ * each popout document and gate on `ownsElement`, so `Ctrl+M` docking can be
+ * driven from *inside* a popped-out window — and its narration routes to that
+ * window's live region. None of this is reachable in jsdom (the mock popout
+ * shares the main document, so there is no second window to listen on).
+ */
+test.describe('cross-window keyboard docking', () => {
+    const popout = async (page: Page, context) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => {
+            (window as any).__dv.addPanel('alpha');
+            (window as any).__dv.addPanel('beta'); // beta active, same group
+        });
+        const [win] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__dv.popoutActiveGroup()),
+        ]);
+        await (win as Page).waitForLoadState();
+        return win as Page;
+    };
+
+    test('Ctrl+M inside a popout narrates into the popout and Esc cancels there', async ({
+        page,
+        context,
+    }) => {
+        const win = await popout(page, context);
+
+        // Activate + focus a panel in the popout, then arm keyboard docking
+        // with a keystroke made *in the popout document*.
+        await win.locator('.dv-test-panel').first().click();
+        await win.keyboard.press('Control+m');
+
+        // The keydown was seen by the popout's own listener (not the opener's),
+        // passed the cross-document `ownsElement` gate, and the narration routed
+        // to the popout's live region.
+        await expect(win.locator('.dv-live-region')).toContainText(
+            'Moving beta'
+        );
+
+        await win.keyboard.press('Escape');
+        await expect(win.locator('.dv-live-region')).toHaveText(
+            'Move cancelled.'
+        );
+    });
+
+    test('a keyboard split committed inside a popout acts on the popout group', async ({
+        page,
+        context,
+    }) => {
+        const win = await popout(page, context);
+
+        // Popping out leaves a placeholder group in the main grid, so capture
+        // the starting count rather than assume it.
+        const before = await page.evaluate(() =>
+            (window as any).__dv.groupCount()
+        );
+
+        await win.locator('.dv-test-panel').first().click();
+        await win.keyboard.press('Control+m'); // arm: target = own group
+        await win.keyboard.press('Enter'); // choose this group -> edge phase
+        await win.keyboard.press('ArrowLeft'); // left edge (split)
+        await win.keyboard.press('Enter'); // commit
+
+        // The split ran inside the popout's own gridview: beta is now its own
+        // group, so the component reports exactly one more group than before.
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
+            .toBe(before + 1);
+        await expect(win.locator('.dv-live-region')).toContainText('beta');
+    });
+});

--- a/e2e/tests/live-region.spec.ts
+++ b/e2e/tests/live-region.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Per-window live regions: a popout window gets its own aria-live regions, and
+ * announcements route to the window that currently has focus — so a screen
+ * reader user working in a popout actually hears them. None of this is
+ * expressible in jsdom (the mock popout shares the main document).
+ */
+test.describe('cross-window live regions', () => {
+    const popout = async (page: Page, context) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => {
+            (window as any).__dv.addPanel('alpha');
+            (window as any).__dv.addPanel('beta'); // beta active, same group
+        });
+        const [win] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__dv.popoutActiveGroup()),
+        ]);
+        await (win as Page).waitForLoadState();
+        return win as Page;
+    };
+
+    test('a popout window has its own polite and assertive regions', async ({
+        page,
+        context,
+    }) => {
+        const win = await popout(page, context);
+
+        await expect(win.locator('.dv-live-region')).toHaveCount(1);
+        await expect(win.locator('.dv-live-region-assertive')).toHaveCount(1);
+    });
+
+    test('announcements route to the focused popout, not the opener', async ({
+        page,
+        context,
+    }) => {
+        const win = await popout(page, context);
+
+        // Put focus in the popout, then close a panel there. The "closed"
+        // announcement must land in the popout's region, not the opener's.
+        await win.locator('.dv-test-panel').first().focus();
+        await page.evaluate(() => (window as any).__dv.closePanel('beta'));
+
+        // The close lands in the popout's region...
+        await expect(win.locator('.dv-live-region')).toHaveText('beta closed');
+        // ...and never leaks into the opener's region. (The opener's region
+        // still holds the earlier "opened in a new window" note, which routed
+        // to it because the main window had focus at popout time.)
+        await expect(page.locator('.dv-live-region')).not.toHaveText(
+            'beta closed'
+        );
+        await expect(page.locator('.dv-live-region')).toHaveText(
+            'beta opened in a new window'
+        );
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/liveRegion.spec.ts
@@ -255,6 +255,22 @@ describe('LiveRegion announcer', () => {
         expect(region().textContent).toBe('P2 opened in a new window');
     });
 
+    test('a popout sharing the document does not get a duplicate region', async () => {
+        window.open = () => setupMockWindow();
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        const p2 = dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'P2',
+        });
+        await dockview.addPopoutGroup(p2);
+        // The mock popout reuses the main document, so per-window mounting is
+        // skipped — there is still exactly one polite region and announcements
+        // stay on it. (Real cross-document behaviour is covered by the e2e.)
+        expect(container.querySelectorAll('.dv-live-region')).toHaveLength(1);
+        expect(region().textContent).toBe('P2 opened in a new window');
+    });
+
     test('the messages catalog localises announcement strings', () => {
         dockview.dispose();
         container = document.createElement('div');

--- a/packages/dockview-core/src/__tests__/dockview/ownsElement.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/ownsElement.spec.ts
@@ -1,0 +1,96 @@
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { IContentRenderer } from '../../dockview/types';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * `ownsElement` is the cross-document containment primitive the keyboard
+ * accessibility services use instead of a single-document `rootElement.contains`
+ * — so a keydown / focus inside a popped-out window (a separate `document`) is
+ * still recognised as belonging to this dock. jsdom can't open a real second
+ * window, so the popout document is simulated by stubbing `getPopoutWindows`.
+ */
+describe('DockviewComponent.ownsElement', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(800, 600);
+    });
+
+    afterEach(() => {
+        dockview.dispose();
+        container.remove();
+    });
+
+    test('owns an element inside its own shell', () => {
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        const tab = container.querySelector('.dv-tab')!;
+        expect(dockview.ownsElement(tab)).toBe(true);
+        expect(dockview.ownsElement(dockview.element)).toBe(true);
+    });
+
+    test('does not own an element in the main document outside the dock', () => {
+        const stray = document.createElement('div');
+        document.body.appendChild(stray);
+        expect(dockview.ownsElement(stray)).toBe(false);
+        stray.remove();
+    });
+
+    test('does not own a foreign-document element with no matching popout', () => {
+        const foreignDoc =
+            document.implementation.createHTMLDocument('foreign');
+        const node = foreignDoc.createElement('div');
+        foreignDoc.body.appendChild(node);
+        expect(dockview.ownsElement(node)).toBe(false);
+    });
+
+    test('owns an element in a popout document it controls', () => {
+        const popoutDoc = document.implementation.createHTMLDocument('popout');
+        const node = popoutDoc.createElement('div');
+        popoutDoc.body.appendChild(node);
+        const popoutWindow = { document: popoutDoc } as unknown as Window;
+
+        jest.spyOn(dockview, 'getPopoutWindows').mockReturnValue([
+            popoutWindow,
+        ]);
+
+        expect(dockview.ownsElement(node)).toBe(true);
+
+        // A node in a *different* foreign document is still not owned.
+        const otherDoc = document.implementation.createHTMLDocument('other');
+        const otherNode = otherDoc.createElement('div');
+        otherDoc.body.appendChild(otherNode);
+        expect(dockview.ownsElement(otherNode)).toBe(false);
+    });
+
+    test('a same-document popout never claims sibling main-document nodes', () => {
+        // The jsdom mock popout shares the main document; ownsElement must fall
+        // back to true containment for it (not blanket-own the whole document).
+        const samedocWindow = { document } as unknown as Window;
+        jest.spyOn(dockview, 'getPopoutWindows').mockReturnValue([
+            samedocWindow,
+        ]);
+
+        const stray = document.createElement('div');
+        document.body.appendChild(stray);
+        expect(dockview.ownsElement(stray)).toBe(false);
+        stray.remove();
+    });
+});

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -553,6 +553,12 @@ export class DockviewComponent
     readonly onDidRemovePopoutGroup: Event<PopoutGroup> =
         this._onDidRemovePopoutGroup.event;
 
+    private readonly _onDidChangePopouts = new Emitter<void>();
+    /** Fires whenever a popout window opens or closes — i.e. the set of popout
+     *  documents changed. Used by accessibility services that mirror per-window
+     *  state (e.g. a live region in each popout). */
+    readonly onDidChangePopouts: Event<void> = this._onDidChangePopouts.event;
+
     private readonly _onDidOpenPopoutWindowFail = new Emitter<void>();
     readonly onDidOpenPopoutWindowFail: Event<void> =
         this._onDidOpenPopoutWindowFail.event;
@@ -1094,6 +1100,15 @@ export class DockviewComponent
             this._onDidPopoutGroupPositionChange,
             this._onDidAddPopoutGroup,
             this._onDidRemovePopoutGroup,
+            this._onDidChangePopouts,
+            // Coalesce popout add/remove into a single "the popout set changed"
+            // signal for per-window accessibility state.
+            this._onDidAddPopoutGroup.event(() =>
+                this._onDidChangePopouts.fire()
+            ),
+            this._onDidRemovePopoutGroup.event(() =>
+                this._onDidChangePopouts.fire()
+            ),
             this._onDidOpenPopoutWindowFail,
             this._onDidCreateTabGroup,
             this._onDidDestroyTabGroup,
@@ -1297,6 +1312,12 @@ export class DockviewComponent
                 window: entry.getWindow(),
             })) ?? []
         );
+    }
+
+    /** The live popout `Window` handles — one per open popout group. The
+     *  narrow surface accessibility services need to mirror per-window state. */
+    getPopoutWindows(): Window[] {
+        return this.getPopouts().map((popout) => popout.window);
     }
 
     private _doAddPopoutGroup(

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -835,6 +835,26 @@ export class DockviewComponent
     }
 
     /**
+     * Does this dock own `node`, in any of its windows? True when the node is
+     * inside the main shell, or inside one of this component's popout documents.
+     * A popout window hosts only this component's content, so whole-document
+     * membership is sufficient there; the main document may hold sibling docks,
+     * so it must be a containment check. A same-document popout (the jsdom mock)
+     * is already covered by the main check and contributes nothing.
+     */
+    ownsElement(node: Node): boolean {
+        if (this.rootElement.contains(node)) {
+            return true;
+        }
+        const mainDoc = this.rootElement.ownerDocument;
+        const doc = node.ownerDocument;
+        if (!doc || doc === mainDoc) {
+            return false;
+        }
+        return this.getPopoutWindows().some((win) => win.document === doc);
+    }
+
+    /**
      * The next / previous group in gridview (spatial) order, wrapping round.
      * The keyboard accessibility module's focus navigation is built on this
      * primitive — the only piece that needs the grid internals; the rest of

--- a/packages/dockview-core/src/dockview/liveRegionService.ts
+++ b/packages/dockview-core/src/dockview/liveRegionService.ts
@@ -27,6 +27,10 @@ export interface ILiveRegionHost {
     readonly onDidMaximizedGroupChange: Event<DockviewMaximizedGroupChangeEvent>;
     readonly onDidAddGroup: Event<DockviewGroupPanel>;
     readonly onDidRemoveGroup: Event<DockviewGroupPanel>;
+    /** Live popout windows + a signal when that set changes, so the service can
+     *  mount a live region inside each popout document and route to it. */
+    getPopoutWindows(): Window[];
+    readonly onDidChangePopouts: Event<void>;
 }
 
 export interface ILiveRegionService extends IDisposable {
@@ -42,8 +46,13 @@ export interface ILiveRegionService extends IDisposable {
 const isBulk = (kind: DockviewLayoutMutationKind): boolean =>
     kind === 'load' || kind === 'clear';
 
-function createLiveRegion(politeness: 'polite' | 'assertive'): HTMLElement {
-    const el = document.createElement('div');
+type RegionPair = { polite: HTMLElement; assertive: HTMLElement };
+
+function createLiveRegion(
+    doc: Document,
+    politeness: 'polite' | 'assertive'
+): HTMLElement {
+    const el = doc.createElement('div');
     el.className =
         politeness === 'assertive'
             ? 'dv-live-region-assertive'
@@ -84,8 +93,9 @@ export class LiveRegionService
     implements ILiveRegionService
 {
     private readonly _host: ILiveRegionHost;
-    private readonly _polite: HTMLElement;
-    private readonly _assertive: HTMLElement;
+    private readonly _mainWindow: Window;
+    /** One live-region pair per window (main + each popout document). */
+    private readonly _regions = new Map<Window, RegionPair>();
     private _suppressDepth = 0;
     private readonly _locationSubs = new Map<string, IDisposable>();
 
@@ -93,14 +103,24 @@ export class LiveRegionService
         super();
 
         this._host = host;
-        this._polite = createLiveRegion('polite');
-        this._assertive = createLiveRegion('assertive');
-        host.element.appendChild(this._polite);
-        host.element.appendChild(this._assertive);
+        const mainDoc = host.element.ownerDocument;
+        this._mainWindow = mainDoc.defaultView ?? window;
+
+        // The main window's region lives inside the dockview element (existing
+        // behaviour). Popout windows get their own pair in their own document.
+        const mainPair: RegionPair = {
+            polite: createLiveRegion(mainDoc, 'polite'),
+            assertive: createLiveRegion(mainDoc, 'assertive'),
+        };
+        host.element.appendChild(mainPair.polite);
+        host.element.appendChild(mainPair.assertive);
+        this._regions.set(this._mainWindow, mainPair);
+        this._syncPopoutRegions();
 
         this.addDisposables(
-            { dispose: () => this._polite.remove() },
-            { dispose: () => this._assertive.remove() },
+            { dispose: () => this._disposeRegions() },
+            // Mount / unmount a region as popout windows open and close.
+            host.onDidChangePopouts(() => this._syncPopoutRegions()),
             host.onDidAddPanel((panel) => this._announce(panel, 'open')),
             host.onDidRemovePanel((panel) => this._announce(panel, 'close')),
             // Bracket bulk transactions so a fromJSON / clear doesn't announce
@@ -139,6 +159,69 @@ export class LiveRegionService
                 },
             }
         );
+    }
+
+    /** Create a live region in every popout document that lacks one, and remove
+     *  regions for popouts that have closed. The main window's pair is permanent. */
+    private _syncPopoutRegions(): void {
+        const mainDoc = this._host.element.ownerDocument;
+        const desired = new Set<Window>([this._mainWindow]);
+
+        for (const win of this._host.getPopoutWindows()) {
+            // A popout that shares the main document (e.g. the jsdom test mock)
+            // must not get a duplicate region in the same tree.
+            if (win.document === mainDoc) {
+                continue;
+            }
+            desired.add(win);
+            if (this._regions.has(win)) {
+                continue;
+            }
+            const doc = win.document;
+            const mount = doc.body ?? doc.documentElement;
+            const pair: RegionPair = {
+                polite: createLiveRegion(doc, 'polite'),
+                assertive: createLiveRegion(doc, 'assertive'),
+            };
+            mount.appendChild(pair.polite);
+            mount.appendChild(pair.assertive);
+            this._regions.set(win, pair);
+        }
+
+        for (const [win, pair] of [...this._regions]) {
+            if (!desired.has(win)) {
+                pair.polite.remove();
+                pair.assertive.remove();
+                this._regions.delete(win);
+            }
+        }
+    }
+
+    private _disposeRegions(): void {
+        for (const pair of this._regions.values()) {
+            pair.polite.remove();
+            pair.assertive.remove();
+        }
+        this._regions.clear();
+    }
+
+    /** Route announcements to the live region of the window that currently has
+     *  focus, so a screen-reader user in a popout hears them — falling back to
+     *  the main window. */
+    private _focusedRegions(): RegionPair {
+        for (const [win, pair] of this._regions) {
+            if (win === this._mainWindow) {
+                continue;
+            }
+            try {
+                if (win.document.hasFocus()) {
+                    return pair;
+                }
+            } catch {
+                // A closing / cross-origin window can throw on access — ignore.
+            }
+        }
+        return this._regions.get(this._mainWindow)!;
     }
 
     private _trackLocation(group: DockviewGroupPanel): void {
@@ -184,8 +267,9 @@ export class LiveRegionService
             return;
         }
         // Clearing first forces SRs to re-announce an identical message.
+        const pair = this._focusedRegions();
         const region =
-            politeness === 'assertive' ? this._assertive : this._polite;
+            politeness === 'assertive' ? pair.assertive : pair.polite;
         region.textContent = '';
         region.textContent = message;
     }

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -97,6 +97,20 @@ export interface IAccessibilityHost {
     readonly activeGroup: DockviewGroupPanel | undefined;
     readonly activePanel: IDockviewPanel | undefined;
     /**
+     * Live popout `Window` handles + a signal when that set changes. Keyboard
+     * services attach their document listeners to each popout document too, so
+     * the keys work *inside* a popped-out window (a separate `document`).
+     */
+    getPopoutWindows(): Window[];
+    readonly onDidChangePopouts: Event<void>;
+    /**
+     * Does this dock own `node`, in *any* of its windows? True when the node is
+     * inside the main shell, or inside one of this component's popout documents.
+     * Replaces a single-document `rootElement.contains` so keyboard handling and
+     * focus gating recognise events/elements that live in a popout window.
+     */
+    ownsElement(node: Node): boolean;
+    /**
      * The next / previous group in gridview (spatial) order, wrapping round —
      * the one piece of navigation that needs the grid internals. All other
      * focus logic lives in the service, using the public group API.

--- a/packages/dockview-modules/src/accessibilityService.ts
+++ b/packages/dockview-modules/src/accessibilityService.ts
@@ -1,12 +1,10 @@
-import {
-    DockviewCompositeDisposable as CompositeDisposable,
-    DockviewIDisposable as IDisposable,
-} from 'dockview-core';
+import { DockviewCompositeDisposable as CompositeDisposable } from 'dockview-core';
 import { DockviewGroupPanel } from 'dockview-core';
 import { DockviewKeybindings, KeyboardNavigationOptions } from 'dockview-core';
 import { defineModule } from 'dockview-core';
 import { IAccessibilityHost, IAccessibilityService } from 'dockview-core';
 import {
+    bindDocumentListeners,
     KEYBOARD_MOVE_ATTRIBUTE,
     matchesBinding,
     readKeyboardNavigation,
@@ -55,43 +53,36 @@ export class AccessibilityService
         // Listen on the document (capture) rather than the dockview element:
         // edge groups live in the shell *outside* the gridview, and the shell
         // is created after this service, so a fixed element would miss them.
-        const doc = host.rootElement.ownerDocument;
-        const onKeyDown = (e: KeyboardEvent): void => this._onKeyDown(e);
-        doc.addEventListener('keydown', onKeyDown, true);
+        // Mirrored onto each popout document too (a separate `document`), so the
+        // keys, focus tracking and Esc-from-float work inside a popped-out window.
+        const onKeyDown = (e: Event): void =>
+            this._onKeyDown(e as KeyboardEvent);
 
-        // Remember the last control focused in the main dock (outside any
+        // Remember the last control focused anywhere in this dock (outside any
         // float) so Esc inside a floating group can return focus to its
         // invoking control. Observe-only — never consumes.
-        const onFocusIn = (e: FocusEvent): void => {
-            const t = e.target;
+        const onFocusIn = (e: Event): void => {
+            const t = (e as FocusEvent).target;
             if (
                 t instanceof HTMLElement &&
-                this.host.rootElement.contains(t) &&
+                this.host.ownsElement(t) &&
                 !t.closest('[role="dialog"]')
             ) {
                 this._lastNonFloatFocus = t;
             }
         };
-        doc.addEventListener('focusin', onFocusIn, true);
 
         // Esc-from-float restore runs in the BUBBLE phase and respects
         // defaultPrevented, so panel content that uses Esc keeps priority.
-        const onEscape = (e: KeyboardEvent): void => this._onFloatingEscape(e);
-        doc.addEventListener('keydown', onEscape, false);
+        const onEscape = (e: Event): void =>
+            this._onFloatingEscape(e as KeyboardEvent);
 
         this.addDisposables(
-            {
-                dispose: () =>
-                    doc.removeEventListener('keydown', onKeyDown, true),
-            },
-            {
-                dispose: () =>
-                    doc.removeEventListener('focusin', onFocusIn, true),
-            },
-            {
-                dispose: () =>
-                    doc.removeEventListener('keydown', onEscape, false),
-            },
+            bindDocumentListeners(host, [
+                { type: 'keydown', handler: onKeyDown, capture: true },
+                { type: 'focusin', handler: onFocusIn, capture: true },
+                { type: 'keydown', handler: onEscape, capture: false },
+            ]),
             // When a close pulls focus out of the dock, return it to the
             // neighbour the component just activated rather than leaving it
             // stranded on <body>. Snapshot before the teardown (focus still on
@@ -118,9 +109,29 @@ export class AccessibilityService
         return this.host.rootElement.hasAttribute(KEYBOARD_MOVE_ATTRIBUTE);
     }
 
+    /**
+     * The element that actually has focus, across windows — the `activeElement`
+     * of whichever document currently holds focus (a popout, else the main
+     * document). Each document tracks its own `activeElement` even when blurred,
+     * so we must pick the focused one rather than trust the main document.
+     */
+    private _activeElement(): Element | null {
+        const mainDoc = this.host.rootElement.ownerDocument;
+        for (const win of this.host.getPopoutWindows()) {
+            try {
+                if (win.document !== mainDoc && win.document.hasFocus()) {
+                    return win.document.activeElement;
+                }
+            } catch {
+                // A closing / cross-origin window can throw on access — ignore.
+            }
+        }
+        return mainDoc.activeElement;
+    }
+
     private _isFocusInside(): boolean {
-        const active = this.host.rootElement.ownerDocument.activeElement;
-        return active instanceof Node && this.host.rootElement.contains(active);
+        const active = this._activeElement();
+        return active instanceof Node && this.host.ownsElement(active);
     }
 
     private _onFloatingEscape(e: KeyboardEvent): void {
@@ -136,9 +147,10 @@ export class AccessibilityService
         if (!(target instanceof Element)) {
             return;
         }
-        // Only when focus is inside one of *this* dock's floating groups.
+        // Only when focus is inside one of *this* dock's floating groups
+        // (in any window).
         const float = target.closest('[role="dialog"]');
-        if (!float || !this.host.rootElement.contains(float)) {
+        if (!float || !this.host.ownsElement(float)) {
             return;
         }
         e.preventDefault();
@@ -157,7 +169,7 @@ export class AccessibilityService
             return false;
         }
         const float = target.closest('[role="dialog"]');
-        if (!float || !this.host.rootElement.contains(float)) {
+        if (!float || !this.host.ownsElement(float)) {
             return false;
         }
         // Always manage Tab inside a float, never just at the boundary: focus
@@ -200,7 +212,7 @@ export class AccessibilityService
         if (
             prev &&
             prev.isConnected &&
-            this.host.rootElement.contains(prev) &&
+            this.host.ownsElement(prev) &&
             !prev.closest('[role="dialog"]')
         ) {
             prev.focus();
@@ -228,11 +240,8 @@ export class AccessibilityService
         if (this._moveActive) {
             return;
         }
-        // Only act on events originating inside *this* dockview.
-        if (
-            !(e.target instanceof Node) ||
-            !this.host.rootElement.contains(e.target)
-        ) {
+        // Only act on events originating inside *this* dockview (any window).
+        if (!(e.target instanceof Node) || !this.host.ownsElement(e.target)) {
             return;
         }
         // Trap Tab within a floating group so focus doesn't leak to the grid

--- a/packages/dockview-modules/src/keyboardDockingService.ts
+++ b/packages/dockview-modules/src/keyboardDockingService.ts
@@ -11,6 +11,7 @@ import { AdvancedDnDModule } from './advancedDnDService';
 import { LiveRegionModule } from 'dockview-core';
 import { IAccessibilityHost, IKeyboardDockingService } from 'dockview-core';
 import {
+    bindDocumentListeners,
     KEYBOARD_MOVE_ATTRIBUTE,
     matchesBinding,
     readKeyboardNavigation,
@@ -88,17 +89,17 @@ export class KeyboardDockingService
         super();
 
         // Capture phase, on the document — matches the navigation listener so
-        // edge groups (outside the gridview) are covered.
-        const doc = host.rootElement.ownerDocument;
-        const onKeyDown = (e: KeyboardEvent): void => this._onKeyDown(e);
-        doc.addEventListener('keydown', onKeyDown, true);
+        // edge groups (outside the gridview) are covered. Mirrored onto each
+        // popout document so docking can be driven from inside a popped-out
+        // window (a separate `document`).
+        const onKeyDown = (e: Event): void =>
+            this._onKeyDown(e as KeyboardEvent);
 
         this.addDisposables(
             { dispose: () => this._exit() },
-            {
-                dispose: () =>
-                    doc.removeEventListener('keydown', onKeyDown, true),
-            }
+            bindDocumentListeners(host, [
+                { type: 'keydown', handler: onKeyDown, capture: true },
+            ])
         );
     }
 
@@ -137,11 +138,8 @@ export class KeyboardDockingService
             this._onMoveKey(e);
             return;
         }
-        // Only act on events originating inside *this* dockview.
-        if (
-            !(e.target instanceof Node) ||
-            !this.host.rootElement.contains(e.target)
-        ) {
+        // Only act on events originating inside *this* dockview (any window).
+        if (!(e.target instanceof Node) || !this.host.ownsElement(e.target)) {
             return;
         }
         const keymap = this._keymap;

--- a/packages/dockview-modules/src/keyboardShared.ts
+++ b/packages/dockview-modules/src/keyboardShared.ts
@@ -1,5 +1,6 @@
 import {
     DockviewComponentOptions,
+    DockviewIDisposable as IDisposable,
     KeyboardNavigationOptions,
 } from 'dockview-core';
 
@@ -41,4 +42,87 @@ export function readKeyboardNavigation(
         return undefined;
     }
     return opt === true ? {} : opt;
+}
+
+/** A document-level listener to mirror across every window the dock occupies. */
+export interface DocumentListenerSpec {
+    readonly type: string;
+    readonly handler: (e: Event) => void;
+    /** Capture phase? Must match the value used to remove the listener. */
+    readonly capture: boolean;
+}
+
+/** The slice of the accessibility host the multi-window binder needs. */
+interface MultiWindowHost {
+    readonly rootElement: HTMLElement;
+    getPopoutWindows(): Window[];
+    onDidChangePopouts(listener: () => void): IDisposable;
+}
+
+/**
+ * Attach `specs` to the main document **and to every popout document**, keeping
+ * the set in sync as popouts open and close. A popout window is a separate
+ * `document`, so a capture-phase listener on the main document alone never sees
+ * keystrokes made inside a popout — each document needs its own listener.
+ *
+ * A popout that shares the main document (the jsdom mock) is skipped, since the
+ * main document's listener already covers it and a second would double-fire.
+ *
+ * Returns a disposable that removes every listener from every document.
+ */
+export function bindDocumentListeners(
+    host: MultiWindowHost,
+    specs: DocumentListenerSpec[]
+): IDisposable {
+    const mainDoc = host.rootElement.ownerDocument;
+    const attached = new Set<Document>();
+
+    const attach = (doc: Document): void => {
+        if (attached.has(doc)) {
+            return;
+        }
+        for (const s of specs) {
+            doc.addEventListener(s.type, s.handler, s.capture);
+        }
+        attached.add(doc);
+    };
+    const detach = (doc: Document): void => {
+        if (!attached.has(doc)) {
+            return;
+        }
+        for (const s of specs) {
+            doc.removeEventListener(s.type, s.handler, s.capture);
+        }
+        attached.delete(doc);
+    };
+
+    const sync = (): void => {
+        const desired = new Set<Document>([mainDoc]);
+        for (const win of host.getPopoutWindows()) {
+            const doc = win.document;
+            if (doc === mainDoc) {
+                continue;
+            }
+            desired.add(doc);
+            attach(doc);
+        }
+        for (const doc of [...attached]) {
+            if (!desired.has(doc)) {
+                detach(doc);
+            }
+        }
+    };
+
+    attach(mainDoc);
+    sync();
+    const sub = host.onDidChangePopouts(sync);
+
+    return {
+        dispose: () => {
+            sub.dispose();
+            for (const doc of [...attached]) {
+                detach(doc);
+            }
+        },
+    };
 }


### PR DESCRIPTION
## Summary
Completes the deferred **popout cross-window accessibility** work (a11y pack §6/§7). A popout window is a separate `document`; the single main-window `aria-live` region and the single main-document keyboard listeners never reached a screen-reader / keyboard user working in a popout. Two slices, building on a shared core seam.

### 1. Per-window live regions (announcements)
- `LiveRegionService` mounts a polite + assertive region **in each popout document**, synced as popouts open/close.
- `announce()` **routes to the live region of the focused window** (`document.hasFocus()`), falling back to main.
- New core seam: `getPopoutWindows()` + `onDidChangePopouts` on the component + `ILiveRegionHost`.

### 2. Cross-window keyboard navigation & docking
- New core primitive `IAccessibilityHost.ownsElement(node)` — cross-document containment (main-shell containment **or** whole-document membership of a popout this component controls). Replaces every single-document `rootElement.contains` gate.
- `bindDocumentListeners` (keyboardShared) mirrors a service's document listeners onto **every popout document**, synced on `onDidChangePopouts`, skipping a same-document mock.
- `AccessibilityService` + `KeyboardDockingService` adopt both: `Ctrl+M` docking, spatial group focus, `Esc`/Tab-trap and focus-restore now work **inside a popout window**, operating on the popout's own gridview. Focus-inside detection reads the *focused* window's `activeElement` so close-focus-restore is correct when focus is in a popout.

## Test
Cross-document behaviour is unprovable in jsdom (the mock popout shares the main document), so it's split between unit + the Playwright harness:
- **core unit** `liveRegion.spec` (20) + new `ownsElement.spec` (5: containment, foreign-doc rejection, popout-doc ownership, same-doc no-overclaim).
- **e2e** (`e2e/tests/`): per-window regions + focused-window routing (`live-region.spec`), and `keyboard-docking.spec` — `Ctrl+M` armed inside a popout narrates to the popout region and `Esc` cancels there; a keyboard split committed in the popout acts on the popout's gridview.
- **Green:** 5 e2e + 107 dockview-modules + 1080 dockview-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)