### PR TITLE
feat(auto-hide edge groups): VS pinnable tool windows + reusable core primitives

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -29,6 +29,7 @@ DEFAULT_TAB_GROUP_COLORS
 DefaultDockviewDeserialzier
 DefaultTab
 Direction
+DismissableLayerOptions
 DistributeSizing
 DockviewActivePanelChangeEvent
 DockviewApi
@@ -263,9 +264,12 @@ VisibilityEvent
 WatermarkRendererInitParameters
 applyTabGroupAccent
 clearRegisteredModules
+createCloseButton
+createDismissableLayer
 createDockview
 createGridview
 createPaneview
+createPinButton
 createSplitview
 defineModule
 directionToPosition
@@ -287,8 +291,10 @@ isPanelOptionsWithPanel
 markDockviewPackageLoaded
 orthogonal
 positionToDirection
+prefersReducedMotion
 registerModules
 resolveMessages
+resolveOpaqueBackground
 resolveTabGroupAccent
 themeAbyss
 themeAbyssSpaced

--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -53,6 +53,7 @@ DockviewGroupPanelApi
 DockviewGroupPanelCollapsedChangeEvent
 DockviewGroupPanelLocationChangeEvent
 DockviewGroupPanelModel
+DockviewGroupPanelPeekChangeEvent
 DockviewHeaderDirection
 DockviewHeaderPosition
 DockviewIDisposable

--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -10,6 +10,7 @@ AddSplitviewComponentOptions
 AnchorPosition
 AnchoredBox
 AnnouncementEvent
+AutoHideEdgeGroupOptions
 BaseComponentOptions
 BaseGrid
 BaseGridOptions
@@ -83,6 +84,7 @@ DockviewWillShowOverlayLocationEvent
 DraggablePaneviewPanel
 DropOverlayModelParams
 DroptargetOverlayModel
+EdgeGroupModule
 EdgeGroupOptions
 EdgeGroupPosition
 ExpansionEvent
@@ -114,6 +116,8 @@ IAccessibilityHost
 IAccessibilityService
 IAdvancedDnDHost
 IAdvancedDnDService
+IAutoHideEdgeGroupHost
+IAutoHideEdgeGroupService
 IBaseGrid
 IBaseView
 IContentContainer

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -47,6 +47,8 @@
                     // Record layout history so the harness can exercise undo/redo
                     // (incl. async popout re-open).
                     layoutHistory: { enabled: true },
+                    // Enable auto-hide edge groups (collapsed-strip peek).
+                    autoHideEdgeGroups: true,
                     // A served (not about:blank) target avoids a 404 when the
                     // popout window navigates before dockview injects content.
                     popoutUrl: '/e2e/fixtures/popout.html',
@@ -103,6 +105,29 @@
                     redo: () => dockview.redo(),
                     canUndo: () => dockview.canUndo,
                     awaitPopoutRestore: () => dockview.popoutRestorationPromise,
+                    // Auto-hide edge: a center panel + a collapsed left edge
+                    // group with one panel, for peek tests.
+                    setupAutoHideEdge: () => {
+                        dockview.addPanel({
+                            id: 'main',
+                            component: 'default',
+                            title: 'main',
+                        });
+                        dockview.addEdgeGroup('left', {
+                            id: 'edge-left',
+                            initialSize: 220,
+                        });
+                        dockview.addPanel({
+                            id: 'sidebar',
+                            component: 'default',
+                            title: 'Sidebar',
+                            position: {
+                                referenceGroup: 'edge-left',
+                                direction: 'within',
+                            },
+                        });
+                        dockview.autoHideEdgeGroup('left');
+                    },
                 };
                 window.__ready = true;
             })();

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -139,6 +139,35 @@
                         });
                         dockview.autoHideEdgeGroup('left');
                     },
+                    // Two `always`-rendered panels in one edge group, for the
+                    // peek tab-switch test (each renders its own overlay).
+                    setupAutoHideEdgeMulti: () => {
+                        dockview.addPanel({
+                            id: 'main',
+                            component: 'default',
+                            title: 'main',
+                        });
+                        dockview.addEdgeGroup('left', {
+                            id: 'edge-left',
+                            initialSize: 220,
+                        });
+                        for (const [id, title] of [
+                            ['a', 'Alpha'],
+                            ['b', 'Bravo'],
+                        ]) {
+                            dockview.addPanel({
+                                id,
+                                component: 'default',
+                                title,
+                                renderer: 'always',
+                                position: {
+                                    referenceGroup: 'edge-left',
+                                    direction: 'within',
+                                },
+                            });
+                        }
+                        dockview.autoHideEdgeGroup('left');
+                    },
                 };
                 window.__ready = true;
             })();

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -117,7 +117,7 @@
                     // Auto-hide edge: a center panel + a collapsed left edge
                     // group with one panel, for peek tests.
                     setupAutoHideEdge: (renderer) => {
-                        dockview.addPanel({
+                        const main = dockview.addPanel({
                             id: 'main',
                             component: 'default',
                             title: 'main',
@@ -139,6 +139,11 @@
                             },
                         });
                         dockview.autoHideEdgeGroup('left');
+                        // Activate main so the collapsed edge group is NOT the
+                        // active group — this makes its panel report isVisible
+                        // false (as in a real app), exercising the peek's
+                        // force-visible path for `always` content.
+                        main.api.setActive();
                     },
                 };
                 window.__ready = true;

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -115,9 +115,10 @@
                     peekEdge: (position, on) =>
                         dockview.api.peekEdgeGroup(position, on),
                     // Auto-hide edge: a center panel + a collapsed left edge
-                    // group with one panel, for peek tests.
+                    // group with one panel, for peek tests. Pass renderer
+                    // 'always' to exercise the render-overlay (z-index) path.
                     setupAutoHideEdge: (renderer) => {
-                        const main = dockview.addPanel({
+                        dockview.addPanel({
                             id: 'main',
                             component: 'default',
                             title: 'main',
@@ -130,8 +131,6 @@
                             id: 'sidebar',
                             component: 'default',
                             title: 'Sidebar',
-                            // default 'onlyWhenVisible'; pass 'always' to exercise
-                            // the render-overlay re-anchor path of the peek.
                             renderer: renderer || undefined,
                             position: {
                                 referenceGroup: 'edge-left',
@@ -139,11 +138,6 @@
                             },
                         });
                         dockview.autoHideEdgeGroup('left');
-                        // Activate main so the collapsed edge group is NOT the
-                        // active group — this makes its panel report isVisible
-                        // false (as in a real app), exercising the peek's
-                        // force-visible path for `always` content.
-                        main.api.setActive();
                     },
                 };
                 window.__ready = true;

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -112,9 +112,11 @@
                     redo: () => dockview.redo(),
                     canUndo: () => dockview.canUndo,
                     awaitPopoutRestore: () => dockview.popoutRestorationPromise,
+                    peekEdge: (position, on) =>
+                        dockview.api.peekEdgeGroup(position, on),
                     // Auto-hide edge: a center panel + a collapsed left edge
                     // group with one panel, for peek tests.
-                    setupAutoHideEdge: () => {
+                    setupAutoHideEdge: (renderer) => {
                         dockview.addPanel({
                             id: 'main',
                             component: 'default',
@@ -128,6 +130,9 @@
                             id: 'sidebar',
                             component: 'default',
                             title: 'Sidebar',
+                            // default 'onlyWhenVisible'; pass 'always' to exercise
+                            // the render-overlay re-anchor path of the peek.
+                            renderer: renderer || undefined,
                             position: {
                                 referenceGroup: 'edge-left',
                                 direction: 'within',

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -21,6 +21,13 @@
     <body>
         <div id="app"></div>
 
+        <!-- Built stylesheet so layout-sensitive behaviour (overlay host
+             positioning, edge-group peek) matches real usage. -->
+        <link
+            rel="stylesheet"
+            href="/packages/dockview-core/dist/styles/dockview.css"
+        />
+
         <!-- Built UMD bundles. dockview-core exposes the global "dockview-core";
              dockview-modules expects it aliased as DockviewCore. -->
         <script src="/packages/dockview-core/dist/dockview-core.js"></script>

--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -3,58 +3,99 @@ import { test, expect } from '@playwright/test';
 /**
  * Auto-hide edge groups — the slide-out peek. Real-browser only: the
  * load-bearing rule is that peeking floats the panel over content WITHOUT
- * reflowing the grid (jsdom has no layout). Triggers are the collapsed edge
- * group's native tabs.
+ * reflowing the grid (jsdom has no layout), and that BOTH render modes
+ * (`onlyWhenVisible` and `always`) slide out.
+ *
+ * Interaction model (VS-style): hover / keyboard-focus the collapsed strip's
+ * native tab → peek; click the tab → natively expands (pins) the group.
  */
 test.describe('auto-hide edge groups (peek)', () => {
-    const setup = async (page) => {
+    const setup = async (page, renderer) => {
         await page.goto('/e2e/fixtures/index.html');
         await page.waitForFunction(() => (window as any).__ready === true);
-        await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
+        await page.evaluate(
+            (r) => (window as any).__dv.setupAutoHideEdge(r),
+            renderer
+        );
     };
     const edgeTab = (page) =>
         page.locator('.dv-groupview-edge .dv-tab').first();
+    const mainBox = (page) =>
+        page.locator('.dv-test-panel', { hasText: 'main' }).boundingBox();
 
-    test('clicking a collapsed edge tab peeks over the content without reflow', async ({
+    test('hovering a collapsed edge tab peeks over the content without reflow', async ({
         page,
     }) => {
         await setup(page);
-        const main = page.locator('.dv-test-panel', { hasText: 'main' });
-        const before = (await main.boundingBox())!;
+        const before = (await mainBox(page))!;
 
-        await edgeTab(page).click();
+        await edgeTab(page).hover();
         const overlay = page.locator('.dv-edge-peek');
         await expect(overlay).toBeVisible();
         expect((await overlay.boundingBox())!.width).toBeGreaterThan(100);
-        // the peeked panel content is shown inside the overlay
         await expect(overlay.locator('.dv-test-panel')).toBeVisible();
 
-        const during = (await main.boundingBox())!;
+        const during = (await mainBox(page))!;
         expect(Math.abs(during.width - before.width)).toBeLessThan(2);
 
-        await page.keyboard.press('Escape');
+        await page.mouse.move(900, 500);
         await expect(overlay).toHaveCount(0);
     });
 
-    test('hovering a collapsed edge tab opens the peek', async ({ page }) => {
+    test("an 'always'-rendered panel also slides out over the peek", async ({
+        page,
+    }) => {
+        await setup(page, 'always');
+        const before = (await mainBox(page))!;
+
+        // open via the api (deterministic) — the always-rendered content lives in
+        // the shared render overlay and must re-anchor over the peek region.
+        await page.evaluate(() => (window as any).__dv.peekEdge('left', true));
+        const overlay = page.locator('.dv-edge-peek');
+        await expect(overlay).toBeVisible();
+        const ob = (await overlay.boundingBox())!;
+
+        const sidebar = page.locator('.dv-test-panel', { hasText: 'sidebar' });
+        await expect(sidebar).toBeVisible();
+        const sb = (await sidebar.boundingBox())!;
+        expect(sb.x).toBeGreaterThanOrEqual(ob.x - 3);
+        expect(sb.x).toBeLessThan(ob.x + ob.width);
+
+        // its parent stays the render overlay (always panels are never reparented)
+        const stillInRenderOverlay = await sidebar.evaluate(
+            (el) => !!el.closest('.dv-render-overlay')
+        );
+        expect(stillInRenderOverlay).toBe(true);
+
+        // no grid reflow while peeking
+        expect(
+            Math.abs((await mainBox(page))!.width - before.width)
+        ).toBeLessThan(2);
+    });
+
+    test('clicking a collapsed edge tab pins (expands) the group', async ({
+        page,
+    }) => {
         await setup(page);
-        await edgeTab(page).hover();
-        await expect(page.locator('.dv-edge-peek')).toBeVisible();
-        await page.mouse.move(900, 500);
+        const before = (await mainBox(page))!;
+
+        await edgeTab(page).click();
+
         await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
+        expect((await mainBox(page))!.width).toBeLessThan(before.width);
     });
 
     test('the pin button re-docks the edge group (reflows once)', async ({
         page,
     }) => {
         await setup(page);
-        const main = page.locator('.dv-test-panel', { hasText: 'main' });
-        const before = (await main.boundingBox())!;
+        const before = (await mainBox(page))!;
 
-        await edgeTab(page).click();
+        await page.evaluate(() => (window as any).__dv.peekEdge('left', true));
+        await expect(page.locator('.dv-edge-peek')).toBeVisible();
         await page.locator('.dv-edge-peek-pin').click();
 
         await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
-        expect((await main.boundingBox())!.width).toBeLessThan(before.width);
+        expect((await mainBox(page))!.width).toBeLessThan(before.width);
     });
 });

--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Auto-hide edge groups — the slide-out peek (Phase 2). Real-browser only: the
+ * load-bearing rule is that peeking floats the panel over content **without
+ * reflowing the grid**, which needs real layout (jsdom has none).
+ */
+test.describe('auto-hide edge groups (peek)', () => {
+    test('clicking an activator peeks over the content without reflowing it', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
+
+        const main = page.locator('.dv-test-panel', { hasText: 'main' });
+        const before = (await main.boundingBox())!;
+        expect(before.width).toBeGreaterThan(0);
+
+        // peek
+        await page.locator('.dv-edge-activator').first().click();
+        const overlay = page.locator('.dv-edge-peek');
+        await expect(overlay).toBeVisible();
+        const box = (await overlay.boundingBox())!;
+        expect(box.width).toBeGreaterThan(100); // slid out to the expanded size
+
+        // the main content kept its width — the peek floated over, no reflow
+        const during = (await main.boundingBox())!;
+        expect(Math.abs(during.width - before.width)).toBeLessThan(2);
+
+        // Escape closes the peek
+        await page.keyboard.press('Escape');
+        await expect(overlay).toHaveCount(0);
+    });
+
+    test('the pin button re-docks the edge group (and now reflows once)', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
+
+        const main = page.locator('.dv-test-panel', { hasText: 'main' });
+        const before = (await main.boundingBox())!;
+
+        await page.locator('.dv-edge-activator').first().click();
+        await page.locator('.dv-edge-peek-pin').click();
+
+        await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
+        // pinning expands the edge group, so the main content is now narrower
+        const after = (await main.boundingBox())!;
+        expect(after.width).toBeLessThan(before.width);
+    });
+});

--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -33,6 +33,20 @@ test.describe('auto-hide edge groups (peek)', () => {
         await expect(overlay).toHaveCount(0);
     });
 
+    test('hovering an activator opens the peek', async ({ page }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
+
+        await page.locator('.dv-edge-activator').first().hover();
+        // opens after the hover (openDelay); expect auto-waits
+        await expect(page.locator('.dv-edge-peek')).toBeVisible();
+
+        // moving the pointer far away closes it after closeDelay
+        await page.mouse.move(900, 500);
+        await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
+    });
+
     test('the pin button re-docks the edge group (and now reflows once)', async ({
         page,
     }) => {

--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -67,6 +67,19 @@ test.describe('auto-hide edge groups (peek)', () => {
         );
         expect(stillInRenderOverlay).toBe(true);
 
+        // STACKING: the always content must paint ABOVE the peek's opaque
+        // backdrop — position alone isn't enough (regression guard).
+        const topIsContent = await page.evaluate(() => {
+            const pk = document.querySelector('.dv-edge-peek')!;
+            const r = pk.getBoundingClientRect();
+            const el = document.elementFromPoint(
+                r.x + r.width / 2,
+                r.y + r.height / 2
+            );
+            return !!el?.closest('.dv-render-overlay');
+        });
+        expect(topIsContent).toBe(true);
+
         // no grid reflow while peeking
         expect(
             Math.abs((await mainBox(page))!.width - before.width)

--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -6,8 +6,10 @@ import { test, expect } from '@playwright/test';
  * reflowing the grid (jsdom has no layout), and that BOTH render modes
  * (`onlyWhenVisible` and `always`) slide out.
  *
- * Interaction model (VS-style): hover / keyboard-focus the collapsed strip's
- * native tab → peek; click the tab → natively expands (pins) the group.
+ * Interaction model (Visual Studio pinnable tool windows, click-driven — NO
+ * hover): click a collapsed tab → peek it as a non-reflowing overlay with a
+ * title bar (title + pin + close); click the tab again / outside / Esc → hide;
+ * the pin button → dock (reflow once); the close button → close the panel.
  */
 test.describe('auto-hide edge groups (peek)', () => {
     const setup = async (page, renderer) => {
@@ -23,22 +25,28 @@ test.describe('auto-hide edge groups (peek)', () => {
     const mainBox = (page) =>
         page.locator('.dv-test-panel', { hasText: 'main' }).boundingBox();
 
-    test('hovering a collapsed edge tab peeks over the content without reflow', async ({
+    test('clicking a collapsed edge tab peeks over the content without reflow', async ({
         page,
     }) => {
         await setup(page);
         const before = (await mainBox(page))!;
 
-        await edgeTab(page).hover();
+        await edgeTab(page).click();
         const overlay = page.locator('.dv-edge-peek');
         await expect(overlay).toBeVisible();
         expect((await overlay.boundingBox())!.width).toBeGreaterThan(100);
         await expect(overlay.locator('.dv-test-panel')).toBeVisible();
 
+        // title bar with the panel title + pin + close
+        await expect(page.locator('.dv-edge-peek-title')).toHaveText('Sidebar');
+        await expect(page.locator('.dv-edge-peek-pin')).toBeVisible();
+        await expect(page.locator('.dv-edge-peek-close')).toBeVisible();
+
         const during = (await mainBox(page))!;
         expect(Math.abs(during.width - before.width)).toBeLessThan(2);
 
-        await page.mouse.move(900, 500);
+        // click outside → hide
+        await page.mouse.click(900, 500);
         await expect(overlay).toHaveCount(0);
     });
 
@@ -86,16 +94,90 @@ test.describe('auto-hide edge groups (peek)', () => {
         ).toBeLessThan(2);
     });
 
-    test('clicking a collapsed edge tab pins (expands) the group', async ({
+    test('clicking the peeked tab again hides it; moving the mouse away does not', async ({
         page,
     }) => {
         await setup(page);
         const before = (await mainBox(page))!;
 
         await edgeTab(page).click();
+        const overlay = page.locator('.dv-edge-peek');
+        await expect(overlay).toBeVisible();
 
+        // no reflow, and (no hover model) the peek survives the mouse moving away
+        expect(
+            Math.abs((await mainBox(page))!.width - before.width)
+        ).toBeLessThan(2);
+        await page.mouse.move(900, 500);
+        await expect(overlay).toBeVisible();
+
+        // clicking the peeked tab again hides it (still no reflow)
+        await edgeTab(page).click();
+        await expect(overlay).toHaveCount(0);
+        expect(
+            Math.abs((await mainBox(page))!.width - before.width)
+        ).toBeLessThan(2);
+    });
+
+    test('pinning docks the group as a tool window — title bar on top, tabs at the bottom', async ({
+        page,
+    }) => {
+        await setup(page);
+        await edgeTab(page).click();
+        await page.locator('.dv-edge-peek-pin').click(); // pin → dock
+
+        // a docked title bar is rendered inside the (now expanded) group
+        const dockedBar = page.locator(
+            '.dv-groupview-edge .dv-edge-peek-header'
+        );
+        await expect(dockedBar).toBeVisible();
+        await expect(dockedBar.locator('.dv-edge-peek-title')).toHaveText(
+            'Sidebar'
+        );
+
+        // title bar above the content; tab strip below it (tabs moved to bottom)
+        const geo = await page.evaluate(() => {
+            const g = document.querySelector('.dv-groupview-edge')!;
+            const bar = g
+                .querySelector('.dv-edge-peek-header')!
+                .getBoundingClientRect();
+            const tabs = g
+                .querySelector('.dv-tabs-and-actions-container')!
+                .getBoundingClientRect();
+            const content = g
+                .querySelector('.dv-content-container')!
+                .getBoundingClientRect();
+            return {
+                barBottom: bar.bottom,
+                tabsTop: tabs.top,
+                contentTop: content.top,
+                contentBottom: content.bottom,
+            };
+        });
+        expect(geo.barBottom).toBeLessThanOrEqual(geo.contentTop + 1);
+        expect(geo.tabsTop).toBeGreaterThanOrEqual(geo.contentBottom - 1);
+
+        // the docked pushpin auto-hides back to the strip
+        await page.locator('.dv-groupview-edge .dv-edge-peek-pin').click();
+        await expect(
+            page.locator('.dv-groupview-edge .dv-edge-peek-header')
+        ).toHaveCount(0);
         await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
-        expect((await mainBox(page))!.width).toBeLessThan(before.width);
+    });
+
+    test('the close button closes the panel and removes the peek', async ({
+        page,
+    }) => {
+        await setup(page);
+        await edgeTab(page).click();
+        await expect(page.locator('.dv-edge-peek')).toBeVisible();
+
+        await page.locator('.dv-edge-peek-close').click();
+        await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
+        // the sidebar panel is gone
+        await expect(
+            page.locator('.dv-test-panel', { hasText: 'sidebar' })
+        ).toHaveCount(0);
     });
 
     test('the pin button re-docks the edge group (reflows once)', async ({
@@ -110,5 +192,98 @@ test.describe('auto-hide edge groups (peek)', () => {
 
         await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
         expect((await mainBox(page))!.width).toBeLessThan(before.width);
+    });
+
+    test('the peek reveals from the strip inner edge, not the screen edge', async ({
+        page,
+    }) => {
+        await setup(page);
+        await edgeTab(page).click();
+        await expect(page.locator('.dv-edge-peek-clip')).toBeVisible();
+
+        // A fixed `overflow:hidden` clip frame anchored at the strip's inner
+        // edge bounds the sliding overlay — so no matter the animation phase,
+        // nothing paints on the dock side of that edge (the old bug slid the
+        // panel in from the screen edge across the strip).
+        const geom = await page.evaluate(() => {
+            const strip = document
+                .querySelector('.dv-groupview-edge')!
+                .getBoundingClientRect();
+            const clip = document.querySelector('.dv-edge-peek-clip')!;
+            const cb = clip.getBoundingClientRect();
+            return {
+                stripRight: strip.right,
+                clipLeft: cb.left,
+                clipWidth: cb.width,
+                overflow: getComputedStyle(clip).overflow,
+            };
+        });
+        expect(geom.overflow).toBe('hidden');
+        expect(geom.clipLeft).toBeGreaterThanOrEqual(geom.stripRight - 1);
+        expect(geom.clipWidth).toBeGreaterThan(100);
+    });
+
+    test("an 'always' panel's overlay is clipped to the reveal window during peek", async ({
+        page,
+    }) => {
+        await setup(page, 'always');
+        await page.evaluate(() => (window as any).__dv.peekEdge('left', true));
+        await expect(page.locator('.dv-edge-peek')).toBeVisible();
+
+        const sidebarClip = () =>
+            page.evaluate(() => {
+                const el = [
+                    ...document.querySelectorAll('.dv-render-overlay'),
+                ].find((e) => e.textContent?.includes('sidebar')) as
+                    | HTMLElement
+                    | undefined;
+                return el ? getComputedStyle(el).clipPath : 'none';
+            });
+
+        // the always render overlay (a sibling, never reparented) is clipped to
+        // the same reveal window so it can't slide in from the screen edge
+        await expect.poll(sidebarClip).not.toBe('none');
+
+        // ...and the clip is cleared once the peek closes
+        await page.evaluate(() => (window as any).__dv.peekEdge('left', false));
+        await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
+        await expect.poll(sidebarClip).toBe('none');
+    });
+
+    test('switching peeked always-tabs back and forth keeps content rendered', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() =>
+            (window as any).__dv.setupAutoHideEdgeMulti()
+        );
+
+        const tabs = page.locator('.dv-groupview-edge .dv-tab');
+        await tabs.nth(0).click(); // peek Alpha
+        await expect(page.locator('.dv-edge-peek')).toBeVisible();
+
+        // switch to Bravo, then back to Alpha
+        await tabs.nth(1).click();
+        await tabs.nth(0).click();
+
+        // The re-peeked panel's always-overlay must still render — exactly one
+        // overlay visible + sized. The bug clobbered the force-show, leaving the
+        // active panel hidden (zero visible → blank peek).
+        const visibleOverlays = () =>
+            page.evaluate(
+                () =>
+                    [...document.querySelectorAll('.dv-render-overlay')].filter(
+                        (e) => {
+                            const r = e.getBoundingClientRect();
+                            return (
+                                getComputedStyle(e).visibility !== 'hidden' &&
+                                r.width > 10 &&
+                                r.height > 10
+                            );
+                        }
+                    ).length
+            );
+        await expect.poll(visibleOverlays).toBe(1);
     });
 });

--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -1,68 +1,60 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Auto-hide edge groups — the slide-out peek (Phase 2). Real-browser only: the
- * load-bearing rule is that peeking floats the panel over content **without
- * reflowing the grid**, which needs real layout (jsdom has none).
+ * Auto-hide edge groups — the slide-out peek. Real-browser only: the
+ * load-bearing rule is that peeking floats the panel over content WITHOUT
+ * reflowing the grid (jsdom has no layout). Triggers are the collapsed edge
+ * group's native tabs.
  */
 test.describe('auto-hide edge groups (peek)', () => {
-    test('clicking an activator peeks over the content without reflowing it', async ({
-        page,
-    }) => {
+    const setup = async (page) => {
         await page.goto('/e2e/fixtures/index.html');
         await page.waitForFunction(() => (window as any).__ready === true);
         await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
+    };
+    const edgeTab = (page) =>
+        page.locator('.dv-groupview-edge .dv-tab').first();
 
+    test('clicking a collapsed edge tab peeks over the content without reflow', async ({
+        page,
+    }) => {
+        await setup(page);
         const main = page.locator('.dv-test-panel', { hasText: 'main' });
         const before = (await main.boundingBox())!;
-        expect(before.width).toBeGreaterThan(0);
 
-        // peek
-        await page.locator('.dv-edge-activator').first().click();
+        await edgeTab(page).click();
         const overlay = page.locator('.dv-edge-peek');
         await expect(overlay).toBeVisible();
-        const box = (await overlay.boundingBox())!;
-        expect(box.width).toBeGreaterThan(100); // slid out to the expanded size
+        expect((await overlay.boundingBox())!.width).toBeGreaterThan(100);
+        // the peeked panel content is shown inside the overlay
+        await expect(overlay.locator('.dv-test-panel')).toBeVisible();
 
-        // the main content kept its width — the peek floated over, no reflow
         const during = (await main.boundingBox())!;
         expect(Math.abs(during.width - before.width)).toBeLessThan(2);
 
-        // Escape closes the peek
         await page.keyboard.press('Escape');
         await expect(overlay).toHaveCount(0);
     });
 
-    test('hovering an activator opens the peek', async ({ page }) => {
-        await page.goto('/e2e/fixtures/index.html');
-        await page.waitForFunction(() => (window as any).__ready === true);
-        await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
-
-        await page.locator('.dv-edge-activator').first().hover();
-        // opens after the hover (openDelay); expect auto-waits
+    test('hovering a collapsed edge tab opens the peek', async ({ page }) => {
+        await setup(page);
+        await edgeTab(page).hover();
         await expect(page.locator('.dv-edge-peek')).toBeVisible();
-
-        // moving the pointer far away closes it after closeDelay
         await page.mouse.move(900, 500);
         await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
     });
 
-    test('the pin button re-docks the edge group (and now reflows once)', async ({
+    test('the pin button re-docks the edge group (reflows once)', async ({
         page,
     }) => {
-        await page.goto('/e2e/fixtures/index.html');
-        await page.waitForFunction(() => (window as any).__ready === true);
-        await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
-
+        await setup(page);
         const main = page.locator('.dv-test-panel', { hasText: 'main' });
         const before = (await main.boundingBox())!;
 
-        await page.locator('.dv-edge-activator').first().click();
+        await edgeTab(page).click();
         await page.locator('.dv-edge-peek-pin').click();
 
         await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
-        // pinning expands the edge group, so the main content is now narrower
-        const after = (await main.boundingBox())!;
-        expect(after.width).toBeLessThan(before.width);
+        expect((await main.boundingBox())!.width).toBeLessThan(before.width);
     });
 });

--- a/packages/dockview-core/src/__tests__/dismissableLayer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dismissableLayer.spec.ts
@@ -124,4 +124,36 @@ describe('createDismissableLayer', () => {
         keydown('Escape');
         expect(onDismiss).toHaveBeenCalledTimes(1); // no further calls
     });
+
+    test('focusOut dismisses when focus lands outside the layer', () => {
+        const onDismiss = jest.fn();
+        const layer = createDismissableLayer({
+            onDismiss,
+            focusOut: true,
+            elements: () => [inside],
+        });
+
+        inside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        expect(onDismiss).not.toHaveBeenCalled();
+        outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+
+        layer.dispose();
+    });
+
+    test('focusOut uses an isFocusInside predicate when provided', () => {
+        const onDismiss = jest.fn();
+        const layer = createDismissableLayer({
+            onDismiss,
+            focusOut: true,
+            isFocusInside: (el) => el === inside,
+        });
+
+        inside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        expect(onDismiss).not.toHaveBeenCalled();
+        outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+
+        layer.dispose();
+    });
 });

--- a/packages/dockview-core/src/__tests__/dismissableLayer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dismissableLayer.spec.ts
@@ -1,0 +1,127 @@
+import { createDismissableLayer } from '../dismissableLayer';
+
+describe('createDismissableLayer', () => {
+    let inside: HTMLElement;
+    let outside: HTMLElement;
+
+    beforeEach(() => {
+        inside = document.createElement('div');
+        outside = document.createElement('div');
+        document.body.appendChild(inside);
+        document.body.appendChild(outside);
+    });
+
+    afterEach(() => {
+        inside.remove();
+        outside.remove();
+    });
+
+    const keydown = (key: string) =>
+        window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+    const pointerdownOn = (el: HTMLElement, x = 0) =>
+        el.dispatchEvent(
+            new MouseEvent('pointerdown', { bubbles: true, clientX: x })
+        );
+
+    test('Escape dismisses by default; other keys do not', () => {
+        const onDismiss = jest.fn();
+        const layer = createDismissableLayer({ onDismiss });
+
+        keydown('a');
+        expect(onDismiss).not.toHaveBeenCalled();
+        keydown('Escape');
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+
+        layer.dispose();
+    });
+
+    test('extra keys dismiss when configured', () => {
+        const onDismiss = jest.fn();
+        const layer = createDismissableLayer({ onDismiss, keys: ['Enter'] });
+
+        keydown('Enter');
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+
+        layer.dispose();
+    });
+
+    test('outside pointerdown dismisses; inside (contains) does not', () => {
+        const onDismiss = jest.fn();
+        const layer = createDismissableLayer({
+            onDismiss,
+            elements: () => [inside],
+        });
+
+        pointerdownOn(inside);
+        expect(onDismiss).not.toHaveBeenCalled();
+        pointerdownOn(outside);
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+
+        layer.dispose();
+    });
+
+    test('onInsidePointerDown fires for inside pointerdowns', () => {
+        const onDismiss = jest.fn();
+        const onInsidePointerDown = jest.fn();
+        const layer = createDismissableLayer({
+            onDismiss,
+            onInsidePointerDown,
+            elements: () => [inside],
+        });
+
+        pointerdownOn(inside);
+        expect(onInsidePointerDown).toHaveBeenCalledTimes(1);
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        layer.dispose();
+    });
+
+    test('an isInside predicate overrides the contains check (geometry)', () => {
+        const onDismiss = jest.fn();
+        const layer = createDismissableLayer({
+            onDismiss,
+            isInside: (e) => e.clientX < 100,
+        });
+
+        pointerdownOn(outside, 50); // "inside" by geometry
+        expect(onDismiss).not.toHaveBeenCalled();
+        pointerdownOn(outside, 150); // outside
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+
+        layer.dispose();
+    });
+
+    test('the grace window ignores outside-pointerdowns just after opening', () => {
+        const onDismiss = jest.fn();
+        let clock = 1000;
+        const layer = createDismissableLayer({
+            onDismiss,
+            elements: () => [inside],
+            pointerDownGraceMs: 200,
+            now: () => clock,
+        });
+
+        clock = 1100; // within the 200ms grace
+        pointerdownOn(outside);
+        expect(onDismiss).not.toHaveBeenCalled();
+
+        clock = 1300; // past the grace
+        pointerdownOn(outside);
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+
+        layer.dispose();
+    });
+
+    test('resize dismisses when enabled, and dispose detaches every listener', () => {
+        const onDismiss = jest.fn();
+        const layer = createDismissableLayer({ onDismiss, resize: true });
+
+        window.dispatchEvent(new Event('resize'));
+        expect(onDismiss).toHaveBeenCalledTimes(1);
+
+        layer.dispose();
+        window.dispatchEvent(new Event('resize'));
+        keydown('Escape');
+        expect(onDismiss).toHaveBeenCalledTimes(1); // no further calls
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -300,6 +300,44 @@ describe('dockviewComponent', () => {
             expect(voidContainer.draggable).toBe(false);
         });
 
+        test('group.model.getPanelForTab maps a tab element to its panel', () => {
+            dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    return new PanelContentPartTest(options.id, options.name);
+                },
+            });
+            dockview.layout(500, 500);
+            const p1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+            });
+            dockview.addPanel({ id: 'panel2', component: 'default' });
+            const group = p1.group;
+
+            const tabEls = Array.from(
+                group.element.querySelectorAll('.dv-tab')
+            ) as HTMLElement[];
+            expect(tabEls.length).toBe(2);
+
+            // each tab element resolves to a distinct panel
+            const r1 = group.model.getPanelForTab(tabEls[0]);
+            const r2 = group.model.getPanelForTab(tabEls[1]);
+            expect(new Set([r1?.id, r2?.id])).toEqual(
+                new Set(['panel1', 'panel2'])
+            );
+
+            // a descendant of a tab resolves to the same panel as the tab
+            const inner = (tabEls[0].querySelector('*') ??
+                tabEls[0]) as HTMLElement;
+            expect(group.model.getPanelForTab(inner)?.id).toBe(r1?.id);
+
+            // a non-tab element (the void container) resolves to undefined
+            const voidEl = group.element.querySelector(
+                '.dv-void-container'
+            ) as HTMLElement;
+            expect(group.model.getPanelForTab(voidEl)).toBeUndefined();
+        });
+
         test('disableDnd overrides dndStrategy', () => {
             dockview = new DockviewComponent(container, {
                 createComponent(options) {

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -1176,6 +1176,15 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         this.component.autoHideEdgeGroup(position);
     }
 
+    /**
+     * Peek (slide out as an overlay, without reflowing the grid) or close the
+     * collapsed edge group at `position`. No-op when the auto-hide module is
+     * absent or the group is not collapsed.
+     */
+    peekEdgeGroup(position: EdgeGroupPosition, peek: boolean): void {
+        this.component.peekEdgeGroup(position, peek);
+    }
+
     updateOptions(options: Partial<DockviewComponentOptions>) {
         this.component.updateOptions(options);
     }

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -1163,6 +1163,19 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
         this.component.removeEdgeGroup(position);
     }
 
+    /**
+     * Pin (expand) the collapsed edge group at `position`. Requires the
+     * auto-hide edge groups module; no-op when it is absent.
+     */
+    pinEdgeGroup(position: EdgeGroupPosition): void {
+        this.component.pinEdgeGroup(position);
+    }
+
+    /** Auto-hide (collapse to a strip) the edge group at `position`. */
+    autoHideEdgeGroup(position: EdgeGroupPosition): void {
+        this.component.autoHideEdgeGroup(position);
+    }
+
     updateOptions(options: Partial<DockviewComponentOptions>) {
         this.component.updateOptions(options);
     }

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -32,6 +32,10 @@ export interface DockviewGroupPanelCollapsedChangeEvent {
     readonly isCollapsed: boolean;
 }
 
+export interface DockviewGroupPanelPeekChangeEvent {
+    readonly isPeeking: boolean;
+}
+
 export interface DockviewGroupPanelApi extends GridviewPanelApi {
     readonly onDidLocationChange: Event<DockviewGroupPanelLocationChangeEvent>;
     /**
@@ -47,6 +51,12 @@ export interface DockviewGroupPanelApi extends GridviewPanelApi {
      * Never fires for non-edge groups.
      */
     readonly onDidCollapsedChange: Event<DockviewGroupPanelCollapsedChangeEvent>;
+    /**
+     * Fired when an edge group's auto-hide *peek* state changes (the slid-out
+     * overlay shown/hidden while the group stays logically collapsed). Never
+     * fires for non-edge groups or without the auto-hide module.
+     */
+    readonly onDidPeekChange: Event<DockviewGroupPanelPeekChangeEvent>;
     readonly location: DockviewGroupLocation;
     /**
      * Whether this group is locked against drop interactions.
@@ -79,6 +89,8 @@ export interface DockviewGroupPanelApi extends GridviewPanelApi {
      * Always returns false for non-edge groups.
      */
     isCollapsed(): boolean;
+    /** True while this edge group is peeking (auto-hide slid-out overlay). */
+    isPeeking(): boolean;
 }
 
 export interface DockviewGroupPanelLocationChangeEvent {
@@ -105,6 +117,11 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
         new Emitter<DockviewGroupPanelCollapsedChangeEvent>();
     readonly onDidCollapsedChange: Event<DockviewGroupPanelCollapsedChangeEvent> =
         this._onDidCollapsedChange.event;
+
+    readonly _onDidPeekChange =
+        new Emitter<DockviewGroupPanelPeekChangeEvent>();
+    readonly onDidPeekChange: Event<DockviewGroupPanelPeekChangeEvent> =
+        this._onDidPeekChange.event;
 
     get location(): DockviewGroupLocation {
         if (!this._group) {
@@ -157,6 +174,7 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             this._onDidLocationChange,
             this._onDidActivePanelChange,
             this._onDidCollapsedChange,
+            this._onDidPeekChange,
             this._onDidVisibilityChange.event((event) => {
                 // When becoming visible, apply any pending size change
                 if (event.isVisible && this._pendingSize) {
@@ -277,6 +295,13 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             return false;
         }
         return this.accessor.isEdgeGroupCollapsed(this._group);
+    }
+
+    isPeeking(): boolean {
+        if (!this._group) {
+            return false;
+        }
+        return this.accessor.isEdgeGroupPeeking(this._group);
     }
 
     initialize(group: DockviewGroupPanel): void {

--- a/packages/dockview-core/src/dismissableLayer.ts
+++ b/packages/dockview-core/src/dismissableLayer.ts
@@ -1,0 +1,139 @@
+import { addDisposableListener } from './events';
+import { CompositeDisposable, IDisposable } from './lifecycle';
+
+/** Touch-primary input (coarse pointer, no fine pointer). On these devices a
+ *  window resize is usually an on-screen-keyboard pop / orientation change /
+ *  address-bar collapse — none of which mean "dismiss". */
+function isCoarsePrimaryInput(win: Window): boolean {
+    if (!win.matchMedia) {
+        return false;
+    }
+    const coarse = win.matchMedia('(pointer: coarse)').matches;
+    const fine = win.matchMedia('(pointer: fine)').matches;
+    return coarse && !fine;
+}
+
+export interface DismissableLayerOptions {
+    /** Window to listen on — pass the popout window for popout-hosted layers.
+     *  Defaults to the global `window`. */
+    readonly window?: Window;
+    /** Invoked when any enabled dismiss signal fires. */
+    readonly onDismiss: () => void;
+    /** A pointerdown landed *inside* the layer (not a dismissal). Use it to
+     *  mark interaction (e.g. make a transient layer sticky). */
+    readonly onInsidePointerDown?: (event: PointerEvent) => void;
+    /** Whether a pointer event is inside the layer. Defaults to a DOM
+     *  `contains` check against {@link DismissableLayerOptions.elements} —
+     *  provide this for geometry-based hit testing (e.g. when the visible
+     *  content is a sibling overlay stacked on top of the layer). */
+    readonly isInside?: (event: PointerEvent) => boolean;
+    /** Elements treated as "inside" by the default contains check. */
+    readonly elements?: () => HTMLElement[];
+    /** Dismiss on `Escape` (default `true`). */
+    readonly escape?: boolean;
+    /** Extra keys that also dismiss (e.g. `'Enter'`). */
+    readonly keys?: readonly string[];
+    /** Dismiss on a pointerdown outside the layer (default `true`). */
+    readonly outsidePointerDown?: boolean;
+    /** Ignore outside-pointerdowns for this many ms after opening — covers the
+     *  gesture that opened the layer (e.g. a touch long-press) dispatching a
+     *  follow-up pointerdown just outside it. */
+    readonly pointerDownGraceMs?: number;
+    /** Dismiss on window resize, skipping touch-driven resizes (default
+     *  `false`). */
+    readonly resize?: boolean;
+    /** Listen in the capture phase (default `false`). Use capture when the
+     *  layer must see the event before content handlers stop its propagation. */
+    readonly capture?: boolean;
+    /** Clock source for the grace window — defaults to `Date.now`. */
+    readonly now?: () => number;
+}
+
+/**
+ * The shared dismissal lifecycle behind transient surfaces (popovers, menus,
+ * peeks): while it lives it watches a configurable set of dismiss signals
+ * (Escape / extra keys, outside-pointerdown with an optional grace window,
+ * window resize) and calls `onDismiss`. Inside/outside is decided by an
+ * `isInside` predicate (geometry) or a `contains` check against `elements`.
+ * Dispose to detach every listener.
+ *
+ * It owns only the *signals* — not the surface element, its position, or any
+ * hover/keep-open policy — so callers keep their own element lifecycle and
+ * layer this underneath.
+ */
+export function createDismissableLayer(
+    options: DismissableLayerOptions
+): IDisposable {
+    const win = options.window ?? window;
+    const capture = options.capture ?? false;
+    const escape = options.escape ?? true;
+    const keys = options.keys ?? [];
+    const outside = options.outsidePointerDown ?? true;
+    const grace = options.pointerDownGraceMs ?? 0;
+    const now = options.now ?? Date.now;
+    const openedAt = now();
+
+    const disposables = new CompositeDisposable();
+
+    const isInside = (event: PointerEvent): boolean => {
+        if (options.isInside) {
+            return options.isInside(event);
+        }
+        const target = event.target;
+        if (!(target instanceof Node)) {
+            return false;
+        }
+        return (options.elements?.() ?? []).some((el) => el.contains(target));
+    };
+
+    if (escape || keys.length > 0) {
+        disposables.addDisposables(
+            addDisposableListener(
+                win,
+                'keydown',
+                (event) => {
+                    if (
+                        (escape && event.key === 'Escape') ||
+                        keys.includes(event.key)
+                    ) {
+                        options.onDismiss();
+                    }
+                },
+                capture
+            )
+        );
+    }
+
+    if (outside || options.onInsidePointerDown) {
+        disposables.addDisposables(
+            addDisposableListener(
+                win,
+                'pointerdown',
+                (event) => {
+                    if (isInside(event)) {
+                        options.onInsidePointerDown?.(event);
+                        return;
+                    }
+                    if (!outside || now() - openedAt < grace) {
+                        return;
+                    }
+                    options.onDismiss();
+                },
+                capture
+            )
+        );
+    }
+
+    if (options.resize) {
+        disposables.addDisposables(
+            addDisposableListener(win, 'resize', () => {
+                if (isCoarsePrimaryInput(win)) {
+                    return;
+                }
+                options.onDismiss();
+            })
+        );
+    }
+
+    return disposables;
+}

--- a/packages/dockview-core/src/dismissableLayer.ts
+++ b/packages/dockview-core/src/dismissableLayer.ts
@@ -42,6 +42,14 @@ export interface DismissableLayerOptions {
     /** Dismiss on window resize, skipping touch-driven resizes (default
      *  `false`). */
     readonly resize?: boolean;
+    /** Dismiss when focus moves to an element *outside* the layer (default
+     *  `false`) — the "slide back on focus loss" behaviour. */
+    readonly focusOut?: boolean;
+    /** Whether a newly-focused element is inside the layer (for
+     *  {@link focusOut}). Defaults to a `contains` check against
+     *  {@link elements} — provide this for geometry-based testing when the
+     *  content is a sibling overlay stacked on top of the layer. */
+    readonly isFocusInside?: (focused: Element) => boolean;
     /** Listen in the capture phase (default `false`). Use capture when the
      *  layer must see the event before content handlers stop its propagation. */
     readonly capture?: boolean;
@@ -53,9 +61,9 @@ export interface DismissableLayerOptions {
  * The shared dismissal lifecycle behind transient surfaces (popovers, menus,
  * peeks): while it lives it watches a configurable set of dismiss signals
  * (Escape / extra keys, outside-pointerdown with an optional grace window,
- * window resize) and calls `onDismiss`. Inside/outside is decided by an
- * `isInside` predicate (geometry) or a `contains` check against `elements`.
- * Dispose to detach every listener.
+ * window resize, focus moving outside) and calls `onDismiss`. Inside/outside is
+ * decided by an `isInside` predicate (geometry) or a `contains` check against
+ * `elements`. Dispose to detach every listener.
  *
  * It owns only the *signals* — not the surface element, its position, or any
  * hover/keep-open policy — so callers keep their own element lifecycle and
@@ -133,6 +141,30 @@ export function createDismissableLayer(
                 options.onDismiss();
             })
         );
+    }
+
+    if (options.focusOut) {
+        const isFocusInside = (focused: Element): boolean => {
+            if (options.isFocusInside) {
+                return options.isFocusInside(focused);
+            }
+            return (options.elements?.() ?? []).some((el) =>
+                el.contains(focused)
+            );
+        };
+        // `focusin` bubbles to the window; capture so it's seen regardless of
+        // content handlers.
+        const onFocusIn = (event: FocusEvent): void => {
+            const target = event.target;
+            if (target instanceof Element && !isFocusInside(target)) {
+                options.onDismiss();
+            }
+        };
+        win.addEventListener('focusin', onFocusIn, capture);
+        disposables.addDisposables({
+            dispose: () =>
+                win.removeEventListener('focusin', onFocusIn, capture),
+        });
     }
 
     return disposables;

--- a/packages/dockview-core/src/dockview/components/popupService.ts
+++ b/packages/dockview-core/src/dockview/components/popupService.ts
@@ -1,19 +1,10 @@
 import { shiftAbsoluteElementIntoView } from '../../dom';
-import { addDisposableListener } from '../../events';
+import { createDismissableLayer } from '../../dismissableLayer';
 import {
     CompositeDisposable,
     Disposable,
     MutableDisposable,
 } from '../../lifecycle';
-
-function isCoarsePrimaryInput(win: Window): boolean {
-    if (!win.matchMedia) {
-        return false;
-    }
-    const coarse = win.matchMedia('(pointer: coarse)').matches;
-    const fine = win.matchMedia('(pointer: fine)').matches;
-    return coarse && !fine;
-}
 
 export class PopupService extends CompositeDisposable {
     private readonly _element: HTMLElement;
@@ -77,63 +68,24 @@ export class PopupService extends CompositeDisposable {
 
         this._active = wrapper;
 
-        // Outside-pointerdown dismissal is suppressed for a short grace
-        // window after opening. Touch long-press callers (chip / tab context
-        // menus) open the popover while the user's finger is still pressing
-        // the source element — Android Chrome can dispatch a follow-up
-        // synthetic pointerdown tied to the gesture, and the release-then-
-        // retap motion can land just outside the wrapper. Either would
-        // dismiss the popover before the user can see or interact with it.
-        // The grace window is short enough that intentional outside taps
-        // still feel responsive.
-        const openedAt = Date.now();
+        // Outside-pointerdown dismissal is suppressed for a short grace window:
+        // touch long-press callers (chip / tab context menus) open the popover
+        // while the user's finger is still pressing the source — Android Chrome
+        // can dispatch a follow-up pointerdown tied to the gesture that lands
+        // just outside the wrapper and would dismiss it before it's seen. Enter
+        // dismisses as well (commit-and-close); resize dismisses except on
+        // touch-primary input, where a resize is usually the on-screen keyboard
+        // (e.g. focusing a rename input) rather than intent to dismiss.
         const POINTERDOWN_GRACE_MS = 200;
 
-        this._activeDisposable.value = new CompositeDisposable(
-            addDisposableListener(this._window, 'pointerdown', (event) => {
-                if (Date.now() - openedAt < POINTERDOWN_GRACE_MS) {
-                    return;
-                }
-
-                const target = event.target;
-
-                if (!(target instanceof HTMLElement)) {
-                    return;
-                }
-
-                let el: HTMLElement | null = target;
-
-                while (el && el !== wrapper) {
-                    el = el?.parentElement ?? null;
-                }
-
-                if (el) {
-                    return; // clicked within popover
-                }
-
-                this.close();
-            }),
-            addDisposableListener(this._window, 'keydown', (event) => {
-                if (event.key === 'Escape' || event.key === 'Enter') {
-                    this.close();
-                }
-            }),
-            addDisposableListener(this._window, 'resize', () => {
-                // On touch-primary devices, common interactions resize the
-                // window: on-screen keyboard pop, orientation change, browser
-                // address-bar collapse. None of these mean "the user wants
-                // the popover dismissed". Specifically, focusing the chip
-                // context menu's rename input pops the keyboard, which would
-                // otherwise close the menu the moment the user goes to edit
-                // it. Desktop / hybrid input keeps the existing behaviour —
-                // there a resize genuinely means the user has resized the
-                // window and the popover position is now stale.
-                if (isCoarsePrimaryInput(this._window)) {
-                    return;
-                }
-                this.close();
-            })
-        );
+        this._activeDisposable.value = createDismissableLayer({
+            window: this._window,
+            onDismiss: () => this.close(),
+            elements: () => (this._active ? [this._active] : []),
+            keys: ['Enter'],
+            pointerDownGraceMs: POINTERDOWN_GRACE_MS,
+            resize: true,
+        });
 
         this._window.requestAnimationFrame(() => {
             shiftAbsoluteElementIntoView(wrapper, this._root);

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -523,6 +523,17 @@ export class Tabs extends CompositeDisposable {
         return this._tabMap.get(panelId)?.value.element.id;
     }
 
+    /** Inverse of {@link getTabId}: the panel whose tab owns `element` (the tab
+     *  itself or any descendant of it), or `undefined` for non-tab targets. */
+    getPanelForTab(element: Element): IDockviewPanel | undefined {
+        for (const { value } of this._tabs) {
+            if (value.element === element || value.element.contains(element)) {
+                return value.panel;
+            }
+        }
+        return undefined;
+    }
+
     isActive(tab: Tab): boolean {
         return (
             this.selectedIndex > -1 &&

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -57,6 +57,7 @@ export interface ITabsContainer extends IDisposable {
     delete(id: string): void;
     indexOf(id: string): number;
     getTabId(panelId: string): string | undefined;
+    getPanelForTab(element: Element): IDockviewPanel | undefined;
     setActive(isGroupActive: boolean): void;
     setActivePanel(panel: IDockviewPanel): void;
     focusActiveTab(): void;
@@ -364,6 +365,10 @@ export class TabsContainer
 
     getTabId(panelId: string): string | undefined {
         return this.tabs.getTabId(panelId);
+    }
+
+    getPanelForTab(element: Element): IDockviewPanel | undefined {
+        return this.tabs.getPanelForTab(element);
     }
 
     setActive(_isGroupActive: boolean) {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -432,7 +432,7 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     pinEdgeGroup(position: EdgeGroupPosition): void;
     autoHideEdgeGroup(position: EdgeGroupPosition): void;
     peekEdgeGroup(position: EdgeGroupPosition, peek: boolean): void;
-    readonly floatingOverlayHost: HTMLElement;
+    readonly overlayRoot: HTMLElement;
     getEdgeGroupExpandedSize(position: EdgeGroupPosition): number;
     // layout history (undo / redo)
     undo(): void;
@@ -2535,9 +2535,11 @@ export class DockviewComponent
         );
     }
 
-    /** The shared overlay host the auto-hide peek mounts on. */
-    get floatingOverlayHost(): HTMLElement {
-        return this._floatingOverlayHost ?? this.gridview.element;
+    /** The auto-hide peek mounts on the shell — the same element the
+     *  `OverlayRenderContainer` roots on — so `always` content re-anchors in the
+     *  peek's coordinate space. */
+    get overlayRoot(): HTMLElement {
+        return this.rootElement;
     }
 
     /** The size an edge group expands to (pre-collapse) — sizes the peek. */

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2613,6 +2613,29 @@ export class DockviewComponent
             : false;
     }
 
+    /** Edge groups currently peeking (auto-hide). The peek state is owned by the
+     *  auto-hide module; the component just records it so `group.api.isPeeking()`
+     *  / `onDidPeekChange` work. */
+    private readonly _peekingGroups = new Set<DockviewGroupPanel>();
+
+    isEdgeGroupPeeking(group: DockviewGroupPanel): boolean {
+        return this._peekingGroups.has(group);
+    }
+
+    /** Set the peek state and fire the group's `onDidPeekChange` (called by the
+     *  auto-hide service). */
+    setEdgeGroupPeeking(group: DockviewGroupPanel, peeking: boolean): void {
+        if (this._peekingGroups.has(group) === peeking) {
+            return;
+        }
+        if (peeking) {
+            this._peekingGroups.add(group);
+        } else {
+            this._peekingGroups.delete(group);
+        }
+        group.api._onDidPeekChange.fire({ isPeeking: peeking });
+    }
+
     private updateDragAndDropState(): void {
         // Update draggable state for all tabs and void containers
         for (const group of this.groups) {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2547,10 +2547,15 @@ export class DockviewComponent
         return this._shellManager?.getEdgeGroupExpandedSize(position) ?? 0;
     }
 
-    /** Re-anchor `renderer:'always'` overlays (used by the auto-hide peek as it
-     *  reparents / slides a group's content container). */
-    repositionOverlays(): void {
-        this.overlayRenderContainer.updateAllPositions();
+    /** Reposition a single `renderer:'always'` panel's overlay over its
+     *  reference container, optionally forcing it visible (the auto-hide peek
+     *  slides an `always` panel out without reparenting it or touching its
+     *  visibility state). No-op for non-overlay-rendered panels. */
+    repositionPanelOverlay(panel: IDockviewPanel, forceVisible: boolean): void {
+        this.overlayRenderContainer.repositionPanelOverlay(
+            panel.api.id,
+            forceVisible
+        );
     }
 
     setEdgeGroupVisible(position: EdgeGroupPosition, visible: boolean): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -88,6 +88,7 @@ import { IEdgeGroupServiceHost } from './edgeGroupService';
 import {
     IAccessibilityHost,
     IAdvancedDnDHost,
+    IAutoHideEdgeGroupHost,
     IContextMenuHost,
     IContextMenuService,
     ILayoutHistoryHost,
@@ -425,6 +426,11 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     setEdgeGroupVisible(position: EdgeGroupPosition, visible: boolean): void;
     isEdgeGroupVisible(position: EdgeGroupPosition): boolean;
     removeEdgeGroup(position: EdgeGroupPosition): void;
+    getEdgeGroupPanel(
+        position: EdgeGroupPosition
+    ): DockviewGroupPanel | undefined;
+    pinEdgeGroup(position: EdgeGroupPosition): void;
+    autoHideEdgeGroup(position: EdgeGroupPosition): void;
     // layout history (undo / redo)
     undo(): void;
     redo(): void;
@@ -491,7 +497,8 @@ export class DockviewComponent
         IAdvancedDnDHost,
         ILiveRegionHost,
         IAccessibilityHost,
-        ILayoutHistoryHost
+        ILayoutHistoryHost,
+        IAutoHideEdgeGroupHost
 {
     private readonly nextGroupId = sequentialNumberGenerator();
     private readonly _deserializer = new DefaultDockviewDeserialzier(this);
@@ -2496,6 +2503,25 @@ export class DockviewComponent
         position: EdgeGroupPosition
     ): DockviewGroupPanelApi | undefined {
         return this._edgeGroupService?.get(position)?.api;
+    }
+
+    /** The edge group panel at a position (the model, not the api). */
+    getEdgeGroupPanel(
+        position: EdgeGroupPosition
+    ): DockviewGroupPanel | undefined {
+        return this._edgeGroupService?.get(position);
+    }
+
+    /** Pin (expand) the edge group at a position — auto-hide module feature. */
+    pinEdgeGroup(position: EdgeGroupPosition): void {
+        this._moduleRegistry.services.autoHideEdgeGroupService?.pin(position);
+    }
+
+    /** Auto-hide (collapse to strip) the edge group at a position. */
+    autoHideEdgeGroup(position: EdgeGroupPosition): void {
+        this._moduleRegistry.services.autoHideEdgeGroupService?.autoHide(
+            position
+        );
     }
 
     setEdgeGroupVisible(position: EdgeGroupPosition, visible: boolean): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2547,6 +2547,12 @@ export class DockviewComponent
         return this._shellManager?.getEdgeGroupExpandedSize(position) ?? 0;
     }
 
+    /** Re-anchor `renderer:'always'` overlays (used by the auto-hide peek as it
+     *  reparents / slides a group's content container). */
+    repositionOverlays(): void {
+        this.overlayRenderContainer.updateAllPositions();
+    }
+
     setEdgeGroupVisible(position: EdgeGroupPosition, visible: boolean): void {
         this._shellManager!.setEdgeGroupVisible(position, visible);
     }

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -431,6 +431,9 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     ): DockviewGroupPanel | undefined;
     pinEdgeGroup(position: EdgeGroupPosition): void;
     autoHideEdgeGroup(position: EdgeGroupPosition): void;
+    peekEdgeGroup(position: EdgeGroupPosition, peek: boolean): void;
+    readonly floatingOverlayHost: HTMLElement;
+    getEdgeGroupExpandedSize(position: EdgeGroupPosition): number;
     // layout history (undo / redo)
     undo(): void;
     redo(): void;
@@ -2522,6 +2525,24 @@ export class DockviewComponent
         this._moduleRegistry.services.autoHideEdgeGroupService?.autoHide(
             position
         );
+    }
+
+    /** Peek (slide out) / close the collapsed edge group at a position. */
+    peekEdgeGroup(position: EdgeGroupPosition, peek: boolean): void {
+        this._moduleRegistry.services.autoHideEdgeGroupService?.peek(
+            position,
+            peek
+        );
+    }
+
+    /** The shared overlay host the auto-hide peek mounts on. */
+    get floatingOverlayHost(): HTMLElement {
+        return this._floatingOverlayHost ?? this.gridview.element;
+    }
+
+    /** The size an edge group expands to (pre-collapse) — sizes the peek. */
+    getEdgeGroupExpandedSize(position: EdgeGroupPosition): number {
+        return this._shellManager?.getEdgeGroupExpandedSize(position) ?? 0;
     }
 
     setEdgeGroupVisible(position: EdgeGroupPosition, visible: boolean): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2551,10 +2551,15 @@ export class DockviewComponent
      *  reference container, optionally forcing it visible (the auto-hide peek
      *  slides an `always` panel out without reparenting it or touching its
      *  visibility state). No-op for non-overlay-rendered panels. */
-    repositionPanelOverlay(panel: IDockviewPanel, forceVisible: boolean): void {
+    repositionPanelOverlay(
+        panel: IDockviewPanel,
+        forceVisible: boolean,
+        clip?: DOMRect
+    ): void {
         this.overlayRenderContainer.repositionPanelOverlay(
             panel.api.id,
-            forceVisible
+            forceVisible,
+            clip
         );
     }
 

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -417,6 +417,13 @@ export class DockviewGroupPanelModel
         return this.tabsContainer;
     }
 
+    /** The panel whose tab owns `element` (the tab itself or a descendant of
+     *  it), or `undefined` when the target isn't a tab. The robust inverse of a
+     *  tab→panel lookup — no positional/DOM-order assumptions. */
+    getPanelForTab(element: Element): IDockviewPanel | undefined {
+        return this.tabsContainer.getPanelForTab(element);
+    }
+
     get isContentFocused(): boolean {
         if (!document.activeElement) {
             return false;

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -777,6 +777,12 @@ export class ShellManager implements IDisposable {
         return this._getView(position)?.isCollapsed ?? false;
     }
 
+    /** The size an edge group expands to (its pre-collapse size) — used to size
+     *  the auto-hide peek overlay. */
+    getEdgeGroupExpandedSize(position: EdgeGroupPosition): number {
+        return this._getView(position)?.lastExpandedSize ?? 0;
+    }
+
     private _getView(position: EdgeGroupPosition): EdgeGroupView | undefined {
         switch (position) {
             case 'top':

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -276,11 +276,12 @@ export interface IAutoHideEdgeGroupHost {
     /** Record the peek state so `group.api.isPeeking()` / `onDidPeekChange`
      *  reflect it (the module owns the actual overlay). */
     setEdgeGroupPeeking(group: DockviewGroupPanel, peeking: boolean): void;
-    /** Re-anchor `renderer:'always'` panel overlays over their reference
-     *  containers. The peek reparents a group's content container into the
-     *  slide-out overlay, so the always-rendered content must re-anchor over its
-     *  new (and, during the slide, moving) box. */
-    repositionOverlays(): void;
+    /** Reposition a single `renderer:'always'` panel's overlay over its
+     *  reference container, optionally forcing it visible. The peek reparents a
+     *  group's content container into the slide-out overlay; the always-rendered
+     *  content is NOT reparented (its parent stays constant) — it's re-anchored
+     *  over the moving container and force-shown for the duration of the peek. */
+    repositionPanelOverlay(panel: IDockviewPanel, forceVisible: boolean): void;
 }
 
 export interface IAutoHideEdgeGroupService extends IDisposable {

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -267,9 +267,10 @@ export interface IAutoHideEdgeGroupHost {
     /** Collapse/expand an edge group — the single mutate path (fires
      *  `onDidCollapsedChange`, no-op guarded). */
     setEdgeGroupCollapsed(group: DockviewGroupPanel, collapsed: boolean): void;
-    /** The shared overlay host the slide-out peek mounts on (same stacking
-     *  context as floating groups). */
-    readonly floatingOverlayHost: HTMLElement;
+    /** The element the slide-out peek mounts on — the shell, which is also the
+     *  `OverlayRenderContainer` root, so `always`-rendered content anchors in
+     *  the same coordinate space as the peek. */
+    readonly overlayRoot: HTMLElement;
     /** The size an edge group expands to — sizes the peek overlay. */
     getEdgeGroupExpandedSize(position: EdgeGroupPosition): number;
     /** Record the peek state so `group.api.isPeeking()` / `onDidPeekChange`

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -280,8 +280,18 @@ export interface IAutoHideEdgeGroupHost {
      *  reference container, optionally forcing it visible. The peek reparents a
      *  group's content container into the slide-out overlay; the always-rendered
      *  content is NOT reparented (its parent stays constant) — it's re-anchored
-     *  over the moving container and force-shown for the duration of the peek. */
-    repositionPanelOverlay(panel: IDockviewPanel, forceVisible: boolean): void;
+     *  over the moving container and force-shown for the duration of the peek.
+     *  `clip` (viewport rect) clips the overlay to the peek's reveal window so an
+     *  `always` panel emerges from the strip's inner edge instead of sliding in
+     *  from the screen edge; omit it to clear any clip. */
+    repositionPanelOverlay(
+        panel: IDockviewPanel,
+        forceVisible: boolean,
+        clip?: DOMRect
+    ): void;
+    /** Announce a message to assistive technology via the shared live region
+     *  (no-op when no live-region service / `announcements: false`). */
+    announce(message: string): void;
 }
 
 export interface IAutoHideEdgeGroupService extends IDisposable {

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -272,6 +272,9 @@ export interface IAutoHideEdgeGroupHost {
     readonly floatingOverlayHost: HTMLElement;
     /** The size an edge group expands to — sizes the peek overlay. */
     getEdgeGroupExpandedSize(position: EdgeGroupPosition): number;
+    /** Record the peek state so `group.api.isPeeking()` / `onDidPeekChange`
+     *  reflect it (the module owns the actual overlay). */
+    setEdgeGroupPeeking(group: DockviewGroupPanel, peeking: boolean): void;
 }
 
 export interface IAutoHideEdgeGroupService extends IDisposable {

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -276,6 +276,11 @@ export interface IAutoHideEdgeGroupHost {
     /** Record the peek state so `group.api.isPeeking()` / `onDidPeekChange`
      *  reflect it (the module owns the actual overlay). */
     setEdgeGroupPeeking(group: DockviewGroupPanel, peeking: boolean): void;
+    /** Re-anchor `renderer:'always'` panel overlays over their reference
+     *  containers. The peek reparents a group's content container into the
+     *  slide-out overlay, so the always-rendered content must re-anchor over its
+     *  new (and, during the slide, moving) box. */
+    repositionOverlays(): void;
 }
 
 export interface IAutoHideEdgeGroupService extends IDisposable {

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -23,6 +23,7 @@ import {
     SerializedDockview,
 } from './dockviewComponent';
 import { DockviewWillDropEvent } from './dockviewGroupPanelModel';
+import { EdgeGroupPosition } from './dockviewShell';
 import {
     GroupDragEvent,
     TabDragEvent,
@@ -244,4 +245,33 @@ export interface ILayoutHistoryService extends IDisposable {
     redo(): void;
     /** Drop both stacks (e.g. on document switch). */
     clear(): void;
+}
+
+// --- AutoHideEdgeGroup ---
+
+/**
+ * The narrow surface the auto-hide service needs from the host
+ * (`DockviewComponent`). Collapse/expand is delegated to the existing free
+ * edge-group machinery (`setEdgeGroupCollapsed` → shell) — the module owns
+ * interaction + presentation, never layout/sizing.
+ */
+export interface IAutoHideEdgeGroupHost {
+    readonly options: DockviewComponentOptions;
+    /** Fires when any group is added — the service filters for `location.type === 'edge'`. */
+    readonly onDidAddGroup: Event<DockviewGroupPanel>;
+    readonly onDidRemoveGroup: Event<DockviewGroupPanel>;
+    /** The edge group at a position, or undefined. */
+    getEdgeGroupPanel(
+        position: EdgeGroupPosition
+    ): DockviewGroupPanel | undefined;
+    /** Collapse/expand an edge group — the single mutate path (fires
+     *  `onDidCollapsedChange`, no-op guarded). */
+    setEdgeGroupCollapsed(group: DockviewGroupPanel, collapsed: boolean): void;
+}
+
+export interface IAutoHideEdgeGroupService extends IDisposable {
+    /** Pin (re-dock / expand) the edge group at `position`. */
+    pin(position: EdgeGroupPosition): void;
+    /** Auto-hide (collapse to strip) the edge group at `position`. */
+    autoHide(position: EdgeGroupPosition): void;
 }

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -267,9 +267,16 @@ export interface IAutoHideEdgeGroupHost {
     /** Collapse/expand an edge group — the single mutate path (fires
      *  `onDidCollapsedChange`, no-op guarded). */
     setEdgeGroupCollapsed(group: DockviewGroupPanel, collapsed: boolean): void;
+    /** The shared overlay host the slide-out peek mounts on (same stacking
+     *  context as floating groups). */
+    readonly floatingOverlayHost: HTMLElement;
+    /** The size an edge group expands to — sizes the peek overlay. */
+    getEdgeGroupExpandedSize(position: EdgeGroupPosition): number;
 }
 
 export interface IAutoHideEdgeGroupService extends IDisposable {
+    /** Peek (true) / close (false) the collapsed edge group at `position`. */
+    peek(position: EdgeGroupPosition, peek: boolean): void;
     /** Pin (re-dock / expand) the edge group at `position`. */
     pin(position: EdgeGroupPosition): void;
     /** Auto-hide (collapse to strip) the edge group at `position`. */

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -20,6 +20,7 @@ import { ILiveRegionService } from './liveRegionService';
 import {
     IAccessibilityService,
     IAdvancedDnDService,
+    IAutoHideEdgeGroupService,
     IContextMenuService,
     IKeyboardDockingService,
     ILayoutHistoryService,
@@ -40,6 +41,7 @@ export interface ServiceCollection {
     accessibilityService?: IAccessibilityService;
     keyboardDockingService?: IKeyboardDockingService;
     layoutHistoryService?: ILayoutHistoryService;
+    autoHideEdgeGroupService?: IAutoHideEdgeGroupService;
 }
 
 export interface DockviewModule<THost = unknown> {

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -373,6 +373,12 @@ export interface DockviewOptions {
      */
     layoutHistory?: LayoutHistoryOptions;
     /**
+     * VS Code-style "auto hide" for edge groups: render clickable activators in
+     * a collapsed edge group's strip so it can be pinned back. Off by default →
+     * today's baseline (an empty collapsed strip) is unchanged.
+     */
+    autoHideEdgeGroups?: boolean | AutoHideEdgeGroupOptions;
+    /**
      * Replace the built-in tab group color palette with a user-defined list.
      *
      * Each entry has an `id` (stored on `tabGroup.color` and serialized),
@@ -413,6 +419,12 @@ export interface LayoutHistoryOptions {
     /** Debounce window (ms) for coalescing a continuous resize drag into one
      *  undo entry. Default `400`. */
     coalesceMs?: number;
+}
+
+export interface AutoHideEdgeGroupOptions {
+    /** Show panel icons (where available) alongside the strip activators.
+     *  Default true. */
+    showIcons?: boolean;
 }
 
 export type TabAnimation = 'smooth' | 'default';
@@ -479,6 +491,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         messages: undefined,
         keyboardNavigation: undefined,
         layoutHistory: undefined,
+        autoHideEdgeGroups: undefined,
         tabGroupColors: undefined,
         tabGroupAccent: undefined,
     };

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -422,10 +422,7 @@ export interface LayoutHistoryOptions {
 }
 
 export interface AutoHideEdgeGroupOptions {
-    /** Show panel icons (where available) alongside the strip activators.
-     *  Default true. */
-    showIcons?: boolean;
-    /** ms the pointer must dwell on a strip activator before the peek opens.
+    /** ms the pointer must dwell on the collapsed strip before the peek opens.
      *  Default 250. Keyboard focus opens immediately (no delay). */
     openDelay?: number;
     /** ms after the pointer leaves both the strip and the peek overlay before

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -425,6 +425,12 @@ export interface AutoHideEdgeGroupOptions {
     /** Show panel icons (where available) alongside the strip activators.
      *  Default true. */
     showIcons?: boolean;
+    /** ms the pointer must dwell on a strip activator before the peek opens.
+     *  Default 250. Keyboard focus opens immediately (no delay). */
+    openDelay?: number;
+    /** ms after the pointer leaves both the strip and the peek overlay before
+     *  the peek closes. Re-entering either cancels it. Default 300. */
+    closeDelay?: number;
 }
 
 export type TabAnimation = 'smooth' | 'default';

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -431,6 +431,9 @@ export interface AutoHideEdgeGroupOptions {
     /** ms after the pointer leaves both the strip and the peek overlay before
      *  the peek closes. Re-entering either cancels it. Default 300. */
     closeDelay?: number;
+    /** Slide the peek overlay in. Default true; ignored when the OS requests
+     *  reduced motion. */
+    animate?: boolean;
 }
 
 export type TabAnimation = 'smooth' | 'default';

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -547,3 +547,35 @@ export function findRelativeZIndexParent(el: HTMLElement): HTMLElement | null {
 
     return tmp;
 }
+
+/** Whether the user has requested reduced motion — the JS counterpart to the
+ *  `prefers-reduced-motion` media query, for animations driven in script. */
+export function prefersReducedMotion(doc: Document = document): boolean {
+    const mq = doc.defaultView?.matchMedia?.(
+        '(prefers-reduced-motion: reduce)'
+    );
+    return !!mq?.matches;
+}
+
+/** The first opaque computed background colour walking up from `element` (the
+ *  element itself, then its ancestors). Use to give a floating/overlapping
+ *  surface a non-see-through backdrop derived from the live DOM. Returns `''`
+ *  when nothing opaque is found (let the stylesheet decide). */
+export function resolveOpaqueBackground(element: HTMLElement): string {
+    const win = element.ownerDocument.defaultView;
+    if (!win) {
+        return '';
+    }
+    let el: HTMLElement | null = element;
+    while (el) {
+        const bg = win.getComputedStyle(el).backgroundColor;
+        // Skip `transparent` and any fully-transparent colour — a computed
+        // `rgba(…, 0)` (e.g. `rgba(255,255,255,0)`) is see-through regardless of
+        // its RGB, so it isn't an opaque backdrop.
+        if (bg && bg !== 'transparent' && !/,\s*0\)\s*$/.test(bg)) {
+            return bg;
+        }
+        el = el.parentElement;
+    }
+    return '';
+}

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -194,6 +194,8 @@ export {
     IAccessibilityService,
     IAdvancedDnDHost,
     IAdvancedDnDService,
+    IAutoHideEdgeGroupHost,
+    IAutoHideEdgeGroupService,
     IContextMenuHost,
     IContextMenuService,
     IKeyboardDockingService,
@@ -208,3 +210,4 @@ export { resolveMessages } from './dockview/accessibilityMessages';
 export { findRelativeZIndexParent } from './dom';
 export { IDragGhostSpec } from './dnd/backend';
 export { LiveRegionModule } from './dockview/liveRegionService';
+export { EdgeGroupModule } from './dockview/edgeGroupService';

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -208,7 +208,16 @@ export {
     ITabGroupChipsService,
 } from './dockview/moduleContracts';
 export { resolveMessages } from './dockview/accessibilityMessages';
-export { findRelativeZIndexParent } from './dom';
+export {
+    findRelativeZIndexParent,
+    prefersReducedMotion,
+    resolveOpaqueBackground,
+} from './dom';
+export {
+    createDismissableLayer,
+    DismissableLayerOptions,
+} from './dismissableLayer';
 export { IDragGhostSpec } from './dnd/backend';
 export { LiveRegionModule } from './dockview/liveRegionService';
 export { EdgeGroupModule } from './dockview/edgeGroupService';
+export { createCloseButton, createPinButton } from './svg';

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -163,6 +163,7 @@ export {
     DockviewGroupPanelApi,
     DockviewGroupPanelLocationChangeEvent,
     DockviewGroupPanelCollapsedChangeEvent,
+    DockviewGroupPanelPeekChangeEvent,
     DockviewGroupMoveParams,
 } from './api/dockviewGroupPanelApi';
 export {

--- a/packages/dockview-core/src/overlay/overlay.scss
+++ b/packages/dockview-core/src/overlay/overlay.scss
@@ -34,6 +34,43 @@
     }
 }
 
+// Auto-hide edge group "peek": the active panel slid out over the content.
+.dv-edge-peek {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--dv-group-view-background-color);
+    border: 1px solid var(--dv-separator-border);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+
+    > .dv-edge-peek-header {
+        display: flex;
+        justify-content: flex-end;
+        flex-shrink: 0;
+        padding: 2px;
+    }
+
+    // the reparented panel content fills the rest of the overlay
+    > :not(.dv-edge-peek-header) {
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow: auto;
+    }
+
+    .dv-edge-peek-pin {
+        cursor: pointer;
+        border: none;
+        border-radius: 3px;
+        padding: 2px 8px;
+        font-size: 11px;
+        color: var(--dv-activegroup-visiblepanel-tab-color);
+        background-color: transparent;
+
+        &:hover {
+            background-color: var(--dv-icon-hover-background-color);
+        }
+    }
+}
+
 // A floating window hosts its own gridview as the overlay content; it must
 // fill the resize container so its size tracks the overlay box.
 .dv-resize-container > .dv-grid-view {

--- a/packages/dockview-core/src/overlay/overlay.scss
+++ b/packages/dockview-core/src/overlay/overlay.scss
@@ -34,40 +34,44 @@
     }
 }
 
-// Auto-hide edge group "peek": the active panel slid out over the content.
+// Auto-hide edge group "peek": the active panel slid out over the content. The
+// backdrop, the peeked content, and the Pin header are three separate sibling
+// overlays (the `always` render overlay can't be nested), layered by z-index.
 .dv-edge-peek {
-    display: flex;
-    flex-direction: column;
     background-color: var(--dv-group-view-background-color);
     border: 1px solid var(--dv-separator-border);
     box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
 
-    > .dv-edge-peek-header {
-        display: flex;
-        justify-content: flex-end;
-        flex-shrink: 0;
-        padding: 2px;
-    }
-
-    // the reparented panel content fills the rest of the overlay
-    > :not(.dv-edge-peek-header) {
-        flex: 1 1 auto;
-        min-height: 0;
+    // the reparented content container fills the backdrop
+    > * {
+        width: 100%;
+        height: 100%;
         overflow: auto;
     }
+}
 
-    .dv-edge-peek-pin {
-        cursor: pointer;
-        border: none;
-        border-radius: 3px;
-        padding: 2px 8px;
-        font-size: 11px;
-        color: var(--dv-activegroup-visiblepanel-tab-color);
-        background-color: transparent;
+// The Pin header is a sibling overlay so it can sit above an `always` panel's
+// render overlay; click-through except for the button itself.
+.dv-edge-peek-header {
+    display: flex;
+    justify-content: flex-end;
+    align-items: flex-start;
+    padding: 4px;
+    pointer-events: none;
+}
 
-        &:hover {
-            background-color: var(--dv-icon-hover-background-color);
-        }
+.dv-edge-peek-pin {
+    pointer-events: auto;
+    cursor: pointer;
+    border: 1px solid var(--dv-separator-border);
+    border-radius: 3px;
+    padding: 2px 8px;
+    font-size: 11px;
+    color: var(--dv-activegroup-visiblepanel-tab-color);
+    background-color: var(--dv-group-view-background-color);
+
+    &:hover {
+        background-color: var(--dv-icon-hover-background-color);
     }
 }
 

--- a/packages/dockview-core/src/overlay/overlay.scss
+++ b/packages/dockview-core/src/overlay/overlay.scss
@@ -50,28 +50,60 @@
     }
 }
 
-// The Pin header is a sibling overlay so it can sit above an `always` panel's
-// render overlay; click-through except for the button itself.
+// The title bar is a sibling overlay so it can sit above an `always` panel's
+// render overlay. It occupies the top band of the peek (the content is inset
+// below it), with the panel title to the left and pin + close to the right.
 .dv-edge-peek-header {
     display: flex;
-    justify-content: flex-end;
-    align-items: flex-start;
-    padding: 4px;
-    pointer-events: none;
+    align-items: center;
+    gap: 4px;
+    padding: 0 4px 0 8px;
+    box-sizing: border-box;
+    background-color: var(--dv-group-view-background-color);
+    border: 1px solid var(--dv-separator-border);
+    border-bottom: none;
+    color: var(--dv-activegroup-visiblepanel-tab-color);
+    font-size: 12px;
 }
 
-.dv-edge-peek-pin {
-    pointer-events: auto;
-    cursor: pointer;
-    border: 1px solid var(--dv-separator-border);
-    border-radius: 3px;
-    padding: 2px 8px;
-    font-size: 11px;
-    color: var(--dv-activegroup-visiblepanel-tab-color);
-    background-color: var(--dv-group-view-background-color);
+.dv-edge-peek-title {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 
-    &:hover {
-        background-color: var(--dv-icon-hover-background-color);
+// Nested under the header so the two-class selector (specificity 0,2,0) wins
+// over broad app `button {}` rules (e.g. `.app button`, 0,1,1) that would
+// otherwise paint a border/outline on the chrome icons.
+.dv-edge-peek-header {
+    // Behave like the tab close icon: borderless, monotone, with a hover
+    // background highlight.
+    .dv-edge-peek-pin,
+    .dv-edge-peek-close {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        cursor: pointer;
+        border: none;
+        padding: 4px;
+        color: inherit;
+        background: transparent;
+        outline: none;
+
+        &:hover {
+            border-radius: 2px;
+            background-color: var(--dv-icon-hover-background-color);
+        }
+
+        // Keyboard-only focus ring (suppressed on mouse click).
+        &:focus-visible {
+            border-radius: 2px;
+            outline: 1px solid var(--dv-tab-divider-color);
+            outline-offset: -1px;
+        }
     }
 }
 

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -72,7 +72,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
             disposable: IDisposable;
             destroy: IDisposable;
             element: HTMLElement;
-            resize?: () => void;
+            resize?: (forceVisible?: boolean) => void;
         }
     > = {};
 
@@ -111,6 +111,21 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 entry.resize();
             }
         }
+    }
+
+    /**
+     * Reposition a single panel's overlay over its reference container,
+     * optionally forcing it visible even when the panel is not currently
+     * "visible" (e.g. its group is collapsed). Used by the auto-hide peek to
+     * slide an `always`-rendered panel out without reparenting it or mutating
+     * the panel's visibility state. No-op if the panel isn't overlay-rendered.
+     */
+    repositionPanelOverlay(panelId: string, forceVisible = false): void {
+        if (this._disposed) {
+            return;
+        }
+        this.positionCache.invalidate();
+        this.map[panelId]?.resize?.(forceVisible);
     }
 
     detatch(panel: IDockviewPanel): boolean {
@@ -163,7 +178,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
             this.element.appendChild(focusContainer);
         }
 
-        const resize = () => {
+        const resize = (forceVisible = false) => {
             const panelId = panel.api.id;
 
             if (this.pendingUpdates.has(panelId)) {
@@ -201,7 +216,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 // leave a hidden panel visually visible at a stale position,
                 // because onDidDimensionsChange skips non-visible panels and
                 // never recomputes their box on subsequent resizes.
-                if (panel.api.isVisible) {
+                if (panel.api.isVisible || forceVisible) {
                     focusContainer.style.visibility = '';
                     focusContainer.style.pointerEvents = '';
                 } else {

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -72,7 +72,12 @@ export class OverlayRenderContainer extends CompositeDisposable {
             disposable: IDisposable;
             destroy: IDisposable;
             element: HTMLElement;
-            resize?: (forceVisible?: boolean) => void;
+            resize?: () => void;
+            /** Sticky peek state (set via `repositionPanelOverlay`): force the
+             *  overlay visible despite the panel being collapsed, and clip it to
+             *  the peek's reveal window. Preserved across internal resizes. */
+            forceVisible?: boolean;
+            clip?: DOMRect;
         }
     > = {};
 
@@ -120,12 +125,24 @@ export class OverlayRenderContainer extends CompositeDisposable {
      * slide an `always`-rendered panel out without reparenting it or mutating
      * the panel's visibility state. No-op if the panel isn't overlay-rendered.
      */
-    repositionPanelOverlay(panelId: string, forceVisible = false): void {
+    repositionPanelOverlay(
+        panelId: string,
+        forceVisible = false,
+        clip?: DOMRect
+    ): void {
         if (this._disposed) {
             return;
         }
+        const entry = this.map[panelId];
+        if (!entry) {
+            return;
+        }
+        // Set the sticky peek state, then reposition; `resize()` reads it back
+        // so it survives any concurrent internal resize.
+        entry.forceVisible = forceVisible;
+        entry.clip = clip;
         this.positionCache.invalidate();
-        this.map[panelId]?.resize?.(forceVisible);
+        entry.resize?.();
     }
 
     detatch(panel: IDockviewPanel): boolean {
@@ -178,7 +195,7 @@ export class OverlayRenderContainer extends CompositeDisposable {
             this.element.appendChild(focusContainer);
         }
 
-        const resize = (forceVisible = false) => {
+        const resize = () => {
             const panelId = panel.api.id;
 
             if (this.pendingUpdates.has(panelId)) {
@@ -190,9 +207,18 @@ export class OverlayRenderContainer extends CompositeDisposable {
             requestAnimationFrame(() => {
                 this.pendingUpdates.delete(panelId);
 
-                if (this.isDisposed || !this.map[panelId]) {
+                const entry = this.map[panelId];
+                if (this.isDisposed || !entry) {
                     return;
                 }
+                // `forceVisible` / `clip` are sticky per-panel state owned by
+                // the peek (set via `repositionPanelOverlay`). Read them at paint
+                // time so an unrelated `resize()` (visibility / layout) can't
+                // clobber a force-shown, clipped peek panel back to hidden — a
+                // peeked panel's `isVisible` is false (its group is collapsed),
+                // so without the sticky force it would render nothing.
+                const forceVisible = entry.forceVisible ?? false;
+                const clip = entry.clip;
 
                 const box = this.positionCache.getPosition(
                     referenceContainer.element
@@ -227,6 +253,33 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 // the peek's own (opaque) backdrop so the content is visible;
                 // otherwise leave the default stacking.
                 focusContainer.style.zIndex = forceVisible ? '1000' : '';
+
+                // Clip to the peek's reveal window so an `always` panel emerges
+                // from the strip's inner edge as the container slides, rather
+                // than appearing on the dock side of it. `box` is in page
+                // coordinates (`getDomNodePagePosition`) but `clip` is a
+                // viewport rect, so shift it by the scroll offset before taking
+                // the inset (otherwise the clip is wrong in a scrolled document).
+                if (clip) {
+                    const view = this.element.ownerDocument.defaultView;
+                    const sx = view?.scrollX ?? 0;
+                    const sy = view?.scrollY ?? 0;
+                    const top = clip.top + sy;
+                    const left = clip.left + sx;
+                    const insetTop = Math.max(0, top - box.top);
+                    const insetLeft = Math.max(0, left - box.left);
+                    const insetRight = Math.max(
+                        0,
+                        box.left + width - (clip.right + sx)
+                    );
+                    const insetBottom = Math.max(
+                        0,
+                        box.top + height - (clip.bottom + sy)
+                    );
+                    focusContainer.style.clipPath = `inset(${insetTop}px ${insetRight}px ${insetBottom}px ${insetLeft}px)`;
+                } else {
+                    focusContainer.style.clipPath = '';
+                }
 
                 toggleClass(
                     focusContainer,

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -223,6 +223,10 @@ export class OverlayRenderContainer extends CompositeDisposable {
                     focusContainer.style.visibility = 'hidden';
                     focusContainer.style.pointerEvents = 'none';
                 }
+                // When force-shown for an auto-hide peek, lift the overlay above
+                // the peek's own (opaque) backdrop so the content is visible;
+                // otherwise leave the default stacking.
+                focusContainer.style.zIndex = forceVisible ? '1000' : '';
 
                 toggleClass(
                     focusContainer,

--- a/packages/dockview-core/src/svg.ts
+++ b/packages/dockview-core/src/svg.ts
@@ -25,6 +25,14 @@ export const createCloseButton = (): SVGSVGElement =>
         path: 'M2.1 27.3L0 25.2L11.55 13.65L0 2.1L2.1 0L13.65 11.55L25.2 0L27.3 2.1L15.75 13.65L27.3 25.2L25.2 27.3L13.65 15.75L2.1 27.3Z',
     });
 
+export const createPinButton = (): SVGSVGElement =>
+    createSvgElementFromPath({
+        width: '11',
+        height: '11',
+        viewbox: '0 0 24 24',
+        path: 'M16 9V4h1c.55 0 1-.45 1-1s-.45-1-1-1H6c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3z',
+    });
+
 export const createExpandMoreButton = (): SVGSVGElement =>
     createSvgElementFromPath({
         width: '11',

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -148,6 +148,28 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
+    test('group.api.isPeeking + onDidPeekChange reflect the peek', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+        const api = d.getEdgeGroup('left')!;
+        const events: boolean[] = [];
+        const sub = api.onDidPeekChange((e) => events.push(e.isPeeking));
+
+        expect(api.isPeeking()).toBe(false);
+
+        activators()[0].click();
+        expect(api.isPeeking()).toBe(true);
+
+        document.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+        expect(api.isPeeking()).toBe(false);
+        expect(events).toEqual([true, false]);
+
+        sub.dispose();
+        d.dispose();
+    });
+
     test('the strip tracks panel add/remove while collapsed', () => {
         const d = make(true);
         collapsedEdgeWithPanel(d, 'A');

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -1,0 +1,136 @@
+import { DockviewComponent } from 'dockview-core';
+import { IContentRenderer } from 'dockview-core';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+/**
+ * Auto-hide edge groups (Phase 1) — a collapsed edge group renders clickable
+ * activators in its strip; clicking one pins (expands) the group. Opt-in via
+ * `autoHideEdgeGroups`; off → today's baseline (empty strip) is unchanged.
+ */
+describe('auto-hide edge groups', () => {
+    let container: HTMLElement;
+
+    const make = (
+        autoHideEdgeGroups: DockviewComponent['options']['autoHideEdgeGroups']
+    ): DockviewComponent => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            autoHideEdgeGroups,
+        });
+        dockview.layout(1000, 1000);
+        return dockview;
+    };
+
+    /** Add a left edge group with one panel, then collapse it. */
+    const collapsedEdgeWithPanel = (
+        dockview: DockviewComponent,
+        title = 'Explorer'
+    ): void => {
+        dockview.addEdgeGroup('left', { id: 'edge-left', initialSize: 200 });
+        dockview.addPanel({
+            id: 'p1',
+            component: 'default',
+            title,
+            position: { referenceGroup: 'edge-left', direction: 'within' },
+        });
+        dockview.autoHideEdgeGroup('left');
+    };
+
+    const activators = (): HTMLElement[] =>
+        Array.from(
+            container.querySelectorAll('.dv-edge-activator')
+        ) as HTMLElement[];
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    test('renders an activator per panel when the edge group is collapsed', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d, 'Explorer');
+
+        expect(d.getEdgeGroup('left')!.isCollapsed()).toBe(true);
+        const buttons = activators();
+        expect(buttons.length).toBe(1);
+        expect(buttons[0].textContent).toBe('Explorer');
+
+        d.dispose();
+    });
+
+    test('clicking an activator pins (expands) the group and clears the strip', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+        expect(activators().length).toBe(1);
+
+        activators()[0].click();
+
+        expect(d.getEdgeGroup('left')!.isCollapsed()).toBe(false);
+        expect(activators().length).toBe(0);
+
+        d.dispose();
+    });
+
+    test('api.pinEdgeGroup / autoHideEdgeGroup toggle the strip', () => {
+        const d = make(true);
+        d.addEdgeGroup('left', { id: 'edge-left', initialSize: 200 });
+        d.addPanel({
+            id: 'p1',
+            component: 'default',
+            title: 'Output',
+            position: { referenceGroup: 'edge-left', direction: 'within' },
+        });
+
+        d.api.autoHideEdgeGroup('left');
+        expect(activators().length).toBe(1);
+
+        d.api.pinEdgeGroup('left');
+        expect(activators().length).toBe(0);
+        expect(d.getEdgeGroup('left')!.isCollapsed()).toBe(false);
+
+        d.dispose();
+    });
+
+    test('the strip tracks panel add/remove while collapsed', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d, 'A');
+        expect(activators().length).toBe(1);
+
+        d.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'B',
+            position: { referenceGroup: 'edge-left', direction: 'within' },
+        });
+        expect(
+            activators()
+                .map((b) => b.textContent)
+                .sort()
+        ).toEqual(['A', 'B']);
+
+        d.dispose();
+    });
+
+    test('off (default): a collapsed edge group renders no activators', () => {
+        const d = make(undefined);
+        collapsedEdgeWithPanel(d);
+
+        expect(d.getEdgeGroup('left')!.isCollapsed()).toBe(true);
+        expect(activators().length).toBe(0); // baseline strip untouched
+
+        d.dispose();
+    });
+});

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -188,12 +188,14 @@ describe('auto-hide edge groups', () => {
             d.dispose();
         });
 
-        test('focus opens immediately', () => {
+        test('focus opens (deferred out of the focus event)', () => {
             const d = make({ openDelay: 100, closeDelay: 100 });
             collapsedEdgeWithPanel(d);
             jest.useFakeTimers();
 
             fireEvent.focusIn(strip(d));
+            expect(peek()).toBeNull(); // scheduled, not synchronous
+            jest.advanceTimersByTime(0);
             expect(peek()).toBeTruthy();
 
             d.dispose();

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -366,6 +366,57 @@ describe('auto-hide edge groups', () => {
             d.dispose();
         });
 
+        test('focus landing outside the peek closes it (keyboard tab-away)', () => {
+            const d = make(true);
+            collapsedEdgeWithPanel(d);
+            d.api.peekEdgeGroup('left', true);
+            expect(peek()).toBeTruthy();
+
+            // the strip is the keep-open region (peek/header rects stay 0×0)
+            jest.spyOn(strip(d), 'getBoundingClientRect').mockReturnValue({
+                left: 0,
+                top: 0,
+                right: 40,
+                bottom: 600,
+                width: 40,
+                height: 600,
+                x: 0,
+                y: 0,
+                toJSON() {},
+            } as DOMRect);
+
+            const mkAt = (cx: number, cy: number): HTMLElement => {
+                const el = document.createElement('button');
+                document.body.appendChild(el);
+                jest.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+                    left: cx - 5,
+                    top: cy - 5,
+                    right: cx + 5,
+                    bottom: cy + 5,
+                    width: 10,
+                    height: 10,
+                    x: cx - 5,
+                    y: cy - 5,
+                    toJSON() {},
+                } as DOMRect);
+                return el;
+            };
+
+            // focus inside the region → stays open
+            const inside = mkAt(20, 300);
+            inside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+            expect(peek()).toBeTruthy();
+
+            // focus outside → closes
+            const outside = mkAt(500, 500);
+            outside.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+            expect(peek()).toBeNull();
+
+            inside.remove();
+            outside.remove();
+            d.dispose();
+        });
+
         test('announces the panel when peeked and when pinned', () => {
             const messages: string[] = [];
             const d = make(true, {

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -19,22 +19,24 @@ class TestPanel implements IContentRenderer {
 }
 
 /**
- * Auto-hide edge groups. A collapsed edge group's native tabs are the peek
- * triggers (hover/focus/click) — no parallel strip. Peeking slides the active
- * panel out as a non-reflowing overlay; a pin button re-docks; Esc / leave /
- * focus-out close. Opt-in via `autoHideEdgeGroups`.
+ * Auto-hide ("pinnable") edge groups — VS tool-window model. A collapsed edge
+ * group's native tabs are CLICK triggers (no hover): click a tab → peek it as a
+ * non-reflowing overlay with a title bar (title + pin + close); click it again /
+ * outside / Esc → hide; pin → dock; close → close the panel.
  */
 describe('auto-hide edge groups', () => {
     let container: HTMLElement;
 
     const make = (
-        autoHideEdgeGroups: DockviewComponent['options']['autoHideEdgeGroups']
+        autoHideEdgeGroups: DockviewComponent['options']['autoHideEdgeGroups'],
+        extra: Partial<DockviewComponent['options']> = {}
     ): DockviewComponent => {
         container = document.createElement('div');
         document.body.appendChild(container);
         const dockview = new DockviewComponent(container, {
             createComponent: () => new TestPanel(),
             autoHideEdgeGroups,
+            ...extra,
         });
         dockview.layout(1000, 1000);
         return dockview;
@@ -60,6 +62,8 @@ describe('auto-hide edge groups', () => {
         d.getEdgeGroup('left')!.isCollapsed();
     const strip = (d: DockviewComponent): HTMLElement =>
         d.getEdgeGroupPanel('left')!.element;
+    const tabs = (d: DockviewComponent): HTMLElement[] =>
+        Array.from(strip(d).querySelectorAll('.dv-tab'));
 
     afterEach(() => {
         container.remove();
@@ -77,7 +81,37 @@ describe('auto-hide edge groups', () => {
 
         d.api.peekEdgeGroup('left', false);
         expect(peek()).toBeNull();
-        expect(strip(d).querySelector('.dv-test-content')).toBeTruthy(); // content restored
+        expect(strip(d).querySelector('.dv-test-content')).toBeTruthy();
+
+        d.dispose();
+    });
+
+    test('clicking a tab peeks it; clicking it again hides it (no reflow)', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+
+        fireEvent.click(tabs(d)[0]);
+        expect(peek()).toBeTruthy();
+        expect(collapsed(d)).toBe(true); // native expand suppressed
+
+        fireEvent.click(tabs(d)[0]);
+        expect(peek()).toBeNull();
+        expect(collapsed(d)).toBe(true);
+
+        d.dispose();
+    });
+
+    test('the peek has a title bar with the title, a pin and a close button', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d, 'Explorer');
+        d.api.peekEdgeGroup('left', true);
+
+        const title = container.querySelector('.dv-edge-peek-title');
+        const pin = container.querySelector('.dv-edge-peek-pin');
+        const close = container.querySelector('.dv-edge-peek-close');
+        expect(title?.textContent).toBe('Explorer');
+        expect(pin?.getAttribute('aria-label')).toBe('Pin');
+        expect(close?.getAttribute('aria-label')).toBe('Close');
 
         d.dispose();
     });
@@ -87,12 +121,23 @@ describe('auto-hide edge groups', () => {
         collapsedEdgeWithPanel(d);
         d.api.peekEdgeGroup('left', true);
 
-        // the Pin button is a separate sibling overlay (so it can layer above an
-        // `always` render overlay), not a child of the peek element.
         (container.querySelector('.dv-edge-peek-pin') as HTMLElement).click();
 
         expect(collapsed(d)).toBe(false);
         expect(peek()).toBeNull();
+
+        d.dispose();
+    });
+
+    test('the close button closes the panel and removes the peek', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+        d.api.peekEdgeGroup('left', true);
+
+        (container.querySelector('.dv-edge-peek-close') as HTMLElement).click();
+
+        expect(peek()).toBeNull();
+        expect(d.panels.find((p) => p.id === 'p1')).toBeUndefined();
 
         d.dispose();
     });
@@ -110,6 +155,35 @@ describe('auto-hide edge groups', () => {
         expect(peek()).toBeNull();
         expect(collapsed(d)).toBe(true);
         expect(strip(d).querySelector('.dv-test-content')).toBeTruthy();
+
+        d.dispose();
+    });
+
+    test('clicking outside hides; clicking empty strip space does not', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+        d.api.peekEdgeGroup('left', true);
+
+        // give the strip a real box; the peek/overlay rects stay 0×0 at origin
+        jest.spyOn(strip(d), 'getBoundingClientRect').mockReturnValue({
+            left: 0,
+            top: 0,
+            right: 40,
+            bottom: 600,
+            width: 40,
+            height: 600,
+            x: 0,
+            y: 0,
+            toJSON() {},
+        } as DOMRect);
+
+        // pointer-down on empty strip space → stays open
+        fireEvent.pointerDown(document, { clientX: 20, clientY: 300 });
+        expect(peek()).toBeTruthy();
+
+        // pointer-down outside the strip + peek → hides
+        fireEvent.pointerDown(document, { clientX: 500, clientY: 300 });
+        expect(peek()).toBeNull();
 
         d.dispose();
     });
@@ -132,10 +206,43 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
+    test('clicking a different tab switches the peeked panel and retitles', () => {
+        const d = make(true);
+        d.addEdgeGroup('left', { id: 'edge-left', initialSize: 200 });
+        const p1 = d.addPanel({
+            id: 'p1',
+            component: 'default',
+            title: 'One',
+            position: { referenceGroup: 'edge-left', direction: 'within' },
+        });
+        d.addPanel({
+            id: 'p2',
+            component: 'default',
+            title: 'Two',
+            position: { referenceGroup: 'edge-left', direction: 'within' },
+        });
+        p1.api.setActive();
+        d.autoHideEdgeGroup('left');
+
+        fireEvent.click(tabs(d)[0]); // peek One
+        expect(peek()).toBeTruthy();
+        expect(
+            container.querySelector('.dv-edge-peek-title')?.textContent
+        ).toBe('One');
+
+        fireEvent.click(tabs(d)[1]); // switch to Two
+        expect(peek()).toBeTruthy();
+        expect(d.getEdgeGroupPanel('left')!.activePanel!.id).toBe('p2');
+        expect(
+            container.querySelector('.dv-edge-peek-title')?.textContent
+        ).toBe('Two');
+
+        d.dispose();
+    });
+
     test('the peek gets an opaque background so it is never see-through', () => {
         const d = make(true);
         collapsedEdgeWithPanel(d);
-        // simulate a themed group background (the floating peek must inherit it)
         strip(d).style.backgroundColor = 'rgb(10, 20, 30)';
 
         d.api.peekEdgeGroup('left', true);
@@ -155,66 +262,124 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
-    describe('hover / focus triggers', () => {
-        afterEach(() => jest.useRealTimers());
+    describe('docked (pinned) tool-window chrome', () => {
+        test('pinning renders a docked title bar and moves tabs to the bottom', () => {
+            const d = make(true);
+            collapsedEdgeWithPanel(d, 'Explorer');
+            expect(collapsed(d)).toBe(true);
 
-        test('hover (pointerenter) opens after openDelay', () => {
-            const d = make({ openDelay: 100, closeDelay: 100 });
-            collapsedEdgeWithPanel(d);
-            jest.useFakeTimers();
+            // pin (expand)
+            d.api.peekEdgeGroup('left', true);
+            (
+                container.querySelector('.dv-edge-peek-pin') as HTMLElement
+            ).click();
+            expect(collapsed(d)).toBe(false);
 
-            fireEvent.pointerEnter(strip(d));
-            jest.advanceTimersByTime(99);
-            expect(peek()).toBeNull();
-            jest.advanceTimersByTime(1);
-            expect(peek()).toBeTruthy();
+            // docked chrome: a title bar inside the group + header at the bottom
+            const bar = strip(d).querySelector(
+                '.dv-edge-peek-header'
+            ) as HTMLElement;
+            expect(bar).toBeTruthy();
+            expect(bar.querySelector('.dv-edge-peek-title')?.textContent).toBe(
+                'Explorer'
+            );
+            expect(d.getEdgeGroupPanel('left')!.api.getHeaderPosition()).toBe(
+                'bottom'
+            );
 
             d.dispose();
         });
 
-        test('leaving the strip closes after closeDelay', () => {
-            const d = make({ openDelay: 100, closeDelay: 100 });
+        test('auto-hiding (docked pin) removes the chrome and restores the strip orientation', () => {
+            const d = make(true);
+            collapsedEdgeWithPanel(d, 'Explorer');
+            d.api.peekEdgeGroup('left', true);
+            (
+                container.querySelector('.dv-edge-peek-pin') as HTMLElement
+            ).click(); // dock
+            expect(collapsed(d)).toBe(false);
+
+            // the docked pushpin auto-hides
+            (
+                strip(d).querySelector('.dv-edge-peek-pin') as HTMLElement
+            ).click();
+
+            expect(collapsed(d)).toBe(true);
+            expect(strip(d).querySelector('.dv-edge-peek-header')).toBeNull();
+            // strip orientation restored to the edge position
+            expect(d.getEdgeGroupPanel('left')!.api.getHeaderPosition()).toBe(
+                'left'
+            );
+
+            d.dispose();
+        });
+
+        test('the docked close button closes the active panel', () => {
+            const d = make(true);
             collapsedEdgeWithPanel(d);
             d.api.peekEdgeGroup('left', true);
-            jest.useFakeTimers();
+            (
+                container.querySelector('.dv-edge-peek-pin') as HTMLElement
+            ).click(); // dock
 
-            fireEvent.pointerLeave(strip(d));
-            jest.advanceTimersByTime(99);
+            (
+                strip(d).querySelector('.dv-edge-peek-close') as HTMLElement
+            ).click();
+            expect(d.panels.find((p) => p.id === 'p1')).toBeUndefined();
+
+            d.dispose();
+        });
+    });
+
+    describe('accessibility', () => {
+        test('Enter on a focused tab toggles the peek (focus into content)', () => {
+            const d = make(true);
+            collapsedEdgeWithPanel(d);
+            const tab = tabs(d)[0];
+            tab.focus();
+
+            fireEvent.keyDown(tab, { key: 'Enter' });
             expect(peek()).toBeTruthy();
-            jest.advanceTimersByTime(1);
+            expect(peek()!.contains(document.activeElement)).toBe(true);
+
+            fireEvent.keyDown(tab, { key: 'Enter' });
             expect(peek()).toBeNull();
 
             d.dispose();
         });
 
-        test('pointer over the peek region cancels the close (no flicker)', () => {
-            const d = make({ openDelay: 100, closeDelay: 100 });
+        test('Escape returns focus to the tab', () => {
+            const d = make(true);
             collapsedEdgeWithPanel(d);
-            d.api.peekEdgeGroup('left', true);
-            jest.useFakeTimers();
+            const tab = tabs(d)[0];
+            tab.focus();
+            fireEvent.keyDown(tab, { key: 'Enter' });
+            expect(peek()!.contains(document.activeElement)).toBe(true);
 
-            // leaving the strip schedules a close...
-            fireEvent.pointerLeave(strip(d));
-            // ...but a pointermove within the peek box cancels it. Keep-open is
-            // geometry-based (the peeked content may be a sibling overlay on
-            // top); in jsdom all rects are 0×0 at the origin, so (0,0) is
-            // "within" and a non-zero point is "outside".
-            fireEvent.pointerMove(document, { clientX: 0, clientY: 0 });
-            jest.advanceTimersByTime(1000);
-            expect(peek()).toBeTruthy();
+            document.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+            );
+
+            expect(peek()).toBeNull();
+            expect(document.activeElement).toBe(tab);
 
             d.dispose();
         });
 
-        test('focus opens (deferred out of the focus event)', () => {
-            const d = make({ openDelay: 100, closeDelay: 100 });
-            collapsedEdgeWithPanel(d);
-            jest.useFakeTimers();
+        test('announces the panel when peeked and when pinned', () => {
+            const messages: string[] = [];
+            const d = make(true, {
+                announcer: (e) => messages.push(e.message),
+            });
+            collapsedEdgeWithPanel(d, 'Explorer');
 
-            fireEvent.focusIn(strip(d));
-            expect(peek()).toBeNull(); // scheduled, not synchronous
-            jest.advanceTimersByTime(0);
-            expect(peek()).toBeTruthy();
+            d.api.peekEdgeGroup('left', true);
+            expect(messages).toContain('Explorer shown');
+
+            (
+                container.querySelector('.dv-edge-peek-pin') as HTMLElement
+            ).click();
+            expect(messages).toContain('Explorer pinned');
 
             d.dispose();
         });

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/dom';
 import { DockviewComponent } from 'dockview-core';
 import { IContentRenderer } from 'dockview-core';
 
@@ -177,5 +178,71 @@ describe('auto-hide edge groups', () => {
         expect(peek()).toBeNull();
 
         d.dispose();
+    });
+
+    describe('hover / focus peek (Phase 3)', () => {
+        const strip = (d: DockviewComponent): HTMLElement =>
+            d.getEdgeGroupPanel('left')!.element;
+
+        afterEach(() => jest.useRealTimers());
+
+        test('hover opens the peek after openDelay', () => {
+            const d = make({ openDelay: 100, closeDelay: 100 });
+            collapsedEdgeWithPanel(d);
+            jest.useFakeTimers();
+
+            fireEvent.pointerEnter(activators()[0]);
+            jest.advanceTimersByTime(99);
+            expect(peek()).toBeNull(); // not yet
+
+            jest.advanceTimersByTime(1);
+            expect(peek()).toBeTruthy(); // openDelay elapsed
+
+            d.dispose();
+        });
+
+        test('leaving the strip closes the peek after closeDelay', () => {
+            const d = make({ openDelay: 100, closeDelay: 100 });
+            collapsedEdgeWithPanel(d);
+            activators()[0].click(); // open immediately
+            expect(peek()).toBeTruthy();
+            jest.useFakeTimers();
+
+            fireEvent.pointerLeave(strip(d));
+            jest.advanceTimersByTime(99);
+            expect(peek()).toBeTruthy(); // still open within the window
+
+            jest.advanceTimersByTime(1);
+            expect(peek()).toBeNull(); // closed
+
+            d.dispose();
+        });
+
+        test('re-entering the overlay cancels the close (no flicker)', () => {
+            const d = make({ openDelay: 100, closeDelay: 100 });
+            collapsedEdgeWithPanel(d);
+            activators()[0].click();
+            const overlay = peek()!;
+            jest.useFakeTimers();
+
+            fireEvent.pointerLeave(strip(d)); // arm close
+            fireEvent.pointerEnter(overlay); // crossing the gap cancels it
+            jest.advanceTimersByTime(1000);
+
+            expect(peek()).toBeTruthy(); // never closed
+
+            d.dispose();
+        });
+
+        test('keyboard focus opens immediately (no delay)', () => {
+            const d = make({ openDelay: 100, closeDelay: 100 });
+            collapsedEdgeWithPanel(d);
+            jest.useFakeTimers();
+
+            fireEvent.focus(activators()[0]);
+            expect(peek()).toBeTruthy(); // no timer advance needed
+
+            d.dispose();
+        });
     });
 });

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -3,6 +3,9 @@ import { IContentRenderer } from 'dockview-core';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');
+    constructor() {
+        this.element.className = 'dv-test-content';
+    }
     init(): void {
         // noop
     }
@@ -15,9 +18,10 @@ class TestPanel implements IContentRenderer {
 }
 
 /**
- * Auto-hide edge groups (Phase 1) — a collapsed edge group renders clickable
- * activators in its strip; clicking one pins (expands) the group. Opt-in via
- * `autoHideEdgeGroups`; off → today's baseline (empty strip) is unchanged.
+ * Auto-hide edge groups. Phase 1: a collapsed edge group renders clickable
+ * activators. Phase 2: clicking one slides the panel out as a non-reflowing
+ * overlay (peek) on the floating-overlay host; a pin button re-docks it; Esc /
+ * pointer-down outside closes it. Opt-in via `autoHideEdgeGroups`.
  */
 describe('auto-hide edge groups', () => {
     let container: HTMLElement;
@@ -35,7 +39,6 @@ describe('auto-hide edge groups', () => {
         return dockview;
     };
 
-    /** Add a left edge group with one panel, then collapse it. */
     const collapsedEdgeWithPanel = (
         dockview: DockviewComponent,
         title = 'Explorer'
@@ -54,6 +57,10 @@ describe('auto-hide edge groups', () => {
         Array.from(
             container.querySelectorAll('.dv-edge-activator')
         ) as HTMLElement[];
+    const peek = (): HTMLElement | null =>
+        container.querySelector('.dv-edge-peek');
+    const collapsed = (d: DockviewComponent): boolean =>
+        d.getEdgeGroup('left')!.isCollapsed();
 
     afterEach(() => {
         container.remove();
@@ -63,7 +70,7 @@ describe('auto-hide edge groups', () => {
         const d = make(true);
         collapsedEdgeWithPanel(d, 'Explorer');
 
-        expect(d.getEdgeGroup('left')!.isCollapsed()).toBe(true);
+        expect(collapsed(d)).toBe(true);
         const buttons = activators();
         expect(buttons.length).toBe(1);
         expect(buttons[0].textContent).toBe('Explorer');
@@ -71,35 +78,71 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
-    test('clicking an activator pins (expands) the group and clears the strip', () => {
+    test('clicking an activator peeks: overlay shown, content reparented, no reflow', () => {
         const d = make(true);
         collapsedEdgeWithPanel(d);
-        expect(activators().length).toBe(1);
 
         activators()[0].click();
 
-        expect(d.getEdgeGroup('left')!.isCollapsed()).toBe(false);
-        expect(activators().length).toBe(0);
+        const overlay = peek();
+        expect(overlay).toBeTruthy();
+        expect(overlay!.querySelector('.dv-test-content')).toBeTruthy();
+        expect(collapsed(d)).toBe(true);
 
         d.dispose();
     });
 
-    test('api.pinEdgeGroup / autoHideEdgeGroup toggle the strip', () => {
+    test('the pin button re-docks (expands) the group and removes the peek', () => {
         const d = make(true);
-        d.addEdgeGroup('left', { id: 'edge-left', initialSize: 200 });
-        d.addPanel({
-            id: 'p1',
-            component: 'default',
-            title: 'Output',
-            position: { referenceGroup: 'edge-left', direction: 'within' },
-        });
+        collapsedEdgeWithPanel(d);
+        activators()[0].click();
+        expect(peek()).toBeTruthy();
 
-        d.api.autoHideEdgeGroup('left');
-        expect(activators().length).toBe(1);
+        (peek()!.querySelector('.dv-edge-peek-pin') as HTMLElement).click();
+
+        expect(collapsed(d)).toBe(false);
+        expect(peek()).toBeNull();
+
+        d.dispose();
+    });
+
+    test('Escape closes the peek, restores content, stays collapsed', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+        activators()[0].click();
+        expect(peek()).toBeTruthy();
+
+        document.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+
+        expect(peek()).toBeNull();
+        expect(collapsed(d)).toBe(true);
+        expect(
+            d
+                .getEdgeGroupPanel('left')!
+                .element.querySelector('.dv-test-content')
+        ).toBeTruthy();
+
+        d.dispose();
+    });
+
+    test('api.peekEdgeGroup / pinEdgeGroup / autoHideEdgeGroup', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+
+        d.api.peekEdgeGroup('left', true);
+        expect(peek()).toBeTruthy();
+        expect(collapsed(d)).toBe(true);
+
+        d.api.peekEdgeGroup('left', false);
+        expect(peek()).toBeNull();
 
         d.api.pinEdgeGroup('left');
-        expect(activators().length).toBe(0);
-        expect(d.getEdgeGroup('left')!.isCollapsed()).toBe(false);
+        expect(collapsed(d)).toBe(false);
+
+        d.api.autoHideEdgeGroup('left');
+        expect(collapsed(d)).toBe(true);
 
         d.dispose();
     });
@@ -124,12 +167,14 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
-    test('off (default): a collapsed edge group renders no activators', () => {
+    test('off (default): no activators and no peek', () => {
         const d = make(undefined);
         collapsedEdgeWithPanel(d);
 
-        expect(d.getEdgeGroup('left')!.isCollapsed()).toBe(true);
-        expect(activators().length).toBe(0); // baseline strip untouched
+        expect(collapsed(d)).toBe(true);
+        expect(activators().length).toBe(0);
+        d.api.peekEdgeGroup('left', true);
+        expect(peek()).toBeNull();
 
         d.dispose();
     });

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -87,7 +87,9 @@ describe('auto-hide edge groups', () => {
         collapsedEdgeWithPanel(d);
         d.api.peekEdgeGroup('left', true);
 
-        (peek()!.querySelector('.dv-edge-peek-pin') as HTMLElement).click();
+        // the Pin button is a separate sibling overlay (so it can layer above an
+        // `always` render overlay), not a child of the peek element.
+        (container.querySelector('.dv-edge-peek-pin') as HTMLElement).click();
 
         expect(collapsed(d)).toBe(false);
         expect(peek()).toBeNull();
@@ -185,15 +187,19 @@ describe('auto-hide edge groups', () => {
             d.dispose();
         });
 
-        test('re-entering the overlay cancels the close (no flicker)', () => {
+        test('pointer over the peek region cancels the close (no flicker)', () => {
             const d = make({ openDelay: 100, closeDelay: 100 });
             collapsedEdgeWithPanel(d);
             d.api.peekEdgeGroup('left', true);
-            const overlay = peek()!;
             jest.useFakeTimers();
 
+            // leaving the strip schedules a close...
             fireEvent.pointerLeave(strip(d));
-            fireEvent.pointerEnter(overlay);
+            // ...but a pointermove within the peek box cancels it. Keep-open is
+            // geometry-based (the peeked content may be a sibling overlay on
+            // top); in jsdom all rects are 0×0 at the origin, so (0,0) is
+            // "within" and a non-zero point is "outside".
+            fireEvent.pointerMove(document, { clientX: 0, clientY: 0 });
             jest.advanceTimersByTime(1000);
             expect(peek()).toBeTruthy();
 

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -19,10 +19,10 @@ class TestPanel implements IContentRenderer {
 }
 
 /**
- * Auto-hide edge groups. Phase 1: a collapsed edge group renders clickable
- * activators. Phase 2: clicking one slides the panel out as a non-reflowing
- * overlay (peek) on the floating-overlay host; a pin button re-docks it; Esc /
- * pointer-down outside closes it. Opt-in via `autoHideEdgeGroups`.
+ * Auto-hide edge groups. A collapsed edge group's native tabs are the peek
+ * triggers (hover/focus/click) — no parallel strip. Peeking slides the active
+ * panel out as a non-reflowing overlay; a pin button re-docks; Esc / leave /
+ * focus-out close. Opt-in via `autoHideEdgeGroups`.
  */
 describe('auto-hide edge groups', () => {
     let container: HTMLElement;
@@ -54,41 +54,30 @@ describe('auto-hide edge groups', () => {
         dockview.autoHideEdgeGroup('left');
     };
 
-    const activators = (): HTMLElement[] =>
-        Array.from(
-            container.querySelectorAll('.dv-edge-activator')
-        ) as HTMLElement[];
     const peek = (): HTMLElement | null =>
         container.querySelector('.dv-edge-peek');
     const collapsed = (d: DockviewComponent): boolean =>
         d.getEdgeGroup('left')!.isCollapsed();
+    const strip = (d: DockviewComponent): HTMLElement =>
+        d.getEdgeGroupPanel('left')!.element;
 
     afterEach(() => {
         container.remove();
     });
 
-    test('renders an activator per panel when the edge group is collapsed', () => {
-        const d = make(true);
-        collapsedEdgeWithPanel(d, 'Explorer');
-
-        expect(collapsed(d)).toBe(true);
-        const buttons = activators();
-        expect(buttons.length).toBe(1);
-        expect(buttons[0].textContent).toBe('Explorer');
-
-        d.dispose();
-    });
-
-    test('clicking an activator peeks: overlay shown, content reparented, no reflow', () => {
+    test('api.peekEdgeGroup opens a non-reflowing peek with the content reparented', () => {
         const d = make(true);
         collapsedEdgeWithPanel(d);
 
-        activators()[0].click();
-
+        d.api.peekEdgeGroup('left', true);
         const overlay = peek();
         expect(overlay).toBeTruthy();
         expect(overlay!.querySelector('.dv-test-content')).toBeTruthy();
-        expect(collapsed(d)).toBe(true);
+        expect(collapsed(d)).toBe(true); // no grid reflow
+
+        d.api.peekEdgeGroup('left', false);
+        expect(peek()).toBeNull();
+        expect(strip(d).querySelector('.dv-test-content')).toBeTruthy(); // content restored
 
         d.dispose();
     });
@@ -96,8 +85,7 @@ describe('auto-hide edge groups', () => {
     test('the pin button re-docks (expands) the group and removes the peek', () => {
         const d = make(true);
         collapsedEdgeWithPanel(d);
-        activators()[0].click();
-        expect(peek()).toBeTruthy();
+        d.api.peekEdgeGroup('left', true);
 
         (peek()!.querySelector('.dv-edge-peek-pin') as HTMLElement).click();
 
@@ -110,7 +98,7 @@ describe('auto-hide edge groups', () => {
     test('Escape closes the peek, restores content, stays collapsed', () => {
         const d = make(true);
         collapsedEdgeWithPanel(d);
-        activators()[0].click();
+        d.api.peekEdgeGroup('left', true);
         expect(peek()).toBeTruthy();
 
         document.dispatchEvent(
@@ -119,31 +107,7 @@ describe('auto-hide edge groups', () => {
 
         expect(peek()).toBeNull();
         expect(collapsed(d)).toBe(true);
-        expect(
-            d
-                .getEdgeGroupPanel('left')!
-                .element.querySelector('.dv-test-content')
-        ).toBeTruthy();
-
-        d.dispose();
-    });
-
-    test('api.peekEdgeGroup / pinEdgeGroup / autoHideEdgeGroup', () => {
-        const d = make(true);
-        collapsedEdgeWithPanel(d);
-
-        d.api.peekEdgeGroup('left', true);
-        expect(peek()).toBeTruthy();
-        expect(collapsed(d)).toBe(true);
-
-        d.api.peekEdgeGroup('left', false);
-        expect(peek()).toBeNull();
-
-        d.api.pinEdgeGroup('left');
-        expect(collapsed(d)).toBe(false);
-
-        d.api.autoHideEdgeGroup('left');
-        expect(collapsed(d)).toBe(true);
+        expect(strip(d).querySelector('.dv-test-content')).toBeTruthy();
 
         d.dispose();
     });
@@ -156,13 +120,9 @@ describe('auto-hide edge groups', () => {
         const sub = api.onDidPeekChange((e) => events.push(e.isPeeking));
 
         expect(api.isPeeking()).toBe(false);
-
-        activators()[0].click();
+        d.api.peekEdgeGroup('left', true);
         expect(api.isPeeking()).toBe(true);
-
-        document.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
-        );
+        d.api.peekEdgeGroup('left', false);
         expect(api.isPeeking()).toBe(false);
         expect(events).toEqual([true, false]);
 
@@ -170,72 +130,45 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
-    test('the strip tracks panel add/remove while collapsed', () => {
-        const d = make(true);
-        collapsedEdgeWithPanel(d, 'A');
-        expect(activators().length).toBe(1);
-
-        d.addPanel({
-            id: 'p2',
-            component: 'default',
-            title: 'B',
-            position: { referenceGroup: 'edge-left', direction: 'within' },
-        });
-        expect(
-            activators()
-                .map((b) => b.textContent)
-                .sort()
-        ).toEqual(['A', 'B']);
-
-        d.dispose();
-    });
-
-    test('off (default): no activators and no peek', () => {
+    test('off (default): peeking is a no-op', () => {
         const d = make(undefined);
         collapsedEdgeWithPanel(d);
 
         expect(collapsed(d)).toBe(true);
-        expect(activators().length).toBe(0);
         d.api.peekEdgeGroup('left', true);
         expect(peek()).toBeNull();
 
         d.dispose();
     });
 
-    describe('hover / focus peek (Phase 3)', () => {
-        const strip = (d: DockviewComponent): HTMLElement =>
-            d.getEdgeGroupPanel('left')!.element;
-
+    describe('hover / focus triggers', () => {
         afterEach(() => jest.useRealTimers());
 
-        test('hover opens the peek after openDelay', () => {
+        test('hover (pointerenter) opens after openDelay', () => {
             const d = make({ openDelay: 100, closeDelay: 100 });
             collapsedEdgeWithPanel(d);
             jest.useFakeTimers();
 
-            fireEvent.pointerEnter(activators()[0]);
+            fireEvent.pointerEnter(strip(d));
             jest.advanceTimersByTime(99);
-            expect(peek()).toBeNull(); // not yet
-
+            expect(peek()).toBeNull();
             jest.advanceTimersByTime(1);
-            expect(peek()).toBeTruthy(); // openDelay elapsed
+            expect(peek()).toBeTruthy();
 
             d.dispose();
         });
 
-        test('leaving the strip closes the peek after closeDelay', () => {
+        test('leaving the strip closes after closeDelay', () => {
             const d = make({ openDelay: 100, closeDelay: 100 });
             collapsedEdgeWithPanel(d);
-            activators()[0].click(); // open immediately
-            expect(peek()).toBeTruthy();
+            d.api.peekEdgeGroup('left', true);
             jest.useFakeTimers();
 
             fireEvent.pointerLeave(strip(d));
             jest.advanceTimersByTime(99);
-            expect(peek()).toBeTruthy(); // still open within the window
-
+            expect(peek()).toBeTruthy();
             jest.advanceTimersByTime(1);
-            expect(peek()).toBeNull(); // closed
+            expect(peek()).toBeNull();
 
             d.dispose();
         });
@@ -243,26 +176,25 @@ describe('auto-hide edge groups', () => {
         test('re-entering the overlay cancels the close (no flicker)', () => {
             const d = make({ openDelay: 100, closeDelay: 100 });
             collapsedEdgeWithPanel(d);
-            activators()[0].click();
+            d.api.peekEdgeGroup('left', true);
             const overlay = peek()!;
             jest.useFakeTimers();
 
-            fireEvent.pointerLeave(strip(d)); // arm close
-            fireEvent.pointerEnter(overlay); // crossing the gap cancels it
+            fireEvent.pointerLeave(strip(d));
+            fireEvent.pointerEnter(overlay);
             jest.advanceTimersByTime(1000);
-
-            expect(peek()).toBeTruthy(); // never closed
+            expect(peek()).toBeTruthy();
 
             d.dispose();
         });
 
-        test('keyboard focus opens immediately (no delay)', () => {
+        test('focus opens immediately', () => {
             const d = make({ openDelay: 100, closeDelay: 100 });
             collapsedEdgeWithPanel(d);
             jest.useFakeTimers();
 
-            fireEvent.focus(activators()[0]);
-            expect(peek()).toBeTruthy(); // no timer advance needed
+            fireEvent.focusIn(strip(d));
+            expect(peek()).toBeTruthy();
 
             d.dispose();
         });

--- a/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-modules/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -130,6 +130,18 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
+    test('the peek gets an opaque background so it is never see-through', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+        // simulate a themed group background (the floating peek must inherit it)
+        strip(d).style.backgroundColor = 'rgb(10, 20, 30)';
+
+        d.api.peekEdgeGroup('left', true);
+        expect(peek()!.style.backgroundColor).toBe('rgb(10, 20, 30)');
+
+        d.dispose();
+    });
+
     test('off (default): peeking is a no-op', () => {
         const d = make(undefined);
         collapsedEdgeWithPanel(d);

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -8,8 +8,17 @@ import {
     IAutoHideEdgeGroupService,
 } from 'dockview-core';
 
-function isEnabled(o: boolean | AutoHideEdgeGroupOptions | undefined): boolean {
-    return !!o;
+function resolveOptions(o: boolean | AutoHideEdgeGroupOptions | undefined): {
+    enabled: boolean;
+    openDelay: number;
+    closeDelay: number;
+} {
+    const obj = typeof o === 'object' ? o : {};
+    return {
+        enabled: !!o,
+        openDelay: obj.openDelay ?? 250,
+        closeDelay: obj.closeDelay ?? 300,
+    };
 }
 
 /**
@@ -34,12 +43,22 @@ class EdgeGroupController extends CompositeDisposable {
         | { overlay: HTMLElement; content: HTMLElement; parent: HTMLElement }
         | undefined;
     private _closeListeners: CompositeDisposable | undefined;
+    private _openTimer: ReturnType<typeof setTimeout> | undefined;
+    private _closeTimer: ReturnType<typeof setTimeout> | undefined;
 
     constructor(
         private readonly group: DockviewGroupPanel,
         private readonly host: IAutoHideEdgeGroupHost
     ) {
         super();
+
+        const strip = this.group.element;
+        // Crossing the gap between strip and the slid-out overlay must not flap
+        // the peek: a single shared close timer, cancelled by re-entering either.
+        const onEnter = (): void => this._cancelClose();
+        const onLeave = (): void => this._scheduleClose();
+        strip.addEventListener('pointerenter', onEnter);
+        strip.addEventListener('pointerleave', onLeave);
 
         this.addDisposables(
             this.group.api.onDidCollapsedChange(() => {
@@ -50,6 +69,9 @@ class EdgeGroupController extends CompositeDisposable {
             this.group.model.onDidRemovePanel(() => this._renderStrip()),
             {
                 dispose: () => {
+                    strip.removeEventListener('pointerenter', onEnter);
+                    strip.removeEventListener('pointerleave', onLeave);
+                    this._clearTimers();
                     this._closePeek();
                     this._removeStrip();
                 },
@@ -59,8 +81,12 @@ class EdgeGroupController extends CompositeDisposable {
         this._renderStrip();
     }
 
+    private get _opts() {
+        return resolveOptions(this.host.options.autoHideEdgeGroups);
+    }
+
     private get _enabled(): boolean {
-        return isEnabled(this.host.options.autoHideEdgeGroups);
+        return this._opts.enabled;
     }
 
     private get _position(): EdgeGroupPosition | undefined {
@@ -88,7 +114,13 @@ class EdgeGroupController extends CompositeDisposable {
             button.className = 'dv-edge-activator';
             button.type = 'button';
             button.textContent = panel.title ?? panel.id;
-            button.addEventListener('click', () => this._onActivator(panel));
+            // Click or keyboard-focus opens immediately (discoverable); hover
+            // opens after `openDelay`.
+            button.addEventListener('click', () => this._openFor(panel));
+            button.addEventListener('focus', () => this._openFor(panel));
+            button.addEventListener('pointerenter', () =>
+                this._scheduleOpen(panel)
+            );
             strip.appendChild(button);
         }
 
@@ -101,10 +133,49 @@ class EdgeGroupController extends CompositeDisposable {
         this._strip = undefined;
     }
 
-    private _onActivator(panel: IDockviewPanel): void {
-        // Make the clicked panel active, then peek it (or pin if it can't peek).
+    /** Open the peek for a specific panel now (click / focus path). */
+    private _openFor(panel: IDockviewPanel): void {
+        this._cancelOpen();
+        this._cancelClose();
         panel.api.setActive();
         this.openPeek();
+    }
+
+    /** Open the peek for a panel after `openDelay` (hover path). */
+    private _scheduleOpen(panel: IDockviewPanel): void {
+        this._cancelOpen();
+        this._cancelClose();
+        this._openTimer = setTimeout(
+            () => this._openFor(panel),
+            this._opts.openDelay
+        );
+    }
+
+    private _cancelOpen(): void {
+        if (this._openTimer !== undefined) {
+            clearTimeout(this._openTimer);
+            this._openTimer = undefined;
+        }
+    }
+
+    private _scheduleClose(): void {
+        this._cancelClose();
+        this._closeTimer = setTimeout(
+            () => this._closePeek(),
+            this._opts.closeDelay
+        );
+    }
+
+    private _cancelClose(): void {
+        if (this._closeTimer !== undefined) {
+            clearTimeout(this._closeTimer);
+            this._closeTimer = undefined;
+        }
+    }
+
+    private _clearTimers(): void {
+        this._cancelOpen();
+        this._cancelClose();
     }
 
     // --- peek ---
@@ -235,6 +306,27 @@ class EdgeGroupController extends CompositeDisposable {
         };
         doc.addEventListener('keydown', onKeyDown, true);
         doc.addEventListener('pointerdown', onPointerDown, true);
+
+        // Hover bookkeeping on the overlay itself, mirroring the strip: entering
+        // cancels the shared close timer, leaving (re)arms it.
+        const overlay = this._peek!.overlay;
+        const onOverlayEnter = (): void => this._cancelClose();
+        const onOverlayLeave = (): void => this._scheduleClose();
+        // Keyboard: tabbing focus out of the whole peek (strip + overlay) closes.
+        const onFocusOut = (e: Event): void => {
+            const next = (e as FocusEvent).relatedTarget;
+            if (
+                next instanceof Node &&
+                (overlay.contains(next) || this.group.element.contains(next))
+            ) {
+                return;
+            }
+            this._scheduleClose();
+        };
+        overlay.addEventListener('pointerenter', onOverlayEnter);
+        overlay.addEventListener('pointerleave', onOverlayLeave);
+        overlay.addEventListener('focusout', onFocusOut);
+
         this._closeListeners = new CompositeDisposable(
             {
                 dispose: () =>
@@ -243,12 +335,20 @@ class EdgeGroupController extends CompositeDisposable {
             {
                 dispose: () =>
                     doc.removeEventListener('pointerdown', onPointerDown, true),
+            },
+            {
+                dispose: () => {
+                    overlay.removeEventListener('pointerenter', onOverlayEnter);
+                    overlay.removeEventListener('pointerleave', onOverlayLeave);
+                    overlay.removeEventListener('focusout', onFocusOut);
+                },
             }
         );
     }
 
     /** Restore the reparented content and remove the overlay (no layout change). */
     private _closePeek(): void {
+        this._clearTimers();
         this._closeListeners?.dispose();
         this._closeListeners = undefined;
         const peek = this._peek;

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -1,0 +1,166 @@
+import { DockviewCompositeDisposable as CompositeDisposable } from 'dockview-core';
+import { DockviewGroupPanel } from 'dockview-core';
+import { EdgeGroupPosition } from 'dockview-core';
+import { AutoHideEdgeGroupOptions } from 'dockview-core';
+import { defineModule, EdgeGroupModule } from 'dockview-core';
+import {
+    IAutoHideEdgeGroupHost,
+    IAutoHideEdgeGroupService,
+} from 'dockview-core';
+
+function resolveOptions(o: boolean | AutoHideEdgeGroupOptions | undefined): {
+    enabled: boolean;
+    showIcons: boolean;
+} {
+    if (!o) {
+        return { enabled: false, showIcons: true };
+    }
+    if (o === true) {
+        return { enabled: true, showIcons: true };
+    }
+    return { enabled: true, showIcons: o.showIcons ?? true };
+}
+
+/**
+ * Renders the collapsed-strip activators for a single edge group and pins the
+ * group when one is clicked. The activator list mirrors the group's panels and
+ * is shown only while the group is collapsed and the feature is enabled — so
+ * with `autoHideEdgeGroups` off the baseline (empty) strip is untouched.
+ */
+class EdgeStripController extends CompositeDisposable {
+    private _strip: HTMLElement | undefined;
+
+    constructor(
+        private readonly group: DockviewGroupPanel,
+        private readonly host: IAutoHideEdgeGroupHost
+    ) {
+        super();
+
+        this.addDisposables(
+            this.group.api.onDidCollapsedChange(() => this._render()),
+            this.group.model.onDidAddPanel(() => this._render()),
+            this.group.model.onDidRemovePanel(() => this._render()),
+            { dispose: () => this._removeStrip() }
+        );
+
+        this._render();
+    }
+
+    private get _enabled(): boolean {
+        return resolveOptions(this.host.options.autoHideEdgeGroups).enabled;
+    }
+
+    /** Rebuild the activator strip from the current panels, or remove it when
+     *  the group is expanded / the feature is off. */
+    private _render(): void {
+        if (!this._enabled || !this.group.api.isCollapsed()) {
+            this._removeStrip();
+            return;
+        }
+        this._removeStrip();
+
+        const doc = this.group.element.ownerDocument;
+        const strip = doc.createElement('div');
+        strip.className = 'dv-edge-activator-strip';
+        // Minimal inline layout so the strip is usable before any theme styles
+        // it; visual polish (orientation, icons) is a follow-up phase.
+        strip.style.display = 'flex';
+        strip.style.flexWrap = 'wrap';
+
+        for (const panel of this.group.panels) {
+            const button = doc.createElement('button');
+            button.className = 'dv-edge-activator';
+            button.type = 'button';
+            button.textContent = panel.title ?? panel.id;
+            // Clicking an activator pins (expands) the group and activates the
+            // panel. Pin goes through the host's single collapse mutate path.
+            // (Listeners are GC'd with the button when the strip is removed.)
+            button.addEventListener('click', () => {
+                this.host.setEdgeGroupCollapsed(this.group, false);
+                panel.api.setActive();
+            });
+            strip.appendChild(button);
+        }
+
+        this.group.element.appendChild(strip);
+        this._strip = strip;
+    }
+
+    private _removeStrip(): void {
+        this._strip?.remove();
+        this._strip = undefined;
+    }
+}
+
+/**
+ * Auto-hide edge groups (VS-style). Phase 1: a collapsed edge group renders
+ * clickable activators in its strip; clicking one pins (expands) the group.
+ * Opt-in via `autoHideEdgeGroups` (default off → baseline strip unchanged).
+ * The slide-out peek + pin/unpin animation + serialization are later phases.
+ */
+export class AutoHideEdgeGroupService
+    extends CompositeDisposable
+    implements IAutoHideEdgeGroupService
+{
+    private readonly _controllers = new Map<
+        DockviewGroupPanel,
+        EdgeStripController
+    >();
+
+    constructor(private readonly host: IAutoHideEdgeGroupHost) {
+        super();
+
+        this.addDisposables(
+            this.host.onDidAddGroup((group) => this._track(group)),
+            this.host.onDidRemoveGroup((group) => this._untrack(group)),
+            {
+                dispose: () => {
+                    this._controllers.forEach((c) => c.dispose());
+                    this._controllers.clear();
+                },
+            }
+        );
+    }
+
+    private _track(group: DockviewGroupPanel): void {
+        if (
+            group.api.location.type !== 'edge' ||
+            this._controllers.has(group)
+        ) {
+            return;
+        }
+        this._controllers.set(group, new EdgeStripController(group, this.host));
+    }
+
+    private _untrack(group: DockviewGroupPanel): void {
+        const controller = this._controllers.get(group);
+        if (controller) {
+            controller.dispose();
+            this._controllers.delete(group);
+        }
+    }
+
+    pin(position: EdgeGroupPosition): void {
+        const group = this.host.getEdgeGroupPanel(position);
+        if (group) {
+            this.host.setEdgeGroupCollapsed(group, false);
+        }
+    }
+
+    autoHide(position: EdgeGroupPosition): void {
+        const group = this.host.getEdgeGroupPanel(position);
+        if (group) {
+            this.host.setEdgeGroupCollapsed(group, true);
+        }
+    }
+}
+
+export const AutoHideEdgeGroupModule = defineModule<
+    'autoHideEdgeGroupService',
+    IAutoHideEdgeGroupHost
+>({
+    name: 'AutoHideEdgeGroup',
+    serviceKey: 'autoHideEdgeGroupService',
+    dependsOn: [EdgeGroupModule],
+    create: (host) => new AutoHideEdgeGroupService(host),
+});

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -12,13 +12,22 @@ function resolveOptions(o: boolean | AutoHideEdgeGroupOptions | undefined): {
     enabled: boolean;
     openDelay: number;
     closeDelay: number;
+    animate: boolean;
 } {
     const obj = typeof o === 'object' ? o : {};
     return {
         enabled: !!o,
         openDelay: obj.openDelay ?? 250,
         closeDelay: obj.closeDelay ?? 300,
+        animate: obj.animate ?? true,
     };
+}
+
+function prefersReducedMotion(doc: Document): boolean {
+    const mq = doc.defaultView?.matchMedia?.(
+        '(prefers-reduced-motion: reduce)'
+    );
+    return !!mq?.matches;
 }
 
 /**
@@ -231,7 +240,38 @@ class EdgeGroupController extends CompositeDisposable {
         this.host.floatingOverlayHost.appendChild(overlay);
         this._peek = { overlay, content, parent };
         this._positionOverlay(overlay);
+        this._animateIn(overlay);
         this._armCloseListeners();
+        this.host.setEdgeGroupPeeking(this.group, true);
+    }
+
+    /** Slide the overlay in from the strip edge (unless reduced-motion / off). */
+    private _animateIn(overlay: HTMLElement): void {
+        const position = this._position;
+        const doc = this.group.element.ownerDocument;
+        if (
+            !position ||
+            !this._opts.animate ||
+            prefersReducedMotion(doc) ||
+            typeof doc.defaultView?.requestAnimationFrame !== 'function'
+        ) {
+            return;
+        }
+        const from =
+            position === 'left'
+                ? 'translateX(-100%)'
+                : position === 'right'
+                  ? 'translateX(100%)'
+                  : position === 'top'
+                    ? 'translateY(-100%)'
+                    : 'translateY(100%)';
+        overlay.style.transform = from;
+        // force a reflow so the transition runs from `from`
+        void overlay.offsetWidth;
+        overlay.style.transition = 'transform 150ms ease-out';
+        doc.defaultView.requestAnimationFrame(() => {
+            overlay.style.transform = 'translate(0, 0)';
+        });
     }
 
     /** Anchor the overlay to the strip's inner edge, sized to the group's
@@ -359,6 +399,7 @@ class EdgeGroupController extends CompositeDisposable {
         // Put the live content back where it came from before removing the overlay.
         peek.parent.appendChild(peek.content);
         peek.overlay.remove();
+        this.host.setEdgeGroupPeeking(this.group, false);
     }
 
     isPeeking(): boolean {

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -57,6 +57,7 @@ class EdgeGroupController extends CompositeDisposable {
     private _peek:
         | {
               overlay: HTMLElement;
+              header: HTMLElement;
               content: HTMLElement;
               parent: HTMLElement;
               panel: IDockviewPanel;
@@ -161,7 +162,11 @@ class EdgeGroupController extends CompositeDisposable {
     }
 
     private _scheduleClose(): void {
-        this._cancelClose();
+        // Idempotent: a document pointermove drives this on every move, so don't
+        // restart a running timer (that would prevent it ever firing).
+        if (this._closeTimer !== undefined) {
+            return;
+        }
         this._closeTimer = setTimeout(
             () => this._closePeek(),
             this._opts.closeDelay
@@ -247,24 +252,39 @@ class EdgeGroupController extends CompositeDisposable {
             overlay.style.backgroundColor = background;
         }
 
+        // The Pin header is a SEPARATE sibling overlay (not a child of the peek)
+        // so it can sit ABOVE an `always` panel's render overlay, which is itself
+        // a sibling lifted above the peek backdrop (peek bg < always content <
+        // pin). It's click-through except for the button so it never blocks the
+        // peeked content.
         const header = doc.createElement('div');
         header.className = 'dv-edge-peek-header';
-        // Float the header so the content container can fill the whole overlay
-        // (its box anchors `always`-rendered content) — layout must not depend
-        // on the consumer loading the stylesheet.
         header.style.position = 'absolute';
-        header.style.top = '0';
-        header.style.right = '0';
-        header.style.zIndex = '1';
+        header.style.zIndex = '1001';
+        header.style.pointerEvents = 'none';
+        header.style.display = 'flex';
+        header.style.justifyContent = 'flex-end';
+        header.style.alignItems = 'flex-start';
+        header.style.padding = '4px';
         const pinButton = doc.createElement('button');
         pinButton.className = 'dv-edge-peek-pin';
         pinButton.type = 'button';
         pinButton.title = 'Pin';
         pinButton.setAttribute('aria-label', 'Pin');
         pinButton.textContent = 'Pin';
+        // Self-contained cosmetics (it floats over the content, so needs its own
+        // surface) — the stylesheet refines these but they must not depend on it.
+        pinButton.style.pointerEvents = 'auto';
+        pinButton.style.cursor = 'pointer';
+        pinButton.style.border = '1px solid transparent';
+        pinButton.style.borderRadius = '3px';
+        pinButton.style.padding = '2px 8px';
+        pinButton.style.fontSize = '11px';
+        if (background) {
+            pinButton.style.backgroundColor = background;
+        }
         pinButton.addEventListener('click', () => this.pin());
         header.appendChild(pinButton);
-        overlay.appendChild(header);
 
         // Reparent the live content into the overlay (state preserved). Fill the
         // overlay so it doesn't depend on the consumer's stylesheet for layout.
@@ -273,7 +293,8 @@ class EdgeGroupController extends CompositeDisposable {
         overlay.appendChild(content);
 
         this.host.overlayRoot.appendChild(overlay);
-        this._peek = { overlay, content, parent, panel };
+        this.host.overlayRoot.appendChild(header);
+        this._peek = { overlay, header, content, parent, panel };
         this._positionOverlay(overlay);
         this._armCloseListeners();
         this.host.setEdgeGroupPeeking(this.group, true);
@@ -334,7 +355,9 @@ class EdgeGroupController extends CompositeDisposable {
     }
 
     /** Anchor the overlay to the strip's inner edge, sized to the group's
-     *  expanded size — relative to the floating-overlay host. No grid reflow. */
+     *  expanded size — relative to the overlay root. No grid reflow. The Pin
+     *  header tracks the same box (it's a separate sibling so it can sit above
+     *  an `always` render overlay). */
     private _positionOverlay(overlay: HTMLElement): void {
         const position = this._position;
         if (!position) {
@@ -346,40 +369,68 @@ class EdgeGroupController extends CompositeDisposable {
         const left = strip.left - host.left;
         const top = strip.top - host.top;
 
+        let box: { left: number; top: number; width: number; height: number };
         switch (position) {
             case 'left':
-                Object.assign(overlay.style, {
-                    left: `${left + strip.width}px`,
-                    top: `${top}px`,
-                    width: `${size}px`,
-                    height: `${strip.height}px`,
-                });
+                box = {
+                    left: left + strip.width,
+                    top,
+                    width: size,
+                    height: strip.height,
+                };
                 break;
             case 'right':
-                Object.assign(overlay.style, {
-                    left: `${left - size}px`,
-                    top: `${top}px`,
-                    width: `${size}px`,
-                    height: `${strip.height}px`,
-                });
+                box = {
+                    left: left - size,
+                    top,
+                    width: size,
+                    height: strip.height,
+                };
                 break;
             case 'top':
-                Object.assign(overlay.style, {
-                    left: `${left}px`,
-                    top: `${top + strip.height}px`,
-                    width: `${strip.width}px`,
-                    height: `${size}px`,
-                });
+                box = {
+                    left,
+                    top: top + strip.height,
+                    width: strip.width,
+                    height: size,
+                };
                 break;
             case 'bottom':
-                Object.assign(overlay.style, {
-                    left: `${left}px`,
-                    top: `${top - size}px`,
-                    width: `${strip.width}px`,
-                    height: `${size}px`,
-                });
+                box = {
+                    left,
+                    top: top - size,
+                    width: strip.width,
+                    height: size,
+                };
                 break;
         }
+
+        const apply = (el: HTMLElement): void => {
+            el.style.left = `${box.left}px`;
+            el.style.top = `${box.top}px`;
+            el.style.width = `${box.width}px`;
+            el.style.height = `${box.height}px`;
+        };
+        apply(overlay);
+        if (this._peek) {
+            apply(this._peek.header);
+        }
+    }
+
+    /** Is the point within the strip or the peek's box? Geometry-based so it
+     *  works regardless of which stacking layer the pointer is actually over —
+     *  for `always` the content is a separate render overlay ON TOP of the peek,
+     *  so element-based enter/leave on the peek would miss it. */
+    private _pointWithinPeek(x: number, y: number): boolean {
+        if (!this._peek) {
+            return false;
+        }
+        const within = (r: DOMRect): boolean =>
+            x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
+        return (
+            within(this._peek.overlay.getBoundingClientRect()) ||
+            within(this.group.element.getBoundingClientRect())
+        );
     }
 
     private _armCloseListeners(): void {
@@ -391,20 +442,22 @@ class EdgeGroupController extends CompositeDisposable {
             }
         };
         const onPointerDown = (e: Event): void => {
-            const target = e.target;
-            if (!(target instanceof Node)) {
-                return;
-            }
-            if (
-                overlay.contains(target) ||
-                this.group.element.contains(target)
-            ) {
+            const pe = e as PointerEvent;
+            if (this._pointWithinPeek(pe.clientX, pe.clientY)) {
                 return;
             }
             this._closePeek();
         };
-        const onOverlayEnter = (): void => this._cancelClose();
-        const onOverlayLeave = (): void => this._scheduleClose();
+        // Keep-open / close by pointer geometry, not by element containment —
+        // the peeked content may be a sibling render overlay on top of the peek.
+        const onPointerMove = (e: Event): void => {
+            const pe = e as PointerEvent;
+            if (this._pointWithinPeek(pe.clientX, pe.clientY)) {
+                this._cancelClose();
+            } else {
+                this._scheduleClose();
+            }
+        };
         const onFocusOut = (e: Event): void => {
             const next = (e as FocusEvent).relatedTarget;
             if (
@@ -417,8 +470,7 @@ class EdgeGroupController extends CompositeDisposable {
         };
         doc.addEventListener('keydown', onKeyDown, true);
         doc.addEventListener('pointerdown', onPointerDown, true);
-        overlay.addEventListener('pointerenter', onOverlayEnter);
-        overlay.addEventListener('pointerleave', onOverlayLeave);
+        doc.addEventListener('pointermove', onPointerMove, true);
         overlay.addEventListener('focusout', onFocusOut);
 
         this._closeListeners = new CompositeDisposable(
@@ -431,11 +483,12 @@ class EdgeGroupController extends CompositeDisposable {
                     doc.removeEventListener('pointerdown', onPointerDown, true),
             },
             {
-                dispose: () => {
-                    overlay.removeEventListener('pointerenter', onOverlayEnter);
-                    overlay.removeEventListener('pointerleave', onOverlayLeave);
-                    overlay.removeEventListener('focusout', onFocusOut);
-                },
+                dispose: () =>
+                    doc.removeEventListener('pointermove', onPointerMove, true),
+            },
+            {
+                dispose: () =>
+                    overlay.removeEventListener('focusout', onFocusOut),
             }
         );
     }
@@ -455,6 +508,7 @@ class EdgeGroupController extends CompositeDisposable {
         peek.content.style.height = '';
         peek.parent.appendChild(peek.content);
         peek.overlay.remove();
+        peek.header.remove();
         this.host.setEdgeGroupPeeking(this.group, false);
         // Re-anchor the `always` overlay back over the (now collapsed, in-group)
         // container — forceVisible:false lets it hide again as the panel is no

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -1,5 +1,5 @@
 import { DockviewCompositeDisposable as CompositeDisposable } from 'dockview-core';
-import { DockviewGroupPanel, IDockviewPanel } from 'dockview-core';
+import { DockviewGroupPanel } from 'dockview-core';
 import { EdgeGroupPosition } from 'dockview-core';
 import { AutoHideEdgeGroupOptions } from 'dockview-core';
 import { defineModule, EdgeGroupModule } from 'dockview-core';
@@ -31,23 +31,24 @@ function prefersReducedMotion(doc: Document): boolean {
 }
 
 /**
- * Strip activators + slide-out peek for a single edge group.
+ * Auto-hide peek for a single edge group. The collapsed edge group already
+ * renders its tabs along the strip (the native "activity bar") — this reuses
+ * them as the peek triggers rather than rendering a parallel strip:
  *
- * - **Strip** (Phase 1): when the group is collapsed, render a clickable
- *   activator per panel.
- * - **Peek** (Phase 2): clicking an activator slides the panel out as an
- *   overlay on the shared floating-overlay host — the live content element is
- *   reparented (state preserved) and the grid is **not** reflowed (the splitview
- *   view stays locked at `collapsedSize`). A pin button re-docks it; `Esc` or a
- *   pointer-down outside closes it.
+ * - **Hover** the collapsed strip → after `openDelay`, the active panel slides
+ *   out as an overlay on the shell overlay root. The live content element is
+ *   reparented (state preserved) and the grid is NOT reflowed (the splitview
+ *   view stays locked at `collapsedSize`).
+ * - **Focus / click** a collapsed tab → opens immediately; clicking a different
+ *   tab swaps the peeked panel.
+ * - **Leave** both the strip and the overlay → closes after `closeDelay`; a
+ *   single shared timer, cancelled by re-entering either (the flicker fix).
+ *   `Esc` / pointer-down outside / focus-out also close. A pin button re-docks.
  *
- * Limited to `onlyWhenVisible` renderers; an `always`-renderer panel (whose live
- * element lives in the shared render overlay) falls back to pinning. Hover/focus
- * debounce + animation are later phases.
+ * Limited to `onlyWhenVisible` renderers; an `always`-renderer panel (whose
+ * live element lives in the shared render overlay) falls back to pinning.
  */
 class EdgeGroupController extends CompositeDisposable {
-    private _strip: HTMLElement | undefined;
-    // open peek: the reparented content + where to put it back
     private _peek:
         | { overlay: HTMLElement; content: HTMLElement; parent: HTMLElement }
         | undefined;
@@ -62,40 +63,62 @@ class EdgeGroupController extends CompositeDisposable {
         super();
 
         const strip = this.group.element;
-        // Crossing the gap between strip and the slid-out overlay must not flap
-        // the peek: a single shared close timer, cancelled by re-entering either.
-        const onEnter = (): void => this._cancelClose();
-        const onLeave = (): void => this._scheduleClose();
+        const onEnter = (): void => {
+            if (this._gate()) {
+                this._cancelClose();
+                this._scheduleOpen();
+            }
+        };
+        const onLeave = (): void => {
+            this._cancelOpen();
+            this._scheduleClose();
+        };
+        // Click / keyboard-focus a collapsed tab opens immediately.
+        const onClick = (): void => {
+            if (this._gate()) {
+                this._openNow();
+            }
+        };
+        const onFocusIn = (): void => {
+            if (this._gate()) {
+                this._openNow();
+            }
+        };
         strip.addEventListener('pointerenter', onEnter);
         strip.addEventListener('pointerleave', onLeave);
+        strip.addEventListener('click', onClick);
+        strip.addEventListener('focusin', onFocusIn);
 
         this.addDisposables(
-            this.group.api.onDidCollapsedChange(() => {
-                this._closePeek();
-                this._renderStrip();
+            // Expanding (pin) tears the peek down; collapsing leaves the native
+            // strip visible with nothing extra to render.
+            this.group.api.onDidCollapsedChange(() => this._closePeek()),
+            // Activating a different tab while peeking swaps the peeked panel.
+            this.group.api.onDidActivePanelChange(() => {
+                if (this._peek) {
+                    this._openNow();
+                }
             }),
-            this.group.model.onDidAddPanel(() => this._renderStrip()),
-            this.group.model.onDidRemovePanel(() => this._renderStrip()),
             {
                 dispose: () => {
                     strip.removeEventListener('pointerenter', onEnter);
                     strip.removeEventListener('pointerleave', onLeave);
+                    strip.removeEventListener('click', onClick);
+                    strip.removeEventListener('focusin', onFocusIn);
                     this._clearTimers();
                     this._closePeek();
-                    this._removeStrip();
                 },
             }
         );
-
-        this._renderStrip();
     }
 
     private get _opts() {
         return resolveOptions(this.host.options.autoHideEdgeGroups);
     }
 
-    private get _enabled(): boolean {
-        return this._opts.enabled;
+    /** Enabled + collapsed — the precondition for peeking. */
+    private _gate(): boolean {
+        return this._opts.enabled && this.group.api.isCollapsed();
     }
 
     private get _position(): EdgeGroupPosition | undefined {
@@ -103,59 +126,18 @@ class EdgeGroupController extends CompositeDisposable {
         return location.type === 'edge' ? location.position : undefined;
     }
 
-    // --- strip ---
+    // --- timers ---
 
-    private _renderStrip(): void {
-        if (!this._enabled || !this.group.api.isCollapsed()) {
-            this._removeStrip();
-            return;
-        }
-        this._removeStrip();
-
-        const doc = this.group.element.ownerDocument;
-        const strip = doc.createElement('div');
-        strip.className = 'dv-edge-activator-strip';
-        strip.style.display = 'flex';
-        strip.style.flexWrap = 'wrap';
-
-        for (const panel of this.group.panels) {
-            const button = doc.createElement('button');
-            button.className = 'dv-edge-activator';
-            button.type = 'button';
-            button.textContent = panel.title ?? panel.id;
-            // Click or keyboard-focus opens immediately (discoverable); hover
-            // opens after `openDelay`.
-            button.addEventListener('click', () => this._openFor(panel));
-            button.addEventListener('focus', () => this._openFor(panel));
-            button.addEventListener('pointerenter', () =>
-                this._scheduleOpen(panel)
-            );
-            strip.appendChild(button);
-        }
-
-        this.group.element.appendChild(strip);
-        this._strip = strip;
-    }
-
-    private _removeStrip(): void {
-        this._strip?.remove();
-        this._strip = undefined;
-    }
-
-    /** Open the peek for a specific panel now (click / focus path). */
-    private _openFor(panel: IDockviewPanel): void {
+    private _openNow(): void {
         this._cancelOpen();
         this._cancelClose();
-        panel.api.setActive();
         this.openPeek();
     }
 
-    /** Open the peek for a panel after `openDelay` (hover path). */
-    private _scheduleOpen(panel: IDockviewPanel): void {
+    private _scheduleOpen(): void {
         this._cancelOpen();
-        this._cancelClose();
         this._openTimer = setTimeout(
-            () => this._openFor(panel),
+            () => this.openPeek(),
             this._opts.openDelay
         );
     }
@@ -190,54 +172,70 @@ class EdgeGroupController extends CompositeDisposable {
     // --- peek ---
 
     openPeek(): void {
-        if (!this._enabled || !this.group.api.isCollapsed()) {
+        if (!this._gate()) {
             return;
         }
         const panel = this.group.activePanel;
         if (!panel) {
             return;
         }
-        // The `always` renderer's element lives in the shared render overlay, not
-        // the content container — reparenting it is a later phase; pin instead.
+        // `always`-rendered content lives in the shared render overlay (not the
+        // content container); peeking it needs render-overlay re-anchoring that
+        // is a dedicated follow-up — pin instead for now.
         if (panel.api.renderer === 'always') {
             this.pin();
+            return;
+        }
+        const content = panel.view.content.element;
+        const parent = content.parentElement;
+        if (!parent) {
+            return;
+        }
+        // Already peeking the same content? nothing to do.
+        if (this._peek?.content === content) {
             return;
         }
         if (this._peek) {
             this._closePeek();
         }
 
-        const content = panel.view.content.element;
-        const parent = content.parentElement;
-        if (!parent) {
-            return;
-        }
-
         const doc = this.group.element.ownerDocument;
         const overlay = doc.createElement('div');
         overlay.className = 'dv-edge-peek';
         overlay.style.position = 'absolute';
-        overlay.style.background = 'var(--dv-group-view-background-color)';
         overlay.style.overflow = 'hidden';
         overlay.style.boxSizing = 'border-box';
-        // Sit above grid content (the floating-overlay host is pointer-events:
-        // none, so opt this child back in) and take pointer events for the
-        // slid-out panel + its pin button.
+        // Above grid content (the floating-overlay host is pointer-events:none,
+        // so opt this child back in).
         overlay.style.zIndex = '999';
         overlay.style.pointerEvents = 'auto';
 
-        // A small header with a pin affordance (re-dock).
+        const header = doc.createElement('div');
+        header.className = 'dv-edge-peek-header';
+        // Float the header so the content container can fill the whole overlay
+        // (its box anchors `always`-rendered content) — layout must not depend
+        // on the consumer loading the stylesheet.
+        header.style.position = 'absolute';
+        header.style.top = '0';
+        header.style.right = '0';
+        header.style.zIndex = '1';
         const pinButton = doc.createElement('button');
         pinButton.className = 'dv-edge-peek-pin';
         pinButton.type = 'button';
+        pinButton.title = 'Pin';
+        pinButton.setAttribute('aria-label', 'Pin');
         pinButton.textContent = 'Pin';
         pinButton.addEventListener('click', () => this.pin());
-        overlay.appendChild(pinButton);
+        header.appendChild(pinButton);
+        overlay.appendChild(header);
 
-        // Reparent the live content into the overlay (state preserved).
+        // Reparent the live content into the overlay (state preserved). Fill the
+        // overlay so it doesn't depend on the consumer's stylesheet for layout.
+        content.style.width = '100%';
+        content.style.height = '100%';
         overlay.appendChild(content);
 
-        this.host.floatingOverlayHost.appendChild(overlay);
+        this.host.overlayRoot.appendChild(overlay);
         this._peek = { overlay, content, parent };
         this._positionOverlay(overlay);
         this._animateIn(overlay);
@@ -245,7 +243,6 @@ class EdgeGroupController extends CompositeDisposable {
         this.host.setEdgeGroupPeeking(this.group, true);
     }
 
-    /** Slide the overlay in from the strip edge (unless reduced-motion / off). */
     private _animateIn(overlay: HTMLElement): void {
         const position = this._position;
         const doc = this.group.element.ownerDocument;
@@ -266,8 +263,7 @@ class EdgeGroupController extends CompositeDisposable {
                     ? 'translateY(-100%)'
                     : 'translateY(100%)';
         overlay.style.transform = from;
-        // force a reflow so the transition runs from `from`
-        void overlay.offsetWidth;
+        void overlay.offsetWidth; // reflow so the transition runs from `from`
         overlay.style.transition = 'transform 150ms ease-out';
         doc.defaultView.requestAnimationFrame(() => {
             overlay.style.transform = 'translate(0, 0)';
@@ -282,7 +278,7 @@ class EdgeGroupController extends CompositeDisposable {
             return;
         }
         const strip = this.group.element.getBoundingClientRect();
-        const host = this.host.floatingOverlayHost.getBoundingClientRect();
+        const host = this.host.overlayRoot.getBoundingClientRect();
         const size = this.host.getEdgeGroupExpandedSize(position);
         const left = strip.left - host.left;
         const top = strip.top - host.top;
@@ -325,6 +321,7 @@ class EdgeGroupController extends CompositeDisposable {
 
     private _armCloseListeners(): void {
         const doc = this.group.element.ownerDocument;
+        const overlay = this._peek!.overlay;
         const onKeyDown = (e: Event): void => {
             if ((e as KeyboardEvent).key === 'Escape') {
                 this._closePeek();
@@ -335,24 +332,16 @@ class EdgeGroupController extends CompositeDisposable {
             if (!(target instanceof Node)) {
                 return;
             }
-            // A click on the strip or inside the peek keeps it open.
             if (
-                this._peek?.overlay.contains(target) ||
+                overlay.contains(target) ||
                 this.group.element.contains(target)
             ) {
                 return;
             }
             this._closePeek();
         };
-        doc.addEventListener('keydown', onKeyDown, true);
-        doc.addEventListener('pointerdown', onPointerDown, true);
-
-        // Hover bookkeeping on the overlay itself, mirroring the strip: entering
-        // cancels the shared close timer, leaving (re)arms it.
-        const overlay = this._peek!.overlay;
         const onOverlayEnter = (): void => this._cancelClose();
         const onOverlayLeave = (): void => this._scheduleClose();
-        // Keyboard: tabbing focus out of the whole peek (strip + overlay) closes.
         const onFocusOut = (e: Event): void => {
             const next = (e as FocusEvent).relatedTarget;
             if (
@@ -363,6 +352,8 @@ class EdgeGroupController extends CompositeDisposable {
             }
             this._scheduleClose();
         };
+        doc.addEventListener('keydown', onKeyDown, true);
+        doc.addEventListener('pointerdown', onPointerDown, true);
         overlay.addEventListener('pointerenter', onOverlayEnter);
         overlay.addEventListener('pointerleave', onOverlayLeave);
         overlay.addEventListener('focusout', onFocusOut);
@@ -386,7 +377,6 @@ class EdgeGroupController extends CompositeDisposable {
         );
     }
 
-    /** Restore the reparented content and remove the overlay (no layout change). */
     private _closePeek(): void {
         this._clearTimers();
         this._closeListeners?.dispose();
@@ -396,7 +386,10 @@ class EdgeGroupController extends CompositeDisposable {
         if (!peek) {
             return;
         }
-        // Put the live content back where it came from before removing the overlay.
+        // Restore the live content before removing the overlay, clearing the
+        // fill styles applied for the peek.
+        peek.content.style.width = '';
+        peek.content.style.height = '';
         peek.parent.appendChild(peek.content);
         peek.overlay.remove();
         this.host.setEdgeGroupPeeking(this.group, false);
@@ -408,7 +401,7 @@ class EdgeGroupController extends CompositeDisposable {
 
     peek(open: boolean): void {
         if (open) {
-            this.openPeek();
+            this._openNow();
         } else {
             this._closePeek();
         }
@@ -422,10 +415,10 @@ class EdgeGroupController extends CompositeDisposable {
 }
 
 /**
- * Auto-hide edge groups (VS-style). A collapsed edge group renders clickable
- * activators; clicking one slides the panel out as a non-reflowing overlay
- * (peek), with a pin button to re-dock. Opt-in via `autoHideEdgeGroups`
- * (default off → baseline strip unchanged).
+ * Auto-hide edge groups (VS-style). A collapsed edge group's native tabs become
+ * peek triggers: hover/focus/click slides the active panel out as a
+ * non-reflowing overlay, with a pin button to re-dock. Opt-in via
+ * `autoHideEdgeGroups` (default off → collapsed edge groups behave as today).
  */
 export class AutoHideEdgeGroupService
     extends CompositeDisposable
@@ -469,23 +462,16 @@ export class AutoHideEdgeGroupService
         }
     }
 
-    private _controllerAt(
-        position: EdgeGroupPosition
-    ): EdgeGroupController | undefined {
-        const group = this.host.getEdgeGroupPanel(position);
-        return group ? this._controllers.get(group) : undefined;
-    }
-
     pin(position: EdgeGroupPosition): void {
         const group = this.host.getEdgeGroupPanel(position);
-        if (group) {
-            // Use the controller so an open peek is torn down cleanly first.
-            const controller = this._controllers.get(group);
-            if (controller) {
-                controller.pin();
-            } else {
-                this.host.setEdgeGroupCollapsed(group, false);
-            }
+        if (!group) {
+            return;
+        }
+        const controller = this._controllers.get(group);
+        if (controller) {
+            controller.pin();
+        } else {
+            this.host.setEdgeGroupCollapsed(group, false);
         }
     }
 
@@ -497,7 +483,9 @@ export class AutoHideEdgeGroupService
     }
 
     peek(position: EdgeGroupPosition, peek: boolean): void {
-        this._controllerAt(position)?.peek(peek);
+        const group = this.host.getEdgeGroupPanel(position);
+        const controller = group && this._controllers.get(group);
+        controller?.peek(peek);
     }
 }
 

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -205,11 +205,9 @@ class EdgeGroupController extends CompositeDisposable {
         const doc = this.group.element.ownerDocument;
         const bar = doc.createElement('div');
         bar.className = 'dv-edge-peek-header';
-        bar.style.display = 'flex';
-        bar.style.alignItems = 'center';
-        bar.style.gap = '4px';
-        bar.style.boxSizing = 'border-box';
-        bar.style.padding = '0 4px 0 8px';
+        // Layout/cosmetics are owned by `.dv-edge-peek-header` / -title in the
+        // stylesheet (overlay.scss). Only the resolved opaque background is
+        // dynamic — the floating peek must never be see-through.
         if (opts.background) {
             bar.style.backgroundColor = opts.background;
         }
@@ -217,11 +215,6 @@ class EdgeGroupController extends CompositeDisposable {
         const titleEl = doc.createElement('span');
         titleEl.className = 'dv-edge-peek-title';
         titleEl.textContent = opts.title;
-        titleEl.style.flex = '1 1 auto';
-        titleEl.style.overflow = 'hidden';
-        titleEl.style.textOverflow = 'ellipsis';
-        titleEl.style.whiteSpace = 'nowrap';
-        titleEl.style.fontSize = '12px';
         bar.appendChild(titleEl);
 
         const mk = (
@@ -551,19 +544,30 @@ class EdgeGroupController extends CompositeDisposable {
 
     private _armCloseListeners(): void {
         const doc = this.group.element.ownerDocument;
-        // Esc + outside-pointerdown dismissal (the shared transient-layer
-        // lifecycle). Inside/outside is geometry-based because an `always`
-        // panel's content is a sibling overlay on top; capture phase so it sees
-        // the event before content handlers can stop it.
+        // The whole dismissal lifecycle (Esc + outside-pointerdown + resize +
+        // focus-out) is the shared layer's job. Inside/outside is geometry-based
+        // — for a pointer event and for a focused element's centre — because an
+        // `always` panel's content is a sibling overlay on top, not inside the
+        // peek's DOM subtree. Capture so it's seen before content handlers.
+        const withinCentre = (el: Element): boolean => {
+            const r = el.getBoundingClientRect();
+            return this._pointWithinPeek(
+                r.left + r.width / 2,
+                r.top + r.height / 2
+            );
+        };
         this._closeListeners = new CompositeDisposable(
             createDismissableLayer({
                 window: doc.defaultView ?? window,
                 capture: true,
                 onDismiss: () => this._closePeek(),
                 isInside: (e) => this._pointWithinPeek(e.clientX, e.clientY),
-                // The peek is anchored to the strip and doesn't re-layout on
-                // resize; close it (popover-style) rather than leave it stale.
+                // Anchored to the strip and not re-laid-out on resize → close
+                // (popover-style) rather than leave it stale. Focus leaving the
+                // peek closes it (the VS "slide back on focus loss").
                 resize: true,
+                focusOut: true,
+                isFocusInside: withinCentre,
             })
         );
     }

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -5,67 +5,69 @@ import { EdgeGroupPosition } from 'dockview-core';
 import { AutoHideEdgeGroupOptions } from 'dockview-core';
 import { defineModule, EdgeGroupModule } from 'dockview-core';
 import {
+    createCloseButton,
+    createDismissableLayer,
+    createPinButton,
+    prefersReducedMotion,
+    resolveOpaqueBackground,
+} from 'dockview-core';
+import {
     IAutoHideEdgeGroupHost,
     IAutoHideEdgeGroupService,
 } from 'dockview-core';
 
+/** Height (px) of the title bar; the content/`always` overlay is inset below it
+ *  so nothing paints under the bar. The title bar's own height is set inline to
+ *  this value, so it's the single source of truth (no theme var). */
+const TITLEBAR_HEIGHT = 28;
+
 function resolveOptions(o: boolean | AutoHideEdgeGroupOptions | undefined): {
     enabled: boolean;
-    openDelay: number;
-    closeDelay: number;
     animate: boolean;
 } {
     const obj = typeof o === 'object' ? o : {};
     return {
         enabled: !!o,
-        openDelay: obj.openDelay ?? 250,
-        closeDelay: obj.closeDelay ?? 300,
         animate: obj.animate ?? true,
     };
 }
 
-function prefersReducedMotion(doc: Document): boolean {
-    const mq = doc.defaultView?.matchMedia?.(
-        '(prefers-reduced-motion: reduce)'
-    );
-    return !!mq?.matches;
-}
-
 /**
- * Auto-hide peek for a single edge group. The collapsed edge group already
- * renders its tabs along the strip (the native "activity bar") — this reuses
- * them as the peek triggers rather than rendering a parallel strip:
+ * Click-driven auto-hide ("pinnable") peek for a single edge group, modelled on
+ * Visual Studio tool windows. The collapsed edge group's native tabs are the
+ * triggers — **no hover**:
  *
- * - **Hover** the collapsed strip → after `openDelay`, the active panel slides
- *   out as an overlay on the shell overlay root. The live content element is
- *   reparented (state preserved) and the grid is NOT reflowed (the splitview
- *   view stays locked at `collapsedSize`).
- * - **Keyboard-focus** a collapsed tab → peeks (so the panel is reachable).
- *   **Clicking** a collapsed tab natively expands (pins) the group instead.
- * - **Leave** both the strip and the overlay → closes after `closeDelay`; a
- *   single shared timer, cancelled by re-entering either (the flicker fix).
- *   `Esc` / pointer-down outside / focus-out also close. A pin button re-docks.
+ * - **Click a tab** → that tab's panel slides out as a non-reflowing overlay
+ *   with a **title bar** (active title left; pin + close right). The content
+ *   container is reparented out (state preserved) and the grid is NOT reflowed.
+ * - **Click the same tab again**, or **click outside** the strip+peek, or
+ *   **Esc** → hide. Clicking empty space inside the tab strip does nothing.
+ * - **Pin** → re-dock (expand) the group. **Close** → close the panel.
  *
- * Both render modes slide out. It reparents the content CONTAINER (not the panel
- * content): for `onlyWhenVisible` the content lives inside it and moves with it;
- * for `always` the container is just the position reference the shared render
- * overlay anchors to — the content's parent (the render overlay) never changes,
- * we only re-run its positioning (`repositionPanelOverlay`, force-visible) as the
- * container slides, so the panel's own visibility state is never touched.
+ * Both render modes slide out: it reparents the content CONTAINER (not the
+ * panel content). For `onlyWhenVisible` the content rides inside it; for
+ * `always` the container is just the position reference the shared render
+ * overlay re-anchors to (`repositionPanelOverlay`, force-visible + clipped to
+ * the reveal window). A fixed clip frame makes the panel emerge from the
+ * strip's inner edge rather than from the screen edge.
  */
 class EdgeGroupController extends CompositeDisposable {
     private _peek:
         | {
+              clip: HTMLElement;
               overlay: HTMLElement;
               header: HTMLElement;
+              title: HTMLElement;
               content: HTMLElement;
               parent: HTMLElement;
               panel: IDockviewPanel;
           }
         | undefined;
     private _closeListeners: CompositeDisposable | undefined;
-    private _openTimer: ReturnType<typeof setTimeout> | undefined;
-    private _closeTimer: ReturnType<typeof setTimeout> | undefined;
+    /** The docked (pinned) tool-window chrome: a title bar at the top of the
+     *  expanded group, with the tab strip moved to the bottom. Present only
+     *  while the group is expanded (pinned); torn down when it auto-hides. */
+    private _docked: { bar: HTMLElement; title: HTMLElement } | undefined;
 
     constructor(
         private readonly group: DockviewGroupPanel,
@@ -74,57 +76,79 @@ class EdgeGroupController extends CompositeDisposable {
         super();
 
         const strip = this.group.element;
-        const onEnter = (): void => {
-            if (this._gate()) {
-                this._cancelClose();
-                this._scheduleOpen();
+        // Click a collapsed tab → toggle the peek for that tab's panel (open it,
+        // switch to it, or — if it's already the peeked tab — hide it). Natively
+        // a collapsed-tab click expands the group; suppress that (the edge-expand
+        // handler bails on a default-prevented click) so click peeks instead.
+        // Capture phase so it runs before the tab's own bubble-phase handler.
+        const onClick = (e: Event): void => {
+            const panel = this._resolveTabPanel((e as MouseEvent).target);
+            if (!panel || !this._gate()) {
+                return;
             }
+            e.preventDefault();
+            this._toggle(panel);
         };
-        const onLeave = (): void => {
-            this._cancelOpen();
-            this._scheduleClose();
-        };
-        // Keyboard-focus a collapsed tab → peek (so the keyboard can reach the
-        // panel). Deferred out of the focus event: reparenting the content
-        // container synchronously during dispatch makes the edge group expand.
-        // No click handler — clicking a collapsed edge tab natively *expands*
-        // (pins) the group, which is the intended VS-style behaviour (hover to
-        // peek, click to pin).
-        const onFocusIn = (): void => {
-            if (this._gate()) {
-                this._cancelClose();
-                this._scheduleOpen(0);
+        // Enter/Space on a focused tab is the keyboard equivalent of a click.
+        const onKeyDown = (e: Event): void => {
+            const ke = e as KeyboardEvent;
+            if (ke.key !== 'Enter' && ke.key !== ' ') {
+                return;
             }
+            const panel = this._resolveTabPanel(ke.target);
+            if (!panel || !this._gate()) {
+                return;
+            }
+            ke.preventDefault();
+            this._toggle(panel);
         };
-        strip.addEventListener('pointerenter', onEnter);
-        strip.addEventListener('pointerleave', onLeave);
-        strip.addEventListener('focusin', onFocusIn);
+        strip.addEventListener('click', onClick, true);
+        strip.addEventListener('keydown', onKeyDown);
 
         this.addDisposables(
-            // Expanding (pin) tears the peek down; collapsing leaves the native
-            // strip visible with nothing extra to render.
-            this.group.api.onDidCollapsedChange(() => this._closePeek()),
-            // Activating a different tab while peeking: the content container
-            // already shows the new active `onlyWhenVisible` panel; release the
-            // old `always` overlay and re-anchor the new active one over it.
+            // Collapse change: tear the peek down, then reconcile the docked
+            // tool-window chrome (expanded ⇒ title bar + tabs-bottom; collapsed
+            // ⇒ just the strip).
+            this.group.api.onDidCollapsedChange(() => {
+                this._closePeek();
+                this._updateDocked();
+            }),
+            // Switching the active tab: re-point whichever title bar is showing
+            // (peek or docked) at the new panel, and re-anchor `always` content.
             this.group.api.onDidActivePanelChange(() => {
                 const next = this.group.activePanel;
-                if (this._peek && next) {
+                if (!next) {
+                    return;
+                }
+                if (this._peek) {
                     this.host.repositionPanelOverlay(this._peek.panel, false);
                     this._peek.panel = next;
-                    this.host.repositionPanelOverlay(next, true);
+                    this._peek.title.textContent = next.title ?? '';
+                    this._syncOverlay();
+                }
+                if (this._docked) {
+                    this._docked.title.textContent = next.title ?? '';
                 }
             }),
             {
                 dispose: () => {
-                    strip.removeEventListener('pointerenter', onEnter);
-                    strip.removeEventListener('pointerleave', onLeave);
-                    strip.removeEventListener('focusin', onFocusIn);
-                    this._clearTimers();
+                    strip.removeEventListener('click', onClick, true);
+                    strip.removeEventListener('keydown', onKeyDown);
                     this._closePeek();
+                    this._teardownDocked();
                 },
             }
         );
+
+        // A pinnable edge group that's already expanded (e.g. restored from a
+        // pinned layout) renders as a tool window. Deferred: at `onDidAddGroup`
+        // time the shell hasn't applied the collapse yet, so an immediate
+        // `isCollapsed()` reads false and would wrongly dock a collapsed strip.
+        queueMicrotask(() => {
+            if (!this.isDisposed) {
+                this._updateDocked();
+            }
+        });
     }
 
     private get _opts() {
@@ -141,181 +165,264 @@ class EdgeGroupController extends CompositeDisposable {
         return location.type === 'edge' ? location.position : undefined;
     }
 
-    // --- timers ---
-
-    private _openNow(): void {
-        this._cancelOpen();
-        this._cancelClose();
-        this.openPeek();
+    /** Map a pointer/keyboard target to the panel of the strip tab under it, or
+     *  `undefined` for non-tab regions. Uses the core's authoritative tab→panel
+     *  lookup (no DOM-order assumptions). */
+    private _resolveTabPanel(
+        target: EventTarget | null
+    ): IDockviewPanel | undefined {
+        if (!(target instanceof Element)) {
+            return undefined;
+        }
+        return this.group.model.getPanelForTab(target);
     }
 
-    private _scheduleOpen(delay = this._opts.openDelay): void {
-        this._cancelOpen();
-        this._openTimer = setTimeout(() => this.openPeek(), delay);
-    }
-
-    private _cancelOpen(): void {
-        if (this._openTimer !== undefined) {
-            clearTimeout(this._openTimer);
-            this._openTimer = undefined;
+    /** Click/activate a tab: hide if it's the peeked one, switch if a different
+     *  one is peeked, else open it. */
+    private _toggle(panel: IDockviewPanel): void {
+        if (this._peek?.panel === panel) {
+            this._closePeek();
+        } else if (this._peek) {
+            panel.api.setActive(); // → onDidActivePanelChange re-anchors + retitles
+        } else {
+            this._openPeek(panel);
         }
     }
 
-    private _scheduleClose(): void {
-        // Idempotent: a document pointermove drives this on every move, so don't
-        // restart a running timer (that would prevent it ever firing).
-        if (this._closeTimer !== undefined) {
+    // --- shared title bar (peek overlay + docked tool window) ---
+
+    /** Build the tool-window title bar: panel title (left), pin + close (right).
+     *  Used by both the peek overlay and the docked group chrome — only the
+     *  mounting/positioning and the pin action differ. */
+    private _buildTitleBar(opts: {
+        title: string;
+        pinLabel: string;
+        closeLabel: string;
+        onPin: () => void;
+        onClose: () => void;
+        background: string;
+    }): { element: HTMLElement; title: HTMLElement } {
+        const doc = this.group.element.ownerDocument;
+        const bar = doc.createElement('div');
+        bar.className = 'dv-edge-peek-header';
+        bar.style.display = 'flex';
+        bar.style.alignItems = 'center';
+        bar.style.gap = '4px';
+        bar.style.boxSizing = 'border-box';
+        bar.style.padding = '0 4px 0 8px';
+        if (opts.background) {
+            bar.style.backgroundColor = opts.background;
+        }
+
+        const titleEl = doc.createElement('span');
+        titleEl.className = 'dv-edge-peek-title';
+        titleEl.textContent = opts.title;
+        titleEl.style.flex = '1 1 auto';
+        titleEl.style.overflow = 'hidden';
+        titleEl.style.textOverflow = 'ellipsis';
+        titleEl.style.whiteSpace = 'nowrap';
+        titleEl.style.fontSize = '12px';
+        bar.appendChild(titleEl);
+
+        const mk = (
+            cls: string,
+            icon: SVGElement,
+            label: string,
+            onClick: () => void
+        ): void => {
+            const btn = doc.createElement('button');
+            btn.className = cls;
+            btn.type = 'button';
+            btn.title = label;
+            btn.setAttribute('aria-label', label);
+            // Monotone SVG (inherits `currentColor` via `.dv-svg`), matching the
+            // tab close button. Cosmetics (incl. the hover background) are owned
+            // by the stylesheet — inline styles here would beat its `:hover`.
+            icon.setAttribute('aria-hidden', 'true');
+            btn.appendChild(icon);
+            btn.addEventListener('click', onClick);
+            bar.appendChild(btn);
+        };
+        mk('dv-edge-peek-pin', createPinButton(), opts.pinLabel, opts.onPin);
+        mk(
+            'dv-edge-peek-close',
+            createCloseButton(),
+            opts.closeLabel,
+            opts.onClose
+        );
+        return { element: bar, title: titleEl };
+    }
+
+    // --- docked (pinned) tool-window chrome ---
+
+    /** Reconcile the docked chrome with the collapse state: an expanded
+     *  (pinned) edge group renders as a tool window (title bar top + tabs
+     *  bottom); a collapsed one is just the strip. */
+    private _updateDocked(): void {
+        const shouldDock = this._opts.enabled && !this.group.api.isCollapsed();
+        if (shouldDock && !this._docked) {
+            this._setupDocked();
+        } else if (!shouldDock && this._docked) {
+            this._teardownDocked();
+        }
+    }
+
+    private _setupDocked(): void {
+        // Tabs to the bottom (existing per-group capability); the strip's edge
+        // orientation is restored on teardown.
+        this.group.api.setHeaderPosition('bottom');
+
+        const title = this.group.activePanel?.title ?? '';
+        const { element, title: titleEl } = this._buildTitleBar({
+            title,
+            // The pushpin here UN-pins (auto-hides), the inverse of the peek's.
+            // Generic labels: the title element carries the panel name and
+            // updates on switch, so the button names never go stale.
+            pinLabel: 'Auto-hide',
+            closeLabel: 'Close',
+            onPin: () => this.host.setEdgeGroupCollapsed(this.group, true),
+            onClose: () => this.group.activePanel?.api.close(),
+            background: resolveOpaqueBackground(this.group.element),
+        });
+        element.style.flexShrink = '0';
+        element.style.height = `${TITLEBAR_HEIGHT}px`;
+        // Appended last → under the group's `column-reverse` (header-bottom)
+        // flow it lands at the visual TOP, above the content, with the tab
+        // strip at the bottom.
+        this.group.element.appendChild(element);
+        this._docked = { bar: element, title: titleEl };
+    }
+
+    private _teardownDocked(): void {
+        if (!this._docked) {
             return;
         }
-        this._closeTimer = setTimeout(
-            () => this._closePeek(),
-            this._opts.closeDelay
-        );
-    }
-
-    private _cancelClose(): void {
-        if (this._closeTimer !== undefined) {
-            clearTimeout(this._closeTimer);
-            this._closeTimer = undefined;
-        }
-    }
-
-    private _clearTimers(): void {
-        this._cancelOpen();
-        this._cancelClose();
-    }
-
-    /** The first opaque computed background walking up from the group — so the
-     *  floating peek is never see-through, whatever (if anything) the consumer
-     *  themed. Returns '' if nothing opaque is found (let the stylesheet win). */
-    private _resolveBackground(): string {
-        const win = this.group.element.ownerDocument.defaultView;
-        if (!win) {
-            return '';
-        }
-        let el: HTMLElement | null = this.group.element;
-        while (el) {
-            const bg = win.getComputedStyle(el).backgroundColor;
-            if (bg && bg !== 'transparent' && bg !== 'rgba(0, 0, 0, 0)') {
-                return bg;
-            }
-            el = el.parentElement;
-        }
-        return '';
+        this._docked.bar.remove();
+        this._docked = undefined;
+        // Restore the strip's edge orientation (left/right/top/bottom).
+        this.group.api.setHeaderPosition(this._position ?? 'top');
     }
 
     // --- peek ---
 
-    openPeek(): void {
-        if (!this._gate()) {
+    /** Pull keyboard focus into the peeked content (best-effort): the first
+     *  focusable descendant, else the content container (it carries tabindex). */
+    private _focusPeekContent(): void {
+        const content = this._peek?.content;
+        if (!content) {
             return;
         }
-        const panel = this.group.activePanel;
-        if (!panel) {
+        const focusable = content.querySelector<HTMLElement>(
+            'a[href], button, input, select, textarea, [tabindex]'
+        );
+        (focusable ?? content).focus();
+    }
+
+    private _openPeek(panel: IDockviewPanel): void {
+        if (!this._gate() || !panel) {
             return;
         }
-        // Reparent the whole content CONTAINER (not the panel's content element)
-        // so BOTH renderers work: `onlyWhenVisible` content lives inside it, and
-        // an `always` panel's render overlay is anchored to it (re-anchored via
-        // repositionPanelOverlay). It un-hides automatically once out of the
-        // collapsed group's subtree.
+        const title = panel.title ?? '';
+        // The content container only shows the active panel, so activate the
+        // target first (the grid stays collapsed).
+        if (this.group.activePanel !== panel) {
+            panel.api.setActive();
+        }
+        // Reparent the whole content CONTAINER so BOTH renderers work (see class
+        // doc). It un-hides automatically once out of the collapsed subtree.
         const content = this.group.element.querySelector<HTMLElement>(
             '.dv-content-container'
         );
         const parent = content?.parentElement;
-        if (!content || !parent) {
-            return;
-        }
-        // Already peeking? nothing to do.
-        if (this._peek?.content === content) {
+        if (!content || !parent || this._peek?.content === content) {
             return;
         }
 
         const doc = this.group.element.ownerDocument;
+        const background = resolveOpaqueBackground(this.group.element);
+
+        // --- peek backdrop (slides inside the clip frame) ---
         const overlay = doc.createElement('div');
         overlay.className = 'dv-edge-peek';
         overlay.style.position = 'absolute';
         overlay.style.overflow = 'hidden';
         overlay.style.boxSizing = 'border-box';
-        // Above grid content (the floating-overlay host is pointer-events:none,
-        // so opt this child back in).
-        overlay.style.zIndex = '999';
+        overlay.style.zIndex = '999'; // float-host is pointer-events:none; opt in
         overlay.style.pointerEvents = 'auto';
-        // The peek FLOATS over other content, so it must be opaque — a docked
-        // group can be transparent (the shell shows through harmlessly), but a
-        // floating one can't. The `.dv-edge-peek` stylesheet rule defaults it to
-        // the group-view background, but if the consumer hasn't set that var the
-        // peek would be see-through; derive an opaque background from the live
-        // group (falling back up the tree) so it's never transparent.
-        const background = this._resolveBackground();
+        overlay.style.left = '0';
+        overlay.style.top = '0';
+        overlay.style.width = '100%';
+        overlay.style.height = '100%';
         if (background) {
             overlay.style.backgroundColor = background;
         }
 
-        // The Pin header is a SEPARATE sibling overlay (not a child of the peek)
-        // so it can sit ABOVE an `always` panel's render overlay, which is itself
-        // a sibling lifted above the peek backdrop (peek bg < always content <
-        // pin). It's click-through except for the button so it never blocks the
-        // peeked content.
-        const header = doc.createElement('div');
-        header.className = 'dv-edge-peek-header';
+        // --- title bar (separate sibling so it layers above an `always` render
+        //     overlay; it sits in the top band ABOVE the content) ---
+        const { element: header, title: titleEl } = this._buildTitleBar({
+            title,
+            pinLabel: 'Pin',
+            closeLabel: 'Close',
+            onPin: () => this.pin(),
+            onClose: () => this.close(),
+            background,
+        });
         header.style.position = 'absolute';
         header.style.zIndex = '1001';
-        header.style.pointerEvents = 'none';
-        header.style.display = 'flex';
-        header.style.justifyContent = 'flex-end';
-        header.style.alignItems = 'flex-start';
-        header.style.padding = '4px';
-        const pinButton = doc.createElement('button');
-        pinButton.className = 'dv-edge-peek-pin';
-        pinButton.type = 'button';
-        pinButton.title = 'Pin';
-        pinButton.setAttribute('aria-label', 'Pin');
-        pinButton.textContent = 'Pin';
-        // Self-contained cosmetics (it floats over the content, so needs its own
-        // surface) — the stylesheet refines these but they must not depend on it.
-        pinButton.style.pointerEvents = 'auto';
-        pinButton.style.cursor = 'pointer';
-        pinButton.style.border = '1px solid transparent';
-        pinButton.style.borderRadius = '3px';
-        pinButton.style.padding = '2px 8px';
-        pinButton.style.fontSize = '11px';
-        if (background) {
-            pinButton.style.backgroundColor = background;
-        }
-        pinButton.addEventListener('click', () => this.pin());
-        header.appendChild(pinButton);
+        // The overlay root is pointer-events:none — opt the title bar back in so
+        // its buttons are clickable. It's in the top band, above the content.
+        header.style.pointerEvents = 'auto';
 
-        // Reparent the live content into the overlay (state preserved). Fill the
-        // overlay so it doesn't depend on the consumer's stylesheet for layout.
+        // --- fixed clip frame (content emerges from the strip's inner edge) ---
+        const clip = doc.createElement('div');
+        clip.className = 'dv-edge-peek-clip';
+        clip.style.position = 'absolute';
+        clip.style.overflow = 'hidden';
+        clip.style.pointerEvents = 'none';
+
         content.style.width = '100%';
         content.style.height = '100%';
         overlay.appendChild(content);
+        clip.appendChild(overlay);
 
-        this.host.overlayRoot.appendChild(overlay);
+        this.host.overlayRoot.appendChild(clip);
         this.host.overlayRoot.appendChild(header);
-        this._peek = { overlay, header, content, parent, panel };
-        this._positionOverlay(overlay);
+        this._peek = {
+            clip,
+            overlay,
+            header,
+            title: titleEl,
+            content,
+            parent,
+            panel,
+        };
+        this._positionOverlay();
         this._armCloseListeners();
         this.host.setEdgeGroupPeeking(this.group, true);
         this._animateIn(overlay);
+        this._focusPeekContent();
+        if (title) {
+            this.host.announce(`${title} shown`);
+        }
     }
 
     /** Re-anchor the peeked `always` panel's render overlay over the (current)
-     *  content-container box, force-showing it. No-op for `onlyWhenVisible`
-     *  (whose content rides inside the reparented container). */
+     *  content box, force-showing it and clipping it to the reveal window. No-op
+     *  for `onlyWhenVisible` (whose content rides inside the reparented box). */
     private _syncOverlay(): void {
         if (this._peek) {
-            this.host.repositionPanelOverlay(this._peek.panel, true);
+            this.host.repositionPanelOverlay(
+                this._peek.panel,
+                true,
+                this._peek.clip.getBoundingClientRect()
+            );
         }
     }
 
     /**
-     * Slide the overlay in from the strip edge. Driven by a manual rAF loop
-     * (not a CSS transition) so that on every frame we also re-anchor any
-     * `always`-rendered content over the container's *moving* box — otherwise
-     * `onlyWhenVisible` content (inside the overlay) would slide but `always`
-     * content (positioned in the shared render overlay) would not.
+     * Slide the content overlay in from the strip edge via a manual rAF loop, so
+     * that each frame re-anchors any `always` content over the moving box. The
+     * title bar is fixed (it doesn't slide) — the content slides in beneath it.
      */
     private _animateIn(overlay: HTMLElement): void {
         const position = this._position;
@@ -345,7 +452,6 @@ class EdgeGroupController extends CompositeDisposable {
             const remaining = (1 - eased) * 100 * sign;
             overlay.style.transform =
                 t >= 1 ? '' : `translate${axis}(${remaining}%)`;
-            // Re-anchor `always` content over the container's transformed box.
             this._syncOverlay();
             if (t < 1) {
                 win.requestAnimationFrame(step);
@@ -354,13 +460,12 @@ class EdgeGroupController extends CompositeDisposable {
         win.requestAnimationFrame(step);
     }
 
-    /** Anchor the overlay to the strip's inner edge, sized to the group's
-     *  expanded size — relative to the overlay root. No grid reflow. The Pin
-     *  header tracks the same box (it's a separate sibling so it can sit above
-     *  an `always` render overlay). */
-    private _positionOverlay(overlay: HTMLElement): void {
+    /** Anchor the title bar (top band) and the clip frame (content, inset below
+     *  the title bar) to the strip's inner edge, sized to the group's expanded
+     *  size — relative to the overlay root. No grid reflow. */
+    private _positionOverlay(): void {
         const position = this._position;
-        if (!position) {
+        if (!position || !this._peek) {
             return;
         }
         const strip = this.group.element.getBoundingClientRect();
@@ -405,96 +510,65 @@ class EdgeGroupController extends CompositeDisposable {
                 break;
         }
 
-        const apply = (el: HTMLElement): void => {
-            el.style.left = `${box.left}px`;
-            el.style.top = `${box.top}px`;
-            el.style.width = `${box.width}px`;
-            el.style.height = `${box.height}px`;
+        // Title bar fills the top band; content occupies the rest below it.
+        const bar = Math.min(TITLEBAR_HEIGHT, box.height);
+        const set = (
+            el: HTMLElement,
+            b: { left: number; top: number; width: number; height: number }
+        ): void => {
+            el.style.left = `${b.left}px`;
+            el.style.top = `${b.top}px`;
+            el.style.width = `${b.width}px`;
+            el.style.height = `${b.height}px`;
         };
-        apply(overlay);
-        if (this._peek) {
-            apply(this._peek.header);
-        }
+        set(this._peek.header, { ...box, height: bar });
+        set(this._peek.clip, {
+            left: box.left,
+            top: box.top + bar,
+            width: box.width,
+            height: box.height - bar,
+        });
     }
 
-    /** Is the point within the strip or the peek's box? Geometry-based so it
-     *  works regardless of which stacking layer the pointer is actually over —
-     *  for `always` the content is a separate render overlay ON TOP of the peek,
-     *  so element-based enter/leave on the peek would miss it. */
+    /** Is the point within the peek (overlay or title bar) or the strip
+     *  container? In the click model, clicking anywhere in the strip — tab or
+     *  empty space — must NOT dismiss; only an outside click does. */
     private _pointWithinPeek(x: number, y: number): boolean {
         if (!this._peek) {
             return false;
         }
         const within = (r: DOMRect): boolean =>
             x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
+        // Use the FIXED clip frame (the reveal window), not the sliding overlay
+        // — during the slide-in the overlay doesn't yet cover the whole reveal,
+        // so a click on the revealed content would otherwise read as "outside".
         return (
-            within(this._peek.overlay.getBoundingClientRect()) ||
-            within(this.group.element.getBoundingClientRect())
+            within(this.group.element.getBoundingClientRect()) ||
+            within(this._peek.clip.getBoundingClientRect()) ||
+            within(this._peek.header.getBoundingClientRect())
         );
     }
 
     private _armCloseListeners(): void {
         const doc = this.group.element.ownerDocument;
-        const overlay = this._peek!.overlay;
-        const onKeyDown = (e: Event): void => {
-            if ((e as KeyboardEvent).key === 'Escape') {
-                this._closePeek();
-            }
-        };
-        const onPointerDown = (e: Event): void => {
-            const pe = e as PointerEvent;
-            if (this._pointWithinPeek(pe.clientX, pe.clientY)) {
-                return;
-            }
-            this._closePeek();
-        };
-        // Keep-open / close by pointer geometry, not by element containment —
-        // the peeked content may be a sibling render overlay on top of the peek.
-        const onPointerMove = (e: Event): void => {
-            const pe = e as PointerEvent;
-            if (this._pointWithinPeek(pe.clientX, pe.clientY)) {
-                this._cancelClose();
-            } else {
-                this._scheduleClose();
-            }
-        };
-        const onFocusOut = (e: Event): void => {
-            const next = (e as FocusEvent).relatedTarget;
-            if (
-                next instanceof Node &&
-                (overlay.contains(next) || this.group.element.contains(next))
-            ) {
-                return;
-            }
-            this._scheduleClose();
-        };
-        doc.addEventListener('keydown', onKeyDown, true);
-        doc.addEventListener('pointerdown', onPointerDown, true);
-        doc.addEventListener('pointermove', onPointerMove, true);
-        overlay.addEventListener('focusout', onFocusOut);
-
+        // Esc + outside-pointerdown dismissal (the shared transient-layer
+        // lifecycle). Inside/outside is geometry-based because an `always`
+        // panel's content is a sibling overlay on top; capture phase so it sees
+        // the event before content handlers can stop it.
         this._closeListeners = new CompositeDisposable(
-            {
-                dispose: () =>
-                    doc.removeEventListener('keydown', onKeyDown, true),
-            },
-            {
-                dispose: () =>
-                    doc.removeEventListener('pointerdown', onPointerDown, true),
-            },
-            {
-                dispose: () =>
-                    doc.removeEventListener('pointermove', onPointerMove, true),
-            },
-            {
-                dispose: () =>
-                    overlay.removeEventListener('focusout', onFocusOut),
-            }
+            createDismissableLayer({
+                window: doc.defaultView ?? window,
+                capture: true,
+                onDismiss: () => this._closePeek(),
+                isInside: (e) => this._pointWithinPeek(e.clientX, e.clientY),
+                // The peek is anchored to the strip and doesn't re-layout on
+                // resize; close it (popover-style) rather than leave it stale.
+                resize: true,
+            })
         );
     }
 
     private _closePeek(): void {
-        this._clearTimers();
         this._closeListeners?.dispose();
         this._closeListeners = undefined;
         const peek = this._peek;
@@ -502,18 +576,30 @@ class EdgeGroupController extends CompositeDisposable {
         if (!peek) {
             return;
         }
-        // Restore the content container before removing the overlay, clearing
-        // the fill styles applied for the peek.
+        // If focus is inside the peek (a keyboard close — Esc / pin / close),
+        // return it to the strip tab so it isn't dropped onto <body>.
+        const doc = this.group.element.ownerDocument;
+        const restoreFocus =
+            doc.activeElement instanceof Node &&
+            (peek.overlay.contains(doc.activeElement) ||
+                peek.header.contains(doc.activeElement));
+        // Restore the content container before removing the overlay.
         peek.content.style.width = '';
         peek.content.style.height = '';
         peek.parent.appendChild(peek.content);
-        peek.overlay.remove();
+        peek.clip.remove(); // removes the overlay (its child) too
         peek.header.remove();
         this.host.setEdgeGroupPeeking(this.group, false);
-        // Re-anchor the `always` overlay back over the (now collapsed, in-group)
-        // container — forceVisible:false lets it hide again as the panel is no
-        // longer visible.
+        // Re-anchor the `always` overlay back over the collapsed in-group
+        // container (forceVisible:false lets it hide again, and clears the clip).
         this.host.repositionPanelOverlay(peek.panel, false);
+        if (restoreFocus) {
+            const tab =
+                this.group.element.querySelector<HTMLElement>(
+                    '.dv-active-tab'
+                ) ?? this.group.element.querySelector<HTMLElement>('.dv-tab');
+            tab?.focus();
+        }
     }
 
     isPeeking(): boolean {
@@ -522,24 +608,39 @@ class EdgeGroupController extends CompositeDisposable {
 
     peek(open: boolean): void {
         if (open) {
-            this._openNow();
+            const panel = this.group.activePanel;
+            if (panel) {
+                this._openPeek(panel);
+            }
         } else {
             this._closePeek();
         }
     }
 
-    /** Re-dock: restore content, then expand via the host's collapse path. */
+    /** Re-dock: restore content, then expand (pin) the group via the host. */
     pin(): void {
+        const title = this._peek?.panel.title ?? this.group.activePanel?.title;
         this._closePeek();
         this.host.setEdgeGroupCollapsed(this.group, false);
+        if (title) {
+            this.host.announce(`${title} pinned`);
+        }
+    }
+
+    /** Close the peeked (active) panel and tear the peek down. */
+    close(): void {
+        const panel = this._peek?.panel ?? this.group.activePanel;
+        this._closePeek();
+        panel?.api.close();
     }
 }
 
 /**
- * Auto-hide edge groups (VS-style). A collapsed edge group's native tabs become
- * peek triggers: hover/focus/click slides the active panel out as a
- * non-reflowing overlay, with a pin button to re-dock. Opt-in via
- * `autoHideEdgeGroups` (default off → collapsed edge groups behave as today).
+ * Auto-hide ("pinnable") edge groups, modelled on Visual Studio tool windows. A
+ * collapsed edge group's native tabs are click triggers: clicking a tab slides
+ * the panel out as a non-reflowing overlay with a title bar (pin + close);
+ * pinning re-docks the group. Opt-in via `autoHideEdgeGroups` (default off →
+ * collapsed edge groups behave as today).
  */
 export class AutoHideEdgeGroupService
     extends CompositeDisposable

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -170,6 +170,25 @@ class EdgeGroupController extends CompositeDisposable {
         this._cancelClose();
     }
 
+    /** The first opaque computed background walking up from the group — so the
+     *  floating peek is never see-through, whatever (if anything) the consumer
+     *  themed. Returns '' if nothing opaque is found (let the stylesheet win). */
+    private _resolveBackground(): string {
+        const win = this.group.element.ownerDocument.defaultView;
+        if (!win) {
+            return '';
+        }
+        let el: HTMLElement | null = this.group.element;
+        while (el) {
+            const bg = win.getComputedStyle(el).backgroundColor;
+            if (bg && bg !== 'transparent' && bg !== 'rgba(0, 0, 0, 0)') {
+                return bg;
+            }
+            el = el.parentElement;
+        }
+        return '';
+    }
+
     // --- peek ---
 
     openPeek(): void {
@@ -206,6 +225,16 @@ class EdgeGroupController extends CompositeDisposable {
         // so opt this child back in).
         overlay.style.zIndex = '999';
         overlay.style.pointerEvents = 'auto';
+        // The peek FLOATS over other content, so it must be opaque — a docked
+        // group can be transparent (the shell shows through harmlessly), but a
+        // floating one can't. The `.dv-edge-peek` stylesheet rule defaults it to
+        // the group-view background, but if the consumer hasn't set that var the
+        // peek would be see-through; derive an opaque background from the live
+        // group (falling back up the tree) so it's never transparent.
+        const background = this._resolveBackground();
+        if (background) {
+            overlay.style.backgroundColor = background;
+        }
 
         const header = doc.createElement('div');
         header.className = 'dv-edge-peek-header';

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -1,5 +1,5 @@
 import { DockviewCompositeDisposable as CompositeDisposable } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
+import { DockviewGroupPanel, IDockviewPanel } from 'dockview-core';
 import { EdgeGroupPosition } from 'dockview-core';
 import { AutoHideEdgeGroupOptions } from 'dockview-core';
 import { defineModule, EdgeGroupModule } from 'dockview-core';
@@ -8,27 +8,32 @@ import {
     IAutoHideEdgeGroupService,
 } from 'dockview-core';
 
-function resolveOptions(o: boolean | AutoHideEdgeGroupOptions | undefined): {
-    enabled: boolean;
-    showIcons: boolean;
-} {
-    if (!o) {
-        return { enabled: false, showIcons: true };
-    }
-    if (o === true) {
-        return { enabled: true, showIcons: true };
-    }
-    return { enabled: true, showIcons: o.showIcons ?? true };
+function isEnabled(o: boolean | AutoHideEdgeGroupOptions | undefined): boolean {
+    return !!o;
 }
 
 /**
- * Renders the collapsed-strip activators for a single edge group and pins the
- * group when one is clicked. The activator list mirrors the group's panels and
- * is shown only while the group is collapsed and the feature is enabled — so
- * with `autoHideEdgeGroups` off the baseline (empty) strip is untouched.
+ * Strip activators + slide-out peek for a single edge group.
+ *
+ * - **Strip** (Phase 1): when the group is collapsed, render a clickable
+ *   activator per panel.
+ * - **Peek** (Phase 2): clicking an activator slides the panel out as an
+ *   overlay on the shared floating-overlay host — the live content element is
+ *   reparented (state preserved) and the grid is **not** reflowed (the splitview
+ *   view stays locked at `collapsedSize`). A pin button re-docks it; `Esc` or a
+ *   pointer-down outside closes it.
+ *
+ * Limited to `onlyWhenVisible` renderers; an `always`-renderer panel (whose live
+ * element lives in the shared render overlay) falls back to pinning. Hover/focus
+ * debounce + animation are later phases.
  */
-class EdgeStripController extends CompositeDisposable {
+class EdgeGroupController extends CompositeDisposable {
     private _strip: HTMLElement | undefined;
+    // open peek: the reparented content + where to put it back
+    private _peek:
+        | { overlay: HTMLElement; content: HTMLElement; parent: HTMLElement }
+        | undefined;
+    private _closeListeners: CompositeDisposable | undefined;
 
     constructor(
         private readonly group: DockviewGroupPanel,
@@ -37,22 +42,35 @@ class EdgeStripController extends CompositeDisposable {
         super();
 
         this.addDisposables(
-            this.group.api.onDidCollapsedChange(() => this._render()),
-            this.group.model.onDidAddPanel(() => this._render()),
-            this.group.model.onDidRemovePanel(() => this._render()),
-            { dispose: () => this._removeStrip() }
+            this.group.api.onDidCollapsedChange(() => {
+                this._closePeek();
+                this._renderStrip();
+            }),
+            this.group.model.onDidAddPanel(() => this._renderStrip()),
+            this.group.model.onDidRemovePanel(() => this._renderStrip()),
+            {
+                dispose: () => {
+                    this._closePeek();
+                    this._removeStrip();
+                },
+            }
         );
 
-        this._render();
+        this._renderStrip();
     }
 
     private get _enabled(): boolean {
-        return resolveOptions(this.host.options.autoHideEdgeGroups).enabled;
+        return isEnabled(this.host.options.autoHideEdgeGroups);
     }
 
-    /** Rebuild the activator strip from the current panels, or remove it when
-     *  the group is expanded / the feature is off. */
-    private _render(): void {
+    private get _position(): EdgeGroupPosition | undefined {
+        const location = this.group.api.location;
+        return location.type === 'edge' ? location.position : undefined;
+    }
+
+    // --- strip ---
+
+    private _renderStrip(): void {
         if (!this._enabled || !this.group.api.isCollapsed()) {
             this._removeStrip();
             return;
@@ -62,8 +80,6 @@ class EdgeStripController extends CompositeDisposable {
         const doc = this.group.element.ownerDocument;
         const strip = doc.createElement('div');
         strip.className = 'dv-edge-activator-strip';
-        // Minimal inline layout so the strip is usable before any theme styles
-        // it; visual polish (orientation, icons) is a follow-up phase.
         strip.style.display = 'flex';
         strip.style.flexWrap = 'wrap';
 
@@ -72,13 +88,7 @@ class EdgeStripController extends CompositeDisposable {
             button.className = 'dv-edge-activator';
             button.type = 'button';
             button.textContent = panel.title ?? panel.id;
-            // Clicking an activator pins (expands) the group and activates the
-            // panel. Pin goes through the host's single collapse mutate path.
-            // (Listeners are GC'd with the button when the strip is removed.)
-            button.addEventListener('click', () => {
-                this.host.setEdgeGroupCollapsed(this.group, false);
-                panel.api.setActive();
-            });
+            button.addEventListener('click', () => this._onActivator(panel));
             strip.appendChild(button);
         }
 
@@ -90,13 +100,191 @@ class EdgeStripController extends CompositeDisposable {
         this._strip?.remove();
         this._strip = undefined;
     }
+
+    private _onActivator(panel: IDockviewPanel): void {
+        // Make the clicked panel active, then peek it (or pin if it can't peek).
+        panel.api.setActive();
+        this.openPeek();
+    }
+
+    // --- peek ---
+
+    openPeek(): void {
+        if (!this._enabled || !this.group.api.isCollapsed()) {
+            return;
+        }
+        const panel = this.group.activePanel;
+        if (!panel) {
+            return;
+        }
+        // The `always` renderer's element lives in the shared render overlay, not
+        // the content container — reparenting it is a later phase; pin instead.
+        if (panel.api.renderer === 'always') {
+            this.pin();
+            return;
+        }
+        if (this._peek) {
+            this._closePeek();
+        }
+
+        const content = panel.view.content.element;
+        const parent = content.parentElement;
+        if (!parent) {
+            return;
+        }
+
+        const doc = this.group.element.ownerDocument;
+        const overlay = doc.createElement('div');
+        overlay.className = 'dv-edge-peek';
+        overlay.style.position = 'absolute';
+        overlay.style.background = 'var(--dv-group-view-background-color)';
+        overlay.style.overflow = 'hidden';
+        overlay.style.boxSizing = 'border-box';
+        // Sit above grid content (the floating-overlay host is pointer-events:
+        // none, so opt this child back in) and take pointer events for the
+        // slid-out panel + its pin button.
+        overlay.style.zIndex = '999';
+        overlay.style.pointerEvents = 'auto';
+
+        // A small header with a pin affordance (re-dock).
+        const pinButton = doc.createElement('button');
+        pinButton.className = 'dv-edge-peek-pin';
+        pinButton.type = 'button';
+        pinButton.textContent = 'Pin';
+        pinButton.addEventListener('click', () => this.pin());
+        overlay.appendChild(pinButton);
+
+        // Reparent the live content into the overlay (state preserved).
+        overlay.appendChild(content);
+
+        this.host.floatingOverlayHost.appendChild(overlay);
+        this._peek = { overlay, content, parent };
+        this._positionOverlay(overlay);
+        this._armCloseListeners();
+    }
+
+    /** Anchor the overlay to the strip's inner edge, sized to the group's
+     *  expanded size — relative to the floating-overlay host. No grid reflow. */
+    private _positionOverlay(overlay: HTMLElement): void {
+        const position = this._position;
+        if (!position) {
+            return;
+        }
+        const strip = this.group.element.getBoundingClientRect();
+        const host = this.host.floatingOverlayHost.getBoundingClientRect();
+        const size = this.host.getEdgeGroupExpandedSize(position);
+        const left = strip.left - host.left;
+        const top = strip.top - host.top;
+
+        switch (position) {
+            case 'left':
+                Object.assign(overlay.style, {
+                    left: `${left + strip.width}px`,
+                    top: `${top}px`,
+                    width: `${size}px`,
+                    height: `${strip.height}px`,
+                });
+                break;
+            case 'right':
+                Object.assign(overlay.style, {
+                    left: `${left - size}px`,
+                    top: `${top}px`,
+                    width: `${size}px`,
+                    height: `${strip.height}px`,
+                });
+                break;
+            case 'top':
+                Object.assign(overlay.style, {
+                    left: `${left}px`,
+                    top: `${top + strip.height}px`,
+                    width: `${strip.width}px`,
+                    height: `${size}px`,
+                });
+                break;
+            case 'bottom':
+                Object.assign(overlay.style, {
+                    left: `${left}px`,
+                    top: `${top - size}px`,
+                    width: `${strip.width}px`,
+                    height: `${size}px`,
+                });
+                break;
+        }
+    }
+
+    private _armCloseListeners(): void {
+        const doc = this.group.element.ownerDocument;
+        const onKeyDown = (e: Event): void => {
+            if ((e as KeyboardEvent).key === 'Escape') {
+                this._closePeek();
+            }
+        };
+        const onPointerDown = (e: Event): void => {
+            const target = e.target;
+            if (!(target instanceof Node)) {
+                return;
+            }
+            // A click on the strip or inside the peek keeps it open.
+            if (
+                this._peek?.overlay.contains(target) ||
+                this.group.element.contains(target)
+            ) {
+                return;
+            }
+            this._closePeek();
+        };
+        doc.addEventListener('keydown', onKeyDown, true);
+        doc.addEventListener('pointerdown', onPointerDown, true);
+        this._closeListeners = new CompositeDisposable(
+            {
+                dispose: () =>
+                    doc.removeEventListener('keydown', onKeyDown, true),
+            },
+            {
+                dispose: () =>
+                    doc.removeEventListener('pointerdown', onPointerDown, true),
+            }
+        );
+    }
+
+    /** Restore the reparented content and remove the overlay (no layout change). */
+    private _closePeek(): void {
+        this._closeListeners?.dispose();
+        this._closeListeners = undefined;
+        const peek = this._peek;
+        this._peek = undefined;
+        if (!peek) {
+            return;
+        }
+        // Put the live content back where it came from before removing the overlay.
+        peek.parent.appendChild(peek.content);
+        peek.overlay.remove();
+    }
+
+    isPeeking(): boolean {
+        return this._peek !== undefined;
+    }
+
+    peek(open: boolean): void {
+        if (open) {
+            this.openPeek();
+        } else {
+            this._closePeek();
+        }
+    }
+
+    /** Re-dock: restore content, then expand via the host's collapse path. */
+    pin(): void {
+        this._closePeek();
+        this.host.setEdgeGroupCollapsed(this.group, false);
+    }
 }
 
 /**
- * Auto-hide edge groups (VS-style). Phase 1: a collapsed edge group renders
- * clickable activators in its strip; clicking one pins (expands) the group.
- * Opt-in via `autoHideEdgeGroups` (default off → baseline strip unchanged).
- * The slide-out peek + pin/unpin animation + serialization are later phases.
+ * Auto-hide edge groups (VS-style). A collapsed edge group renders clickable
+ * activators; clicking one slides the panel out as a non-reflowing overlay
+ * (peek), with a pin button to re-dock. Opt-in via `autoHideEdgeGroups`
+ * (default off → baseline strip unchanged).
  */
 export class AutoHideEdgeGroupService
     extends CompositeDisposable
@@ -104,7 +292,7 @@ export class AutoHideEdgeGroupService
 {
     private readonly _controllers = new Map<
         DockviewGroupPanel,
-        EdgeStripController
+        EdgeGroupController
     >();
 
     constructor(private readonly host: IAutoHideEdgeGroupHost) {
@@ -129,7 +317,7 @@ export class AutoHideEdgeGroupService
         ) {
             return;
         }
-        this._controllers.set(group, new EdgeStripController(group, this.host));
+        this._controllers.set(group, new EdgeGroupController(group, this.host));
     }
 
     private _untrack(group: DockviewGroupPanel): void {
@@ -140,10 +328,23 @@ export class AutoHideEdgeGroupService
         }
     }
 
+    private _controllerAt(
+        position: EdgeGroupPosition
+    ): EdgeGroupController | undefined {
+        const group = this.host.getEdgeGroupPanel(position);
+        return group ? this._controllers.get(group) : undefined;
+    }
+
     pin(position: EdgeGroupPosition): void {
         const group = this.host.getEdgeGroupPanel(position);
         if (group) {
-            this.host.setEdgeGroupCollapsed(group, false);
+            // Use the controller so an open peek is torn down cleanly first.
+            const controller = this._controllers.get(group);
+            if (controller) {
+                controller.pin();
+            } else {
+                this.host.setEdgeGroupCollapsed(group, false);
+            }
         }
     }
 
@@ -152,6 +353,10 @@ export class AutoHideEdgeGroupService
         if (group) {
             this.host.setEdgeGroupCollapsed(group, true);
         }
+    }
+
+    peek(position: EdgeGroupPosition, peek: boolean): void {
+        this._controllerAt(position)?.peek(peek);
     }
 }
 

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -1,5 +1,6 @@
 import { DockviewCompositeDisposable as CompositeDisposable } from 'dockview-core';
 import { DockviewGroupPanel } from 'dockview-core';
+import { IDockviewPanel } from 'dockview-core';
 import { EdgeGroupPosition } from 'dockview-core';
 import { AutoHideEdgeGroupOptions } from 'dockview-core';
 import { defineModule, EdgeGroupModule } from 'dockview-core';
@@ -49,11 +50,17 @@ function prefersReducedMotion(doc: Document): boolean {
  * content): for `onlyWhenVisible` the content lives inside it and moves with it;
  * for `always` the container is just the position reference the shared render
  * overlay anchors to — the content's parent (the render overlay) never changes,
- * we only re-run its positioning (`repositionOverlays`) as the container slides.
+ * we only re-run its positioning (`repositionPanelOverlay`, force-visible) as the
+ * container slides, so the panel's own visibility state is never touched.
  */
 class EdgeGroupController extends CompositeDisposable {
     private _peek:
-        | { overlay: HTMLElement; content: HTMLElement; parent: HTMLElement }
+        | {
+              overlay: HTMLElement;
+              content: HTMLElement;
+              parent: HTMLElement;
+              panel: IDockviewPanel;
+          }
         | undefined;
     private _closeListeners: CompositeDisposable | undefined;
     private _openTimer: ReturnType<typeof setTimeout> | undefined;
@@ -97,11 +104,14 @@ class EdgeGroupController extends CompositeDisposable {
             // strip visible with nothing extra to render.
             this.group.api.onDidCollapsedChange(() => this._closePeek()),
             // Activating a different tab while peeking: the content container
-            // already shows the new active `onlyWhenVisible` panel; re-anchor so
-            // the new active `always` panel covers it too.
+            // already shows the new active `onlyWhenVisible` panel; release the
+            // old `always` overlay and re-anchor the new active one over it.
             this.group.api.onDidActivePanelChange(() => {
-                if (this._peek) {
-                    this.host.repositionOverlays();
+                const next = this.group.activePanel;
+                if (this._peek && next) {
+                    this.host.repositionPanelOverlay(this._peek.panel, false);
+                    this._peek.panel = next;
+                    this.host.repositionPanelOverlay(next, true);
                 }
             }),
             {
@@ -195,13 +205,14 @@ class EdgeGroupController extends CompositeDisposable {
         if (!this._gate()) {
             return;
         }
-        if (!this.group.activePanel) {
+        const panel = this.group.activePanel;
+        if (!panel) {
             return;
         }
         // Reparent the whole content CONTAINER (not the panel's content element)
         // so BOTH renderers work: `onlyWhenVisible` content lives inside it, and
         // an `always` panel's render overlay is anchored to it (re-anchored via
-        // repositionOverlays). It un-hides automatically once out of the
+        // repositionPanelOverlay). It un-hides automatically once out of the
         // collapsed group's subtree.
         const content = this.group.element.querySelector<HTMLElement>(
             '.dv-content-container'
@@ -262,11 +273,20 @@ class EdgeGroupController extends CompositeDisposable {
         overlay.appendChild(content);
 
         this.host.overlayRoot.appendChild(overlay);
-        this._peek = { overlay, content, parent };
+        this._peek = { overlay, content, parent, panel };
         this._positionOverlay(overlay);
         this._armCloseListeners();
         this.host.setEdgeGroupPeeking(this.group, true);
         this._animateIn(overlay);
+    }
+
+    /** Re-anchor the peeked `always` panel's render overlay over the (current)
+     *  content-container box, force-showing it. No-op for `onlyWhenVisible`
+     *  (whose content rides inside the reparented container). */
+    private _syncOverlay(): void {
+        if (this._peek) {
+            this.host.repositionPanelOverlay(this._peek.panel, true);
+        }
     }
 
     /**
@@ -286,7 +306,7 @@ class EdgeGroupController extends CompositeDisposable {
             typeof win?.requestAnimationFrame !== 'function' ||
             typeof win.performance?.now !== 'function'
         ) {
-            this.host.repositionOverlays();
+            this._syncOverlay();
             return;
         }
 
@@ -305,7 +325,7 @@ class EdgeGroupController extends CompositeDisposable {
             overlay.style.transform =
                 t >= 1 ? '' : `translate${axis}(${remaining}%)`;
             // Re-anchor `always` content over the container's transformed box.
-            this.host.repositionOverlays();
+            this._syncOverlay();
             if (t < 1) {
                 win.requestAnimationFrame(step);
             }
@@ -436,8 +456,10 @@ class EdgeGroupController extends CompositeDisposable {
         peek.parent.appendChild(peek.content);
         peek.overlay.remove();
         this.host.setEdgeGroupPeeking(this.group, false);
-        // Re-anchor `always` content back over the (now collapsed) container.
-        this.host.repositionOverlays();
+        // Re-anchor the `always` overlay back over the (now collapsed, in-group)
+        // container — forceVisible:false lets it hide again as the panel is no
+        // longer visible.
+        this.host.repositionPanelOverlay(peek.panel, false);
     }
 
     isPeeking(): boolean {

--- a/packages/dockview-modules/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-modules/src/autoHideEdgeGroupService.ts
@@ -39,14 +39,17 @@ function prefersReducedMotion(doc: Document): boolean {
  *   out as an overlay on the shell overlay root. The live content element is
  *   reparented (state preserved) and the grid is NOT reflowed (the splitview
  *   view stays locked at `collapsedSize`).
- * - **Focus / click** a collapsed tab → opens immediately; clicking a different
- *   tab swaps the peeked panel.
+ * - **Keyboard-focus** a collapsed tab → peeks (so the panel is reachable).
+ *   **Clicking** a collapsed tab natively expands (pins) the group instead.
  * - **Leave** both the strip and the overlay → closes after `closeDelay`; a
  *   single shared timer, cancelled by re-entering either (the flicker fix).
  *   `Esc` / pointer-down outside / focus-out also close. A pin button re-docks.
  *
- * Limited to `onlyWhenVisible` renderers; an `always`-renderer panel (whose
- * live element lives in the shared render overlay) falls back to pinning.
+ * Both render modes slide out. It reparents the content CONTAINER (not the panel
+ * content): for `onlyWhenVisible` the content lives inside it and moves with it;
+ * for `always` the container is just the position reference the shared render
+ * overlay anchors to — the content's parent (the render overlay) never changes,
+ * we only re-run its positioning (`repositionOverlays`) as the container slides.
  */
 class EdgeGroupController extends CompositeDisposable {
     private _peek:
@@ -73,37 +76,38 @@ class EdgeGroupController extends CompositeDisposable {
             this._cancelOpen();
             this._scheduleClose();
         };
-        // Click / keyboard-focus a collapsed tab opens immediately.
-        const onClick = (): void => {
-            if (this._gate()) {
-                this._openNow();
-            }
-        };
+        // Keyboard-focus a collapsed tab → peek (so the keyboard can reach the
+        // panel). Deferred out of the focus event: reparenting the content
+        // container synchronously during dispatch makes the edge group expand.
+        // No click handler — clicking a collapsed edge tab natively *expands*
+        // (pins) the group, which is the intended VS-style behaviour (hover to
+        // peek, click to pin).
         const onFocusIn = (): void => {
             if (this._gate()) {
-                this._openNow();
+                this._cancelClose();
+                this._scheduleOpen(0);
             }
         };
         strip.addEventListener('pointerenter', onEnter);
         strip.addEventListener('pointerleave', onLeave);
-        strip.addEventListener('click', onClick);
         strip.addEventListener('focusin', onFocusIn);
 
         this.addDisposables(
             // Expanding (pin) tears the peek down; collapsing leaves the native
             // strip visible with nothing extra to render.
             this.group.api.onDidCollapsedChange(() => this._closePeek()),
-            // Activating a different tab while peeking swaps the peeked panel.
+            // Activating a different tab while peeking: the content container
+            // already shows the new active `onlyWhenVisible` panel; re-anchor so
+            // the new active `always` panel covers it too.
             this.group.api.onDidActivePanelChange(() => {
                 if (this._peek) {
-                    this._openNow();
+                    this.host.repositionOverlays();
                 }
             }),
             {
                 dispose: () => {
                     strip.removeEventListener('pointerenter', onEnter);
                     strip.removeEventListener('pointerleave', onLeave);
-                    strip.removeEventListener('click', onClick);
                     strip.removeEventListener('focusin', onFocusIn);
                     this._clearTimers();
                     this._closePeek();
@@ -134,12 +138,9 @@ class EdgeGroupController extends CompositeDisposable {
         this.openPeek();
     }
 
-    private _scheduleOpen(): void {
+    private _scheduleOpen(delay = this._opts.openDelay): void {
         this._cancelOpen();
-        this._openTimer = setTimeout(
-            () => this.openPeek(),
-            this._opts.openDelay
-        );
+        this._openTimer = setTimeout(() => this.openPeek(), delay);
     }
 
     private _cancelOpen(): void {
@@ -175,28 +176,24 @@ class EdgeGroupController extends CompositeDisposable {
         if (!this._gate()) {
             return;
         }
-        const panel = this.group.activePanel;
-        if (!panel) {
+        if (!this.group.activePanel) {
             return;
         }
-        // `always`-rendered content lives in the shared render overlay (not the
-        // content container); peeking it needs render-overlay re-anchoring that
-        // is a dedicated follow-up — pin instead for now.
-        if (panel.api.renderer === 'always') {
-            this.pin();
+        // Reparent the whole content CONTAINER (not the panel's content element)
+        // so BOTH renderers work: `onlyWhenVisible` content lives inside it, and
+        // an `always` panel's render overlay is anchored to it (re-anchored via
+        // repositionOverlays). It un-hides automatically once out of the
+        // collapsed group's subtree.
+        const content = this.group.element.querySelector<HTMLElement>(
+            '.dv-content-container'
+        );
+        const parent = content?.parentElement;
+        if (!content || !parent) {
             return;
         }
-        const content = panel.view.content.element;
-        const parent = content.parentElement;
-        if (!parent) {
-            return;
-        }
-        // Already peeking the same content? nothing to do.
+        // Already peeking? nothing to do.
         if (this._peek?.content === content) {
             return;
-        }
-        if (this._peek) {
-            this._closePeek();
         }
 
         const doc = this.group.element.ownerDocument;
@@ -238,36 +235,53 @@ class EdgeGroupController extends CompositeDisposable {
         this.host.overlayRoot.appendChild(overlay);
         this._peek = { overlay, content, parent };
         this._positionOverlay(overlay);
-        this._animateIn(overlay);
         this._armCloseListeners();
         this.host.setEdgeGroupPeeking(this.group, true);
+        this._animateIn(overlay);
     }
 
+    /**
+     * Slide the overlay in from the strip edge. Driven by a manual rAF loop
+     * (not a CSS transition) so that on every frame we also re-anchor any
+     * `always`-rendered content over the container's *moving* box — otherwise
+     * `onlyWhenVisible` content (inside the overlay) would slide but `always`
+     * content (positioned in the shared render overlay) would not.
+     */
     private _animateIn(overlay: HTMLElement): void {
         const position = this._position;
-        const doc = this.group.element.ownerDocument;
+        const win = this.group.element.ownerDocument.defaultView;
         if (
             !position ||
             !this._opts.animate ||
-            prefersReducedMotion(doc) ||
-            typeof doc.defaultView?.requestAnimationFrame !== 'function'
+            prefersReducedMotion(this.group.element.ownerDocument) ||
+            typeof win?.requestAnimationFrame !== 'function' ||
+            typeof win.performance?.now !== 'function'
         ) {
+            this.host.repositionOverlays();
             return;
         }
-        const from =
-            position === 'left'
-                ? 'translateX(-100%)'
-                : position === 'right'
-                  ? 'translateX(100%)'
-                  : position === 'top'
-                    ? 'translateY(-100%)'
-                    : 'translateY(100%)';
-        overlay.style.transform = from;
-        void overlay.offsetWidth; // reflow so the transition runs from `from`
-        overlay.style.transition = 'transform 150ms ease-out';
-        doc.defaultView.requestAnimationFrame(() => {
-            overlay.style.transform = 'translate(0, 0)';
-        });
+
+        const axis = position === 'left' || position === 'right' ? 'X' : 'Y';
+        const sign = position === 'left' || position === 'top' ? -1 : 1;
+        const duration = 150;
+        const start = win.performance.now();
+
+        const step = (now: number): void => {
+            if (this._peek?.overlay !== overlay) {
+                return; // closed mid-animation
+            }
+            const t = Math.min(1, (now - start) / duration);
+            const eased = 1 - Math.pow(1 - t, 3); // easeOutCubic
+            const remaining = (1 - eased) * 100 * sign;
+            overlay.style.transform =
+                t >= 1 ? '' : `translate${axis}(${remaining}%)`;
+            // Re-anchor `always` content over the container's transformed box.
+            this.host.repositionOverlays();
+            if (t < 1) {
+                win.requestAnimationFrame(step);
+            }
+        };
+        win.requestAnimationFrame(step);
     }
 
     /** Anchor the overlay to the strip's inner edge, sized to the group's
@@ -386,13 +400,15 @@ class EdgeGroupController extends CompositeDisposable {
         if (!peek) {
             return;
         }
-        // Restore the live content before removing the overlay, clearing the
-        // fill styles applied for the peek.
+        // Restore the content container before removing the overlay, clearing
+        // the fill styles applied for the peek.
         peek.content.style.width = '';
         peek.content.style.height = '';
         peek.parent.appendChild(peek.content);
         peek.overlay.remove();
         this.host.setEdgeGroupPeeking(this.group, false);
+        // Re-anchor `always` content back over the (now collapsed) container.
+        this.host.repositionOverlays();
     }
 
     isPeeking(): boolean {

--- a/packages/dockview-modules/src/index.ts
+++ b/packages/dockview-modules/src/index.ts
@@ -4,6 +4,7 @@ import { ContextMenuModule } from './contextMenu';
 import { AdvancedDnDModule } from './advancedDnDService';
 import { AccessibilityModule } from './accessibilityService';
 import { LayoutHistoryModule } from './layoutHistoryService';
+import { AutoHideEdgeGroupModule } from './autoHideEdgeGroupService';
 
 export {
     TabGroupChipsService,
@@ -19,6 +20,10 @@ export {
     LayoutHistoryService,
     LayoutHistoryModule,
 } from './layoutHistoryService';
+export {
+    AutoHideEdgeGroupService,
+    AutoHideEdgeGroupModule,
+} from './autoHideEdgeGroupService';
 // Advanced keyboard docking is an optional module — exported for explicit
 // registration, but not part of the default `Modules` bundle below.
 export {
@@ -36,4 +41,5 @@ export const Modules: DockviewModule<any>[] = [
     AdvancedDnDModule,
     AccessibilityModule,
     LayoutHistoryModule,
+    AutoHideEdgeGroupModule,
 ];

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -91,6 +91,14 @@ const config = {
                                         __dirname,
                                         '../dockview/src'
                                     ),
+                                    // Without this, dockview-modules resolves to
+                                    // its built dist/, so editing module source
+                                    // (e.g. auto-hide edge groups) does nothing
+                                    // until a rebuild + dev-server restart.
+                                    'dockview-modules$': path.join(
+                                        __dirname,
+                                        '../dockview-modules/src'
+                                    ),
                                 }),
                                 react: path.join(
                                     __dirname,

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -788,6 +788,7 @@ const DockviewDemo = (props: {
                                             }
                                             onReady={onReady}
                                             theme={effectiveTheme}
+                                            autoHideEdgeGroups
                                             floatingGroupDragHandle="titlebar"
                                             getTabContextMenuItems={
                                                 getTabContextMenuItems


### PR DESCRIPTION
VS-style **auto-hide edge groups** — an edge group can collapse to a strip and behave like a Visual Studio tool window: click a tab to peek it out over the content, pin it to dock, auto-hide it back. Built on the existing edge-group collapse machinery (never re-implements layout / sizing / DnD).

## Interaction (Visual Studio tool windows — click-driven, no hover)
- **Auto-hidden** — the collapsed edge group shows its tabs as a strip. **Click a tab** to peek that panel out as a **non-reflowing** overlay with a title bar (title + pin + close); click the tab again / click outside / `Esc` to hide; click another tab to switch.
- **Pinned** — the pushpin docks the group: it renders with the **title bar on top** and the **tab strip at the bottom**; the pushpin auto-hides it back to the strip. Close closes the panel.
- Both render modes (`onlyWhenVisible` and `always`) slide out; a fixed clip frame makes the panel emerge from the strip's inner edge.
- Opt-in via `autoHideEdgeGroups` (default off → unchanged). API: `api.peekEdgeGroup` / `api.pinEdgeGroup` / `api.autoHideEdgeGroup`; `group.api.isPeeking()` + `onDidPeekChange`.

## Reusable core primitives (extracted)
The generic glue the feature needs now lives in `dockview-core` rather than being bespoke to one module:
- `createDismissableLayer` — shared Esc / outside-pointerdown / resize dismissal; `PopupService` and the peek both consume it.
- `DockviewGroupPanelModel.getPanelForTab` — robust tab-element → panel lookup (inverse of `getTabId`).
- `prefersReducedMotion`, `resolveOpaqueBackground` (`dom`), `createCloseButton` / `createPinButton` (`svg`).
- `OverlayRenderContainer.repositionPanelOverlay` gains an optional clip rect, with sticky per-panel force-visible / clip state so a concurrent resize can't blank a peeked `always` panel.

## Removability
Module absent → no peek/dock chrome, the `*EdgeGroup` apis no-op, and edge-group collapse still works (`EdgeGroupModule`).

## Tests
`dockview-core` + `dockview-modules` unit suites and a Playwright e2e (peek / click-toggle / outside-close / pin→dock / docked geometry / `always`-clip / tab-switch) all green. Format + exports-gen snapshot updated.

Targets `v8-branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
