### PR TITLE
fix(dockview-core): localise tab close-button name and make its role honest

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -34,7 +34,7 @@
                 const core = window['dockview-core'];
                 const modules = window['dockview-modules'];
 
-                // Register the pro module set plus the optional keyboard-docking
+                // Register the full module set plus the optional keyboard-docking
                 // module so the harness can exercise cross-window keyboard work.
                 core.registerModules([
                     ...modules.Modules,

--- a/packages/dockview-core/src/__tests__/dockview/components/tab/defaultTab.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/tab/defaultTab.spec.ts
@@ -4,6 +4,7 @@ import { DefaultTab } from '../../../../dockview/components/tab/defaultTab';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { Emitter } from '../../../../events';
 import { fireEvent } from '@testing-library/dom';
+import { resolveMessages } from '../../../../dockview/accessibilityMessages';
 
 describe('defaultTab', () => {
     test('that title updates', () => {
@@ -133,6 +134,11 @@ describe('defaultTab', () => {
 
         // role is set at construction, before init
         expect(action.getAttribute('role')).toBe('button');
+        // focusable programmatically / by AT, but kept out of the sequential
+        // tab order (the strip's roving tabindex owns that)
+        expect(action.getAttribute('tabindex')).toBe('-1');
+        // a plain accessible name before a title is known
+        expect(action.getAttribute('aria-label')).toBe('Close');
         // the decorative glyph is hidden from assistive technology
         expect(action.querySelector('svg')!.getAttribute('aria-hidden')).toBe(
             'true'
@@ -150,6 +156,30 @@ describe('defaultTab', () => {
 
         onDidTitleChange.fire({ title: 'title_def' });
         expect(action.getAttribute('aria-label')).toBe('Close title_def');
+    });
+
+    test('that the close button name is localised via the messages catalog', () => {
+        const cut = new DefaultTab();
+
+        const api = fromPartial<DockviewPanelApi>({
+            onDidTitleChange: new Emitter<TitleEvent>().event,
+            close: jest.fn(),
+        });
+        // The app's resolved catalog is exposed on containerApi.messages; the
+        // tab must read its close-button name from there, not a hardcoded string.
+        const containerApi = fromPartial<DockviewApi>({
+            messages: resolveMessages({
+                closeTab: (title) => `Dismiss ${title}`,
+                closeTabPlain: () => 'Dismiss',
+            }),
+        });
+
+        const action = cut.element.querySelector(
+            '.dv-default-tab-action'
+        ) as HTMLElement;
+
+        cut.init({ api, containerApi, params: {}, title: 'report' });
+        expect(action.getAttribute('aria-label')).toBe('Dismiss report');
     });
 
     test('that close button is visible by default', () => {

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -19,6 +19,10 @@ import {
     DockviewDndOverlayEvent,
     MovementOptions,
 } from '../dockview/options';
+import {
+    DockviewMessages,
+    resolveMessages,
+} from '../dockview/accessibilityMessages';
 import { Parameters } from '../panel/types';
 import { Direction } from '../gridview/baseComponentGridview';
 import {
@@ -905,6 +909,15 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      */
     get activeGroup(): DockviewGroupPanel | undefined {
         return this.component.activeGroup;
+    }
+
+    /**
+     * The resolved accessibility message catalog (the app's `messages`
+     * overrides merged over the English defaults). Used by parts that surface
+     * localisable AT strings, e.g. the default tab's close-button label.
+     */
+    get messages(): DockviewMessages {
+        return resolveMessages(this.component.options.messages);
     }
 
     constructor(private readonly component: IDockviewComponent) {}

--- a/packages/dockview-core/src/dockview/accessibilityMessages.ts
+++ b/packages/dockview-core/src/dockview/accessibilityMessages.ts
@@ -19,6 +19,12 @@ export interface DockviewMessages {
     groupDocked(title: string): string;
     groupPoppedOut(title: string): string;
 
+    // --- tab affordances ---
+    /** Accessible name for a tab's close button, qualified with the panel title. */
+    closeTab(title: string): string;
+    /** Accessible name for a tab's close button when the panel has no title. */
+    closeTabPlain(): string;
+
     // --- keyboard-docking narration ---
     /** Target phase: which group is highlighted, and how to proceed. */
     movePickTarget(
@@ -61,6 +67,9 @@ export const DEFAULT_MESSAGES: DockviewMessages = {
     groupFloated: (title) => `${title} floated`,
     groupDocked: (title) => `${title} docked`,
     groupPoppedOut: (title) => `${title} opened in a new window`,
+
+    closeTab: (title) => `Close ${title}`,
+    closeTabPlain: () => `Close`,
 
     movePickTarget: (source, target, current, total) =>
         `Moving ${source}. Target ${target}, ${current} of ${total}. Enter to choose where, Escape to cancel.`,

--- a/packages/dockview-core/src/dockview/components/tab/defaultTab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/defaultTab.ts
@@ -2,12 +2,18 @@ import { CompositeDisposable } from '../../../lifecycle';
 import { ITabRenderer, GroupPanelPartInitParameters } from '../../types';
 import { addDisposableListener } from '../../../events';
 import { createCloseButton } from '../../../svg';
+import {
+    DEFAULT_MESSAGES,
+    DockviewMessages,
+} from '../../accessibilityMessages';
 
 export class DefaultTab extends CompositeDisposable implements ITabRenderer {
     private readonly _element: HTMLElement;
     private readonly _content: HTMLElement;
     private readonly action: HTMLElement;
     private _title: string | undefined;
+    /** English defaults until `init` supplies the app's resolved catalog. */
+    private _messages: DockviewMessages = DEFAULT_MESSAGES;
 
     get element(): HTMLElement {
         return this._element;
@@ -26,10 +32,13 @@ export class DefaultTab extends CompositeDisposable implements ITabRenderer {
         this.action.className = 'dv-default-tab-action';
         // Expose the close affordance to assistive technology: a named button
         // role so screen readers announce it, with the decorative glyph hidden.
-        // Keyboard users close the focused tab via the tab strip's Delete
-        // binding; this element is operated by pointer / AT.
+        // `tabindex=-1` keeps it out of the sequential tab order (the tab strip's
+        // roving tabindex owns that, and keyboard users close via its Delete
+        // binding) while still making it programmatically focusable, so the
+        // button role is honest and AT can activate it (a synthesized click,
+        // handled below).
         this.action.setAttribute('role', 'button');
-        this.action.setAttribute('aria-label', 'Close');
+        this.action.setAttribute('tabindex', '-1');
         const closeIcon = createCloseButton();
         closeIcon.setAttribute('aria-hidden', 'true');
         this.action.appendChild(closeIcon);
@@ -42,6 +51,8 @@ export class DefaultTab extends CompositeDisposable implements ITabRenderer {
 
     init(params: GroupPanelPartInitParameters): void {
         this._title = params.title;
+        // Localise the close-button name via the app's resolved catalog.
+        this._messages = params.containerApi.messages ?? DEFAULT_MESSAGES;
 
         this.addDisposables(
             params.api.onDidTitleChange((event) => {
@@ -72,7 +83,9 @@ export class DefaultTab extends CompositeDisposable implements ITabRenderer {
         // announced name disambiguates it from sibling tabs' close buttons.
         this.action.setAttribute(
             'aria-label',
-            this._title ? `Close ${this._title}` : 'Close'
+            this._title
+                ? this._messages.closeTab(this._title)
+                : this._messages.closeTabPlain()
         );
     }
 }


### PR DESCRIPTION
## Description

Follow-ups from review of the v8 accessibility work. The default tab's close
affordance had two gaps:

1. Its `aria-label` was a hardcoded English `"Close"`, bypassing the
   `DockviewMessages` catalog that every other AT-facing string routes through —
   so apps that localise announcements still got an untranslatable label on the
   most prominent interactive control.
2. It carried `role="button"` on an element that was neither focusable nor
   keyboard-operable, so the role advertised a contract it didn't honour.

### Changes

- Add `closeTab(title)` / `closeTabPlain()` to `DockviewMessages` (English
  defaults unchanged) and expose the resolved catalog as `DockviewApi.messages`.
  `DefaultTab` now reads its close-button name from there, falling back to the
  defaults until `init`.
- Give the close button `tabindex="-1"`: programmatically / AT focusable (so the
  button role is truthful, and AT activation flows through the existing click
  handler) while staying out of the sequential tab order — the strip's roving
  tabindex owns that, and keyboard close stays on the Delete binding.
- Reword a stale comment in the e2e fixture.

## Type of change

- [x] Bug fix
- [x] Accessibility

## Affected packages

- [x] `dockview-core`

## How to test

`yarn nx run dockview-core:test` — `defaultTab` suite extended (label
localisation + `tabindex`), `liveRegion` / `accessibilityMessages` unaffected.

## Checklist

- [x] `yarn format` passes (prettier --check clean)
- [x] `tsc --noEmit` passes
- [x] `yarn test` passes for affected suites
- [x] Added/updated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)