### PR TITLE
fix(dockview-core): popout-window pointer drags + cross-group maximize focus

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -72,6 +72,21 @@
                             component: 'default',
                             title: id,
                         }),
+                    // Create a new panel and move it to the right of the
+                    // popped-out group — the move lands in the popout's own
+                    // gridview, producing a second group (and so a sash) there.
+                    splitIntoPopout: (id) => {
+                        const popoutGroup = dockview.getPopouts()[0].group;
+                        const panel = dockview.addPanel({
+                            id,
+                            component: 'default',
+                            title: id,
+                        });
+                        panel.api.moveTo({
+                            group: popoutGroup,
+                            position: 'right',
+                        });
+                    },
                     popoutActiveGroup: () =>
                         dockview.addPopoutGroup(dockview.activeGroup),
                     groupCount: () => dockview.groups.length,

--- a/e2e/tests/popout-pointer-drag.spec.ts
+++ b/e2e/tests/popout-pointer-drag.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Pointer-drag inside a popout window. The splitview sash (and the scrollbar,
+ * which shares the identical fix) attached its `pointermove`/`pointerup`
+ * listeners to the *opener's* `document`, so a drag started in a popout was
+ * never heard — resizing a split was dead inside a popped-out window. The fix
+ * binds the drag to the element's own document. Only a real second window
+ * exercises this; jsdom reuses the main document.
+ */
+test.describe('cross-window pointer drag', () => {
+    const popoutWithSash = async (page: Page, context) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => {
+            (window as any).__dv.addPanel('alpha');
+            (window as any).__dv.addPanel('beta');
+        });
+        const [win] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__dv.popoutActiveGroup()),
+        ]);
+        await (win as Page).waitForLoadState();
+        // Split a second group into the popout's own gridview, creating a sash
+        // there to drag.
+        await page.evaluate(() =>
+            (window as any).__dv.splitIntoPopout('delta')
+        );
+        await (win as Page).locator('.dv-sash').first().waitFor();
+        return win as Page;
+    };
+
+    test('dragging a sash inside the popout resizes its split', async ({
+        page,
+        context,
+    }) => {
+        const win = await popoutWithSash(page, context);
+
+        const sash = win.locator('.dv-sash').first();
+        const before = (await sash.boundingBox())!;
+        expect(before).toBeTruthy();
+
+        // Drag the sash ~80px to the right, entirely within the popout window.
+        const cx = before.x + before.width / 2;
+        const cy = before.y + before.height / 2;
+        await win.mouse.move(cx, cy);
+        await win.mouse.down();
+        await win.mouse.move(cx + 80, cy, { steps: 8 });
+        await win.mouse.up();
+
+        // The boundary moved — proof the pointermove/up were heard in the
+        // popout's document, not lost to the opener.
+        const after = (await sash.boundingBox())!;
+        expect(after.x).toBeGreaterThan(before.x + 40);
+    });
+});

--- a/packages/dockview-core/src/scrollbar.ts
+++ b/packages/dockview-core/src/scrollbar.ts
@@ -61,6 +61,10 @@ export class Scrollbar extends CompositeDisposable {
             addDisposableListener(this._scrollbar, 'pointerdown', (event) => {
                 event.preventDefault();
 
+                // Bind the drag to the scrollbar's own document so pointermove/up
+                // are heard when the scrollable lives in a popout window.
+                const doc = this._scrollbar.ownerDocument ?? document;
+
                 toggleClass(this.element, 'dv-scrollable-scrolling', true);
 
                 const originalClient =
@@ -92,14 +96,14 @@ export class Scrollbar extends CompositeDisposable {
                 const onEnd = () => {
                     toggleClass(this.element, 'dv-scrollable-scrolling', false);
 
-                    document.removeEventListener('pointermove', onPointerMove);
-                    document.removeEventListener('pointerup', onEnd);
-                    document.removeEventListener('pointercancel', onEnd);
+                    doc.removeEventListener('pointermove', onPointerMove);
+                    doc.removeEventListener('pointerup', onEnd);
+                    doc.removeEventListener('pointercancel', onEnd);
                 };
 
-                document.addEventListener('pointermove', onPointerMove);
-                document.addEventListener('pointerup', onEnd);
-                document.addEventListener('pointercancel', onEnd);
+                doc.addEventListener('pointermove', onPointerMove);
+                doc.addEventListener('pointerup', onEnd);
+                doc.addEventListener('pointercancel', onEnd);
             }),
             addDisposableListener(this.element, 'scroll', () => {
                 this.calculateScrollbarStyles();

--- a/packages/dockview-core/src/splitview/splitview.ts
+++ b/packages/dockview-core/src/splitview/splitview.ts
@@ -439,7 +439,10 @@ export class Splitview {
                     item.enabled = false;
                 }
 
-                const iframes = disableIframePointEvents();
+                // The sash may live in a popout document; bind the drag to that
+                // document so pointermove/up are heard there, not on the opener.
+                const doc = sash.ownerDocument ?? document;
+                const iframes = disableIframePointEvents(doc);
 
                 const start =
                     this._orientation === Orientation.HORIZONTAL
@@ -552,18 +555,18 @@ export class Splitview {
 
                     this.saveProportions();
 
-                    document.removeEventListener('pointermove', onPointerMove);
-                    document.removeEventListener('pointerup', end);
-                    document.removeEventListener('pointercancel', end);
-                    document.removeEventListener('contextmenu', end);
+                    doc.removeEventListener('pointermove', onPointerMove);
+                    doc.removeEventListener('pointerup', end);
+                    doc.removeEventListener('pointercancel', end);
+                    doc.removeEventListener('contextmenu', end);
 
                     this._onDidSashEnd.fire(undefined);
                 };
 
-                document.addEventListener('pointermove', onPointerMove);
-                document.addEventListener('pointerup', end);
-                document.addEventListener('pointercancel', end);
-                document.addEventListener('contextmenu', end);
+                doc.addEventListener('pointermove', onPointerMove);
+                doc.addEventListener('pointerup', end);
+                doc.addEventListener('pointercancel', end);
+                doc.addEventListener('contextmenu', end);
             };
 
             sash.addEventListener('pointerdown', onPointerStart);

--- a/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
+++ b/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
@@ -659,6 +659,41 @@ describe('accessibility: focus across maximize', () => {
         expect(group.api.isMaximized()).toBe(false);
         expect(container.contains(document.activeElement)).toBe(true);
     });
+
+    test('maximizing a different group restores focus into the maximized group', () => {
+        make();
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'P2',
+            position: { direction: 'right' },
+        });
+        const [g1, g2] = dockview.groups;
+
+        // Focus lives in g1; we maximize the *other* group (g2), which hides g1.
+        (g1.element.querySelector('.dv-tab') as HTMLElement).focus();
+        expect(container.contains(document.activeElement)).toBe(true);
+
+        // jsdom doesn't blur a hidden element (the whole reason this case slips
+        // through in unit-land), so emulate the real browser dropping focus to
+        // <body> when g1 is hidden — during the will phase, after the service
+        // has already snapshotted that focus was inside the dock.
+        const sub = dockview.onWillMutateLayout((e) => {
+            if (e.kind === 'maximize') {
+                (document.activeElement as HTMLElement | null)?.blur();
+            }
+        });
+        // setActive (which maximize calls) does not move DOM focus, so a call to
+        // the maximized group's focusContent can only come from the restore.
+        const spy = jest.spyOn(g2.model, 'focusContent');
+
+        g2.api.maximize();
+        sub.dispose();
+
+        expect(g2.api.isMaximized()).toBe(true);
+        expect(spy).toHaveBeenCalled();
+    });
 });
 
 /**

--- a/packages/dockview-modules/src/accessibilityService.ts
+++ b/packages/dockview-modules/src/accessibilityService.ts
@@ -92,18 +92,25 @@ export class AccessibilityService
                 dispose: () =>
                     doc.removeEventListener('keydown', onEscape, false),
             },
-            // When a close pulls focus out of the dock, return it to the
-            // neighbour the component just activated rather than leaving it
-            // stranded on <body>. Snapshot before the teardown (focus still on
-            // the closing panel), restore after.
+            // When a structural change pulls focus out of the dock, return it to
+            // the neighbour the component just activated rather than leaving it
+            // stranded on <body>. Snapshot before the change (focus still on the
+            // affected panel), restore after.
+            //
+            // - `remove`: closing the focused panel/group.
+            // - `maximize`: maximizing a *different* group hides the focused
+            //   one, blurring it to <body>. (Maximizing the focused group keeps
+            //   its DOM in place, so focus stays inside and we no-op — which is
+            //   exactly what the was-inside / not-inside guard checks, so we
+            //   never steal focus from a mouse user who maximized in place.)
             host.onWillMutateLayout((e) => {
-                if (e.kind === 'remove' && this._nav) {
+                if (this._restoresFocus(e) && this._nav) {
                     this._focusWasInside = this._isFocusInside();
                 }
             }),
             host.onDidMutateLayout((e) => {
                 if (
-                    e.kind === 'remove' &&
+                    this._restoresFocus(e) &&
                     this._nav &&
                     this._focusWasInside &&
                     !this._isFocusInside()
@@ -116,6 +123,11 @@ export class AccessibilityService
 
     private get _moveActive(): boolean {
         return this.host.rootElement.hasAttribute(KEYBOARD_MOVE_ATTRIBUTE);
+    }
+
+    /** Mutations that can strand focus on `<body>` and so warrant a restore. */
+    private _restoresFocus(e: { kind: string }): boolean {
+        return e.kind === 'remove' || e.kind === 'maximize';
     }
 
     private _isFocusInside(): boolean {


### PR DESCRIPTION
## Summary
Two popout-window correctness niches found while completing cross-window accessibility (split out from the a11y PR per request — these are general bugs, not a11y-only).

### 1. Pointer drags dead inside a popout window
`splitview` (sash) and `scrollbar` attached their `pointermove` / `pointerup` / `pointercancel` (and the sash's `contextmenu`) listeners to the module-global `document` — i.e. the **opener**, not the popout. A drag begun inside a popped-out window dispatched its move/up events in the *popout's* document, which the opener's listeners never heard, so **resizing a split (and dragging a scrollbar) was dead in a popout**.

Fix: bind each drag to the dragged element's own `ownerDocument` (and shield iframes in that document). This affects **mouse users too**, not just keyboard/a11y.

### 2. Cross-group maximize stranded focus on `<body>`
Maximizing a *different* group than the focused one hides the focused group's DOM, blurring the focused element — and nothing pulled focus back. `AccessibilityService` already snapshots/restores focus across a `remove`; this extends the same **was-inside / not-inside** guard to the `maximize` mutation. Because of that guard, maximizing the focused group *in place* stays a no-op, so a mouse user who maximizes is never robbed of focus.

## Test
Cross-document / hidden-element-blur behaviour isn't reachable in jsdom, so it's split between unit + the Playwright harness:
- **module unit** (`accessibilityDocking.spec`, 108): maximizing another group restores focus into the maximized group. jsdom doesn't blur a hidden element, so the blur is emulated during the `will` phase; `setActive` doesn't move DOM focus, so the `focusContent` spy isolates the restore.
- **e2e** (`popout-pointer-drag.spec`): a sash dragged inside a popout resizes its split — passes only because the listeners now live on the popout document. (Scrollbar shares the identical one-line fix.)
- **Green:** 2 e2e + 108 dockview-modules + 1074 dockview-core.

## Note
Targets `v8-branch` (where the e2e harness lives). These are real v7 bugs too; can be cherry-picked to `master` if a v7 patch is wanted. Touches `accessibilityService.ts`, which PR #1368 also edits — expect a small merge resolution in that file whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)