### PR TITLE
fix(dockview-core): use :focus-visible for keyboard focus indicators

### DIFF
--- a/packages/dockview-core/src/dockview/components/tab/defaultTab.scss
+++ b/packages/dockview-core/src/dockview/components/tab/defaultTab.scss
@@ -27,8 +27,11 @@
 .dv-tab {
     flex-shrink: 0;
 
-    &:focus-within,
-    &:focus {
+    // Keyboard-only focus ring: :focus-visible suppresses it on mouse click,
+    // :has(:focus-visible) keeps it when a child (e.g. the close button) is
+    // keyboard-focused — the descendant case the old :focus-within covered.
+    &:focus-visible,
+    &:has(:focus-visible) {
         position: relative;
 
         &::after {

--- a/packages/dockview-core/src/paneview/paneview.scss
+++ b/packages/dockview-core/src/paneview/paneview.scss
@@ -68,8 +68,8 @@
                 cursor: pointer;
             }
 
-            &:focus,
-            &:focus-within {
+            &:focus-visible,
+            &:has(:focus-visible) {
                 &:before {
                     position: absolute;
                     top: 0;
@@ -94,8 +94,8 @@
             position: relative;
             outline: none;
 
-            &:focus,
-            &:focus-within {
+            &:focus-visible,
+            &:has(:focus-visible) {
                 &:before {
                     position: absolute;
                     top: 0;


### PR DESCRIPTION
Closes #1372.

## Summary
Tab and paneview focus rings were keyed on `:focus` / `:focus-within`, so they appeared on **mouse click** too — visual noise often read as a defect. This switches the indicator rules to `:focus-visible` (keyboard-only).

- `defaultTab.scss` — `.dv-tab:focus-visible, .dv-tab:has(:focus-visible)` (the `:has` keeps the descendant case the old `:focus-within` covered — e.g. a keyboard-focused close button still rings its tab).
- `paneview.scss` — pane header + body, same treatment.
- **Unchanged on purpose:** the inline tab-rename `<input>` keeps `:focus` (inputs should always ring); the group content container keeps `outline: none` (it only ever takes programmatic focus).

`:focus-visible` and `:has()` are supported across all evergreen browsers. SCSS compiles clean (only the pre-existing `@import` deprecation remains).

## Verification
Manual / visual (CSS-only; not unit-testable):
- [ ] Tab/pane to a control → ring shows. Click with mouse → no ring.
- [ ] Keyboard-focus a tab's close button → its tab still rings.
- [ ] Rename input still rings on focus.

Context: one of the theme-dependent items from the accessibility conformance review (WCAG 2.4.7 / 1.4.11). Targets `v8-branch` for consistency with the active a11y work; cherry-pickable to `master` as a v7 patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)