### PR TITLE
feat: Smart Guides — alignment guides + magnetic snapping for floating groups

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -80,6 +80,7 @@ DockviewTheme
 DockviewUnhandledDragOverEvent
 DockviewWillDropEvent
 DockviewWillShowOverlayLocationEvent
+DragModifiers
 DraggablePaneviewPanel
 DropOverlayModelParams
 DroptargetOverlayModel
@@ -240,8 +241,11 @@ ServiceCollection
 SizeEvent
 Sizing
 SmartGuidesOptions
+SmartGuidesSnapEvent
 SmartGuidesSnapPosition
 SmartGuidesSnapTargets
+SmartGuidesSnapTogetherEvent
+SnapModifier
 SplitSizing
 SplitViewOptions
 Splitview

--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -240,6 +240,7 @@ ServiceCollection
 SizeEvent
 Sizing
 SmartGuidesOptions
+SmartGuidesSnapTargets
 SplitSizing
 SplitViewOptions
 Splitview

--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -240,6 +240,7 @@ ServiceCollection
 SizeEvent
 Sizing
 SmartGuidesOptions
+SmartGuidesSnapPosition
 SmartGuidesSnapTargets
 SplitSizing
 SplitViewOptions

--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -87,6 +87,7 @@ EdgeGroupOptions
 EdgeGroupPosition
 ExpansionEvent
 FloatingGroupDragContext
+FloatingGroupModule
 FloatingGroupOptions
 FocusEvent
 GetTabContextMenuItemsParams
@@ -153,6 +154,8 @@ IPaneviewPanel
 ISerializedBranchNode
 ISerializedLeafNode
 ISerializedNode
+ISmartGuidesHost
+ISmartGuidesService
 ISplitViewDescriptor
 ISplitviewComponent
 ISplitviewPanel
@@ -236,6 +239,7 @@ SerializedTabGroup
 ServiceCollection
 SizeEvent
 Sizing
+SmartGuidesOptions
 SplitSizing
 SplitViewOptions
 Splitview

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -48,8 +48,12 @@
                     // (incl. async popout re-open).
                     layoutHistory: { enabled: true },
                     // Smart Guides — alignment + snapping for floating groups.
-                    // Inert unless a float is dragged near another float.
-                    smartGuides: { snapDistance: 12 },
+                    // Float-only here so the harness geometry is deterministic
+                    // (container-edge snapping is covered by unit tests).
+                    smartGuides: {
+                        snapDistance: 12,
+                        snapTargets: { container: false },
+                    },
                     // A served (not about:blank) target avoids a 404 when the
                     // popout window navigates before dockview injects content.
                     popoutUrl: '/e2e/fixtures/popout.html',

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -110,6 +110,7 @@
                     redo: () => dockview.redo(),
                     canUndo: () => dockview.canUndo,
                     awaitPopoutRestore: () => dockview.popoutRestorationPromise,
+                    floatingCount: () => dockview.floatingGroups.length,
                     // Two floating groups for Smart Guides: a target float on
                     // the left (left edge ~120) and a draggable float to its
                     // right. Dragging the right one near x=120 should snap +

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -47,6 +47,9 @@
                     // Record layout history so the harness can exercise undo/redo
                     // (incl. async popout re-open).
                     layoutHistory: { enabled: true },
+                    // Smart Guides — alignment + snapping for floating groups.
+                    // Inert unless a float is dragged near another float.
+                    smartGuides: { snapDistance: 12 },
                     // A served (not about:blank) target avoids a 404 when the
                     // popout window navigates before dockview injects content.
                     popoutUrl: '/e2e/fixtures/popout.html',
@@ -103,6 +106,39 @@
                     redo: () => dockview.redo(),
                     canUndo: () => dockview.canUndo,
                     awaitPopoutRestore: () => dockview.popoutRestorationPromise,
+                    // Two floating groups for Smart Guides: a target float on
+                    // the left (left edge ~120) and a draggable float to its
+                    // right. Dragging the right one near x=120 should snap +
+                    // draw a guide.
+                    setupSmartGuides: () => {
+                        dockview.addPanel({
+                            id: 'main',
+                            component: 'default',
+                            title: 'main',
+                        });
+                        const target = dockview.addPanel({
+                            id: 'target',
+                            component: 'default',
+                            title: 'target',
+                        });
+                        dockview.addFloatingGroup(target, {
+                            x: 120,
+                            y: 80,
+                            width: 200,
+                            height: 160,
+                        });
+                        const mover = dockview.addPanel({
+                            id: 'mover',
+                            component: 'default',
+                            title: 'mover',
+                        });
+                        dockview.addFloatingGroup(mover, {
+                            x: 450,
+                            y: 300,
+                            width: 200,
+                            height: 160,
+                        });
+                    },
                 };
                 window.__ready = true;
             })();

--- a/e2e/tests/smart-guides.spec.ts
+++ b/e2e/tests/smart-guides.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smart Guides — alignment guides + magnetic snapping for floating groups.
+ * Real-browser only: the snap reads the live container/overlay geometry the
+ * float drag loop works in, which jsdom (no layout) can't produce.
+ *
+ * Phase 1: dragging one float so an edge lines up with another float's edge
+ * (within `snapDistance`) snaps it exactly and paints one alignment guide; the
+ * guide is torn down on drop.
+ */
+test.describe('smart guides (floating snap)', () => {
+    const setup = async (page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupSmartGuides());
+    };
+
+    const overlayWith = (page, text: string) =>
+        page.locator('.dv-resize-container', {
+            has: page.locator('.dv-test-panel', { hasText: text }),
+        });
+
+    test('snaps a dragged float edge to another float and draws a guide', async ({
+        page,
+    }) => {
+        await setup(page);
+
+        const mover = overlayWith(page, 'mover');
+        const target = overlayWith(page, 'target');
+        const handle = mover.locator('.dv-floating-titlebar');
+
+        const targetBox = (await target.boundingBox())!;
+        const moverBox = (await mover.boundingBox())!;
+        const tb = (await handle.boundingBox())!;
+
+        const startX = tb.x + tb.width / 2;
+        const startY = tb.y + tb.height / 2;
+        // Pointer offset within the float — the float's left edge tracks
+        // (pointerX - grab) once the drag is underway.
+        const grab = startX - moverBox.x;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        // A tiny first nudge locks a clean grab offset before the long drag
+        // (the overlay captures the offset on the first pointer-move frame).
+        await page.mouse.move(startX + 1, startY);
+        // Land the float's left edge ~4px right of the target's left edge —
+        // inside the 12px snapDistance, so it snaps exactly onto it.
+        const finalX = targetBox.x + grab + 5;
+        await page.mouse.move(finalX, startY, { steps: 20 });
+
+        // a single alignment guide is shown, at the target's left edge
+        const guide = page.locator('.dv-smart-guide');
+        await expect(guide).toBeVisible();
+        const gb = (await guide.boundingBox())!;
+        expect(Math.abs(gb.x - targetBox.x)).toBeLessThan(2);
+
+        // the float snapped exactly onto the target's left edge
+        const snapped = (await mover.boundingBox())!;
+        expect(Math.abs(snapped.x - targetBox.x)).toBeLessThan(2);
+
+        await page.mouse.up();
+
+        // guides are an interaction overlay — gone once the drag ends
+        await expect(page.locator('.dv-smart-guides')).toHaveCount(0);
+        // ...and the snapped position persists
+        const after = (await mover.boundingBox())!;
+        expect(Math.abs(after.x - targetBox.x)).toBeLessThan(2);
+    });
+
+    test('no guide while dragging away from every edge', async ({ page }) => {
+        await setup(page);
+
+        const mover = overlayWith(page, 'mover');
+        const handle = mover.locator('.dv-floating-titlebar');
+        const tb = (await handle.boundingBox())!;
+        const startX = tb.x + tb.width / 2;
+        const startY = tb.y + tb.height / 2;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        // drag further right / into open space, away from the target float
+        await page.mouse.move(startX + 150, startY + 20, { steps: 8 });
+
+        // the guide line is never shown (the layer may exist, the line stays hidden)
+        await expect(page.locator('.dv-smart-guide')).toBeHidden();
+
+        await page.mouse.up();
+        await expect(page.locator('.dv-smart-guides')).toHaveCount(0);
+    });
+});

--- a/e2e/tests/smart-guides.spec.ts
+++ b/e2e/tests/smart-guides.spec.ts
@@ -5,9 +5,10 @@ import { test, expect } from '@playwright/test';
  * Real-browser only: the snap reads the live container/overlay geometry the
  * float drag loop works in, which jsdom (no layout) can't produce.
  *
- * Dragging one float so an edge/center lines up with another float or the
- * container (within `snapDistance`) snaps it and paints alignment guides; X and
- * Y resolve independently; guides are torn down on drop.
+ * Dragging one float so an edge/center lines up with another float (within
+ * `snapDistance`) snaps it and paints alignment guides; bringing a float flush
+ * over another suggests a dock/merge, committed on drop; guides are torn down
+ * on drop.
  */
 test.describe('smart guides (floating snap)', () => {
     const setup = async (page) => {
@@ -60,17 +61,15 @@ test.describe('smart guides (floating snap)', () => {
         await page.mouse.down();
         // Tiny nudge locks a clean grab offset before the long drag.
         await page.mouse.move(startX + 1, startY);
-        // Land the float's left edge ~4px right of the target's left edge —
-        // inside the 12px snapDistance, so it snaps exactly onto it.
+        // Drag left only (Y unchanged → the floats never vertically overlap, so
+        // no dock suggestion): land the left edge ~4px right of the target's.
         await page.mouse.move(targetBox.x + grab + 5, startY, { steps: 20 });
 
-        // a vertical guide is drawn at the target's left edge
         const guides = await visibleGuides(page);
         expect(guides.some((g) => g.w <= 2 && near(g.x, targetBox.x))).toBe(
             true
         );
 
-        // the float snapped exactly onto the target's left edge
         const snapped = (await mover.boundingBox())!;
         expect(near(snapped.x, targetBox.x)).toBe(true);
 
@@ -78,14 +77,19 @@ test.describe('smart guides (floating snap)', () => {
 
         // guides are an interaction overlay — gone once the drag ends
         await expect(page.locator('.dv-smart-guides')).toHaveCount(0);
-        const after = (await mover.boundingBox())!;
-        expect(near(after.x, targetBox.x)).toBe(true);
+        // still two separate floats — an edge alignment is not a merge
+        expect(
+            await page.evaluate(() => (window as any).__dv.floatingCount())
+        ).toBe(2);
     });
 
-    test('X and Y snap independently — aligning to a corner draws both guides', async ({
+    test('snap-together: dropping a float flush over another merges them', async ({
         page,
     }) => {
         await setup(page);
+        expect(
+            await page.evaluate(() => (window as any).__dv.floatingCount())
+        ).toBe(2);
 
         const mover = overlayWith(page, 'mover');
         const target = overlayWith(page, 'target');
@@ -103,29 +107,25 @@ test.describe('smart guides (floating snap)', () => {
         await page.mouse.move(startX, startY);
         await page.mouse.down();
         await page.mouse.move(startX + 1, startY + 1);
-        // Drag toward the target's top-left corner: left edge → target left,
-        // top edge → target top (both within the snap distance).
+        // Drag the mover on top of the target (tops flush, fully overlapping) —
+        // a tabset-merge suggestion.
         await page.mouse.move(
-            targetBox.x + grabX + 5,
-            targetBox.y + grabY + 5,
+            targetBox.x + grabX + 4,
+            targetBox.y + grabY + 4,
             { steps: 25 }
         );
 
-        const guides = await visibleGuides(page);
-        // a vertical guide at the target's left edge...
-        expect(guides.some((g) => g.w <= 2 && near(g.x, targetBox.x))).toBe(
-            true
-        );
-        // ...and a horizontal guide at the target's top edge
-        expect(guides.some((g) => g.h <= 2 && near(g.y, targetBox.y))).toBe(
-            true
-        );
-
-        const snapped = (await mover.boundingBox())!;
-        expect(near(snapped.x, targetBox.x)).toBe(true);
-        expect(near(snapped.y, targetBox.y)).toBe(true);
+        // a drop-preview rectangle is shown over the merge target
+        await expect(page.locator('.dv-smart-guide-preview')).toBeVisible();
 
         await page.mouse.up();
+
+        // the two floats merged into one (mover docked into the target)
+        await expect
+            .poll(() =>
+                page.evaluate(() => (window as any).__dv.floatingCount())
+            )
+            .toBe(1);
         await expect(page.locator('.dv-smart-guides')).toHaveCount(0);
     });
 
@@ -144,6 +144,7 @@ test.describe('smart guides (floating snap)', () => {
         await page.mouse.move(startX + 40, startY + 30, { steps: 8 });
 
         expect(await visibleGuides(page)).toHaveLength(0);
+        await expect(page.locator('.dv-smart-guide-preview')).toHaveCount(0);
 
         await page.mouse.up();
         await expect(page.locator('.dv-smart-guides')).toHaveCount(0);

--- a/e2e/tests/smart-guides.spec.ts
+++ b/e2e/tests/smart-guides.spec.ts
@@ -129,6 +129,38 @@ test.describe('smart guides (floating snap)', () => {
         await expect(page.locator('.dv-smart-guides')).toHaveCount(0);
     });
 
+    test('holding Alt suspends snapping (the float follows the pointer)', async ({
+        page,
+    }) => {
+        await setup(page);
+
+        const mover = overlayWith(page, 'mover');
+        const target = overlayWith(page, 'target');
+        const handle = mover.locator('.dv-floating-titlebar');
+
+        const targetBox = (await target.boundingBox())!;
+        const moverBox = (await mover.boundingBox())!;
+        const tb = (await handle.boundingBox())!;
+        const startX = tb.x + tb.width / 2;
+        const startY = tb.y + tb.height / 2;
+        const grab = startX - moverBox.x;
+
+        await page.keyboard.down('Alt');
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX + 1, startY);
+        // would normally snap the left edge onto the target's — but Alt is held
+        await page.mouse.move(targetBox.x + grab + 5, startY, { steps: 20 });
+
+        // no guides, and the edge is NOT pulled onto the target (stays ~5px off)
+        expect(await visibleGuides(page)).toHaveLength(0);
+        const box = (await mover.boundingBox())!;
+        expect(box.x).toBeGreaterThan(targetBox.x + 2);
+
+        await page.mouse.up();
+        await page.keyboard.up('Alt');
+    });
+
     test('no guide while dragging away from every edge', async ({ page }) => {
         await setup(page);
 

--- a/e2e/tests/smart-guides.spec.ts
+++ b/e2e/tests/smart-guides.spec.ts
@@ -5,9 +5,9 @@ import { test, expect } from '@playwright/test';
  * Real-browser only: the snap reads the live container/overlay geometry the
  * float drag loop works in, which jsdom (no layout) can't produce.
  *
- * Phase 1: dragging one float so an edge lines up with another float's edge
- * (within `snapDistance`) snaps it exactly and paints one alignment guide; the
- * guide is torn down on drop.
+ * Dragging one float so an edge/center lines up with another float or the
+ * container (within `snapDistance`) snaps it and paints alignment guides; X and
+ * Y resolve independently; guides are torn down on drop.
  */
 test.describe('smart guides (floating snap)', () => {
     const setup = async (page) => {
@@ -20,6 +20,24 @@ test.describe('smart guides (floating snap)', () => {
         page.locator('.dv-resize-container', {
             has: page.locator('.dv-test-panel', { hasText: text }),
         });
+
+    // Rects of the guide lines currently being painted (pooled hidden ones out).
+    const visibleGuides = (
+        page
+    ): Promise<{ x: number; y: number; w: number; h: number }[]> =>
+        page.evaluate(() =>
+            Array.from(
+                document.querySelectorAll<HTMLElement>('.dv-smart-guide')
+            )
+                .filter((l) => l.style.display === 'block')
+                .map((l) => {
+                    const r = l.getBoundingClientRect();
+                    return { x: r.x, y: r.y, w: r.width, h: r.height };
+                })
+        );
+
+    const near = (a: number, b: number, tol = 2): boolean =>
+        Math.abs(a - b) < tol;
 
     test('snaps a dragged float edge to another float and draws a guide', async ({
         page,
@@ -36,37 +54,79 @@ test.describe('smart guides (floating snap)', () => {
 
         const startX = tb.x + tb.width / 2;
         const startY = tb.y + tb.height / 2;
-        // Pointer offset within the float — the float's left edge tracks
-        // (pointerX - grab) once the drag is underway.
         const grab = startX - moverBox.x;
 
         await page.mouse.move(startX, startY);
         await page.mouse.down();
-        // A tiny first nudge locks a clean grab offset before the long drag
-        // (the overlay captures the offset on the first pointer-move frame).
+        // Tiny nudge locks a clean grab offset before the long drag.
         await page.mouse.move(startX + 1, startY);
         // Land the float's left edge ~4px right of the target's left edge —
         // inside the 12px snapDistance, so it snaps exactly onto it.
-        const finalX = targetBox.x + grab + 5;
-        await page.mouse.move(finalX, startY, { steps: 20 });
+        await page.mouse.move(targetBox.x + grab + 5, startY, { steps: 20 });
 
-        // a single alignment guide is shown, at the target's left edge
-        const guide = page.locator('.dv-smart-guide');
-        await expect(guide).toBeVisible();
-        const gb = (await guide.boundingBox())!;
-        expect(Math.abs(gb.x - targetBox.x)).toBeLessThan(2);
+        // a vertical guide is drawn at the target's left edge
+        const guides = await visibleGuides(page);
+        expect(guides.some((g) => g.w <= 2 && near(g.x, targetBox.x))).toBe(
+            true
+        );
 
         // the float snapped exactly onto the target's left edge
         const snapped = (await mover.boundingBox())!;
-        expect(Math.abs(snapped.x - targetBox.x)).toBeLessThan(2);
+        expect(near(snapped.x, targetBox.x)).toBe(true);
 
         await page.mouse.up();
 
         // guides are an interaction overlay — gone once the drag ends
         await expect(page.locator('.dv-smart-guides')).toHaveCount(0);
-        // ...and the snapped position persists
         const after = (await mover.boundingBox())!;
-        expect(Math.abs(after.x - targetBox.x)).toBeLessThan(2);
+        expect(near(after.x, targetBox.x)).toBe(true);
+    });
+
+    test('X and Y snap independently — aligning to a corner draws both guides', async ({
+        page,
+    }) => {
+        await setup(page);
+
+        const mover = overlayWith(page, 'mover');
+        const target = overlayWith(page, 'target');
+        const handle = mover.locator('.dv-floating-titlebar');
+
+        const targetBox = (await target.boundingBox())!;
+        const moverBox = (await mover.boundingBox())!;
+        const tb = (await handle.boundingBox())!;
+
+        const startX = tb.x + tb.width / 2;
+        const startY = tb.y + tb.height / 2;
+        const grabX = startX - moverBox.x;
+        const grabY = startY - moverBox.y;
+
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX + 1, startY + 1);
+        // Drag toward the target's top-left corner: left edge → target left,
+        // top edge → target top (both within the snap distance).
+        await page.mouse.move(
+            targetBox.x + grabX + 5,
+            targetBox.y + grabY + 5,
+            { steps: 25 }
+        );
+
+        const guides = await visibleGuides(page);
+        // a vertical guide at the target's left edge...
+        expect(guides.some((g) => g.w <= 2 && near(g.x, targetBox.x))).toBe(
+            true
+        );
+        // ...and a horizontal guide at the target's top edge
+        expect(guides.some((g) => g.h <= 2 && near(g.y, targetBox.y))).toBe(
+            true
+        );
+
+        const snapped = (await mover.boundingBox())!;
+        expect(near(snapped.x, targetBox.x)).toBe(true);
+        expect(near(snapped.y, targetBox.y)).toBe(true);
+
+        await page.mouse.up();
+        await expect(page.locator('.dv-smart-guides')).toHaveCount(0);
     });
 
     test('no guide while dragging away from every edge', async ({ page }) => {
@@ -80,11 +140,10 @@ test.describe('smart guides (floating snap)', () => {
 
         await page.mouse.move(startX, startY);
         await page.mouse.down();
-        // drag further right / into open space, away from the target float
-        await page.mouse.move(startX + 150, startY + 20, { steps: 8 });
+        // a small drag into open space, away from the target float + edges
+        await page.mouse.move(startX + 40, startY + 30, { steps: 8 });
 
-        // the guide line is never shown (the layer may exist, the line stays hidden)
-        await expect(page.locator('.dv-smart-guide')).toBeHidden();
+        expect(await visibleGuides(page)).toHaveLength(0);
 
         await page.mouse.up();
         await expect(page.locator('.dv-smart-guides')).toHaveCount(0);

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -18,6 +18,7 @@ import {
     DockviewComponentOptions,
     DockviewDndOverlayEvent,
     MovementOptions,
+    SmartGuidesOptions,
 } from '../dockview/options';
 import {
     DockviewMessages,
@@ -50,7 +51,11 @@ import {
     IDockviewGroupPanel,
 } from '../dockview/dockviewGroupPanel';
 import { Event } from '../events';
-import { LayoutHistoryChangeEvent } from '../dockview/moduleContracts';
+import {
+    LayoutHistoryChangeEvent,
+    SmartGuidesSnapEvent,
+    SmartGuidesSnapTogetherEvent,
+} from '../dockview/moduleContracts';
 import { IDockviewPanel } from '../dockview/dockviewPanel';
 import { PaneviewDidDropEvent } from '../paneview/draggablePaneviewPanel';
 import {
@@ -1066,6 +1071,35 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
     /** Fires whenever the undo/redo stacks change. */
     get onDidChangeHistory(): Event<LayoutHistoryChangeEvent> {
         return this.component.onDidChangeHistory;
+    }
+
+    /**
+     * Whether Smart Guides snapping is active (the `smartGuides` option is
+     * present + enabled and the module is registered). Reactive via
+     * {@link setSmartGuidesEnabled}.
+     */
+    get smartGuidesEnabled(): boolean {
+        return this.component.smartGuidesEnabled;
+    }
+
+    /** Toggle Smart Guides snapping at runtime (no-op when the module is absent). */
+    setSmartGuidesEnabled(enabled: boolean): void {
+        this.component.setSmartGuidesEnabled(enabled);
+    }
+
+    /** Merge a partial Smart Guides option override in at runtime. */
+    updateSmartGuidesOptions(options: Partial<SmartGuidesOptions>): void {
+        this.component.updateSmartGuidesOptions(options);
+    }
+
+    /** Fires when a dragged floating group commits an alignment snap on drop. */
+    get onDidSnapFloat(): Event<SmartGuidesSnapEvent> {
+        return this.component.onDidSnapFloat;
+    }
+
+    /** Fires when a dragged floating group docks/merges into another on drop. */
+    get onDidSnapTogether(): Event<SmartGuidesSnapTogetherEvent> {
+        return this.component.onDidSnapTogether;
     }
 
     /**

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -768,6 +768,45 @@ export class DockviewComponent
         return this._floatingOverlayHost ?? this.gridview.element;
     }
 
+    /** ISmartGuidesHost — the other floats' group identity + container-relative
+     *  box, for the snap-together detector. */
+    getFloatingGroupSnapshots(
+        exclude: DockviewGroupPanel
+    ): readonly { group: DockviewGroupPanel; box: Box }[] {
+        const container = this.getFloatingContainer();
+        const containerRect = container.getBoundingClientRect();
+        return this.floatingGroups
+            .filter((floating) => floating.group !== exclude)
+            .map((floating) => {
+                const rect = floating.overlay.element.getBoundingClientRect();
+                return {
+                    group: floating.group,
+                    box: {
+                        left: rect.left - containerRect.left,
+                        top: rect.top - containerRect.top,
+                        width: rect.width,
+                        height: rect.height,
+                    },
+                };
+            });
+    }
+
+    /** ISmartGuidesHost — dock/merge a dragged float into a target group via the
+     *  existing move primitive (so events + undo cover it). */
+    mergeFloatInto(
+        dragged: DockviewGroupPanel,
+        target: DockviewGroupPanel,
+        position: Position
+    ): void {
+        if (dragged === target) {
+            return;
+        }
+        this.moveGroupOrPanel({
+            from: { groupId: dragged.id },
+            to: { group: target, position },
+        });
+    }
+
     private get _smartGuidesService() {
         // Optional like every module service — `?.`-guarded everywhere so the
         // module can be removed without crashing the float drag loop.

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -608,6 +608,14 @@ export class DockviewComponent
     readonly onDidOpenPopoutWindowFail: Event<void> =
         this._onDidOpenPopoutWindowFail.event;
 
+    private readonly _onDidStartFloatingGroupDrag =
+        new Emitter<DockviewGroupPanel>();
+    /** Fires with the dragged group when a floating group move-drag first moves
+     *  — consumed by the Smart Guides service (`ISmartGuidesHost`) to start each
+     *  drag from a clean slate (a redock long-press aborts with no end event). */
+    readonly onDidStartFloatingGroupDrag: Event<DockviewGroupPanel> =
+        this._onDidStartFloatingGroupDrag.event;
+
     private readonly _onDidEndFloatingGroupDrag =
         new Emitter<DockviewGroupPanel>();
     /** Fires with the dragged group when a floating group's move/resize drag
@@ -768,19 +776,8 @@ export class DockviewComponent
     private _gatherFloatingGroupBoxes(
         exclude: DockviewGroupPanel
     ): readonly Box[] {
-        const container = this._floatingOverlayHost ?? this.gridview.element;
-        const containerRect = container.getBoundingClientRect();
-        return this.floatingGroups
-            .filter((floating) => floating.group !== exclude)
-            .map((floating) => {
-                const rect = floating.overlay.element.getBoundingClientRect();
-                return {
-                    left: rect.left - containerRect.left,
-                    top: rect.top - containerRect.top,
-                    width: rect.width,
-                    height: rect.height,
-                };
-            });
+        // Same geometry as the snap-together snapshot, minus the group identity.
+        return this.getFloatingGroupSnapshots(exclude).map((s) => s.box);
     }
 
     /**
@@ -821,7 +818,10 @@ export class DockviewComponent
         target: DockviewGroupPanel,
         position: Position
     ): void {
-        if (dragged === target) {
+        // The target was captured at drag start; it may have been closed /
+        // removed before the drop committed. Bail rather than move into a dead
+        // group (a self-drop is also a no-op).
+        if (dragged === target || !this.getPanel(target.id)) {
             return;
         }
         this.moveGroupOrPanel({
@@ -882,9 +882,12 @@ export class DockviewComponent
      * Compose the float drag-position transform from the public
      * `transformFloatingGroupDrag` option and the optional Smart Guides module,
      * so an app and the module can both nudge a single drag rather than one
-     * clobbering the other. Returns `undefined` when neither is active, leaving
-     * the overlay's drag loop byte-for-byte unchanged (removability — the
-     * sibling-box snapshot is skipped too; see {@link ISmartGuidesHost}).
+     * clobbering the other. Returns `undefined` only when the app option is
+     * unset AND the module is absent (the removability case) — then no transform
+     * is installed and the sibling-box snapshot is skipped, so the drag loop is
+     * truly byte-for-byte unchanged. When the module is present but `smartGuides`
+     * is unset it installs a cheap pass-through (the service snaps nothing and
+     * early-returns), so observable drag behaviour is still unchanged.
      */
     private _buildFloatingDragTransform(
         anchorGroup: DockviewGroupPanel,
@@ -1364,6 +1367,7 @@ export class DockviewComponent
                 this._onDidChangePopouts.fire()
             ),
             this._onDidOpenPopoutWindowFail,
+            this._onDidStartFloatingGroupDrag,
             this._onDidEndFloatingGroupDrag,
             this._onDidCreateTabGroup,
             this._onDidDestroyTabGroup,
@@ -2450,9 +2454,15 @@ export class DockviewComponent
             floatingGridview
         );
 
-        // Surface the end of a move/resize drag so the Smart Guides module can
-        // tear down its per-drag guides (no-op when the module is absent).
+        // Surface the start + end of a move drag so the Smart Guides module can
+        // (re)build then tear down its per-drag guides. Start (re)sets a clean
+        // slate even if a prior drag aborted without an end (redock long-press);
+        // end fires on pointerup/cancel (and harmlessly on resize-end). No-ops
+        // when the module is absent.
         floatingGroupPanel.addDisposables(
+            overlay.onDidStartMoving(() =>
+                this._onDidStartFloatingGroupDrag.fire(anchorGroup)
+            ),
             overlay.onDidChangeEnd(() =>
                 this._onDidEndFloatingGroupDrag.fire(anchorGroup)
             )

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -33,6 +33,7 @@ import {
     isPanelOptionsWithPanel,
     MovementOptions,
     DockviewHeaderPosition,
+    SmartGuidesOptions,
 } from './options';
 import {
     BaseGrid,
@@ -93,6 +94,8 @@ import {
     ILayoutHistoryHost,
     LayoutHistoryChangeEvent,
     ISmartGuidesHost,
+    SmartGuidesSnapEvent,
+    SmartGuidesSnapTogetherEvent,
     ITabGroupChipsHost,
 } from './moduleContracts';
 import { IHeaderActionsHost } from './headerActionsService';
@@ -267,6 +270,12 @@ export interface FloatingGroupOptions {
      * group only. See {@link DockviewOptions.floatingGroupDragHandle}.
      */
     dragHandle?: 'titlebar' | 'tabbar';
+    /**
+     * Exclude this floating group from Smart Guides — it never snaps and shows
+     * no guides when dragged (e.g. a pinned HUD). See
+     * {@link DockviewOptions.smartGuides}.
+     */
+    disableSmartGuides?: boolean;
 }
 
 interface FloatingGroupOptionsInternal extends FloatingGroupOptions {
@@ -434,12 +443,26 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
     clearHistory(): void;
     readonly onDidChangeHistory: Event<LayoutHistoryChangeEvent>;
     readonly popoutRestorationPromise: Promise<void>;
+    // smart guides
+    readonly smartGuidesEnabled: boolean;
+    setSmartGuidesEnabled(enabled: boolean): void;
+    updateSmartGuidesOptions(options: Partial<SmartGuidesOptions>): void;
+    readonly onDidSnapFloat: Event<SmartGuidesSnapEvent>;
+    readonly onDidSnapTogether: Event<SmartGuidesSnapTogetherEvent>;
 }
 
 /** A never-firing history-change event — the fallback `onDidChangeHistory`
  *  returns when the LayoutHistory module is absent, so the api event is always
  *  valid and subscribable. */
 const NO_LAYOUT_HISTORY_CHANGES: Event<LayoutHistoryChangeEvent> = () => ({
+    dispose: () => {
+        // noop — nothing ever fires
+    },
+});
+
+/** A never-firing event — the fallback the Smart Guides snap events return when
+ *  the module is absent, so the api events are always subscribable. */
+const NO_EVENT: Event<any> = () => ({
     dispose: () => {
         // noop — nothing ever fires
     },
@@ -807,10 +830,52 @@ export class DockviewComponent
         });
     }
 
+    /** ISmartGuidesHost — the main grid's splitter (sash) rectangles, in the
+     *  floating container's coordinate space, for the optional splitter target. */
+    getGridSplitterRects(): Box[] {
+        const origin = this.getFloatingContainer().getBoundingClientRect();
+        const result: Box[] = [];
+        this.gridview.element.querySelectorAll('.dv-sash').forEach((sash) => {
+            const r = sash.getBoundingClientRect();
+            result.push({
+                left: r.left - origin.left,
+                top: r.top - origin.top,
+                width: r.width,
+                height: r.height,
+            });
+        });
+        return result;
+    }
+
     private get _smartGuidesService() {
         // Optional like every module service — `?.`-guarded everywhere so the
         // module can be removed without crashing the float drag loop.
         return this._moduleRegistry.services.smartGuidesService;
+    }
+
+    /** Whether Smart Guides snapping is currently active. */
+    get smartGuidesEnabled(): boolean {
+        return this._smartGuidesService?.enabled ?? false;
+    }
+
+    /** Toggle Smart Guides snapping at runtime (no-op if the module is absent). */
+    setSmartGuidesEnabled(enabled: boolean): void {
+        this._smartGuidesService?.setEnabled(enabled);
+    }
+
+    /** Merge a partial Smart Guides option override in at runtime. */
+    updateSmartGuidesOptions(options: Partial<SmartGuidesOptions>): void {
+        this._smartGuidesService?.updateOptions(options);
+    }
+
+    /** Fires when a dragged float commits an alignment snap on drop. */
+    get onDidSnapFloat(): Event<SmartGuidesSnapEvent> {
+        return this._smartGuidesService?.onDidSnapFloat ?? NO_EVENT;
+    }
+
+    /** Fires when a dragged float commits a dock/merge on drop. */
+    get onDidSnapTogether(): Event<SmartGuidesSnapTogetherEvent> {
+        return this._smartGuidesService?.onDidSnapTogether ?? NO_EVENT;
     }
 
     /**
@@ -822,14 +887,17 @@ export class DockviewComponent
      * sibling-box snapshot is skipped too; see {@link ISmartGuidesHost}).
      */
     private _buildFloatingDragTransform(
-        anchorGroup: DockviewGroupPanel
+        anchorGroup: DockviewGroupPanel,
+        disableSmartGuides: boolean
     ):
         | ((
               context: OverlayDragContext
           ) => { top: number; left: number } | void)
         | undefined {
         const publicTransform = this.options.transformFloatingGroupDrag;
-        if (!publicTransform && !this._smartGuidesService) {
+        // Per-float opt-out: this window never consults the module.
+        const useGuides = !disableSmartGuides;
+        if (!publicTransform && !(useGuides && this._smartGuidesService)) {
             return undefined;
         }
         return (context) => {
@@ -839,19 +907,22 @@ export class DockviewComponent
                 proposed: context.proposed,
                 container: context.container,
                 others: context.others,
+                modifiers: context.modifiers,
             });
             // 2. ...then the module snaps the (possibly) app-adjusted position,
             //    so its guides reflect the final on-screen alignment.
             const proposed = appResult
                 ? { ...context.proposed, ...appResult }
                 : context.proposed;
-            const snapped =
-                this._smartGuidesService?.transformFloatingGroupDrag({
-                    group: anchorGroup,
-                    proposed,
-                    container: context.container,
-                    others: context.others,
-                });
+            const snapped = useGuides
+                ? this._smartGuidesService?.transformFloatingGroupDrag({
+                      group: anchorGroup,
+                      proposed,
+                      container: context.container,
+                      others: context.others,
+                      modifiers: context.modifiers,
+                  })
+                : undefined;
             return snapped ?? appResult ?? undefined;
         };
     }
@@ -2272,6 +2343,7 @@ export class DockviewComponent
                 dragHandle: options?.dragHandle,
                 inDragMode: options?.inDragMode,
                 skipActiveGroup: options?.skipActiveGroup,
+                disableSmartGuides: options?.disableSmartGuides,
             }
         );
     }
@@ -2308,6 +2380,7 @@ export class DockviewComponent
             dragHandle?: 'titlebar' | 'tabbar';
             inDragMode?: boolean;
             skipActiveGroup?: boolean;
+            disableSmartGuides?: boolean;
         }
     ): void {
         const service = assertModule(
@@ -2349,8 +2422,10 @@ export class DockviewComponent
                     : (this.options.floatingGroupBounds
                           ?.minimumHeightWithinViewport ??
                       DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE),
-            transformDragPosition:
-                this._buildFloatingDragTransform(anchorGroup),
+            transformDragPosition: this._buildFloatingDragTransform(
+                anchorGroup,
+                options?.disableSmartGuides ?? false
+            ),
             getSiblingBoxes: () => this._gatherFloatingGroupBoxes(anchorGroup),
         });
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -59,7 +59,7 @@ import { DockviewGroupPanel } from './dockviewGroupPanel';
 import { DockviewPanelModel } from './dockviewPanelModel';
 import { getPanelData } from '../dnd/dataTransfer';
 import { Parameters } from '../panel/types';
-import { Overlay } from '../overlay/overlay';
+import { Overlay, OverlayDragContext } from '../overlay/overlay';
 import {
     Classnames,
     getDockviewTheme,
@@ -92,6 +92,7 @@ import {
     IContextMenuService,
     ILayoutHistoryHost,
     LayoutHistoryChangeEvent,
+    ISmartGuidesHost,
     ITabGroupChipsHost,
 } from './moduleContracts';
 import { IHeaderActionsHost } from './headerActionsService';
@@ -491,7 +492,8 @@ export class DockviewComponent
         IAdvancedDnDHost,
         ILiveRegionHost,
         IAccessibilityHost,
-        ILayoutHistoryHost
+        ILayoutHistoryHost,
+        ISmartGuidesHost
 {
     private readonly nextGroupId = sequentialNumberGenerator();
     private readonly _deserializer = new DefaultDockviewDeserialzier(this);
@@ -582,6 +584,14 @@ export class DockviewComponent
     private readonly _onDidOpenPopoutWindowFail = new Emitter<void>();
     readonly onDidOpenPopoutWindowFail: Event<void> =
         this._onDidOpenPopoutWindowFail.event;
+
+    private readonly _onDidEndFloatingGroupDrag =
+        new Emitter<DockviewGroupPanel>();
+    /** Fires with the dragged group when a floating group's move/resize drag
+     *  ends — consumed by the Smart Guides service (`ISmartGuidesHost`) to tear
+     *  down its per-drag guides. */
+    readonly onDidEndFloatingGroupDrag: Event<DockviewGroupPanel> =
+        this._onDidEndFloatingGroupDrag.event;
 
     private readonly _onDidLayoutFromJSON = new Emitter<void>();
     readonly onDidLayoutFromJSON: Event<void> = this._onDidLayoutFromJSON.event;
@@ -748,6 +758,63 @@ export class DockviewComponent
                     height: rect.height,
                 };
             });
+    }
+
+    /**
+     * ISmartGuidesHost — the positioning parent floats are placed in, also the
+     * coordinate space the Smart Guides overlay draws its alignment lines in.
+     */
+    getFloatingContainer(): HTMLElement {
+        return this._floatingOverlayHost ?? this.gridview.element;
+    }
+
+    private get _smartGuidesService() {
+        // Optional like every module service — `?.`-guarded everywhere so the
+        // module can be removed without crashing the float drag loop.
+        return this._moduleRegistry.services.smartGuidesService;
+    }
+
+    /**
+     * Compose the float drag-position transform from the public
+     * `transformFloatingGroupDrag` option and the optional Smart Guides module,
+     * so an app and the module can both nudge a single drag rather than one
+     * clobbering the other. Returns `undefined` when neither is active, leaving
+     * the overlay's drag loop byte-for-byte unchanged (removability — the
+     * sibling-box snapshot is skipped too; see {@link ISmartGuidesHost}).
+     */
+    private _buildFloatingDragTransform(
+        anchorGroup: DockviewGroupPanel
+    ):
+        | ((
+              context: OverlayDragContext
+          ) => { top: number; left: number } | void)
+        | undefined {
+        const publicTransform = this.options.transformFloatingGroupDrag;
+        if (!publicTransform && !this._smartGuidesService) {
+            return undefined;
+        }
+        return (context) => {
+            // 1. the app's transform runs first on the raw proposed box...
+            const appResult = publicTransform?.({
+                group: anchorGroup,
+                proposed: context.proposed,
+                container: context.container,
+                others: context.others,
+            });
+            // 2. ...then the module snaps the (possibly) app-adjusted position,
+            //    so its guides reflect the final on-screen alignment.
+            const proposed = appResult
+                ? { ...context.proposed, ...appResult }
+                : context.proposed;
+            const snapped =
+                this._smartGuidesService?.transformFloatingGroupDrag({
+                    group: anchorGroup,
+                    proposed,
+                    container: context.container,
+                    others: context.others,
+                });
+            return snapped ?? appResult ?? undefined;
+        };
     }
 
     private get _floatingGroupService() {
@@ -1187,6 +1254,7 @@ export class DockviewComponent
                 this._onDidChangePopouts.fire()
             ),
             this._onDidOpenPopoutWindowFail,
+            this._onDidEndFloatingGroupDrag,
             this._onDidCreateTabGroup,
             this._onDidDestroyTabGroup,
             this._onDidAddPanelToTabGroup,
@@ -2242,15 +2310,8 @@ export class DockviewComponent
                     : (this.options.floatingGroupBounds
                           ?.minimumHeightWithinViewport ??
                       DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE),
-            transformDragPosition: this.options.transformFloatingGroupDrag
-                ? (context) =>
-                      this.options.transformFloatingGroupDrag!({
-                          group: anchorGroup,
-                          proposed: context.proposed,
-                          container: context.container,
-                          others: context.others,
-                      })
-                : undefined,
+            transformDragPosition:
+                this._buildFloatingDragTransform(anchorGroup),
             getSiblingBoxes: () => this._gatherFloatingGroupBoxes(anchorGroup),
         });
 
@@ -2273,6 +2334,14 @@ export class DockviewComponent
             anchorGroup,
             overlay,
             floatingGridview
+        );
+
+        // Surface the end of a move/resize drag so the Smart Guides module can
+        // tear down its per-drag guides (no-op when the module is absent).
+        floatingGroupPanel.addDisposables(
+            overlay.onDidChangeEnd(() =>
+                this._onDidEndFloatingGroupDrag.fire(anchorGroup)
+            )
         );
 
         if (titleBar) {

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -15,7 +15,11 @@ import { IDockviewPanel } from './dockviewPanel';
 import { ITabGroup } from './tabGroup';
 import { TabGroupColorPalette } from './tabGroupAccent';
 import { PopupService } from './components/popupService';
-import { DockviewComponentOptions, FloatingGroupDragContext } from './options';
+import {
+    DockviewComponentOptions,
+    FloatingGroupDragContext,
+    SmartGuidesOptions,
+} from './options';
 import {
     DockviewLayoutMutationEvent,
     DockviewLayoutMutationKind,
@@ -283,6 +287,12 @@ export interface ISmartGuidesHost {
         exclude: DockviewGroupPanel
     ): readonly { group: DockviewGroupPanel; box: Box }[];
     /**
+     * The underlying grid's splitter (sash) rectangles, in the same
+     * container-relative space, for the optional `snapTargets.splitters` source.
+     * Empty when there are no sashes.
+     */
+    getGridSplitterRects(): Box[];
+    /**
      * Commit a snap-together: dock / merge the dragged float into a target group
      * at `position`. Reuses the existing move primitive (`moveGroupOrPanel`) so
      * events + undo cover it; a no-op when `dragged === target`.
@@ -302,6 +312,20 @@ export type SmartGuidesSnapPosition =
     | 'bottom'
     | 'center';
 
+/** Fired when a dragged float commits an alignment snap on drop. */
+export interface SmartGuidesSnapEvent {
+    readonly group: DockviewGroupPanel;
+    /** Which axes were snapped at release. */
+    readonly axes: ('x' | 'y')[];
+}
+
+/** Fired when a dragged float commits a dock/merge on drop. */
+export interface SmartGuidesSnapTogetherEvent {
+    readonly dragged: DockviewGroupPanel;
+    readonly target: DockviewGroupPanel;
+    readonly position: SmartGuidesSnapPosition;
+}
+
 export interface ISmartGuidesService extends IDisposable {
     /**
      * Snap the proposed drag position against the other floating groups,
@@ -312,4 +336,12 @@ export interface ISmartGuidesService extends IDisposable {
     transformFloatingGroupDrag(
         context: FloatingGroupDragContext
     ): { top: number; left: number } | void;
+    /** Whether snapping is currently active (option present + enabled). */
+    readonly enabled: boolean;
+    /** Toggle snapping at runtime (overrides `smartGuides.enabled`). */
+    setEnabled(enabled: boolean): void;
+    /** Merge a partial option override in at runtime. */
+    updateOptions(options: Partial<SmartGuidesOptions>): void;
+    readonly onDidSnapFloat: Event<SmartGuidesSnapEvent>;
+    readonly onDidSnapTogether: Event<SmartGuidesSnapTogetherEvent>;
 }

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -272,6 +272,13 @@ export interface ISmartGuidesHost {
      */
     getFloatingContainer(): HTMLElement;
     /**
+     * Fires with the dragged group the first time a floating group move-drag
+     * actually moves — the signal to (re)build per-drag state from a clean slate.
+     * Tears down any session left over from a drag that ended without a normal
+     * pointerup (e.g. a redock long-press, which aborts without an end event).
+     */
+    readonly onDidStartFloatingGroupDrag: Event<DockviewGroupPanel>;
+    /**
      * Fires with the dragged group when a floating group's move-drag ends
      * (pointerup / cancel) — the signal to tear down the guides and per-drag
      * state. A resize-end fires it too; with no active drag session that is a

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -7,6 +7,7 @@
 import { IDisposable } from '../lifecycle';
 import { Event } from '../events';
 import { DroptargetOverlayModel, Position } from '../dnd/droptarget';
+import { Box } from '../types';
 import { IDragGhostSpec } from '../dnd/backend';
 import { DockviewApi } from '../api/component.api';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
@@ -273,7 +274,33 @@ export interface ISmartGuidesHost {
      * harmless no-op.
      */
     readonly onDidEndFloatingGroupDrag: Event<DockviewGroupPanel>;
+    /**
+     * The live floating windows other than `exclude`, each with its group
+     * identity and container-relative box — the snap-together detector needs
+     * identity (which neighbour to dock into), not just geometry.
+     */
+    getFloatingGroupSnapshots(
+        exclude: DockviewGroupPanel
+    ): readonly { group: DockviewGroupPanel; box: Box }[];
+    /**
+     * Commit a snap-together: dock / merge the dragged float into a target group
+     * at `position`. Reuses the existing move primitive (`moveGroupOrPanel`) so
+     * events + undo cover it; a no-op when `dragged === target`.
+     */
+    mergeFloatInto(
+        dragged: DockviewGroupPanel,
+        target: DockviewGroupPanel,
+        position: SmartGuidesSnapPosition
+    ): void;
 }
+
+/** Where a snapped-together float docks relative to its target. */
+export type SmartGuidesSnapPosition =
+    | 'left'
+    | 'right'
+    | 'top'
+    | 'bottom'
+    | 'center';
 
 export interface ISmartGuidesService extends IDisposable {
     /**

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -14,7 +14,7 @@ import { IDockviewPanel } from './dockviewPanel';
 import { ITabGroup } from './tabGroup';
 import { TabGroupColorPalette } from './tabGroupAccent';
 import { PopupService } from './components/popupService';
-import { DockviewComponentOptions } from './options';
+import { DockviewComponentOptions, FloatingGroupDragContext } from './options';
 import {
     DockviewLayoutMutationEvent,
     DockviewLayoutMutationKind,
@@ -244,4 +244,45 @@ export interface ILayoutHistoryService extends IDisposable {
     redo(): void;
     /** Drop both stacks (e.g. on document switch). */
     clear(): void;
+}
+
+// --- SmartGuides ---
+
+/**
+ * The narrow surface the Smart Guides service needs from the host
+ * (`DockviewComponent`). The service owns candidate generation, snap resolution
+ * and the guide overlay; it only reads the floating container (for guide
+ * geometry) and the drag-end signal from the host, never mutating layout. The
+ * per-frame snap itself is driven by the component composing the service into
+ * the float drag loop's `transformFloatingGroupDrag`, so it is not a host
+ * member.
+ */
+export interface ISmartGuidesHost {
+    readonly options: DockviewComponentOptions;
+    /**
+     * The positioning parent for floating groups, in whose coordinate space the
+     * guide overlay is drawn (container-relative, never client/viewport space).
+     * This is the same element floats are placed in
+     * (`_floatingOverlayHost ?? gridview.element`).
+     */
+    getFloatingContainer(): HTMLElement;
+    /**
+     * Fires with the dragged group when a floating group's move-drag ends
+     * (pointerup / cancel) — the signal to tear down the guides and per-drag
+     * state. A resize-end fires it too; with no active drag session that is a
+     * harmless no-op.
+     */
+    readonly onDidEndFloatingGroupDrag: Event<DockviewGroupPanel>;
+}
+
+export interface ISmartGuidesService extends IDisposable {
+    /**
+     * Snap the proposed drag position against the other floating groups,
+     * drawing an alignment guide on the snapped edge. Returns an adjusted
+     * top-left, or nothing to leave the proposed position unchanged — which is
+     * also the pass-through when `smartGuides` is unset / disabled.
+     */
+    transformFloatingGroupDrag(
+        context: FloatingGroupDragContext
+    ): { top: number; left: number } | void;
 }

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -23,6 +23,7 @@ import {
     IContextMenuService,
     IKeyboardDockingService,
     ILayoutHistoryService,
+    ISmartGuidesService,
     ITabGroupChipsService,
 } from './moduleContracts';
 
@@ -40,6 +41,7 @@ export interface ServiceCollection {
     accessibilityService?: IAccessibilityService;
     keyboardDockingService?: IKeyboardDockingService;
     layoutHistoryService?: ILayoutHistoryService;
+    smartGuidesService?: ISmartGuidesService;
 }
 
 export interface DockviewModule<THost = unknown> {

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -181,6 +181,17 @@ export interface FloatingGroupDragContext {
     readonly others: readonly Box[];
 }
 
+/** Which alignment sources Smart Guides snaps a dragged floating group to. */
+export interface SmartGuidesSnapTargets {
+    /** Align to the other floating groups' edges + centers. Default `true`. */
+    floats?: boolean;
+    /** Align to the container's edges + center. Default `true`. */
+    container?: boolean;
+    /** Also emit inset guide lines this many px inside the container edges
+     *  (e.g. a content margin). Default `undefined` (no inset lines). */
+    containerInset?: number;
+}
+
 /**
  * Options for the Smart Guides module — Figma-style alignment guides + magnetic
  * snapping while dragging a floating group. Omit `smartGuides` entirely to leave
@@ -190,10 +201,17 @@ export interface FloatingGroupDragContext {
 export interface SmartGuidesOptions {
     /** Master switch. Defaults to `true` when `smartGuides` is present. */
     enabled?: boolean;
-    /** Distance, in px, within which a dragged edge engages a snap. Default `8`. */
+    /** Distance, in px, within which a dragged edge/center engages a snap.
+     *  Default `8`. */
     snapDistance?: number;
+    /** Extra px beyond `snapDistance` the pointer must travel before an engaged
+     *  snap releases — asymmetric hysteresis that stops boundary oscillation.
+     *  Default `4`. */
+    releaseDistance?: number;
     /** Render the alignment guide lines while snapping. Default `true`. */
     showGuides?: boolean;
+    /** Which alignment sources to snap against (floats + container by default). */
+    snapTargets?: SmartGuidesSnapTargets;
     /** Extra class applied to the guide overlay layer, for theming. */
     className?: string;
 }

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -181,6 +181,23 @@ export interface FloatingGroupDragContext {
     readonly others: readonly Box[];
 }
 
+/**
+ * Options for the Smart Guides module — Figma-style alignment guides + magnetic
+ * snapping while dragging a floating group. Omit `smartGuides` entirely to leave
+ * float dragging unchanged: the module is then inert and the drag loop is a
+ * byte-for-byte pass-through.
+ */
+export interface SmartGuidesOptions {
+    /** Master switch. Defaults to `true` when `smartGuides` is present. */
+    enabled?: boolean;
+    /** Distance, in px, within which a dragged edge engages a snap. Default `8`. */
+    snapDistance?: number;
+    /** Render the alignment guide lines while snapping. Default `true`. */
+    showGuides?: boolean;
+    /** Extra class applied to the guide overlay layer, for theming. */
+    className?: string;
+}
+
 export interface DockviewOptions {
     /**
      * Disable the auto-resizing which is controlled through a `ResizeObserver`.
@@ -210,6 +227,12 @@ export interface DockviewOptions {
     transformFloatingGroupDrag?: (
         context: FloatingGroupDragContext
     ) => { top: number; left: number } | void;
+    /**
+     * Enable Smart Guides — alignment guides + magnetic snapping while a
+     * floating group is being dragged. Omit to disable entirely (float dragging
+     * is then unchanged). Provided by the Smart Guides module.
+     */
+    smartGuides?: SmartGuidesOptions;
     /**
      * Selects which element moves a floating group when dragged.
      *
@@ -453,6 +476,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         disableFloatingGroups: undefined,
         floatingGroupBounds: undefined,
         transformFloatingGroupDrag: undefined,
+        smartGuides: undefined,
         floatingGroupDragHandle: undefined,
         popoutUrl: undefined,
         nonce: undefined,

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -210,6 +210,10 @@ export interface SmartGuidesOptions {
     releaseDistance?: number;
     /** Render the alignment guide lines while snapping. Default `true`. */
     showGuides?: boolean;
+    /** Detect a dock/merge intent when the dragged float comes flush against
+     *  another float (edge-adjacency) or overlaps its tab strip (tabset merge),
+     *  and commit it on drop. Default `true`. */
+    snapTogether?: boolean;
     /** Which alignment sources to snap against (floats + container by default). */
     snapTargets?: SmartGuidesSnapTargets;
     /** Extra class applied to the guide overlay layer, for theming. */

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -8,7 +8,7 @@ import { DockviewMessages } from './accessibilityMessages';
 export type { DockviewMessages } from './accessibilityMessages';
 import { PanelTransfer } from '../dnd/dataTransfer';
 import { IDisposable } from '../lifecycle';
-import { Box } from '../types';
+import { Box, DragModifiers } from '../types';
 import { DroptargetOverlayModel, Position } from '../dnd/droptarget';
 import { GroupOptions } from './dockviewGroupPanelModel';
 import { DockviewGroupDropLocation } from './events';
@@ -179,7 +179,12 @@ export interface FloatingGroupDragContext {
      * snapshotted at drag start.
      */
     readonly others: readonly Box[];
+    /** Modifier-key state from this frame's pointer event. */
+    readonly modifiers: DragModifiers;
 }
+
+/** A keyboard modifier that, while held, suspends Smart Guides snapping. */
+export type SnapModifier = 'alt' | 'ctrl' | 'meta' | 'shift';
 
 /** Which alignment sources Smart Guides snaps a dragged floating group to. */
 export interface SmartGuidesSnapTargets {
@@ -190,6 +195,9 @@ export interface SmartGuidesSnapTargets {
     /** Also emit inset guide lines this many px inside the container edges
      *  (e.g. a content margin). Default `undefined` (no inset lines). */
     containerInset?: number;
+    /** Align to the underlying grid's splitter (sash) positions. Default
+     *  `false`. */
+    splitters?: boolean;
 }
 
 /**
@@ -216,6 +224,10 @@ export interface SmartGuidesOptions {
     snapTogether?: boolean;
     /** Which alignment sources to snap against (floats + container by default). */
     snapTargets?: SmartGuidesSnapTargets;
+    /** Hold this modifier while dragging to temporarily suspend snapping +
+     *  guides (Figma/Keynote parity). `false` disables the gate. Default
+     *  `'alt'`. */
+    disableSnapModifier?: SnapModifier | false;
     /** Extra class applied to the guide overlay layer, for theming. */
     className?: string;
 }

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -203,6 +203,7 @@ export {
     LayoutHistoryKind,
     ISmartGuidesHost,
     ISmartGuidesService,
+    SmartGuidesSnapPosition,
     ITabGroupChipsHost,
     ITabGroupChipsService,
 } from './dockview/moduleContracts';

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -123,7 +123,7 @@ export * from './gridview/gridviewPanel';
 export { SplitviewPanel, ISplitviewPanel } from './splitview/splitviewPanel';
 export * from './paneview/paneviewPanel';
 export * from './dockview/types';
-export { Box, AnchorPosition, AnchoredBox } from './types';
+export { Box, AnchorPosition, AnchoredBox, DragModifiers } from './types';
 
 export { DockviewPanelRenderer } from './overlay/overlayRenderContainer';
 
@@ -204,6 +204,8 @@ export {
     ISmartGuidesHost,
     ISmartGuidesService,
     SmartGuidesSnapPosition,
+    SmartGuidesSnapEvent,
+    SmartGuidesSnapTogetherEvent,
     ITabGroupChipsHost,
     ITabGroupChipsService,
 } from './dockview/moduleContracts';

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -201,6 +201,8 @@ export {
     ILayoutHistoryService,
     LayoutHistoryChangeEvent,
     LayoutHistoryKind,
+    ISmartGuidesHost,
+    ISmartGuidesService,
     ITabGroupChipsHost,
     ITabGroupChipsService,
 } from './dockview/moduleContracts';
@@ -208,3 +210,4 @@ export { resolveMessages } from './dockview/accessibilityMessages';
 export { findRelativeZIndexParent } from './dom';
 export { IDragGhostSpec } from './dnd/backend';
 export { LiveRegionModule } from './dockview/liveRegionService';
+export { FloatingGroupModule } from './dockview/floatingGroupService';

--- a/packages/dockview-core/src/overlay/overlay.scss
+++ b/packages/dockview-core/src/overlay/overlay.scss
@@ -264,3 +264,23 @@
         }
     }
 }
+
+// Smart Guides — alignment lines + dock/merge drop-preview painted in the
+// floating container while a float is dragged. The module positions + sizes
+// these inline; only the theming lives here (override the CSS vars to restyle).
+.dv-smart-guides {
+    pointer-events: none;
+}
+
+.dv-smart-guide {
+    background-color: var(--dv-smart-guides-color, #1f9cf0);
+}
+
+.dv-smart-guide-preview {
+    box-sizing: border-box;
+    background-color: var(
+        --dv-smart-guides-preview-color,
+        rgba(31, 156, 240, 0.18)
+    );
+    border: 1px solid var(--dv-smart-guides-color, #1f9cf0);
+}

--- a/packages/dockview-core/src/overlay/overlay.ts
+++ b/packages/dockview-core/src/overlay/overlay.ts
@@ -10,7 +10,7 @@ import {
     MutableDisposable,
 } from '../lifecycle';
 import { clamp } from '../math';
-import { AnchoredBox, Box } from '../types';
+import { AnchoredBox, Box, DragModifiers } from '../types';
 
 /**
  * Context handed to {@link OverlayOptions.transformDragPosition} each
@@ -23,6 +23,8 @@ export interface OverlayDragContext {
     readonly container: { width: number; height: number };
     /** Bounds of the sibling overlays, snapshotted at drag start. */
     readonly others: readonly Box[];
+    /** Modifier-key state from this frame's pointer event. */
+    readonly modifiers: DragModifiers;
 }
 
 class AriaLevelTracker {
@@ -429,6 +431,12 @@ export class Overlay extends CompositeDisposable {
                                 height: containerRect.height,
                             },
                             others: siblingBoxes,
+                            modifiers: {
+                                altKey: e.altKey,
+                                ctrlKey: e.ctrlKey,
+                                metaKey: e.metaKey,
+                                shiftKey: e.shiftKey,
+                            },
                         });
                         if (adjusted) {
                             proposedTop = adjusted.top;

--- a/packages/dockview-core/src/types.ts
+++ b/packages/dockview-core/src/types.ts
@@ -9,6 +9,15 @@ export interface Box {
     width: number;
 }
 
+/** Keyboard modifier state captured from a pointer event (e.g. for snapping
+ *  gates that suspend while a modifier is held). */
+export interface DragModifiers {
+    readonly altKey: boolean;
+    readonly ctrlKey: boolean;
+    readonly metaKey: boolean;
+    readonly shiftKey: boolean;
+}
+
 type TopLeft = { top: number; left: number };
 type TopRight = { top: number; right: number };
 type BottomLeft = { bottom: number; left: number };

--- a/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
+++ b/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
@@ -229,6 +229,25 @@ describe('smart guides', () => {
         expect(visibleLines()).toHaveLength(0);
     });
 
+    test('a guide reappears after the snap is lost and re-acquired', () => {
+        // Guards the per-frame write dedup: a re-acquired alignment must redraw
+        // rather than being skipped as "unchanged".
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        const at = (left: number) =>
+            service.transformFloatingGroupDrag(
+                ctx({ left, top: 400, width: 50, height: 50 }, [other])
+            );
+
+        at(106); // engage x=100
+        expect(visibleLines()).toHaveLength(1);
+        at(500); // well clear of every edge → guide hidden
+        expect(visibleLines()).toHaveLength(0);
+        at(106); // re-acquire the same edge → guide shown again
+        expect(visibleLines()).toHaveLength(1);
+        expect(visibleLines()[0].style.left).toBe('100px');
+    });
+
     test('inert when `smartGuides` is unset — no overlay, no adjustment', () => {
         make(undefined);
         const result = service.transformFloatingGroupDrag(

--- a/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
+++ b/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
@@ -9,7 +9,8 @@ import {
 import { SmartGuidesService } from '../smartGuidesService';
 
 /**
- * Smart Guides — Phase 1 (single-axis edge snapping against other floats).
+ * Smart Guides — independent X/Y edge + center snapping against other floats and
+ * the container, with engage/release hysteresis.
  *
  * Driven at the service boundary with a mock host + synthetic drag contexts:
  * the snap math is pure geometry (container-relative px), so it doesn't need a
@@ -42,8 +43,19 @@ describe('smart guides', () => {
         others,
     });
 
-    const guideLine = (): HTMLElement | null =>
-        container.querySelector('.dv-smart-guide');
+    // Lines the layer is currently painting (pooled hidden ones excluded).
+    const visibleLines = (): HTMLElement[] =>
+        Array.from(
+            container.querySelectorAll<HTMLElement>('.dv-smart-guide')
+        ).filter((l) => l.style.display === 'block');
+
+    // Float-only options — isolate from the container edges that are on by default.
+    const floatsOnly = (
+        extra: SmartGuidesOptions = {}
+    ): SmartGuidesOptions => ({
+        snapTargets: { container: false },
+        ...extra,
+    });
 
     afterEach(() => {
         service?.dispose();
@@ -53,65 +65,143 @@ describe('smart guides', () => {
     test('snaps a float left edge to another float left edge within snapDistance', () => {
         make({});
         const other: Box = { left: 100, top: 50, width: 200, height: 150 };
-        // dragged left edge at 106 — 6px from the other float's left edge (100),
-        // inside the 8px default threshold.
+        // dragged left edge at 106 — 6px from the other float's left edge (100).
         const result = service.transformFloatingGroupDrag(
             ctx({ left: 106, top: 400, width: 50, height: 50 }, [other])
         );
 
         expect(result).toEqual({ top: 400, left: 100 });
-
-        // a single vertical guide line is painted at x = 100
-        const line = guideLine();
-        expect(line).toBeTruthy();
-        expect(line!.style.display).toBe('block');
-        expect(line!.style.left).toBe('100px');
-        expect(line!.style.width).toBe('1px');
+        const lines = visibleLines();
+        expect(lines).toHaveLength(1);
+        expect(lines[0].style.left).toBe('100px');
+        expect(lines[0].style.width).toBe('1px');
     });
 
     test('snaps the top edge (Y axis) and draws a horizontal guide', () => {
-        make({});
+        make(floatsOnly());
         const other: Box = { left: 100, top: 200, width: 200, height: 150 };
-        // dragged top edge at 195 — 5px from the other float's top edge (200);
-        // horizontally far away, so the only snap is on Y.
+        // top edge at 195 — 5px from the other float's top (200); far on X.
         const result = service.transformFloatingGroupDrag(
             ctx({ left: 600, top: 195, width: 50, height: 50 }, [other])
         );
 
         expect(result).toEqual({ top: 200, left: 600 });
-        const line = guideLine();
-        expect(line!.style.display).toBe('block');
-        expect(line!.style.top).toBe('200px');
-        expect(line!.style.height).toBe('1px');
+        const lines = visibleLines();
+        expect(lines).toHaveLength(1);
+        expect(lines[0].style.top).toBe('200px');
+        expect(lines[0].style.height).toBe('1px');
     });
 
-    test('picks the nearest edge when several are in range', () => {
-        make({ snapDistance: 10 });
-        const other: Box = { left: 100, top: 50, width: 60, height: 150 };
-        // left probe 104 → Δ4 to edge 100; right probe 154 → Δ6 to edge 160.
-        // The nearer (left, Δ4) wins.
+    test('resolves X and Y independently — two simultaneous guides', () => {
+        make(floatsOnly());
+        // One neighbour: align the dragged float's left edge AND top edge to it.
+        const other: Box = { left: 100, top: 100, width: 200, height: 150 };
         const result = service.transformFloatingGroupDrag(
-            ctx({ left: 104, top: 400, width: 50, height: 50 }, [other])
+            ctx({ left: 105, top: 104, width: 50, height: 50 }, [other])
         );
-        expect(result).toEqual({ top: 400, left: 100 });
-        expect(guideLine()!.style.left).toBe('100px');
+
+        expect(result).toEqual({ top: 100, left: 100 });
+        const lines = visibleLines();
+        expect(lines).toHaveLength(2);
+        // a vertical guide at x=100 and a horizontal guide at y=100
+        expect(
+            lines.some(
+                (l) => l.style.width === '1px' && l.style.left === '100px'
+            )
+        ).toBe(true);
+        expect(
+            lines.some(
+                (l) => l.style.height === '1px' && l.style.top === '100px'
+            )
+        ).toBe(true);
     });
 
-    test('no snap outside snapDistance — pass-through, guide hidden', () => {
+    test('snaps to the container edge', () => {
+        make({});
+        // near the right container edge (1000); no floats in play.
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 945, top: 400, width: 50, height: 50 }, [])
+        );
+        // right edge 995 → snaps to 1000, so left becomes 950.
+        expect(result).toEqual({ top: 400, left: 950 });
+        const lines = visibleLines();
+        expect(lines).toHaveLength(1);
+        expect(lines[0].style.left).toBe('1000px');
+    });
+
+    test('snaps centers together', () => {
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        // dragged center 202 vs the other float centre 200 — only the centres
+        // line up (no edge is in range).
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 172, top: 400, width: 60, height: 50 }, [other])
+        );
+        expect(result).toEqual({ top: 400, left: 170 });
+        expect(visibleLines()[0].style.left).toBe('200px');
+    });
+
+    test('container inset adds margin guide lines', () => {
+        make({ snapTargets: { floats: false, containerInset: 20 } });
+        // left edge at 24 → snaps to the 20px inset line.
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 24, top: 400, width: 50, height: 50 }, [])
+        );
+        expect(result).toEqual({ top: 400, left: 20 });
+        expect(visibleLines()[0].style.left).toBe('20px');
+    });
+
+    test('hysteresis — stays engaged within release, frees past it (no oscillation)', () => {
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        const at = (left: number) =>
+            service.transformFloatingGroupDrag(
+                ctx({ left, top: 400, width: 50, height: 50 }, [other])
+            );
+
+        // engage exactly on the edge
+        expect(at(100)).toEqual({ top: 400, left: 100 });
+        // 10px away (> snapDistance 8, < snapDistance+release 12): stays snapped
+        expect(at(110)).toEqual({ top: 400, left: 100 });
+        // 13px away (> 12): releases — and is now out of the 8px engage range
+        expect(at(113)).toBeUndefined();
+    });
+
+    test('engages at the snap distance, not beyond', () => {
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        // fresh drag, exactly 8px away → engages
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx({ left: 108, top: 400, width: 50, height: 50 }, [other])
+            )
+        ).toEqual({ top: 400, left: 100 });
+
+        // fresh drag, 9px away → no snap
+        make(floatsOnly());
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx({ left: 109, top: 400, width: 50, height: 50 }, [other])
+            )
+        ).toBeUndefined();
+    });
+
+    test('no snap outside snapDistance — pass-through, no guides', () => {
         make({});
         const other: Box = { left: 100, top: 50, width: 200, height: 150 };
         const result = service.transformFloatingGroupDrag(
-            ctx({ left: 130, top: 500, width: 50, height: 50 }, [other])
+            ctx({ left: 130, top: 400, width: 50, height: 50 }, [other])
         );
         expect(result).toBeUndefined();
-        expect(guideLine()!.style.display).toBe('none');
+        expect(visibleLines()).toHaveLength(0);
     });
 
     test('inert when `smartGuides` is unset — no overlay, no adjustment', () => {
         make(undefined);
-        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
         const result = service.transformFloatingGroupDrag(
-            ctx({ left: 106, top: 400, width: 50, height: 50 }, [other])
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, [
+                { left: 100, top: 50, width: 200, height: 150 },
+            ])
         );
         expect(result).toBeUndefined();
         expect(container.querySelector('.dv-smart-guides')).toBeNull();
@@ -129,14 +219,14 @@ describe('smart guides', () => {
     });
 
     test('`showGuides: false` still snaps but draws no visible guide', () => {
-        make({ showGuides: false });
+        make(floatsOnly({ showGuides: false }));
         const result = service.transformFloatingGroupDrag(
             ctx({ left: 106, top: 400, width: 50, height: 50 }, [
                 { left: 100, top: 50, width: 200, height: 150 },
             ])
         );
         expect(result).toEqual({ top: 400, left: 100 });
-        expect(guideLine()!.style.display).toBe('none');
+        expect(visibleLines()).toHaveLength(0);
     });
 
     test('drag end tears the guide overlay down', () => {
@@ -153,20 +243,19 @@ describe('smart guides', () => {
     });
 
     test('candidates are built once per drag, not per frame', () => {
-        make({});
+        make(floatsOnly());
         const others: Box[] = [{ left: 100, top: 50, width: 200, height: 150 }];
-        const first = ctx(
-            { left: 106, top: 400, width: 50, height: 50 },
-            others
+        service.transformFloatingGroupDrag(
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, others)
         );
-        service.transformFloatingGroupDrag(first);
 
         // A later frame whose `others` snapshot has drifted must NOT rebuild the
         // candidate set — the float at x=100 is still the snap target.
-        const second = ctx({ left: 104, top: 400, width: 50, height: 50 }, [
-            { left: 500, top: 50, width: 200, height: 150 },
-        ]);
-        const result = service.transformFloatingGroupDrag(second);
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 104, top: 400, width: 50, height: 50 }, [
+                { left: 500, top: 50, width: 200, height: 150 },
+            ])
+        );
         expect(result).toEqual({ top: 400, left: 100 });
     });
 });

--- a/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
+++ b/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
@@ -29,6 +29,7 @@ const NO_MODIFIERS: DragModifiers = {
  */
 describe('smart guides', () => {
     let container: HTMLElement;
+    let startEmitter: Emitter<DockviewGroupPanel>;
     let endEmitter: Emitter<DockviewGroupPanel>;
     let service: SmartGuidesService;
     let snapshots: { group: DockviewGroupPanel; box: Box }[];
@@ -47,6 +48,7 @@ describe('smart guides', () => {
     ): void => {
         container = document.createElement('div');
         document.body.appendChild(container);
+        startEmitter = new Emitter<DockviewGroupPanel>();
         endEmitter = new Emitter<DockviewGroupPanel>();
         snapshots = floats;
         splitterRects = [];
@@ -54,6 +56,7 @@ describe('smart guides', () => {
         const host: ISmartGuidesHost = {
             options: { smartGuides } as any,
             getFloatingContainer: () => container,
+            onDidStartFloatingGroupDrag: startEmitter.event,
             onDidEndFloatingGroupDrag: endEmitter.event,
             getFloatingGroupSnapshots: () => snapshots,
             getGridSplitterRects: () => splitterRects,
@@ -476,19 +479,33 @@ describe('smart guides', () => {
         make({
             snapTargets: { floats: false, container: false, splitters: true },
         });
-        // a vertical sash at x = 300
-        splitterRects = [{ left: 300, top: 0, width: 0, height: 1000 }];
+        // a 4px-wide vertical sash spanning 300..304 → candidate at centre 302
+        splitterRects = [{ left: 300, top: 0, width: 4, height: 1000 }];
 
         const result = service.transformFloatingGroupDrag(
             ctx({ left: 305, top: 400, width: 50, height: 50 }, [])
         );
-        expect(result).toEqual({ top: 400, left: 300 });
-        expect(visibleLines()[0].style.left).toBe('300px');
+        expect(result).toEqual({ top: 400, left: 302 });
+        expect(visibleLines()[0].style.left).toBe('302px');
+    });
+
+    test('a hidden (zero-area) sash is not a snap candidate', () => {
+        make({
+            snapTargets: { floats: false, container: false, splitters: true },
+        });
+        // a collapsed sash measures 0×0 — must not become a phantom line at x=0
+        splitterRects = [{ left: 0, top: 0, width: 0, height: 0 }];
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx({ left: 3, top: 400, width: 50, height: 50 }, [])
+            )
+        ).toBeUndefined();
+        expect(visibleLines()).toHaveLength(0);
     });
 
     test('splitters are off by default', () => {
         make({ snapTargets: { floats: false, container: false } });
-        splitterRects = [{ left: 300, top: 0, width: 0, height: 1000 }];
+        splitterRects = [{ left: 300, top: 0, width: 4, height: 1000 }];
         expect(
             service.transformFloatingGroupDrag(
                 ctx({ left: 305, top: 400, width: 50, height: 50 }, [])
@@ -574,5 +591,56 @@ describe('smart guides', () => {
             { dragged: group, target: targetGroup, position: 'left' },
         ]);
         expect(aligned).toHaveLength(0);
+    });
+
+    // --- review regressions ---
+
+    test('a drag that aborts without an end leaves no stale guide for the next drag', () => {
+        // A redock long-press aborts via cancelPendingDrag (no end event); the
+        // next drag's start signal must discard the leftover session + layer.
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        service.transformFloatingGroupDrag(
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, [other])
+        );
+        expect(container.querySelector('.dv-smart-guides')).toBeTruthy();
+
+        // ...no end fires (aborted). Start of the next drag tears it down.
+        startEmitter.fire(group);
+        expect(container.querySelector('.dv-smart-guides')).toBeNull();
+    });
+
+    test('top-aligning a float off to the side of a target is not a merge', () => {
+        // Wide float, tops flush, ≥50% horizontal overlap of the narrow target —
+        // but its CENTRE is past the target's edge, so it is an alignment, not a
+        // tabset stack. Must NOT suggest or commit a merge.
+        const t: Box = { left: 100, top: 100, width: 100, height: 200 };
+        make(noAlign(), [{ group: targetGroup, box: t }]);
+
+        service.transformFloatingGroupDrag(
+            ctx({ left: 120, top: 100, width: 300, height: 200 }, [])
+        );
+        expect(preview()?.style.display ?? 'none').toBe('none');
+
+        endEmitter.fire(group);
+        expect(mergeCalls).toHaveLength(0);
+    });
+
+    test('`showGuides: false` still previews + commits a pending merge', () => {
+        // showGuides hides alignment LINES only — a merge that will commit on
+        // drop must never be silent.
+        const t: Box = { left: 300, top: 100, width: 200, height: 200 };
+        make(noAlign({ showGuides: false }), [{ group: targetGroup, box: t }]);
+
+        service.transformFloatingGroupDrag(
+            ctx({ left: 150, top: 100, width: 150, height: 200 }, [])
+        );
+        expect(visibleLines()).toHaveLength(0); // no alignment lines
+        expect(preview()!.style.display).toBe('block'); // but the merge preview shows
+
+        endEmitter.fire(group);
+        expect(mergeCalls).toEqual([
+            { dragged: group, target: targetGroup, position: 'left' },
+        ]);
     });
 });

--- a/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
+++ b/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
@@ -32,6 +32,8 @@ describe('smart guides', () => {
     let startEmitter: Emitter<DockviewGroupPanel>;
     let endEmitter: Emitter<DockviewGroupPanel>;
     let service: SmartGuidesService;
+    // Mutable so a test can simulate an app-level option update (new reference).
+    let hostOptions: { smartGuides: SmartGuidesOptions | undefined };
     let snapshots: { group: DockviewGroupPanel; box: Box }[];
     let splitterRects: Box[];
     let mergeCalls: {
@@ -53,8 +55,9 @@ describe('smart guides', () => {
         snapshots = floats;
         splitterRects = [];
         mergeCalls = [];
+        hostOptions = { smartGuides };
         const host: ISmartGuidesHost = {
-            options: { smartGuides } as any,
+            options: hostOptions as any,
             getFloatingContainer: () => container,
             onDidStartFloatingGroupDrag: startEmitter.event,
             onDidEndFloatingGroupDrag: endEmitter.event,
@@ -642,5 +645,67 @@ describe('smart guides', () => {
         expect(mergeCalls).toEqual([
             { dragged: group, target: targetGroup, position: 'left' },
         ]);
+    });
+
+    test('an engaged edge stays glued on a small float (no probe switch)', () => {
+        // A 20px-wide float: as it moves, its centre probe can get nearer to the
+        // engaged line than the latched edge. It must keep gluing the EDGE, not
+        // silently re-snap its centre (which would jump the box).
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        // engage the left edge on x=100
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx({ left: 100, top: 400, width: 20, height: 50 }, [other])
+            )
+        ).toEqual({ top: 400, left: 100 });
+        // move to left=92: centre (102) is now nearer 100 than the edge (92),
+        // but the edge stays glued (within release) → left snaps back to 100.
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx({ left: 92, top: 400, width: 20, height: 50 }, [other])
+            )
+        ).toEqual({ top: 400, left: 100 });
+    });
+
+    test('snap-together docks into the nearest target, not the first', () => {
+        const near = { id: 'near' } as DockviewGroupPanel;
+        const far = { id: 'far' } as DockviewGroupPanel;
+        // `far` is first in iteration order but its right edge (96) is further
+        // from the dragged left edge (102) than `near`'s (100).
+        make(noAlign(), [
+            { group: far, box: { left: 0, top: 100, width: 96, height: 200 } },
+            {
+                group: near,
+                box: { left: 0, top: 100, width: 100, height: 200 },
+            },
+        ]);
+
+        service.transformFloatingGroupDrag(
+            ctx({ left: 102, top: 100, width: 100, height: 200 }, [])
+        );
+        endEmitter.fire(group);
+        expect(mergeCalls).toEqual([
+            { dragged: group, target: near, position: 'right' },
+        ]);
+    });
+
+    test('a fresh app-level option update overrides earlier runtime options', () => {
+        make({ snapDistance: 8 });
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        const at = (left: number) =>
+            service.transformFloatingGroupDrag(
+                ctx({ left, top: 400, width: 50, height: 50 }, [other])
+            );
+
+        // runtime override widens the snap distance...
+        service.updateOptions({ snapDistance: 30 });
+        expect(at(125)).toEqual({ top: 400, left: 100 }); // 25px away → snaps
+        endEmitter.fire(group);
+
+        // ...then the app sets `smartGuides` afresh (new reference) → the runtime
+        // override is dropped and the new option wins.
+        hostOptions.smartGuides = { snapDistance: 8 };
+        expect(at(125)).toBeUndefined(); // 25px > 8 → no snap
     });
 });

--- a/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
+++ b/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
@@ -5,6 +5,7 @@ import {
     FloatingGroupDragContext,
     ISmartGuidesHost,
     SmartGuidesOptions,
+    SmartGuidesSnapPosition,
 } from 'dockview-core';
 import { SmartGuidesService } from '../smartGuidesService';
 
@@ -21,17 +22,32 @@ describe('smart guides', () => {
     let container: HTMLElement;
     let endEmitter: Emitter<DockviewGroupPanel>;
     let service: SmartGuidesService;
+    let snapshots: { group: DockviewGroupPanel; box: Box }[];
+    let mergeCalls: {
+        dragged: DockviewGroupPanel;
+        target: DockviewGroupPanel;
+        position: SmartGuidesSnapPosition;
+    }[];
     // Distinct identity per drag — the service keys per-drag state by group.
     const group = {} as DockviewGroupPanel;
 
-    const make = (smartGuides: SmartGuidesOptions | undefined): void => {
+    const make = (
+        smartGuides: SmartGuidesOptions | undefined,
+        floats: { group: DockviewGroupPanel; box: Box }[] = []
+    ): void => {
         container = document.createElement('div');
         document.body.appendChild(container);
         endEmitter = new Emitter<DockviewGroupPanel>();
+        snapshots = floats;
+        mergeCalls = [];
         const host: ISmartGuidesHost = {
             options: { smartGuides } as any,
             getFloatingContainer: () => container,
             onDidEndFloatingGroupDrag: endEmitter.event,
+            getFloatingGroupSnapshots: () => snapshots,
+            mergeFloatInto: (dragged, target, position) => {
+                mergeCalls.push({ dragged, target, position });
+            },
         };
         service = new SmartGuidesService(host);
     };
@@ -257,5 +273,111 @@ describe('smart guides', () => {
             ])
         );
         expect(result).toEqual({ top: 400, left: 100 });
+    });
+
+    // --- snap-together ---
+
+    const targetGroup = { id: 'target' } as DockviewGroupPanel;
+    const preview = (): HTMLElement | null =>
+        container.querySelector('.dv-smart-guide-preview');
+    // Disable alignment (no float/container candidates) so the snapped box is
+    // the raw proposed box — the snap-together geometry is then exact.
+    const noAlign = (extra: SmartGuidesOptions = {}): SmartGuidesOptions => ({
+        snapTargets: { floats: false, container: false },
+        ...extra,
+    });
+
+    test('edge-adjacency suggests docking beside the target and commits on drop', () => {
+        const t: Box = { left: 300, top: 100, width: 200, height: 200 };
+        make(noAlign(), [{ group: targetGroup, box: t }]);
+
+        // dragged right edge (150+150=300) meets the target's left edge (300),
+        // with full vertical overlap → dock on the target's left.
+        service.transformFloatingGroupDrag(
+            ctx({ left: 150, top: 100, width: 150, height: 200 }, [])
+        );
+
+        const p = preview();
+        expect(p).toBeTruthy();
+        expect(p!.style.display).toBe('block');
+        // preview is the left half of the target
+        expect(p!.style.left).toBe('300px');
+        expect(p!.style.width).toBe('100px');
+        expect(p!.style.height).toBe('200px');
+        expect(mergeCalls).toHaveLength(0);
+
+        endEmitter.fire(group);
+        expect(mergeCalls).toEqual([
+            { dragged: group, target: targetGroup, position: 'left' },
+        ]);
+    });
+
+    test('overlapping tab strips suggest a center (tabset) merge', () => {
+        const t: Box = { left: 100, top: 100, width: 200, height: 200 };
+        make(noAlign(), [{ group: targetGroup, box: t }]);
+
+        // tops flush (100) and the boxes stacked (90% horizontal overlap).
+        service.transformFloatingGroupDrag(
+            ctx({ left: 120, top: 100, width: 200, height: 200 }, [])
+        );
+
+        const p = preview()!;
+        expect(p.style.display).toBe('block');
+        // the whole target is previewed for a tabset merge
+        expect(p.style.left).toBe('100px');
+        expect(p.style.width).toBe('200px');
+
+        endEmitter.fire(group);
+        expect(mergeCalls).toEqual([
+            { dragged: group, target: targetGroup, position: 'center' },
+        ]);
+    });
+
+    test('`snapTogether: false` never suggests or commits a merge', () => {
+        const t: Box = { left: 300, top: 100, width: 200, height: 200 };
+        make(noAlign({ snapTogether: false }), [
+            { group: targetGroup, box: t },
+        ]);
+
+        service.transformFloatingGroupDrag(
+            ctx({ left: 150, top: 100, width: 150, height: 200 }, [])
+        );
+        expect(preview()?.style.display ?? 'none').toBe('none');
+
+        endEmitter.fire(group);
+        expect(mergeCalls).toHaveLength(0);
+    });
+
+    test('moving away from a target clears the pending merge before drop', () => {
+        const t: Box = { left: 300, top: 100, width: 200, height: 200 };
+        make(noAlign(), [{ group: targetGroup, box: t }]);
+
+        // engage adjacency...
+        service.transformFloatingGroupDrag(
+            ctx({ left: 150, top: 100, width: 150, height: 200 }, [])
+        );
+        // ...then drag well clear of it
+        service.transformFloatingGroupDrag(
+            ctx({ left: 10, top: 600, width: 150, height: 200 }, [])
+        );
+        expect(preview()!.style.display).toBe('none');
+
+        endEmitter.fire(group);
+        expect(mergeCalls).toHaveLength(0);
+    });
+
+    test('an edge that barely overlaps the target is not an adjacency', () => {
+        // dragged right edge meets target left edge, but only 40% vertical
+        // overlap (< 50%) → no dock suggestion.
+        const t: Box = { left: 300, top: 100, width: 200, height: 200 };
+        make(noAlign(), [{ group: targetGroup, box: t }]);
+
+        service.transformFloatingGroupDrag(
+            ctx({ left: 150, top: 280, width: 150, height: 50 }, [])
+        );
+        expect(preview()?.style.display ?? 'none').toBe('none');
+
+        endEmitter.fire(group);
+        expect(mergeCalls).toHaveLength(0);
     });
 });

--- a/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
+++ b/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
@@ -2,12 +2,21 @@ import { DockviewEmitter as Emitter } from 'dockview-core';
 import {
     Box,
     DockviewGroupPanel,
+    DragModifiers,
     FloatingGroupDragContext,
     ISmartGuidesHost,
     SmartGuidesOptions,
     SmartGuidesSnapPosition,
+    SmartGuidesSnapTogetherEvent,
 } from 'dockview-core';
 import { SmartGuidesService } from '../smartGuidesService';
+
+const NO_MODIFIERS: DragModifiers = {
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+};
 
 /**
  * Smart Guides — independent X/Y edge + center snapping against other floats and
@@ -23,6 +32,7 @@ describe('smart guides', () => {
     let endEmitter: Emitter<DockviewGroupPanel>;
     let service: SmartGuidesService;
     let snapshots: { group: DockviewGroupPanel; box: Box }[];
+    let splitterRects: Box[];
     let mergeCalls: {
         dragged: DockviewGroupPanel;
         target: DockviewGroupPanel;
@@ -39,12 +49,14 @@ describe('smart guides', () => {
         document.body.appendChild(container);
         endEmitter = new Emitter<DockviewGroupPanel>();
         snapshots = floats;
+        splitterRects = [];
         mergeCalls = [];
         const host: ISmartGuidesHost = {
             options: { smartGuides } as any,
             getFloatingContainer: () => container,
             onDidEndFloatingGroupDrag: endEmitter.event,
             getFloatingGroupSnapshots: () => snapshots,
+            getGridSplitterRects: () => splitterRects,
             mergeFloatInto: (dragged, target, position) => {
                 mergeCalls.push({ dragged, target, position });
             },
@@ -52,11 +64,16 @@ describe('smart guides', () => {
         service = new SmartGuidesService(host);
     };
 
-    const ctx = (proposed: Box, others: Box[]): FloatingGroupDragContext => ({
+    const ctx = (
+        proposed: Box,
+        others: Box[],
+        modifiers: DragModifiers = NO_MODIFIERS
+    ): FloatingGroupDragContext => ({
         group,
         proposed,
         container: { width: 1000, height: 1000 },
         others,
+        modifiers,
     });
 
     // Lines the layer is currently painting (pooled hidden ones excluded).
@@ -379,5 +396,164 @@ describe('smart guides', () => {
 
         endEmitter.fire(group);
         expect(mergeCalls).toHaveLength(0);
+    });
+
+    // --- modifier gate ---
+
+    const alt: DragModifiers = { ...NO_MODIFIERS, altKey: true };
+
+    test('holding the disable modifier (default Alt) suspends snapping', () => {
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        const box: Box = { left: 106, top: 400, width: 50, height: 50 };
+
+        // Alt held → no snap, no guides
+        expect(
+            service.transformFloatingGroupDrag(ctx(box, [other], alt))
+        ).toBeUndefined();
+        expect(visibleLines()).toHaveLength(0);
+
+        // released → snaps again on the next frame
+        expect(service.transformFloatingGroupDrag(ctx(box, [other]))).toEqual({
+            top: 400,
+            left: 100,
+        });
+    });
+
+    test('the disable modifier is configurable', () => {
+        make(floatsOnly({ disableSnapModifier: 'shift' }));
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        const box: Box = { left: 106, top: 400, width: 50, height: 50 };
+
+        // Alt is no longer the gate → still snaps with Alt held
+        expect(
+            service.transformFloatingGroupDrag(ctx(box, [other], alt))
+        ).toEqual({ top: 400, left: 100 });
+        // Shift held → suspended
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx(box, [other], { ...NO_MODIFIERS, shiftKey: true })
+            )
+        ).toBeUndefined();
+    });
+
+    test('`disableSnapModifier: false` ignores modifiers', () => {
+        make(floatsOnly({ disableSnapModifier: false }));
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx(
+                    { left: 106, top: 400, width: 50, height: 50 },
+                    [other],
+                    alt
+                )
+            )
+        ).toEqual({ top: 400, left: 100 });
+    });
+
+    // --- splitter targets ---
+
+    test('snaps to a grid splitter when `snapTargets.splitters` is on', () => {
+        make({
+            snapTargets: { floats: false, container: false, splitters: true },
+        });
+        // a vertical sash at x = 300
+        splitterRects = [{ left: 300, top: 0, width: 0, height: 1000 }];
+
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 305, top: 400, width: 50, height: 50 }, [])
+        );
+        expect(result).toEqual({ top: 400, left: 300 });
+        expect(visibleLines()[0].style.left).toBe('300px');
+    });
+
+    test('splitters are off by default', () => {
+        make({ snapTargets: { floats: false, container: false } });
+        splitterRects = [{ left: 300, top: 0, width: 0, height: 1000 }];
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx({ left: 305, top: 400, width: 50, height: 50 }, [])
+            )
+        ).toBeUndefined();
+    });
+
+    // --- runtime options ---
+
+    test('setEnabled toggles snapping at runtime', () => {
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        const box: Box = { left: 106, top: 400, width: 50, height: 50 };
+
+        service.setEnabled(false);
+        expect(service.enabled).toBe(false);
+        expect(
+            service.transformFloatingGroupDrag(ctx(box, [other]))
+        ).toBeUndefined();
+
+        service.setEnabled(true);
+        expect(service.enabled).toBe(true);
+        expect(service.transformFloatingGroupDrag(ctx(box, [other]))).toEqual({
+            top: 400,
+            left: 100,
+        });
+    });
+
+    test('updateOptions merges an override at runtime', () => {
+        make(floatsOnly());
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        // 25px away — outside the default 8px, inside an overridden 30px.
+        service.updateOptions({ snapDistance: 30 });
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx({ left: 125, top: 400, width: 50, height: 50 }, [other])
+            )
+        ).toEqual({ top: 400, left: 100 });
+    });
+
+    test('setEnabled(true) activates even when `smartGuides` was unset', () => {
+        make(undefined);
+        service.setEnabled(true);
+        expect(
+            service.transformFloatingGroupDrag(
+                ctx({ left: 106, top: 400, width: 50, height: 50 }, [
+                    { left: 100, top: 50, width: 200, height: 150 },
+                ])
+            )
+        ).toEqual({ top: 400, left: 100 });
+    });
+
+    // --- events ---
+
+    test('onDidSnapFloat fires on drop with the snapped axes', () => {
+        make(floatsOnly());
+        const events: { axes: ('x' | 'y')[] }[] = [];
+        service.onDidSnapFloat((e) => events.push({ axes: e.axes }));
+
+        service.transformFloatingGroupDrag(
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, [
+                { left: 100, top: 50, width: 200, height: 150 },
+            ])
+        );
+        endEmitter.fire(group);
+        expect(events).toEqual([{ axes: ['x'] }]);
+    });
+
+    test('onDidSnapTogether fires on a merge drop (and not onDidSnapFloat)', () => {
+        const t: Box = { left: 300, top: 100, width: 200, height: 200 };
+        make(noAlign(), [{ group: targetGroup, box: t }]);
+        const together: SmartGuidesSnapTogetherEvent[] = [];
+        const aligned: unknown[] = [];
+        service.onDidSnapTogether((e) => together.push(e));
+        service.onDidSnapFloat((e) => aligned.push(e));
+
+        service.transformFloatingGroupDrag(
+            ctx({ left: 150, top: 100, width: 150, height: 200 }, [])
+        );
+        endEmitter.fire(group);
+
+        expect(together).toEqual([
+            { dragged: group, target: targetGroup, position: 'left' },
+        ]);
+        expect(aligned).toHaveLength(0);
     });
 });

--- a/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
+++ b/packages/dockview-modules/src/__tests__/smartGuides.spec.ts
@@ -1,0 +1,172 @@
+import { DockviewEmitter as Emitter } from 'dockview-core';
+import {
+    Box,
+    DockviewGroupPanel,
+    FloatingGroupDragContext,
+    ISmartGuidesHost,
+    SmartGuidesOptions,
+} from 'dockview-core';
+import { SmartGuidesService } from '../smartGuidesService';
+
+/**
+ * Smart Guides — Phase 1 (single-axis edge snapping against other floats).
+ *
+ * Driven at the service boundary with a mock host + synthetic drag contexts:
+ * the snap math is pure geometry (container-relative px), so it doesn't need a
+ * real browser layout. The component-side composition (and byte-identical
+ * pass-through when the module is absent) is covered by `moduleRemovability`.
+ */
+describe('smart guides', () => {
+    let container: HTMLElement;
+    let endEmitter: Emitter<DockviewGroupPanel>;
+    let service: SmartGuidesService;
+    // Distinct identity per drag — the service keys per-drag state by group.
+    const group = {} as DockviewGroupPanel;
+
+    const make = (smartGuides: SmartGuidesOptions | undefined): void => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        endEmitter = new Emitter<DockviewGroupPanel>();
+        const host: ISmartGuidesHost = {
+            options: { smartGuides } as any,
+            getFloatingContainer: () => container,
+            onDidEndFloatingGroupDrag: endEmitter.event,
+        };
+        service = new SmartGuidesService(host);
+    };
+
+    const ctx = (proposed: Box, others: Box[]): FloatingGroupDragContext => ({
+        group,
+        proposed,
+        container: { width: 1000, height: 1000 },
+        others,
+    });
+
+    const guideLine = (): HTMLElement | null =>
+        container.querySelector('.dv-smart-guide');
+
+    afterEach(() => {
+        service?.dispose();
+        container?.remove();
+    });
+
+    test('snaps a float left edge to another float left edge within snapDistance', () => {
+        make({});
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        // dragged left edge at 106 — 6px from the other float's left edge (100),
+        // inside the 8px default threshold.
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, [other])
+        );
+
+        expect(result).toEqual({ top: 400, left: 100 });
+
+        // a single vertical guide line is painted at x = 100
+        const line = guideLine();
+        expect(line).toBeTruthy();
+        expect(line!.style.display).toBe('block');
+        expect(line!.style.left).toBe('100px');
+        expect(line!.style.width).toBe('1px');
+    });
+
+    test('snaps the top edge (Y axis) and draws a horizontal guide', () => {
+        make({});
+        const other: Box = { left: 100, top: 200, width: 200, height: 150 };
+        // dragged top edge at 195 — 5px from the other float's top edge (200);
+        // horizontally far away, so the only snap is on Y.
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 600, top: 195, width: 50, height: 50 }, [other])
+        );
+
+        expect(result).toEqual({ top: 200, left: 600 });
+        const line = guideLine();
+        expect(line!.style.display).toBe('block');
+        expect(line!.style.top).toBe('200px');
+        expect(line!.style.height).toBe('1px');
+    });
+
+    test('picks the nearest edge when several are in range', () => {
+        make({ snapDistance: 10 });
+        const other: Box = { left: 100, top: 50, width: 60, height: 150 };
+        // left probe 104 → Δ4 to edge 100; right probe 154 → Δ6 to edge 160.
+        // The nearer (left, Δ4) wins.
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 104, top: 400, width: 50, height: 50 }, [other])
+        );
+        expect(result).toEqual({ top: 400, left: 100 });
+        expect(guideLine()!.style.left).toBe('100px');
+    });
+
+    test('no snap outside snapDistance — pass-through, guide hidden', () => {
+        make({});
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 130, top: 500, width: 50, height: 50 }, [other])
+        );
+        expect(result).toBeUndefined();
+        expect(guideLine()!.style.display).toBe('none');
+    });
+
+    test('inert when `smartGuides` is unset — no overlay, no adjustment', () => {
+        make(undefined);
+        const other: Box = { left: 100, top: 50, width: 200, height: 150 };
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, [other])
+        );
+        expect(result).toBeUndefined();
+        expect(container.querySelector('.dv-smart-guides')).toBeNull();
+    });
+
+    test('`enabled: false` snaps nothing', () => {
+        make({ enabled: false });
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, [
+                { left: 100, top: 50, width: 200, height: 150 },
+            ])
+        );
+        expect(result).toBeUndefined();
+        expect(container.querySelector('.dv-smart-guides')).toBeNull();
+    });
+
+    test('`showGuides: false` still snaps but draws no visible guide', () => {
+        make({ showGuides: false });
+        const result = service.transformFloatingGroupDrag(
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, [
+                { left: 100, top: 50, width: 200, height: 150 },
+            ])
+        );
+        expect(result).toEqual({ top: 400, left: 100 });
+        expect(guideLine()!.style.display).toBe('none');
+    });
+
+    test('drag end tears the guide overlay down', () => {
+        make({});
+        service.transformFloatingGroupDrag(
+            ctx({ left: 106, top: 400, width: 50, height: 50 }, [
+                { left: 100, top: 50, width: 200, height: 150 },
+            ])
+        );
+        expect(container.querySelector('.dv-smart-guides')).toBeTruthy();
+
+        endEmitter.fire(group);
+        expect(container.querySelector('.dv-smart-guides')).toBeNull();
+    });
+
+    test('candidates are built once per drag, not per frame', () => {
+        make({});
+        const others: Box[] = [{ left: 100, top: 50, width: 200, height: 150 }];
+        const first = ctx(
+            { left: 106, top: 400, width: 50, height: 50 },
+            others
+        );
+        service.transformFloatingGroupDrag(first);
+
+        // A later frame whose `others` snapshot has drifted must NOT rebuild the
+        // candidate set — the float at x=100 is still the snap target.
+        const second = ctx({ left: 104, top: 400, width: 50, height: 50 }, [
+            { left: 500, top: 50, width: 200, height: 150 },
+        ]);
+        const result = service.transformFloatingGroupDrag(second);
+        expect(result).toEqual({ top: 400, left: 100 });
+    });
+});

--- a/packages/dockview-modules/src/index.ts
+++ b/packages/dockview-modules/src/index.ts
@@ -4,6 +4,7 @@ import { ContextMenuModule } from './contextMenu';
 import { AdvancedDnDModule } from './advancedDnDService';
 import { AccessibilityModule } from './accessibilityService';
 import { LayoutHistoryModule } from './layoutHistoryService';
+import { SmartGuidesModule } from './smartGuidesService';
 
 export {
     TabGroupChipsService,
@@ -19,6 +20,7 @@ export {
     LayoutHistoryService,
     LayoutHistoryModule,
 } from './layoutHistoryService';
+export { SmartGuidesService, SmartGuidesModule } from './smartGuidesService';
 // Advanced keyboard docking is an optional module — exported for explicit
 // registration, but not part of the default `Modules` bundle below.
 export {
@@ -36,4 +38,5 @@ export const Modules: DockviewModule<any>[] = [
     AdvancedDnDModule,
     AccessibilityModule,
     LayoutHistoryModule,
+    SmartGuidesModule,
 ];

--- a/packages/dockview-modules/src/smartGuidesService.ts
+++ b/packages/dockview-modules/src/smartGuidesService.ts
@@ -21,6 +21,10 @@ import { ISmartGuidesHost, ISmartGuidesService } from 'dockview-core';
  *  as an adjacency (dock-beside) rather than a glancing touch. */
 const ADJACENCY_OVERLAP = 0.5;
 
+/** Score offset that ranks every edge-adjacency below every centre stack, so a
+ *  genuine tabset stack always wins over a dock-beside suggestion. */
+const MERGE_ADJACENCY_BASE = 1e6;
+
 interface ResolvedOptions {
     enabled: boolean;
     snapDistance: number;
@@ -83,6 +87,16 @@ interface Probe {
 interface AxisResult {
     readonly coord: number;
     readonly delta: number;
+    /** Index into the 3 probes (leading edge / centre / trailing edge) that
+     *  latched onto the candidate — tracked so the sticky branch keeps gluing
+     *  the SAME part of the box rather than silently switching probes. */
+    readonly probe: number;
+}
+
+/** The candidate an axis is currently snapped to, plus the probe holding it. */
+interface AxisEngagement {
+    readonly coord: number;
+    readonly probe: number;
 }
 
 /**
@@ -226,8 +240,8 @@ interface DragSession {
     readonly layer: GuideLayer;
     /** Other floats with identity + box, for snap-together (built once). */
     readonly targets: readonly { group: DockviewGroupPanel; box: Rect }[];
-    engagedX: number | undefined;
-    engagedY: number | undefined;
+    engagedX: AxisEngagement | undefined;
+    engagedY: AxisEngagement | undefined;
     /** The dock/merge suggestion active this frame, committed on drop. */
     pendingMerge: MergeIntent | undefined;
 }
@@ -331,8 +345,18 @@ export class SmartGuidesService
         // object and a host option change swaps `smartGuides`, so either edit
         // invalidates this without per-frame re-resolution/allocation.
         const base = this.host.options.smartGuides;
-        const override = this._override;
         const cache = this._optsCache;
+        // An explicit app-level option update swaps the `smartGuides` reference
+        // (component `updateOptions` rebuilds the options object). That wins over
+        // earlier runtime overrides — drop them so the two don't fight (#10).
+        if (
+            cache &&
+            cache.base !== base &&
+            Object.keys(this._override).length > 0
+        ) {
+            this._override = {};
+        }
+        const override = this._override;
         if (cache && cache.base === base && cache.override === override) {
             return cache.resolved;
         }
@@ -407,8 +431,12 @@ export class SmartGuidesService
             session.engagedY,
             opts
         );
-        session.engagedX = resX?.coord;
-        session.engagedY = resY?.coord;
+        session.engagedX = resX
+            ? { coord: resX.coord, probe: resX.probe }
+            : undefined;
+        session.engagedY = resY
+            ? { coord: resY.coord, probe: resY.probe }
+            : undefined;
 
         const snappedBox: Rect = {
             left: proposed.left + (resX?.delta ?? 0),
@@ -561,26 +589,31 @@ export class SmartGuidesService
     private _resolveAxis(
         candidates: Candidate[],
         probes: Probe[],
-        engaged: number | undefined,
+        engaged: AxisEngagement | undefined,
         opts: ResolvedOptions
     ): AxisResult | undefined {
-        // Sticky: stay on the engaged line until past snapDistance + release.
+        // Sticky: stay glued via the SAME probe that engaged (not the nearest of
+        // all three) until that probe moves past snapDistance + release — so a
+        // small float can't silently re-latch its centre onto an edge line.
         if (engaged !== undefined) {
-            const delta = this._nearestDelta(engaged, probes);
-            if (
-                delta !== undefined &&
-                Math.abs(delta) <= opts.snapDistance + opts.releaseDistance
-            ) {
-                return { coord: engaged, delta };
+            const delta = engaged.coord - probes[engaged.probe].coord;
+            if (Math.abs(delta) <= opts.snapDistance + opts.releaseDistance) {
+                return { coord: engaged.coord, delta, probe: engaged.probe };
             }
         }
 
         // Acquire: the highest-priority candidate within the engage threshold.
         let best:
-            | { coord: number; delta: number; key: [number, number, number] }
+            | {
+                  coord: number;
+                  delta: number;
+                  probe: number;
+                  key: [number, number, number];
+              }
             | undefined;
         for (const c of candidates) {
-            for (const p of probes) {
+            for (let pi = 0; pi < probes.length; pi++) {
+                const p = probes[pi];
                 const delta = c.coord - p.coord;
                 if (Math.abs(delta) > opts.snapDistance) {
                     continue;
@@ -592,23 +625,13 @@ export class SmartGuidesService
                     Math.abs(delta),
                 ];
                 if (best === undefined || this._keyLess(key, best.key)) {
-                    best = { coord: c.coord, delta, key };
+                    best = { coord: c.coord, delta, probe: pi, key };
                 }
             }
         }
-        return best ? { coord: best.coord, delta: best.delta } : undefined;
-    }
-
-    /** Smallest signed delta from any probe to `coord`. */
-    private _nearestDelta(coord: number, probes: Probe[]): number | undefined {
-        let best: number | undefined;
-        for (const p of probes) {
-            const delta = coord - p.coord;
-            if (best === undefined || Math.abs(delta) < Math.abs(best)) {
-                best = delta;
-            }
-        }
-        return best;
+        return best
+            ? { coord: best.coord, delta: best.delta, probe: best.probe }
+            : undefined;
     }
 
     private _keyLess(
@@ -649,66 +672,106 @@ export class SmartGuidesService
     }
 
     /**
-     * Detect a dock/merge intent for the snapped box against the other floats:
-     * a tab-strip overlap (tops flush + stacked) suggests a **center** merge
-     * into a shared tabset; an edge flush against a target's opposite edge —
-     * with ≥ 50% perpendicular overlap — suggests docking **beside** it. Returns
-     * the first match (with the drop-preview rect), or `undefined`.
+     * Detect a dock/merge intent for the snapped box against the other floats,
+     * choosing the **best** target rather than the first in iteration order: a
+     * tab-strip overlap (the dragged centre over a target) suggests a **center**
+     * merge into a shared tabset; an edge flush against a target's opposite edge
+     * — with ≥ 50% perpendicular overlap — suggests docking **beside** it. Among
+     * matches, a centre stack beats an adjacency, and within a kind the nearest
+     * target wins.
      */
     private _detectSnapTogether(
         box: Rect,
         targets: readonly { group: DockviewGroupPanel; box: Rect }[],
         opts: ResolvedOptions
     ): MergeIntent | undefined {
-        const d = edges(box);
+        let best: { intent: MergeIntent; score: number } | undefined;
         for (const t of targets) {
-            const e = edges(t.box);
-            const within = (a: number, b: number): boolean =>
-                Math.abs(a - b) <= opts.snapDistance;
-            const hOverlap = overlapRatio(d.left, d.right, e.left, e.right);
-            const vOverlap = overlapRatio(d.top, d.bottom, e.top, e.bottom);
+            const candidate = this._intentForTarget(box, t, opts);
+            if (candidate && (!best || candidate.score < best.score)) {
+                best = candidate;
+            }
+        }
+        return best?.intent;
+    }
 
-            // Tabset merge: the dragged float's CENTRE sits over the target (it
-            // is genuinely stacked on top), with the tab strips flush. Requiring
-            // the centre inside — not just top-alignment + edge overlap — stops a
-            // plain top/edge alignment of two overlapping floats from being read
-            // as a merge (§11: tabset-merge only on centre overlap).
-            const cx = (d.left + d.right) / 2;
-            const cy = (d.top + d.bottom) / 2;
-            const centreInside =
-                cx >= e.left && cx <= e.right && cy >= e.top && cy <= e.bottom;
-            if (within(d.top, e.top) && centreInside) {
-                return { target: t.group, position: 'center', preview: t.box };
+    /** The single best dock/merge intent for one target (or undefined), with a
+     *  lower-is-better score: a centre stack always outranks an adjacency, and
+     *  the score breaks ties by nearness so clustered floats dock into the
+     *  closest neighbour. */
+    private _intentForTarget(
+        box: Rect,
+        target: { group: DockviewGroupPanel; box: Rect },
+        opts: ResolvedOptions
+    ): { intent: MergeIntent; score: number } | undefined {
+        const d = edges(box);
+        const e = edges(target.box);
+        const within = (a: number, b: number): boolean =>
+            Math.abs(a - b) <= opts.snapDistance;
+        const hOverlap = overlapRatio(d.left, d.right, e.left, e.right);
+        const vOverlap = overlapRatio(d.top, d.bottom, e.top, e.bottom);
+
+        // Tabset merge: the dragged float's CENTRE sits over the target (it is
+        // genuinely stacked on top), with the tab strips flush. Requiring the
+        // centre inside — not just top-alignment + edge overlap — stops a plain
+        // alignment of two overlapping floats reading as a merge (§11).
+        const cx = (d.left + d.right) / 2;
+        const cy = (d.top + d.bottom) / 2;
+        const centreInside =
+            cx >= e.left && cx <= e.right && cy >= e.top && cy <= e.bottom;
+        if (within(d.top, e.top) && centreInside) {
+            const tcx = (e.left + e.right) / 2;
+            const tcy = (e.top + e.bottom) / 2;
+            return {
+                intent: {
+                    target: target.group,
+                    position: 'center',
+                    preview: target.box,
+                },
+                // centre stacks always beat adjacencies; nearer centre wins
+                score: Math.hypot(cx - tcx, cy - tcy),
+            };
+        }
+
+        // Edge adjacency: a dragged edge meets the target's opposite edge. Take
+        // the side with the smallest gap.
+        type Side = 'left' | 'right' | 'top' | 'bottom';
+        let adj: { position: Side; gap: number } | undefined;
+        const consider = (ok: boolean, gap: number, position: Side): void => {
+            if (ok && (!adj || gap < adj.gap)) {
+                adj = { position, gap };
             }
-            // Edge adjacency: a dragged edge meets the target's opposite edge.
-            if (within(d.right, e.left) && vOverlap >= ADJACENCY_OVERLAP) {
-                return {
-                    target: t.group,
-                    position: 'left',
-                    preview: half(t.box, 'left'),
-                };
-            }
-            if (within(d.left, e.right) && vOverlap >= ADJACENCY_OVERLAP) {
-                return {
-                    target: t.group,
-                    position: 'right',
-                    preview: half(t.box, 'right'),
-                };
-            }
-            if (within(d.bottom, e.top) && hOverlap >= ADJACENCY_OVERLAP) {
-                return {
-                    target: t.group,
-                    position: 'top',
-                    preview: half(t.box, 'top'),
-                };
-            }
-            if (within(d.top, e.bottom) && hOverlap >= ADJACENCY_OVERLAP) {
-                return {
-                    target: t.group,
-                    position: 'bottom',
-                    preview: half(t.box, 'bottom'),
-                };
-            }
+        };
+        consider(
+            within(d.right, e.left) && vOverlap >= ADJACENCY_OVERLAP,
+            Math.abs(d.right - e.left),
+            'left'
+        );
+        consider(
+            within(d.left, e.right) && vOverlap >= ADJACENCY_OVERLAP,
+            Math.abs(d.left - e.right),
+            'right'
+        );
+        consider(
+            within(d.bottom, e.top) && hOverlap >= ADJACENCY_OVERLAP,
+            Math.abs(d.bottom - e.top),
+            'top'
+        );
+        consider(
+            within(d.top, e.bottom) && hOverlap >= ADJACENCY_OVERLAP,
+            Math.abs(d.top - e.bottom),
+            'bottom'
+        );
+        if (adj) {
+            return {
+                intent: {
+                    target: target.group,
+                    position: adj.position,
+                    preview: half(target.box, adj.position),
+                },
+                // ranked after every centre stack; nearer edge wins among these
+                score: MERGE_ADJACENCY_BASE + adj.gap,
+            };
         }
         return undefined;
     }

--- a/packages/dockview-modules/src/smartGuidesService.ts
+++ b/packages/dockview-modules/src/smartGuidesService.ts
@@ -1,9 +1,17 @@
-import { DockviewCompositeDisposable as CompositeDisposable } from 'dockview-core';
+import {
+    DockviewCompositeDisposable as CompositeDisposable,
+    DockviewEmitter as Emitter,
+    DockviewEvent as Event,
+} from 'dockview-core';
 import {
     DockviewGroupPanel,
+    DragModifiers,
     FloatingGroupDragContext,
     SmartGuidesOptions,
+    SmartGuidesSnapEvent,
     SmartGuidesSnapPosition,
+    SmartGuidesSnapTogetherEvent,
+    SnapModifier,
 } from 'dockview-core';
 import { defineModule, FloatingGroupModule } from 'dockview-core';
 import { ISmartGuidesHost, ISmartGuidesService } from 'dockview-core';
@@ -18,10 +26,12 @@ interface ResolvedOptions {
     releaseDistance: number;
     showGuides: boolean;
     snapTogether: boolean;
+    disableSnapModifier: SnapModifier | false;
     className: string | undefined;
     snapFloats: boolean;
     snapContainer: boolean;
     containerInset: number | undefined;
+    snapSplitters: boolean;
 }
 
 function resolveOptions(o: SmartGuidesOptions | undefined): ResolvedOptions {
@@ -32,10 +42,12 @@ function resolveOptions(o: SmartGuidesOptions | undefined): ResolvedOptions {
         releaseDistance: o?.releaseDistance ?? 4,
         showGuides: o?.showGuides ?? true,
         snapTogether: o?.snapTogether ?? true,
+        disableSnapModifier: o?.disableSnapModifier ?? 'alt',
         className: o?.className,
         snapFloats: o?.snapTargets?.floats ?? true,
         snapContainer: o?.snapTargets?.container ?? true,
         containerInset: o?.snapTargets?.containerInset,
+        snapSplitters: o?.snapTargets?.splitters ?? false,
     };
 }
 
@@ -54,7 +66,7 @@ interface MergeIntent {
 }
 
 type CandidateKind = 'edge' | 'center';
-type CandidateSource = 'float' | 'container';
+type CandidateSource = 'float' | 'container' | 'splitter';
 
 /** A 1-D alignment line on one axis: its container-relative px + provenance
  *  (used to prioritise which line wins a contested snap). */
@@ -203,7 +215,11 @@ interface DragSession {
     pendingMerge: MergeIntent | undefined;
 }
 
-const SOURCE_RANK: Record<CandidateSource, number> = { float: 0, container: 1 };
+const SOURCE_RANK: Record<CandidateSource, number> = {
+    float: 0,
+    container: 1,
+    splitter: 2,
+};
 
 /**
  * Smart Guides — Figma-style alignment guides + magnetic snapping for floating
@@ -223,11 +239,25 @@ export class SmartGuidesService
     implements ISmartGuidesService
 {
     private readonly _sessions = new Map<DockviewGroupPanel, DragSession>();
+    /** Runtime option overrides (from `setEnabled` / `updateOptions`), merged
+     *  over the host's `smartGuides` option. */
+    private _override: Partial<SmartGuidesOptions> = {};
+
+    private readonly _onDidSnapFloat = new Emitter<SmartGuidesSnapEvent>();
+    readonly onDidSnapFloat: Event<SmartGuidesSnapEvent> =
+        this._onDidSnapFloat.event;
+
+    private readonly _onDidSnapTogether =
+        new Emitter<SmartGuidesSnapTogetherEvent>();
+    readonly onDidSnapTogether: Event<SmartGuidesSnapTogetherEvent> =
+        this._onDidSnapTogether.event;
 
     constructor(private readonly host: ISmartGuidesHost) {
         super();
 
         this.addDisposables(
+            this._onDidSnapFloat,
+            this._onDidSnapTogether,
             // Drag end (pointerup / cancel): commit any pending snap-together,
             // then tear the per-drag guides down.
             this.host.onDidEndFloatingGroupDrag((group) =>
@@ -243,8 +273,54 @@ export class SmartGuidesService
         );
     }
 
+    get enabled(): boolean {
+        return this._opts.enabled;
+    }
+
+    setEnabled(enabled: boolean): void {
+        this.updateOptions({ enabled });
+    }
+
+    updateOptions(options: Partial<SmartGuidesOptions>): void {
+        this._override = {
+            ...this._override,
+            ...options,
+            // Merge `snapTargets` rather than replacing the whole sub-object.
+            snapTargets: options.snapTargets
+                ? { ...this._override.snapTargets, ...options.snapTargets }
+                : this._override.snapTargets,
+        };
+    }
+
     private get _opts(): ResolvedOptions {
-        return resolveOptions(this.host.options.smartGuides);
+        const base = this.host.options.smartGuides;
+        if (!base && Object.keys(this._override).length === 0) {
+            return resolveOptions(undefined);
+        }
+        return resolveOptions({
+            ...base,
+            ...this._override,
+            snapTargets: {
+                ...base?.snapTargets,
+                ...this._override.snapTargets,
+            },
+        });
+    }
+
+    /** Whether the configured disable-modifier is held this frame. */
+    private _gated(opts: ResolvedOptions, modifiers: DragModifiers): boolean {
+        switch (opts.disableSnapModifier) {
+            case 'alt':
+                return modifiers.altKey;
+            case 'ctrl':
+                return modifiers.ctrlKey;
+            case 'meta':
+                return modifiers.metaKey;
+            case 'shift':
+                return modifiers.shiftKey;
+            default:
+                return false;
+        }
     }
 
     transformFloatingGroupDrag(
@@ -254,6 +330,19 @@ export class SmartGuidesService
         if (!opts.enabled) {
             // Disabled mid-drag (or never on): drop any guides, pass through.
             this._endSession(context.group);
+            return;
+        }
+
+        // Modifier gate (default Alt): suspend snapping + guides while held; the
+        // float follows the pointer freely and re-engages on release.
+        if (this._gated(opts, context.modifiers)) {
+            const existing = this._sessions.get(context.group);
+            if (existing) {
+                existing.layer.clear();
+                existing.engagedX = undefined;
+                existing.engagedY = undefined;
+                existing.pendingMerge = undefined;
+            }
             return;
         }
 
@@ -363,6 +452,25 @@ export class SmartGuidesService
                         source: 'container',
                     }
                 );
+            }
+        }
+        // The grid's splitters behind the float (a vertical sash → an x line,
+        // a horizontal sash → a y line).
+        if (opts.snapSplitters) {
+            for (const r of this.host.getGridSplitterRects()) {
+                if (r.width <= r.height) {
+                    x.push({
+                        coord: r.left + r.width / 2,
+                        kind: 'edge',
+                        source: 'splitter',
+                    });
+                } else {
+                    y.push({
+                        coord: r.top + r.height / 2,
+                        kind: 'edge',
+                        source: 'splitter',
+                    });
+                }
             }
         }
 
@@ -554,10 +662,25 @@ export class SmartGuidesService
             return;
         }
         const pending = session.pendingMerge;
+        const axes: ('x' | 'y')[] = [];
+        if (session.engagedX !== undefined) {
+            axes.push('x');
+        }
+        if (session.engagedY !== undefined) {
+            axes.push('y');
+        }
         // Tear the overlay down before the layout mutates.
         this._endSession(group);
+        // A merge supersedes a plain alignment for the drop's outcome.
         if (pending) {
             this.host.mergeFloatInto(group, pending.target, pending.position);
+            this._onDidSnapTogether.fire({
+                dragged: group,
+                target: pending.target,
+                position: pending.position,
+            });
+        } else if (axes.length > 0) {
+            this._onDidSnapFloat.fire({ group, axes });
         }
     }
 

--- a/packages/dockview-modules/src/smartGuidesService.ts
+++ b/packages/dockview-modules/src/smartGuidesService.ts
@@ -7,47 +7,157 @@ import {
 import { defineModule, FloatingGroupModule } from 'dockview-core';
 import { ISmartGuidesHost, ISmartGuidesService } from 'dockview-core';
 
-function resolveOptions(o: SmartGuidesOptions | undefined): {
+interface ResolvedOptions {
     enabled: boolean;
     snapDistance: number;
+    releaseDistance: number;
     showGuides: boolean;
     className: string | undefined;
-} {
+    snapFloats: boolean;
+    snapContainer: boolean;
+    containerInset: number | undefined;
+}
+
+function resolveOptions(o: SmartGuidesOptions | undefined): ResolvedOptions {
     return {
         // Present + not explicitly disabled. Absent ⇒ inert (pass-through).
         enabled: !!o && o.enabled !== false,
         snapDistance: o?.snapDistance ?? 8,
+        releaseDistance: o?.releaseDistance ?? 4,
         showGuides: o?.showGuides ?? true,
         className: o?.className,
+        snapFloats: o?.snapTargets?.floats ?? true,
+        snapContainer: o?.snapTargets?.container ?? true,
+        containerInset: o?.snapTargets?.containerInset,
     };
 }
 
-/** A 1-D alignment line: the axis it constrains and its container-relative px. */
+type CandidateKind = 'edge' | 'center';
+type CandidateSource = 'float' | 'container';
+
+/** A 1-D alignment line on one axis: its container-relative px + provenance
+ *  (used to prioritise which line wins a contested snap). */
 interface Candidate {
-    readonly axis: 'x' | 'y';
     readonly coord: number;
+    readonly kind: CandidateKind;
+    readonly source: CandidateSource;
 }
 
-/** Per-drag state: the candidate lines (built once at drag start, since only
- *  the dragged float moves) and the DOM overlay that paints the active guide. */
-interface DragSession {
-    readonly xCandidates: number[];
-    readonly yCandidates: number[];
-    readonly layer: HTMLElement;
-    readonly line: HTMLElement;
+/** A coordinate on the dragged box that can land on a candidate. */
+interface Probe {
+    readonly coord: number;
+    readonly kind: CandidateKind;
+}
+
+interface AxisResult {
+    readonly coord: number;
+    readonly delta: number;
 }
 
 /**
+ * The DOM layer that paints guide lines for one drag. Pools the line elements
+ * so a frame only mutates inline styles (no churn of create/remove per line).
+ */
+class GuideLayer {
+    private readonly _element: HTMLElement;
+    private readonly _lines: HTMLElement[] = [];
+
+    constructor(container: HTMLElement, className: string | undefined) {
+        const doc = container.ownerDocument;
+        const el = doc.createElement('div');
+        el.className = 'dv-smart-guides';
+        if (className) {
+            el.classList.add(className);
+        }
+        el.style.position = 'absolute';
+        el.style.left = '0';
+        el.style.top = '0';
+        el.style.width = '100%';
+        el.style.height = '100%';
+        el.style.pointerEvents = 'none';
+        el.style.overflow = 'hidden';
+        container.appendChild(el);
+        this._element = el;
+    }
+
+    render(
+        lines: { axis: 'x' | 'y'; coord: number }[],
+        size: { width: number; height: number }
+    ): void {
+        for (let i = 0; i < lines.length; i++) {
+            const line = this._lineAt(i);
+            const { axis, coord } = lines[i];
+            line.style.display = 'block';
+            if (axis === 'x') {
+                // Vertical line spanning the container height at x = coord.
+                line.style.left = `${coord}px`;
+                line.style.top = '0';
+                line.style.width = '1px';
+                line.style.height = `${size.height}px`;
+            } else {
+                // Horizontal line spanning the container width at y = coord.
+                line.style.top = `${coord}px`;
+                line.style.left = '0';
+                line.style.height = '1px';
+                line.style.width = `${size.width}px`;
+            }
+        }
+        // Hide any pooled lines not used this frame.
+        for (let i = lines.length; i < this._lines.length; i++) {
+            this._lines[i].style.display = 'none';
+        }
+    }
+
+    clear(): void {
+        for (const line of this._lines) {
+            line.style.display = 'none';
+        }
+    }
+
+    dispose(): void {
+        this._element.remove();
+    }
+
+    private _lineAt(i: number): HTMLElement {
+        let line = this._lines[i];
+        if (!line) {
+            line = this._element.ownerDocument.createElement('div');
+            line.className = 'dv-smart-guide';
+            line.style.position = 'absolute';
+            // Themable via a CSS var, with a sensible default so it works untouched.
+            line.style.backgroundColor =
+                'var(--dv-smart-guides-color, #1f9cf0)';
+            this._element.appendChild(line);
+            this._lines[i] = line;
+        }
+        return line;
+    }
+}
+
+/** Per-drag state: the candidate lines (built once at drag start, since only
+ *  the dragged float moves) + the engaged candidate per axis (hysteresis). */
+interface DragSession {
+    readonly x: Candidate[];
+    readonly y: Candidate[];
+    readonly layer: GuideLayer;
+    engagedX: number | undefined;
+    engagedY: number | undefined;
+}
+
+const SOURCE_RANK: Record<CandidateSource, number> = { float: 0, container: 1 };
+
+/**
  * Smart Guides — Figma-style alignment guides + magnetic snapping for floating
- * groups (Phase 1: single-axis edge snapping against other floats).
+ * groups.
  *
  * The float drag loop stays fully owned by `Overlay`; this service is a pure
- * consumer. The component composes it into the loop's position-transform
- * (`transformFloatingGroupDrag`), so each pointer-move frame the proposed,
- * container-relative box is offered here and an adjusted top-left returned. A
- * winning snap also paints one alignment line in the floating container's
- * coordinate space. With `smartGuides` unset the transform is a pass-through
- * and no overlay is created.
+ * consumer. The component composes it into the loop's position-transform, so
+ * each pointer-move frame the proposed, container-relative box is offered here
+ * and an adjusted top-left returned. X and Y are resolved independently against
+ * the other floats' and the container's edges + centers, with asymmetric
+ * engage/release hysteresis to stop boundary oscillation; every alignment the
+ * snapped box lands on is painted as a guide line. With `smartGuides` unset the
+ * transform is a pass-through and no overlay is created.
  */
 export class SmartGuidesService
     extends CompositeDisposable
@@ -73,7 +183,7 @@ export class SmartGuidesService
         );
     }
 
-    private get _opts() {
+    private get _opts(): ResolvedOptions {
         return resolveOptions(this.host.options.smartGuides);
     }
 
@@ -88,119 +198,229 @@ export class SmartGuidesService
         }
 
         const session =
-            this._sessions.get(context.group) ?? this._startSession(context);
+            this._sessions.get(context.group) ??
+            this._startSession(context, opts);
 
         const { proposed } = context;
-        const xProbes = [proposed.left, proposed.left + proposed.width];
-        const yProbes = [proposed.top, proposed.top + proposed.height];
+        const resX = this._resolveAxis(
+            session.x,
+            this._probes('x', proposed),
+            session.engagedX,
+            opts
+        );
+        const resY = this._resolveAxis(
+            session.y,
+            this._probes('y', proposed),
+            session.engagedY,
+            opts
+        );
+        session.engagedX = resX?.coord;
+        session.engagedY = resY?.coord;
 
-        // Single best snap across BOTH axes (Phase 1): the smallest in-threshold
-        // edge delta wins; ties are resolved by encounter order (x before y).
-        let best: { axis: 'x' | 'y'; delta: number; coord: number } | undefined;
-        const consider = (
-            axis: 'x' | 'y',
-            candidates: number[],
-            probes: number[]
-        ): void => {
-            for (const coord of candidates) {
-                for (const probe of probes) {
-                    const delta = coord - probe;
-                    if (
-                        Math.abs(delta) <= opts.snapDistance &&
-                        (best === undefined ||
-                            Math.abs(delta) < Math.abs(best.delta))
-                    ) {
-                        best = { axis, delta, coord };
-                    }
-                }
-            }
-        };
-        consider('x', session.xCandidates, xProbes);
-        consider('y', session.yCandidates, yProbes);
-
-        if (best === undefined) {
-            this._hideGuide(session);
-            return;
-        }
+        const snappedLeft = proposed.left + (resX?.delta ?? 0);
+        const snappedTop = proposed.top + (resY?.delta ?? 0);
 
         if (opts.showGuides) {
-            this._showGuide(session, best.axis, best.coord, context.container);
+            session.layer.render(
+                this._guideLines(session, {
+                    left: snappedLeft,
+                    top: snappedTop,
+                    width: proposed.width,
+                    height: proposed.height,
+                }),
+                context.container
+            );
         } else {
-            this._hideGuide(session);
+            session.layer.clear();
         }
 
-        return {
-            top: proposed.top + (best.axis === 'y' ? best.delta : 0),
-            left: proposed.left + (best.axis === 'x' ? best.delta : 0),
-        };
+        if (!resX && !resY) {
+            return;
+        }
+        return { top: snappedTop, left: snappedLeft };
     }
 
-    private _startSession(context: FloatingGroupDragContext): DragSession {
-        const xCandidates: number[] = [];
-        const yCandidates: number[] = [];
-        // Each other float contributes its leading + trailing edges on each
-        // axis. The dragged float is already excluded from `context.others`.
-        for (const box of context.others) {
-            xCandidates.push(box.left, box.left + box.width);
-            yCandidates.push(box.top, box.top + box.height);
+    private _startSession(
+        context: FloatingGroupDragContext,
+        opts: ResolvedOptions
+    ): DragSession {
+        const x: Candidate[] = [];
+        const y: Candidate[] = [];
+        const pushBox = (
+            box: { left: number; top: number; width: number; height: number },
+            source: CandidateSource
+        ): void => {
+            x.push(
+                { coord: box.left, kind: 'edge', source },
+                { coord: box.left + box.width / 2, kind: 'center', source },
+                { coord: box.left + box.width, kind: 'edge', source }
+            );
+            y.push(
+                { coord: box.top, kind: 'edge', source },
+                { coord: box.top + box.height / 2, kind: 'center', source },
+                { coord: box.top + box.height, kind: 'edge', source }
+            );
+        };
+
+        // Other floats (the dragged one is already excluded from `others`).
+        if (opts.snapFloats) {
+            for (const box of context.others) {
+                pushBox(box, 'float');
+            }
+        }
+        // The container's own edges + center, plus optional inset margin lines.
+        if (opts.snapContainer) {
+            pushBox(
+                {
+                    left: 0,
+                    top: 0,
+                    width: context.container.width,
+                    height: context.container.height,
+                },
+                'container'
+            );
+            const inset = opts.containerInset;
+            if (typeof inset === 'number' && inset > 0) {
+                x.push(
+                    { coord: inset, kind: 'edge', source: 'container' },
+                    {
+                        coord: context.container.width - inset,
+                        kind: 'edge',
+                        source: 'container',
+                    }
+                );
+                y.push(
+                    { coord: inset, kind: 'edge', source: 'container' },
+                    {
+                        coord: context.container.height - inset,
+                        kind: 'edge',
+                        source: 'container',
+                    }
+                );
+            }
         }
 
-        const container = this.host.getFloatingContainer();
-        const doc = container.ownerDocument;
-
-        const layer = doc.createElement('div');
-        layer.className = 'dv-smart-guides';
-        if (this._opts.className) {
-            layer.classList.add(this._opts.className);
-        }
-        layer.style.position = 'absolute';
-        layer.style.left = '0';
-        layer.style.top = '0';
-        layer.style.width = '100%';
-        layer.style.height = '100%';
-        layer.style.pointerEvents = 'none';
-        layer.style.overflow = 'hidden';
-
-        const line = doc.createElement('div');
-        line.className = 'dv-smart-guide';
-        line.style.position = 'absolute';
-        line.style.display = 'none';
-        // Themable via a CSS var, with a sensible default so it works untouched.
-        line.style.backgroundColor = 'var(--dv-smart-guides-color, #1f9cf0)';
-        layer.appendChild(line);
-
-        container.appendChild(layer);
-
-        const session: DragSession = { xCandidates, yCandidates, layer, line };
+        const layer = new GuideLayer(
+            this.host.getFloatingContainer(),
+            opts.className
+        );
+        const session: DragSession = {
+            x,
+            y,
+            layer,
+            engagedX: undefined,
+            engagedY: undefined,
+        };
         this._sessions.set(context.group, session);
         return session;
     }
 
-    private _showGuide(
-        session: DragSession,
+    private _probes(
         axis: 'x' | 'y',
-        coord: number,
-        container: { width: number; height: number }
-    ): void {
-        const { line } = session;
-        line.style.display = 'block';
-        if (axis === 'x') {
-            // Vertical line spanning the container height at x = coord.
-            line.style.left = `${coord}px`;
-            line.style.top = '0';
-            line.style.width = '1px';
-            line.style.height = `${container.height}px`;
-        } else {
-            // Horizontal line spanning the container width at y = coord.
-            line.style.top = `${coord}px`;
-            line.style.left = '0';
-            line.style.height = '1px';
-            line.style.width = `${container.width}px`;
-        }
+        proposed: { left: number; top: number; width: number; height: number }
+    ): Probe[] {
+        const start = axis === 'x' ? proposed.left : proposed.top;
+        const extent = axis === 'x' ? proposed.width : proposed.height;
+        return [
+            { coord: start, kind: 'edge' },
+            { coord: start + extent / 2, kind: 'center' },
+            { coord: start + extent, kind: 'edge' },
+        ];
     }
 
-    private _hideGuide(session: DragSession): void {
-        session.line.style.display = 'none';
+    /**
+     * Resolve one axis: keep the engaged candidate until the pointer moves past
+     * the release threshold, otherwise acquire the best in-range candidate. The
+     * best is ranked edge-over-center, then source priority, then nearest.
+     */
+    private _resolveAxis(
+        candidates: Candidate[],
+        probes: Probe[],
+        engaged: number | undefined,
+        opts: ResolvedOptions
+    ): AxisResult | undefined {
+        // Sticky: stay on the engaged line until past snapDistance + release.
+        if (engaged !== undefined) {
+            const delta = this._nearestDelta(engaged, probes);
+            if (
+                delta !== undefined &&
+                Math.abs(delta) <= opts.snapDistance + opts.releaseDistance
+            ) {
+                return { coord: engaged, delta };
+            }
+        }
+
+        // Acquire: the highest-priority candidate within the engage threshold.
+        let best:
+            | { coord: number; delta: number; key: [number, number, number] }
+            | undefined;
+        for (const c of candidates) {
+            for (const p of probes) {
+                const delta = c.coord - p.coord;
+                if (Math.abs(delta) > opts.snapDistance) {
+                    continue;
+                }
+                const key: [number, number, number] = [
+                    (p.kind === 'center' ? 1 : 0) +
+                        (c.kind === 'center' ? 1 : 0),
+                    SOURCE_RANK[c.source],
+                    Math.abs(delta),
+                ];
+                if (best === undefined || this._keyLess(key, best.key)) {
+                    best = { coord: c.coord, delta, key };
+                }
+            }
+        }
+        return best ? { coord: best.coord, delta: best.delta } : undefined;
+    }
+
+    /** Smallest signed delta from any probe to `coord`. */
+    private _nearestDelta(coord: number, probes: Probe[]): number | undefined {
+        let best: number | undefined;
+        for (const p of probes) {
+            const delta = coord - p.coord;
+            if (best === undefined || Math.abs(delta) < Math.abs(best)) {
+                best = delta;
+            }
+        }
+        return best;
+    }
+
+    private _keyLess(
+        a: [number, number, number],
+        b: [number, number, number]
+    ): boolean {
+        for (let i = 0; i < a.length; i++) {
+            if (a[i] !== b[i]) {
+                return a[i] < b[i];
+            }
+        }
+        return false;
+    }
+
+    /** Every candidate line the (already snapped) box's probes land on, so two
+     *  simultaneous alignments (e.g. left edges AND tops) draw two guides. */
+    private _guideLines(
+        session: DragSession,
+        snapped: { left: number; top: number; width: number; height: number }
+    ): { axis: 'x' | 'y'; coord: number }[] {
+        const lines: { axis: 'x' | 'y'; coord: number }[] = [];
+        const collect = (axis: 'x' | 'y', candidates: Candidate[]): void => {
+            const probes = this._probes(axis, snapped);
+            const seen = new Set<number>();
+            for (const c of candidates) {
+                if (seen.has(c.coord)) {
+                    continue;
+                }
+                if (probes.some((p) => Math.abs(c.coord - p.coord) < 0.5)) {
+                    seen.add(c.coord);
+                    lines.push({ axis, coord: c.coord });
+                }
+            }
+        };
+        collect('x', session.x);
+        collect('y', session.y);
+        return lines;
     }
 
     private _endSession(group: DockviewGroupPanel): void {
@@ -209,7 +429,7 @@ export class SmartGuidesService
             return;
         }
         this._sessions.delete(group);
-        session.layer.remove();
+        session.layer.dispose();
     }
 }
 

--- a/packages/dockview-modules/src/smartGuidesService.ts
+++ b/packages/dockview-modules/src/smartGuidesService.ts
@@ -4,6 +4,7 @@ import {
     DockviewEvent as Event,
 } from 'dockview-core';
 import {
+    Box,
     DockviewGroupPanel,
     DragModifiers,
     FloatingGroupDragContext,
@@ -51,12 +52,9 @@ function resolveOptions(o: SmartGuidesOptions | undefined): ResolvedOptions {
     };
 }
 
-interface Rect {
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-}
+/** Local alias for the core geometry type — keeps these container-relative
+ *  boxes named `Rect` at the call sites while reusing one structural source. */
+type Rect = Box;
 
 /** A pending dock/merge intent the drag is currently suggesting. */
 interface MergeIntent {
@@ -277,6 +275,13 @@ export class SmartGuidesService
         this.addDisposables(
             this._onDidSnapFloat,
             this._onDidSnapTogether,
+            // Drag start: discard any session left over from a drag that ended
+            // without a pointerup (a redock long-press aborts via
+            // `cancelPendingDrag`, which fires no end event) so this drag builds
+            // fresh candidates and never reuses a stale guide layer.
+            this.host.onDidStartFloatingGroupDrag((group) =>
+                this._endSession(group)
+            ),
             // Drag end (pointerup / cancel): commit any pending snap-together,
             // then tear the per-drag guides down.
             this.host.onDidEndFloatingGroupDrag((group) =>
@@ -311,19 +316,39 @@ export class SmartGuidesService
         };
     }
 
+    private _optsCache:
+        | {
+              base: SmartGuidesOptions | undefined;
+              override: Partial<SmartGuidesOptions>;
+              resolved: ResolvedOptions;
+          }
+        | undefined;
+
     private get _opts(): ResolvedOptions {
+        // Read each pointer-move frame, but the inputs (the host option +
+        // runtime override) change only a handful of times per session. Cache by
+        // reference identity — `updateOptions` replaces `_override` with a fresh
+        // object and a host option change swaps `smartGuides`, so either edit
+        // invalidates this without per-frame re-resolution/allocation.
         const base = this.host.options.smartGuides;
-        if (!base && Object.keys(this._override).length === 0) {
-            return resolveOptions(undefined);
+        const override = this._override;
+        const cache = this._optsCache;
+        if (cache && cache.base === base && cache.override === override) {
+            return cache.resolved;
         }
-        return resolveOptions({
-            ...base,
-            ...this._override,
-            snapTargets: {
-                ...base?.snapTargets,
-                ...this._override.snapTargets,
-            },
-        });
+        const resolved =
+            !base && Object.keys(override).length === 0
+                ? resolveOptions(undefined)
+                : resolveOptions({
+                      ...base,
+                      ...override,
+                      snapTargets: {
+                          ...base?.snapTargets,
+                          ...override.snapTargets,
+                      },
+                  });
+        this._optsCache = { base, override, resolved };
+        return resolved;
     }
 
     /** Whether the configured disable-modifier is held this frame. */
@@ -398,15 +423,14 @@ export class SmartGuidesService
             : undefined;
         session.pendingMerge = merge;
 
-        if (opts.showGuides) {
-            session.layer.render(
-                this._guideLines(session, snappedBox),
-                context.container
-            );
-            session.layer.renderPreview(merge?.preview);
-        } else {
-            session.layer.clear();
-        }
+        // `showGuides` governs the alignment lines only. The dock/merge preview
+        // always shows when a merge is pending — it's the warning for an action
+        // that WILL commit on drop, so it must never be silent.
+        session.layer.render(
+            opts.showGuides ? this._guideLines(session, snappedBox) : [],
+            context.container
+        );
+        session.layer.renderPreview(merge?.preview);
 
         if (!resX && !resY) {
             return;
@@ -477,6 +501,12 @@ export class SmartGuidesService
         // a horizontal sash → a y line).
         if (opts.snapSplitters) {
             for (const r of this.host.getGridSplitterRects()) {
+                // Skip hidden / collapsed sashes (zero-area rects) — a real sash
+                // has a positive extent on both axes; a 0×0 rect would otherwise
+                // become a phantom candidate at coord 0 (the container edge).
+                if (r.width <= 0 || r.height <= 0) {
+                    continue;
+                }
                 if (r.width <= r.height) {
                     x.push({
                         coord: r.left + r.width / 2,
@@ -638,8 +668,16 @@ export class SmartGuidesService
             const hOverlap = overlapRatio(d.left, d.right, e.left, e.right);
             const vOverlap = overlapRatio(d.top, d.bottom, e.top, e.bottom);
 
-            // Tabset merge: tops flush + the boxes stacked (strong overlap).
-            if (within(d.top, e.top) && hOverlap >= ADJACENCY_OVERLAP) {
+            // Tabset merge: the dragged float's CENTRE sits over the target (it
+            // is genuinely stacked on top), with the tab strips flush. Requiring
+            // the centre inside — not just top-alignment + edge overlap — stops a
+            // plain top/edge alignment of two overlapping floats from being read
+            // as a merge (§11: tabset-merge only on centre overlap).
+            const cx = (d.left + d.right) / 2;
+            const cy = (d.top + d.bottom) / 2;
+            const centreInside =
+                cx >= e.left && cx <= e.right && cy >= e.top && cy <= e.bottom;
+            if (within(d.top, e.top) && centreInside) {
                 return { target: t.group, position: 'center', preview: t.box };
             }
             // Edge adjacency: a dragged edge meets the target's opposite edge.

--- a/packages/dockview-modules/src/smartGuidesService.ts
+++ b/packages/dockview-modules/src/smartGuidesService.ts
@@ -95,6 +95,11 @@ class GuideLayer {
     private readonly _element: HTMLElement;
     private readonly _lines: HTMLElement[] = [];
     private _preview: HTMLElement | undefined;
+    // Last-applied state — a frame whose guides are unchanged skips the DOM
+    // write entirely (no interleaved reads, so the browser coalesces what does
+    // change into a single reflow at paint).
+    private _lastLines = '';
+    private _lastPreview = '';
 
     constructor(container: HTMLElement, className: string | undefined) {
         const doc = container.ownerDocument;
@@ -118,6 +123,13 @@ class GuideLayer {
         lines: { axis: 'x' | 'y'; coord: number }[],
         size: { width: number; height: number }
     ): void {
+        const signature =
+            `${size.width}x${size.height}:` +
+            lines.map((l) => `${l.axis}${l.coord}`).join('|');
+        if (signature === this._lastLines) {
+            return;
+        }
+        this._lastLines = signature;
         for (let i = 0; i < lines.length; i++) {
             const line = this._lineAt(i);
             const { axis, coord } = lines[i];
@@ -144,6 +156,13 @@ class GuideLayer {
 
     /** Show (or hide, when `box` is undefined) the dock/merge drop-preview. */
     renderPreview(box: Rect | undefined): void {
+        const signature = box
+            ? `${box.left},${box.top},${box.width},${box.height}`
+            : '';
+        if (signature === this._lastPreview) {
+            return;
+        }
+        this._lastPreview = signature;
         if (!box) {
             if (this._preview) {
                 this._preview.style.display = 'none';
@@ -162,6 +181,9 @@ class GuideLayer {
         for (const line of this._lines) {
             line.style.display = 'none';
         }
+        // Invalidate so the next (possibly identical) render re-applies the
+        // now-hidden lines rather than dedup-skipping them.
+        this._lastLines = '';
         this.renderPreview(undefined);
     }
 
@@ -172,13 +194,11 @@ class GuideLayer {
     private _ensurePreview(): HTMLElement {
         if (!this._preview) {
             const preview = this._element.ownerDocument.createElement('div');
+            // Cosmetics (background + border) are owned by the stylesheet
+            // (`.dv-smart-guide-preview` in overlay.scss); only geometry is set
+            // inline below.
             preview.className = 'dv-smart-guide-preview';
             preview.style.position = 'absolute';
-            preview.style.boxSizing = 'border-box';
-            preview.style.backgroundColor =
-                'var(--dv-smart-guides-preview-color, rgba(31, 156, 240, 0.18))';
-            preview.style.border =
-                '1px solid var(--dv-smart-guides-color, #1f9cf0)';
             this._element.appendChild(preview);
             this._preview = preview;
         }
@@ -189,11 +209,10 @@ class GuideLayer {
         let line = this._lines[i];
         if (!line) {
             line = this._element.ownerDocument.createElement('div');
+            // Colour is owned by the stylesheet (`.dv-smart-guide` in
+            // overlay.scss); only geometry is set inline by `render`.
             line.className = 'dv-smart-guide';
             line.style.position = 'absolute';
-            // Themable via a CSS var, with a sensible default so it works untouched.
-            line.style.backgroundColor =
-                'var(--dv-smart-guides-color, #1f9cf0)';
             this._element.appendChild(line);
             this._lines[i] = line;
         }

--- a/packages/dockview-modules/src/smartGuidesService.ts
+++ b/packages/dockview-modules/src/smartGuidesService.ts
@@ -3,15 +3,21 @@ import {
     DockviewGroupPanel,
     FloatingGroupDragContext,
     SmartGuidesOptions,
+    SmartGuidesSnapPosition,
 } from 'dockview-core';
 import { defineModule, FloatingGroupModule } from 'dockview-core';
 import { ISmartGuidesHost, ISmartGuidesService } from 'dockview-core';
+
+/** Fraction of the perpendicular extents that must overlap for an edge to read
+ *  as an adjacency (dock-beside) rather than a glancing touch. */
+const ADJACENCY_OVERLAP = 0.5;
 
 interface ResolvedOptions {
     enabled: boolean;
     snapDistance: number;
     releaseDistance: number;
     showGuides: boolean;
+    snapTogether: boolean;
     className: string | undefined;
     snapFloats: boolean;
     snapContainer: boolean;
@@ -25,11 +31,26 @@ function resolveOptions(o: SmartGuidesOptions | undefined): ResolvedOptions {
         snapDistance: o?.snapDistance ?? 8,
         releaseDistance: o?.releaseDistance ?? 4,
         showGuides: o?.showGuides ?? true,
+        snapTogether: o?.snapTogether ?? true,
         className: o?.className,
         snapFloats: o?.snapTargets?.floats ?? true,
         snapContainer: o?.snapTargets?.container ?? true,
         containerInset: o?.snapTargets?.containerInset,
     };
+}
+
+interface Rect {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+}
+
+/** A pending dock/merge intent the drag is currently suggesting. */
+interface MergeIntent {
+    readonly target: DockviewGroupPanel;
+    readonly position: SmartGuidesSnapPosition;
+    readonly preview: Rect;
 }
 
 type CandidateKind = 'edge' | 'center';
@@ -61,6 +82,7 @@ interface AxisResult {
 class GuideLayer {
     private readonly _element: HTMLElement;
     private readonly _lines: HTMLElement[] = [];
+    private _preview: HTMLElement | undefined;
 
     constructor(container: HTMLElement, className: string | undefined) {
         const doc = container.ownerDocument;
@@ -108,14 +130,47 @@ class GuideLayer {
         }
     }
 
+    /** Show (or hide, when `box` is undefined) the dock/merge drop-preview. */
+    renderPreview(box: Rect | undefined): void {
+        if (!box) {
+            if (this._preview) {
+                this._preview.style.display = 'none';
+            }
+            return;
+        }
+        const preview = this._ensurePreview();
+        preview.style.display = 'block';
+        preview.style.left = `${box.left}px`;
+        preview.style.top = `${box.top}px`;
+        preview.style.width = `${box.width}px`;
+        preview.style.height = `${box.height}px`;
+    }
+
     clear(): void {
         for (const line of this._lines) {
             line.style.display = 'none';
         }
+        this.renderPreview(undefined);
     }
 
     dispose(): void {
         this._element.remove();
+    }
+
+    private _ensurePreview(): HTMLElement {
+        if (!this._preview) {
+            const preview = this._element.ownerDocument.createElement('div');
+            preview.className = 'dv-smart-guide-preview';
+            preview.style.position = 'absolute';
+            preview.style.boxSizing = 'border-box';
+            preview.style.backgroundColor =
+                'var(--dv-smart-guides-preview-color, rgba(31, 156, 240, 0.18))';
+            preview.style.border =
+                '1px solid var(--dv-smart-guides-color, #1f9cf0)';
+            this._element.appendChild(preview);
+            this._preview = preview;
+        }
+        return this._preview;
     }
 
     private _lineAt(i: number): HTMLElement {
@@ -140,8 +195,12 @@ interface DragSession {
     readonly x: Candidate[];
     readonly y: Candidate[];
     readonly layer: GuideLayer;
+    /** Other floats with identity + box, for snap-together (built once). */
+    readonly targets: readonly { group: DockviewGroupPanel; box: Rect }[];
     engagedX: number | undefined;
     engagedY: number | undefined;
+    /** The dock/merge suggestion active this frame, committed on drop. */
+    pendingMerge: MergeIntent | undefined;
 }
 
 const SOURCE_RANK: Record<CandidateSource, number> = { float: 0, container: 1 };
@@ -169,9 +228,10 @@ export class SmartGuidesService
         super();
 
         this.addDisposables(
-            // Drag end (pointerup / cancel) tears the per-drag guides down.
+            // Drag end (pointerup / cancel): commit any pending snap-together,
+            // then tear the per-drag guides down.
             this.host.onDidEndFloatingGroupDrag((group) =>
-                this._endSession(group)
+                this._commitAndEnd(group)
             ),
             {
                 dispose: () => {
@@ -217,19 +277,25 @@ export class SmartGuidesService
         session.engagedX = resX?.coord;
         session.engagedY = resY?.coord;
 
-        const snappedLeft = proposed.left + (resX?.delta ?? 0);
-        const snappedTop = proposed.top + (resY?.delta ?? 0);
+        const snappedBox: Rect = {
+            left: proposed.left + (resX?.delta ?? 0),
+            top: proposed.top + (resY?.delta ?? 0),
+            width: proposed.width,
+            height: proposed.height,
+        };
+
+        // Snap-together: a dock/merge suggestion, committed on drop.
+        const merge = opts.snapTogether
+            ? this._detectSnapTogether(snappedBox, session.targets, opts)
+            : undefined;
+        session.pendingMerge = merge;
 
         if (opts.showGuides) {
             session.layer.render(
-                this._guideLines(session, {
-                    left: snappedLeft,
-                    top: snappedTop,
-                    width: proposed.width,
-                    height: proposed.height,
-                }),
+                this._guideLines(session, snappedBox),
                 context.container
             );
+            session.layer.renderPreview(merge?.preview);
         } else {
             session.layer.clear();
         }
@@ -237,7 +303,7 @@ export class SmartGuidesService
         if (!resX && !resY) {
             return;
         }
-        return { top: snappedTop, left: snappedLeft };
+        return { top: snappedBox.top, left: snappedBox.left };
     }
 
     private _startSession(
@@ -308,8 +374,10 @@ export class SmartGuidesService
             x,
             y,
             layer,
+            targets: this.host.getFloatingGroupSnapshots(context.group),
             engagedX: undefined,
             engagedY: undefined,
+            pendingMerge: undefined,
         };
         this._sessions.set(context.group, session);
         return session;
@@ -423,6 +491,76 @@ export class SmartGuidesService
         return lines;
     }
 
+    /**
+     * Detect a dock/merge intent for the snapped box against the other floats:
+     * a tab-strip overlap (tops flush + stacked) suggests a **center** merge
+     * into a shared tabset; an edge flush against a target's opposite edge —
+     * with ≥ 50% perpendicular overlap — suggests docking **beside** it. Returns
+     * the first match (with the drop-preview rect), or `undefined`.
+     */
+    private _detectSnapTogether(
+        box: Rect,
+        targets: readonly { group: DockviewGroupPanel; box: Rect }[],
+        opts: ResolvedOptions
+    ): MergeIntent | undefined {
+        const d = edges(box);
+        for (const t of targets) {
+            const e = edges(t.box);
+            const within = (a: number, b: number): boolean =>
+                Math.abs(a - b) <= opts.snapDistance;
+            const hOverlap = overlapRatio(d.left, d.right, e.left, e.right);
+            const vOverlap = overlapRatio(d.top, d.bottom, e.top, e.bottom);
+
+            // Tabset merge: tops flush + the boxes stacked (strong overlap).
+            if (within(d.top, e.top) && hOverlap >= ADJACENCY_OVERLAP) {
+                return { target: t.group, position: 'center', preview: t.box };
+            }
+            // Edge adjacency: a dragged edge meets the target's opposite edge.
+            if (within(d.right, e.left) && vOverlap >= ADJACENCY_OVERLAP) {
+                return {
+                    target: t.group,
+                    position: 'left',
+                    preview: half(t.box, 'left'),
+                };
+            }
+            if (within(d.left, e.right) && vOverlap >= ADJACENCY_OVERLAP) {
+                return {
+                    target: t.group,
+                    position: 'right',
+                    preview: half(t.box, 'right'),
+                };
+            }
+            if (within(d.bottom, e.top) && hOverlap >= ADJACENCY_OVERLAP) {
+                return {
+                    target: t.group,
+                    position: 'top',
+                    preview: half(t.box, 'top'),
+                };
+            }
+            if (within(d.top, e.bottom) && hOverlap >= ADJACENCY_OVERLAP) {
+                return {
+                    target: t.group,
+                    position: 'bottom',
+                    preview: half(t.box, 'bottom'),
+                };
+            }
+        }
+        return undefined;
+    }
+
+    private _commitAndEnd(group: DockviewGroupPanel): void {
+        const session = this._sessions.get(group);
+        if (!session) {
+            return;
+        }
+        const pending = session.pendingMerge;
+        // Tear the overlay down before the layout mutates.
+        this._endSession(group);
+        if (pending) {
+            this.host.mergeFloatInto(group, pending.target, pending.position);
+        }
+    }
+
     private _endSession(group: DockviewGroupPanel): void {
         const session = this._sessions.get(group);
         if (!session) {
@@ -430,6 +568,43 @@ export class SmartGuidesService
         }
         this._sessions.delete(group);
         session.layer.dispose();
+    }
+}
+
+interface Edges {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+}
+
+function edges(r: Rect): Edges {
+    return {
+        left: r.left,
+        right: r.left + r.width,
+        top: r.top,
+        bottom: r.top + r.height,
+    };
+}
+
+/** Overlap of `[a1,a2]` and `[b1,b2]` as a fraction of the smaller extent. */
+function overlapRatio(a1: number, a2: number, b1: number, b2: number): number {
+    const overlap = Math.max(0, Math.min(a2, b2) - Math.max(a1, b1));
+    const smaller = Math.min(a2 - a1, b2 - b1);
+    return smaller > 0 ? overlap / smaller : 0;
+}
+
+/** The half of `r` the dragged float would occupy when docked at `side`. */
+function half(r: Rect, side: 'left' | 'right' | 'top' | 'bottom'): Rect {
+    switch (side) {
+        case 'left':
+            return { ...r, width: r.width / 2 };
+        case 'right':
+            return { ...r, left: r.left + r.width / 2, width: r.width / 2 };
+        case 'top':
+            return { ...r, height: r.height / 2 };
+        case 'bottom':
+            return { ...r, top: r.top + r.height / 2, height: r.height / 2 };
     }
 }
 

--- a/packages/dockview-modules/src/smartGuidesService.ts
+++ b/packages/dockview-modules/src/smartGuidesService.ts
@@ -1,0 +1,224 @@
+import { DockviewCompositeDisposable as CompositeDisposable } from 'dockview-core';
+import {
+    DockviewGroupPanel,
+    FloatingGroupDragContext,
+    SmartGuidesOptions,
+} from 'dockview-core';
+import { defineModule, FloatingGroupModule } from 'dockview-core';
+import { ISmartGuidesHost, ISmartGuidesService } from 'dockview-core';
+
+function resolveOptions(o: SmartGuidesOptions | undefined): {
+    enabled: boolean;
+    snapDistance: number;
+    showGuides: boolean;
+    className: string | undefined;
+} {
+    return {
+        // Present + not explicitly disabled. Absent ⇒ inert (pass-through).
+        enabled: !!o && o.enabled !== false,
+        snapDistance: o?.snapDistance ?? 8,
+        showGuides: o?.showGuides ?? true,
+        className: o?.className,
+    };
+}
+
+/** A 1-D alignment line: the axis it constrains and its container-relative px. */
+interface Candidate {
+    readonly axis: 'x' | 'y';
+    readonly coord: number;
+}
+
+/** Per-drag state: the candidate lines (built once at drag start, since only
+ *  the dragged float moves) and the DOM overlay that paints the active guide. */
+interface DragSession {
+    readonly xCandidates: number[];
+    readonly yCandidates: number[];
+    readonly layer: HTMLElement;
+    readonly line: HTMLElement;
+}
+
+/**
+ * Smart Guides — Figma-style alignment guides + magnetic snapping for floating
+ * groups (Phase 1: single-axis edge snapping against other floats).
+ *
+ * The float drag loop stays fully owned by `Overlay`; this service is a pure
+ * consumer. The component composes it into the loop's position-transform
+ * (`transformFloatingGroupDrag`), so each pointer-move frame the proposed,
+ * container-relative box is offered here and an adjusted top-left returned. A
+ * winning snap also paints one alignment line in the floating container's
+ * coordinate space. With `smartGuides` unset the transform is a pass-through
+ * and no overlay is created.
+ */
+export class SmartGuidesService
+    extends CompositeDisposable
+    implements ISmartGuidesService
+{
+    private readonly _sessions = new Map<DockviewGroupPanel, DragSession>();
+
+    constructor(private readonly host: ISmartGuidesHost) {
+        super();
+
+        this.addDisposables(
+            // Drag end (pointerup / cancel) tears the per-drag guides down.
+            this.host.onDidEndFloatingGroupDrag((group) =>
+                this._endSession(group)
+            ),
+            {
+                dispose: () => {
+                    for (const group of [...this._sessions.keys()]) {
+                        this._endSession(group);
+                    }
+                },
+            }
+        );
+    }
+
+    private get _opts() {
+        return resolveOptions(this.host.options.smartGuides);
+    }
+
+    transformFloatingGroupDrag(
+        context: FloatingGroupDragContext
+    ): { top: number; left: number } | void {
+        const opts = this._opts;
+        if (!opts.enabled) {
+            // Disabled mid-drag (or never on): drop any guides, pass through.
+            this._endSession(context.group);
+            return;
+        }
+
+        const session =
+            this._sessions.get(context.group) ?? this._startSession(context);
+
+        const { proposed } = context;
+        const xProbes = [proposed.left, proposed.left + proposed.width];
+        const yProbes = [proposed.top, proposed.top + proposed.height];
+
+        // Single best snap across BOTH axes (Phase 1): the smallest in-threshold
+        // edge delta wins; ties are resolved by encounter order (x before y).
+        let best: { axis: 'x' | 'y'; delta: number; coord: number } | undefined;
+        const consider = (
+            axis: 'x' | 'y',
+            candidates: number[],
+            probes: number[]
+        ): void => {
+            for (const coord of candidates) {
+                for (const probe of probes) {
+                    const delta = coord - probe;
+                    if (
+                        Math.abs(delta) <= opts.snapDistance &&
+                        (best === undefined ||
+                            Math.abs(delta) < Math.abs(best.delta))
+                    ) {
+                        best = { axis, delta, coord };
+                    }
+                }
+            }
+        };
+        consider('x', session.xCandidates, xProbes);
+        consider('y', session.yCandidates, yProbes);
+
+        if (best === undefined) {
+            this._hideGuide(session);
+            return;
+        }
+
+        if (opts.showGuides) {
+            this._showGuide(session, best.axis, best.coord, context.container);
+        } else {
+            this._hideGuide(session);
+        }
+
+        return {
+            top: proposed.top + (best.axis === 'y' ? best.delta : 0),
+            left: proposed.left + (best.axis === 'x' ? best.delta : 0),
+        };
+    }
+
+    private _startSession(context: FloatingGroupDragContext): DragSession {
+        const xCandidates: number[] = [];
+        const yCandidates: number[] = [];
+        // Each other float contributes its leading + trailing edges on each
+        // axis. The dragged float is already excluded from `context.others`.
+        for (const box of context.others) {
+            xCandidates.push(box.left, box.left + box.width);
+            yCandidates.push(box.top, box.top + box.height);
+        }
+
+        const container = this.host.getFloatingContainer();
+        const doc = container.ownerDocument;
+
+        const layer = doc.createElement('div');
+        layer.className = 'dv-smart-guides';
+        if (this._opts.className) {
+            layer.classList.add(this._opts.className);
+        }
+        layer.style.position = 'absolute';
+        layer.style.left = '0';
+        layer.style.top = '0';
+        layer.style.width = '100%';
+        layer.style.height = '100%';
+        layer.style.pointerEvents = 'none';
+        layer.style.overflow = 'hidden';
+
+        const line = doc.createElement('div');
+        line.className = 'dv-smart-guide';
+        line.style.position = 'absolute';
+        line.style.display = 'none';
+        // Themable via a CSS var, with a sensible default so it works untouched.
+        line.style.backgroundColor = 'var(--dv-smart-guides-color, #1f9cf0)';
+        layer.appendChild(line);
+
+        container.appendChild(layer);
+
+        const session: DragSession = { xCandidates, yCandidates, layer, line };
+        this._sessions.set(context.group, session);
+        return session;
+    }
+
+    private _showGuide(
+        session: DragSession,
+        axis: 'x' | 'y',
+        coord: number,
+        container: { width: number; height: number }
+    ): void {
+        const { line } = session;
+        line.style.display = 'block';
+        if (axis === 'x') {
+            // Vertical line spanning the container height at x = coord.
+            line.style.left = `${coord}px`;
+            line.style.top = '0';
+            line.style.width = '1px';
+            line.style.height = `${container.height}px`;
+        } else {
+            // Horizontal line spanning the container width at y = coord.
+            line.style.top = `${coord}px`;
+            line.style.left = '0';
+            line.style.height = '1px';
+            line.style.width = `${container.width}px`;
+        }
+    }
+
+    private _hideGuide(session: DragSession): void {
+        session.line.style.display = 'none';
+    }
+
+    private _endSession(group: DockviewGroupPanel): void {
+        const session = this._sessions.get(group);
+        if (!session) {
+            return;
+        }
+        this._sessions.delete(group);
+        session.layer.remove();
+    }
+}
+
+export const SmartGuidesModule = defineModule<
+    'smartGuidesService',
+    ISmartGuidesHost
+>({
+    name: 'SmartGuides',
+    serviceKey: 'smartGuidesService',
+    dependsOn: [FloatingGroupModule],
+    create: (host) => new SmartGuidesService(host),
+});

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -789,6 +789,7 @@ const DockviewDemo = (props: {
                                             onReady={onReady}
                                             theme={effectiveTheme}
                                             floatingGroupDragHandle="titlebar"
+                                            smartGuides={{ snapDistance: 8 }}
                                             getTabContextMenuItems={
                                                 getTabContextMenuItems
                                             }


### PR DESCRIPTION
Figma-style **alignment guides + magnetic snapping** for floating groups. While a floating window is dragged, it snaps into alignment with other floats, the container, or the grid behind it, drawing crisp guide lines; bringing one flush over another suggests docking/merging them.

Built additively on the existing per-frame float drag-position hook — with the option unset the float drag loop is byte-for-byte unchanged.

## What's included (by phase)

- **Phase 1** — alignment guides + single-edge magnetic snap to other floats.
- **Phase 2** — edges **and** centres; container edges/centre (+ optional inset margins); X and Y resolved independently (two guides at once); asymmetric engage/release **hysteresis** (no boundary jitter).
- **Phase 3** — **snap-together**: edge-adjacency dock-beside + tab-strip-overlap tabset merge, shown as a drop-preview and committed on drop via the existing `moveGroupOrPanel` primitive (so events + undo cover it).
- **Phase 4** — **Alt-to-disable** modifier gate (configurable), snap to grid splitters, per-float opt-out (`disableSmartGuides`), runtime API (`setSmartGuidesEnabled` / `updateSmartGuidesOptions` + `onDidSnapFloat` / `onDidSnapTogether`).
- **Phase 5** — theming via CSS variables (styles moved to the stylesheet), per-frame guide-write dedup.
- **2 review passes** — a self-review + a follow-up fixing a redock-abort session leak, a removed-target merge guard, over-eager tabset merges, silent merges under `showGuides:false`, sticky-probe jumps on tiny floats, nearest-target selection, runtime-vs-option precedence, and cleanups.

## API surface

`DockviewOptions.smartGuides` (option types in core); `DockviewApi.setSmartGuidesEnabled` / `updateSmartGuidesOptions` / `smartGuidesEnabled` + `onDidSnapFloat` / `onDidSnapTogether`; per-float `disableSmartGuides`. The module lives in `dockview-modules`; core holds only the contracts + the composed drag-transform seam.

## Tests

- **core + modules: 1244 unit tests** (37 Smart Guides incl. centres, container, splitters, independent axes, hysteresis, snap-together, modifier gate, runtime options, events, and every review-fix regression).
- **e2e: 5 Smart Guides** (edge snap, two-axis corner, real merge-on-drop, Alt-suspend, no-guide-away) + 12 total green.
- Serialization unaffected (pure interaction overlay — nothing added to `toJSON`).

## Notes

- The last commit enables Smart Guides in the docs demo for try-out; drop it if you'd prefer a core+module-only PR.
- CI `format:check` may flag a pre-existing `paneview.scss` drift on `v8-branch` — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)