### PR TITLE
feat: Drop Guide (compass) drag-drop overlay

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -129,6 +129,8 @@ IDockviewPanel
 IDockviewPanelHeaderProps
 IDockviewPanelProps
 IDragGhostSpec
+IDropGuideHost
+IDropGuideService
 IFrameworkPart
 IGridPanelComponentView
 IGridPanelView

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -50,6 +50,10 @@
                     // A served (not about:blank) target avoids a 404 when the
                     // popout window navigates before dockview injects content.
                     popoutUrl: '/e2e/fixtures/popout.html',
+                    // Drop Guide ("compass") + pointer DnD so a panel drag is
+                    // drivable in the harness. Inert unless a drag occurs.
+                    dndGuide: true,
+                    dndStrategy: 'pointer',
                     createComponent: (options) => {
                         const element = document.createElement('div');
                         element.className = 'dv-test-panel';
@@ -103,6 +107,21 @@
                     redo: () => dockview.redo(),
                     canUndo: () => dockview.canUndo,
                     awaitPopoutRestore: () => dockview.popoutRestorationPromise,
+                    // Two side-by-side groups for Drop Guide: dragging the left
+                    // group's tab over the right group shows the compass.
+                    setupDropGuide: () => {
+                        dockview.addPanel({
+                            id: 'left',
+                            component: 'default',
+                            title: 'left',
+                        });
+                        dockview.addPanel({
+                            id: 'right',
+                            component: 'default',
+                            title: 'right',
+                            position: { direction: 'right' },
+                        });
+                    },
                 };
                 window.__ready = true;
             })();

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -41,9 +41,10 @@ test.describe('drop guide (compass)', () => {
         );
         await page.mouse.move(cx, cy, { steps: 20 });
 
-        // the compass cross is painted over the hovered group
+        // the compass cross is painted over the hovered group (5 inner + 4 outer)
         await expect(page.locator('.dv-drop-guide')).toBeVisible();
-        expect(await page.locator('.dv-drop-guide-cell').count()).toBe(5);
+        expect(await page.locator('.dv-drop-guide-cell').count()).toBe(9);
+        expect(await page.locator('.dv-drop-guide-cell-edge').count()).toBe(4);
 
         // drop on the centre cell → merge into the right group
         await page.mouse.up();
@@ -53,6 +54,39 @@ test.describe('drop guide (compass)', () => {
             .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
             .toBe(1);
         // ...and the compass is gone
+        await expect(page.locator('.dv-drop-guide')).toHaveCount(0);
+    });
+
+    test('dropping on an outer cell docks against the whole layout (not a merge)', async ({
+        page,
+    }) => {
+        await setup(page);
+
+        const leftTab = page.locator('.dv-tab', { hasText: 'left' });
+        const tab = (await leftTab.boundingBox())!;
+        const content = (await rightContent(page).boundingBox())!;
+        const cx = content.x + content.width / 2;
+        const cy = content.y + content.height / 2;
+        // the outer ring sits ~2 cells (CELL 38 + GAP 4 = 42 → 84px) out
+        const outerRightX = cx + 84;
+
+        await page.mouse.move(tab.x + tab.width / 2, tab.y + tab.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(
+            tab.x + tab.width / 2 + 6,
+            tab.y + tab.height / 2
+        );
+        await page.mouse.move(cx, cy, { steps: 15 });
+        await expect(page.locator('.dv-drop-guide')).toBeVisible();
+        // aim at the outer-right cell, then drop
+        await page.mouse.move(outerRightX, cy, { steps: 6 });
+        await page.mouse.up();
+
+        // the left panel docked to the layout's right edge as its OWN group —
+        // still two groups (a centre-cell drop would have merged to one).
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
+            .toBe(2);
         await expect(page.locator('.dv-drop-guide')).toHaveCount(0);
     });
 });

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -98,6 +98,40 @@ test.describe('drop guide (compass)', () => {
         await page.mouse.up();
     });
 
+    test('feedback clears when the cursor moves into a dead zone', async ({
+        page,
+    }) => {
+        await setup(page);
+        const tab = (await page
+            .locator('.dv-tab', { hasText: 'left' })
+            .boundingBox())!;
+        const content = (await rightContent(page).boundingBox())!;
+        const cx = content.x + content.width / 2;
+        const cy = content.y + content.height / 2;
+        const band = page.locator('.dv-drop-guide-edge-preview');
+
+        await page.mouse.move(tab.x + tab.width / 2, tab.y + tab.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(
+            tab.x + tab.width / 2 + 6,
+            tab.y + tab.height / 2
+        );
+
+        await page.mouse.move(cx + 84, cy, { steps: 10 }); // outer-right cell
+        await expect(band).toBeVisible();
+
+        // move far off the cross (still inside the group) — feedback must clear
+        await page.mouse.move(cx + 250, cy + 200, { steps: 10 });
+        await expect(band).toHaveCount(0);
+        await expect(page.locator('.dv-drop-guide-cell-active')).toHaveCount(0);
+
+        // ...and return when back on the cell
+        await page.mouse.move(cx + 84, cy, { steps: 10 });
+        await expect(band).toBeVisible();
+
+        await page.mouse.up();
+    });
+
     test('dropping on an outer cell docks against the whole layout (not a merge)', async ({
         page,
     }) => {

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -57,6 +57,42 @@ test.describe('drop guide (compass)', () => {
         await expect(page.locator('.dv-drop-guide')).toHaveCount(0);
     });
 
+    test('the compass holds position from an inner to an outer cell', async ({
+        page,
+    }) => {
+        await setup(page);
+        const tab = (await page
+            .locator('.dv-tab', { hasText: 'left' })
+            .boundingBox())!;
+        const content = (await rightContent(page).boundingBox())!;
+        const cx = content.x + content.width / 2;
+        const cy = content.y + content.height / 2;
+
+        await page.mouse.move(tab.x + tab.width / 2, tab.y + tab.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(
+            tab.x + tab.width / 2 + 6,
+            tab.y + tab.height / 2
+        );
+
+        const centre = rightContent(page).locator('.dv-drop-guide-cell-center');
+
+        // hover the centre (inner) cell, record where the cross sits
+        await page.mouse.move(cx, cy, { steps: 20 });
+        await expect(centre).toBeVisible();
+        const atInner = (await centre.boundingBox())!;
+
+        // sweep out to the far outer cell — the cross must not move (the drop
+        // target removing its `.dv-drop-target` class once made it re-anchor)
+        await page.mouse.move(cx + 84, cy, { steps: 10 });
+        const atOuter = (await centre.boundingBox())!;
+
+        expect(atOuter.x).toBeCloseTo(atInner.x, 0);
+        expect(atOuter.y).toBeCloseTo(atInner.y, 0);
+
+        await page.mouse.up();
+    });
+
     test('dropping on an outer cell docks against the whole layout (not a merge)', async ({
         page,
     }) => {

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -114,8 +114,11 @@ test.describe('drop guide (compass)', () => {
         );
         await page.mouse.move(cx, cy, { steps: 15 });
         await expect(page.locator('.dv-drop-guide')).toBeVisible();
-        // aim at the outer-right cell, then drop
+        // aim at the outer-right cell → it lights up as the active cell
         await page.mouse.move(outerRightX, cy, { steps: 6 });
+        await expect(
+            page.locator('.dv-drop-guide-cell-edge.dv-drop-guide-cell-active')
+        ).toBeVisible();
         await page.mouse.up();
 
         // the left panel docked to the layout's right edge as its OWN group —

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -114,11 +114,13 @@ test.describe('drop guide (compass)', () => {
         );
         await page.mouse.move(cx, cy, { steps: 15 });
         await expect(page.locator('.dv-drop-guide')).toBeVisible();
-        // aim at the outer-right cell → it lights up as the active cell
+        // aim at the outer-right cell → it lights up + the layout-edge region
+        // is previewed
         await page.mouse.move(outerRightX, cy, { steps: 6 });
         await expect(
             page.locator('.dv-drop-guide-cell-edge.dv-drop-guide-cell-active')
         ).toBeVisible();
+        await expect(page.locator('.dv-drop-guide-edge-preview')).toBeVisible();
         await page.mouse.up();
 
         // the left panel docked to the layout's right edge as its OWN group —

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -78,9 +78,8 @@ test.describe('drop guide (compass)', () => {
         );
         await page.mouse.move(cx, cy, { steps: 15 });
         await expect(page.locator('.dv-drop-guide')).toBeVisible();
-        // aim at the outer-right cell → the layout-edge band previews the dock
+        // aim at the outer-right cell, then drop
         await page.mouse.move(outerRightX, cy, { steps: 6 });
-        await expect(page.locator('.dv-drop-guide-edge-preview')).toBeVisible();
         await page.mouse.up();
 
         // the left panel docked to the layout's right edge as its OWN group —

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Drop Guide ("compass") — the aim-at-a-cell drop overlay. Real-browser only:
+ * it reads the live drop-target geometry the drag loop works in, which jsdom
+ * (no layout) can't produce. The harness uses the pointer DnD backend so a
+ * panel drag is drivable.
+ */
+test.describe('drop guide (compass)', () => {
+    const setup = async (page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupDropGuide());
+    };
+
+    const rightContent = (page) =>
+        page.locator('.dv-content-container', {
+            has: page.locator('.dv-test-panel', { hasText: 'right' }),
+        });
+
+    test('dragging a tab over a group shows the compass and a cell-drop docks', async ({
+        page,
+    }) => {
+        await setup(page);
+        expect(
+            await page.evaluate(() => (window as any).__dv.groupCount())
+        ).toBe(2);
+
+        const leftTab = page.locator('.dv-tab', { hasText: 'left' });
+        const tab = (await leftTab.boundingBox())!;
+        const content = (await rightContent(page).boundingBox())!;
+        const cx = content.x + content.width / 2;
+        const cy = content.y + content.height / 2;
+
+        await page.mouse.move(tab.x + tab.width / 2, tab.y + tab.height / 2);
+        await page.mouse.down();
+        // nudge to start the drag, then move onto the right group's centre
+        await page.mouse.move(
+            tab.x + tab.width / 2 + 6,
+            tab.y + tab.height / 2
+        );
+        await page.mouse.move(cx, cy, { steps: 20 });
+
+        // the compass cross is painted over the hovered group
+        await expect(page.locator('.dv-drop-guide')).toBeVisible();
+        expect(await page.locator('.dv-drop-guide-cell').count()).toBe(5);
+
+        // drop on the centre cell → merge into the right group
+        await page.mouse.up();
+
+        // the two groups collapsed into one (left panel tabbed into right)
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
+            .toBe(1);
+        // ...and the compass is gone
+        await expect(page.locator('.dv-drop-guide')).toHaveCount(0);
+    });
+});

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -88,6 +88,15 @@ test.describe('drop guide (compass)', () => {
         await expect
             .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
             .toBe(2);
+        // ...and it actually moved to that edge: the 'left' tab, which started
+        // left of 'right', is now to its right (a no-op dock would leave it left).
+        const leftAfter = (await page
+            .locator('.dv-tab', { hasText: 'left' })
+            .boundingBox())!;
+        const rightAfter = (await page
+            .locator('.dv-tab', { hasText: 'right' })
+            .boundingBox())!;
+        expect(leftAfter.x).toBeGreaterThan(rightAfter.x);
         await expect(page.locator('.dv-drop-guide')).toHaveCount(0);
     });
 });

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -78,8 +78,9 @@ test.describe('drop guide (compass)', () => {
         );
         await page.mouse.move(cx, cy, { steps: 15 });
         await expect(page.locator('.dv-drop-guide')).toBeVisible();
-        // aim at the outer-right cell, then drop
+        // aim at the outer-right cell → the layout-edge band previews the dock
         await page.mouse.move(outerRightX, cy, { steps: 6 });
+        await expect(page.locator('.dv-drop-guide-edge-preview')).toBeVisible();
         await page.mouse.up();
 
         // the left panel docked to the layout's right edge as its OWN group —

--- a/e2e/tests/drop-guide.spec.ts
+++ b/e2e/tests/drop-guide.spec.ts
@@ -85,6 +85,11 @@ test.describe('drop guide (compass)', () => {
         // sweep out to the far outer cell — the cross must not move (the drop
         // target removing its `.dv-drop-target` class once made it re-anchor)
         await page.mouse.move(cx + 84, cy, { steps: 10 });
+        // guard the regression is actually exercised: confirm we reached an
+        // outer (edge) cell, the only path that removes `.dv-drop-target`
+        await expect(
+            page.locator('.dv-drop-guide-cell-edge.dv-drop-guide-cell-active')
+        ).toBeVisible();
         const atOuter = (await centre.boundingBox())!;
 
         expect(atOuter.x).toBeCloseTo(atInner.x, 0);

--- a/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
@@ -97,6 +97,37 @@ describe('droptarget', () => {
             expect(calls[0].zones.has('center')).toBe(true);
         });
 
+        test('an edge cell reports edge + renders no overlay', () => {
+            let dropped: { position: Position; edge?: boolean } | undefined;
+            droptarget = new Droptarget(element, {
+                canDisplayOverlay: () => true,
+                acceptedTargetZones: ALL,
+                getPositionResolver: () => ({
+                    resolve: () => ({ position: 'top', edge: true }),
+                }),
+            });
+            droptarget.onDrop((e) => {
+                dropped = e;
+            });
+
+            fireEvent.dragEnter(element);
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 100, clientY: 50 })
+            );
+
+            // no group overlay is drawn for an edge cell...
+            expect(
+                element.querySelector('.dv-drop-target-dropzone')
+            ).toBeNull();
+            // ...but the position is still reported on drop, flagged edge
+            expect(droptarget.state).toBe('top');
+            fireEvent.drop(element);
+            expect(dropped).toEqual(
+                expect.objectContaining({ position: 'top', edge: true })
+            );
+        });
+
         test('a null result shows no drop target', () => {
             droptarget = new Droptarget(element, {
                 canDisplayOverlay: () => true,

--- a/packages/dockview-core/src/__tests__/dockview/components/panel/content.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/panel/content.spec.ts
@@ -254,12 +254,13 @@ describe('contentContainer', () => {
         expect(cut.element.childNodes.length).toBe(1);
     });
 
-    test('the dropPositionResolver option drives the content drop target', () => {
+    test('the resolved drop-position resolver drives the content drop target', () => {
         const resolver = { resolve: () => ({ position: 'right' as const }) };
 
         const cut = new ContentContainer(
             fromPartial<DockviewComponent>({
-                options: { dropPositionResolver: resolver },
+                getDropPositionResolver: () => resolver,
+                options: {},
                 resolveDropOverlayModel: () => undefined,
             }),
             fromPartial<DockviewGroupPanelModel>({

--- a/packages/dockview-core/src/__tests__/dockview/components/panel/content.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/panel/content.spec.ts
@@ -264,7 +264,7 @@ describe('contentContainer', () => {
                 resolveDropOverlayModel: () => undefined,
             }),
             fromPartial<DockviewGroupPanelModel>({
-                canDisplayOverlay: () => true,
+                canDisplayContentOverlay: () => true,
             })
         );
 

--- a/packages/dockview-core/src/dnd/droptarget.scss
+++ b/packages/dockview-core/src/dnd/droptarget.scss
@@ -77,3 +77,14 @@
         rgba(31, 156, 240, 0.12)
     );
 }
+
+.dv-drop-guide-edge-preview {
+    // The whole-layout-edge dock preview for an outer compass cell.
+    z-index: 1001;
+    box-sizing: border-box;
+    background-color: var(
+        --dv-drop-guide-edge-preview-color,
+        rgba(31, 156, 240, 0.18)
+    );
+    border: 1px solid var(--dv-drop-guide-color, #1f9cf0);
+}

--- a/packages/dockview-core/src/dnd/droptarget.scss
+++ b/packages/dockview-core/src/dnd/droptarget.scss
@@ -54,3 +54,17 @@
         }
     }
 }
+
+// Drop Guide ("compass") — the aim-at-a-cell cross painted over a group's
+// content while dragging. The module positions + sizes the cells inline; only
+// the theming lives here (override the CSS vars to restyle).
+.dv-drop-guide {
+    z-index: 1001;
+}
+
+.dv-drop-guide-cell {
+    box-sizing: border-box;
+    border-radius: 2px;
+    border: 1px solid var(--dv-drop-guide-color, #1f9cf0);
+    background-color: var(--dv-drop-guide-cell-color, rgba(31, 156, 240, 0.25));
+}

--- a/packages/dockview-core/src/dnd/droptarget.scss
+++ b/packages/dockview-core/src/dnd/droptarget.scss
@@ -77,14 +77,3 @@
         rgba(31, 156, 240, 0.12)
     );
 }
-
-.dv-drop-guide-edge-preview {
-    // The whole-layout-edge dock preview for an outer compass cell.
-    z-index: 1001;
-    box-sizing: border-box;
-    background-color: var(
-        --dv-drop-guide-edge-preview-color,
-        rgba(31, 156, 240, 0.18)
-    );
-    border: 1px solid var(--dv-drop-guide-color, #1f9cf0);
-}

--- a/packages/dockview-core/src/dnd/droptarget.scss
+++ b/packages/dockview-core/src/dnd/droptarget.scss
@@ -68,3 +68,12 @@
     border: 1px solid var(--dv-drop-guide-color, #1f9cf0);
     background-color: var(--dv-drop-guide-cell-color, rgba(31, 156, 240, 0.25));
 }
+
+.dv-drop-guide-cell-edge {
+    // Outer "dock to the whole layout" cells read distinct from the inner ring.
+    border-style: dashed;
+    background-color: var(
+        --dv-drop-guide-edge-cell-color,
+        rgba(31, 156, 240, 0.12)
+    );
+}

--- a/packages/dockview-core/src/dnd/droptarget.scss
+++ b/packages/dockview-core/src/dnd/droptarget.scss
@@ -77,3 +77,13 @@
         rgba(31, 156, 240, 0.12)
     );
 }
+
+.dv-drop-guide-cell-active {
+    // The cell the cursor is aiming at — the hover feedback, especially for the
+    // outer cells (the drop target draws no overlay for them).
+    background-color: var(
+        --dv-drop-guide-active-cell-color,
+        rgba(31, 156, 240, 0.5)
+    );
+    border-style: solid;
+}

--- a/packages/dockview-core/src/dnd/droptarget.scss
+++ b/packages/dockview-core/src/dnd/droptarget.scss
@@ -87,3 +87,13 @@
     );
     border-style: solid;
 }
+
+.dv-drop-guide-edge-preview {
+    // The whole-layout-edge region an outer cell docks into. Reuses the real
+    // drop-overlay theme variables so it reads identically to any other drop
+    // preview; sits beneath the compass cross (z below `.dv-drop-guide`).
+    z-index: 1000;
+    box-sizing: border-box;
+    background-color: var(--dv-drag-over-background-color);
+    border: var(--dv-drag-over-border);
+}

--- a/packages/dockview-core/src/dnd/droptarget.ts
+++ b/packages/dockview-core/src/dnd/droptarget.ts
@@ -12,6 +12,12 @@ export interface DroptargetEvent {
     readonly position: Position;
     /** Narrow with `instanceof DragEvent` before reading `dataTransfer`. */
     readonly nativeEvent: DragEvent | PointerEvent;
+    /**
+     * The resolved cell was marked `edge` by a {@link PositionResolver} — an
+     * "outer" cell that should dock against the whole layout, not this target.
+     * The target renders no overlay for it; the consumer routes the commit.
+     */
+    readonly edge?: boolean;
 }
 
 export class WillShowOverlayEvent
@@ -26,10 +32,16 @@ export class WillShowOverlayEvent
         return this.options.position;
     }
 
+    /** See {@link DroptargetEvent.edge}. */
+    get edge(): boolean {
+        return !!this.options.edge;
+    }
+
     constructor(
         private readonly options: {
             nativeEvent: DragEvent | PointerEvent;
             position: Position;
+            edge?: boolean;
         }
     ) {
         super();
@@ -182,6 +194,8 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
     private targetElement: HTMLElement | undefined;
     private overlayElement: HTMLElement | undefined;
     private _state: Position | undefined;
+    /** The current state was resolved as an `edge` cell (see DroptargetEvent). */
+    private _edge = false;
     private _acceptedTargetZonesSet: Set<Position>;
 
     private readonly _onDrop = new Emitter<DroptargetEvent>();
@@ -257,18 +271,20 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 const x = (e.clientX ?? 0) - rect.left;
                 const y = (e.clientY ?? 0) - rect.top;
 
-                const quadrant = this.resolvePosition(x, y, width, height, e);
+                const resolved = this.resolvePosition(x, y, width, height, e);
 
                 /**
                  * If the event has already been used by another DropTarget instance
                  * then don't show a second drop target, only one target should be
                  * active at any one time
                  */
-                if (this.isAlreadyUsed(e) || quadrant === null) {
+                if (this.isAlreadyUsed(e) || resolved === null) {
                     // no drop target should be displayed
                     this.removeDropTarget();
                     return;
                 }
+
+                const quadrant = resolved.position;
 
                 if (!this.options.canDisplayOverlay(e, quadrant)) {
                     if (overrideTarget) {
@@ -281,6 +297,7 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 const willShowOverlayEvent = new WillShowOverlayEvent({
                     nativeEvent: e,
                     position: quadrant,
+                    edge: resolved.edge,
                 });
 
                 /**
@@ -295,6 +312,16 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 }
 
                 this.markAsUsed(e);
+
+                // An `edge` cell reports its position but renders nothing — the
+                // consumer (e.g. the layout-edge dock) owns the preview + commit.
+                if (resolved.edge) {
+                    this.removeDropTarget();
+                    this._state = quadrant;
+                    this._edge = true;
+                    return;
+                }
+                this._edge = false;
 
                 if (overrideTarget) {
                     //
@@ -332,6 +359,7 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                         this._onDrop.fire({
                             position: this._state,
                             nativeEvent: e,
+                            edge: this._edge,
                         });
                     }
                 }
@@ -344,6 +372,7 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 e.preventDefault();
 
                 const state = this._state;
+                const edge = this._edge;
 
                 this.removeDropTarget();
 
@@ -353,7 +382,11 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                     // only stop the propagation of the event if we are dealing with it
                     // which is only when the target has state
                     e.stopPropagation();
-                    this._onDrop.fire({ position: state, nativeEvent: e });
+                    this._onDrop.fire({
+                        position: state,
+                        nativeEvent: e,
+                        edge,
+                    });
                 }
             },
         });
@@ -435,27 +468,29 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
         width: number,
         height: number,
         event: DragEvent | PointerEvent
-    ): Position | null {
+    ): { position: Position; edge: boolean } | null {
         const resolver = this.options.getPositionResolver?.();
         if (resolver) {
-            return (
-                resolver.resolve({
-                    x,
-                    y,
-                    width,
-                    height,
-                    zones: this._acceptedTargetZonesSet,
-                    event,
-                })?.position ?? null
-            );
+            const result = resolver.resolve({
+                x,
+                y,
+                width,
+                height,
+                zones: this._acceptedTargetZonesSet,
+                event,
+            });
+            return result
+                ? { position: result.position, edge: !!result.edge }
+                : null;
         }
-        return this.calculateQuadrant(
+        const position = this.calculateQuadrant(
             this._acceptedTargetZonesSet,
             x,
             y,
             width,
             height
         );
+        return position ? { position, edge: false } : null;
     }
 
     private calculateQuadrant(
@@ -493,8 +528,10 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
     }
 
     private removeDropTarget(): void {
+        // Always clear state — an `edge` cell sets state with no overlay element.
+        this._state = undefined;
+        this._edge = false;
         if (this.targetElement) {
-            this._state = undefined;
             this.targetElement.parentElement?.classList.remove(
                 'dv-drop-target'
             );

--- a/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
@@ -51,6 +51,7 @@ export class PointerDropTarget
     private _targetElement: HTMLElement | undefined;
     private _overlayElement: HTMLElement | undefined;
     private _state: Position | undefined;
+    private _edge = false;
     private _acceptedTargetZonesSet: Set<Position>;
 
     private readonly _onDrop = new Emitter<DroptargetEvent>();
@@ -140,7 +141,7 @@ export class PointerDropTarget
         const x = event.clientX - rect.left;
         const y = event.clientY - rect.top;
 
-        const quadrant = this._resolvePosition(
+        const resolved = this._resolvePosition(
             x,
             y,
             width,
@@ -148,10 +149,12 @@ export class PointerDropTarget
             event.pointerEvent
         );
 
-        if (quadrant === null) {
+        if (resolved === null) {
             this._removeOverlay();
             return;
         }
+
+        const quadrant = resolved.position;
 
         if (!this.options.canDisplayOverlay(event.pointerEvent, quadrant)) {
             if (overrideTarget) {
@@ -164,12 +167,23 @@ export class PointerDropTarget
         const willShow = new WillShowOverlayEvent({
             nativeEvent: event.pointerEvent,
             position: quadrant,
+            edge: resolved.edge,
         });
         this._onWillShowOverlay.fire(willShow);
         if (willShow.defaultPrevented) {
             this._removeOverlay();
             return;
         }
+
+        // An `edge` cell reports its position but renders nothing — the consumer
+        // (e.g. the layout-edge dock) owns the preview + commit.
+        if (resolved.edge) {
+            this._removeOverlay();
+            this._state = quadrant;
+            this._edge = true;
+            return;
+        }
+        this._edge = false;
 
         if (overrideTarget) {
             renderAnchoredOverlay({
@@ -220,6 +234,7 @@ export class PointerDropTarget
 
     private _onDropEvent(event: PointerDragEvent): void {
         const state = this._state;
+        const edge = this._edge;
         const overrideTarget = this.options.getOverrideTarget?.();
         this._removeOverlay();
         overrideTarget?.clear();
@@ -227,6 +242,7 @@ export class PointerDropTarget
             this._onDrop.fire({
                 position: state,
                 nativeEvent: event.pointerEvent,
+                edge,
             });
         }
     }
@@ -243,21 +259,23 @@ export class PointerDropTarget
         width: number,
         height: number,
         event: DragEvent | PointerEvent
-    ): Position | null {
+    ): { position: Position; edge: boolean } | null {
         const resolver = this.options.getPositionResolver?.();
         if (resolver) {
-            return (
-                resolver.resolve({
-                    x,
-                    y,
-                    width,
-                    height,
-                    zones: this._acceptedTargetZonesSet,
-                    event,
-                })?.position ?? null
-            );
+            const result = resolver.resolve({
+                x,
+                y,
+                width,
+                height,
+                zones: this._acceptedTargetZonesSet,
+                event,
+            });
+            return result
+                ? { position: result.position, edge: !!result.edge }
+                : null;
         }
-        return this._calculateQuadrant(x, y, width, height);
+        const position = this._calculateQuadrant(x, y, width, height);
+        return position ? { position, edge: false } : null;
     }
 
     private _calculateQuadrant(
@@ -292,6 +310,7 @@ export class PointerDropTarget
     }
 
     private _removeOverlay(): void {
+        this._edge = false;
         if (this._targetElement) {
             this._state = undefined;
             this._targetElement.parentElement?.classList.remove(

--- a/packages/dockview-core/src/dockview/components/panel/content.ts
+++ b/packages/dockview-core/src/dockview/components/panel/content.ts
@@ -11,7 +11,6 @@ import { DockviewComponent } from '../../dockviewComponent';
 import { Droptarget, IDropTarget, Position } from '../../../dnd/droptarget';
 import { pointerBackend } from '../../../dnd/backend';
 import { DockviewGroupPanelModel } from '../../dockviewGroupPanelModel';
-import { getPanelData } from '../../../dnd/dataTransfer';
 
 let _contentId = 0;
 /** Stable DOM id so each tab's `aria-controls` can reference its tabpanel. */
@@ -83,30 +82,7 @@ export class ContentContainer
         const canDisplayOverlay = (
             event: DragEvent | PointerEvent,
             position: Position
-        ): boolean => {
-            if (
-                this.group.locked === 'no-drop-target' ||
-                (this.group.locked && position === 'center')
-            ) {
-                return false;
-            }
-
-            const data = getPanelData();
-
-            if (
-                !data &&
-                event.shiftKey &&
-                this.group.location.type !== 'floating'
-            ) {
-                return false;
-            }
-
-            if (data && data.viewId === this.accessor.id) {
-                return true;
-            }
-
-            return this.group.canDisplayOverlay(event, position, 'content');
-        };
+        ): boolean => this.group.canDisplayContentOverlay(event, position);
 
         // `dropTarget` stays the concrete `Droptarget` (not via the backend
         // factory) because overlayRenderContainer forwards HTML5 drag events

--- a/packages/dockview-core/src/dockview/components/panel/content.ts
+++ b/packages/dockview-core/src/dockview/components/panel/content.ts
@@ -122,7 +122,7 @@ export class ContentContainer
             canDisplayOverlay,
             getOverrideTarget,
             overlayModel: this.accessor.resolveDropOverlayModel?.('content'),
-            getPositionResolver: () => accessor.options.dropPositionResolver,
+            getPositionResolver: () => accessor.getDropPositionResolver?.(),
         });
 
         this.pointerDropTarget = pointerBackend.createDropTarget(this.element, {
@@ -136,7 +136,7 @@ export class ContentContainer
             className: 'dv-drop-target-content',
             getOverrideTarget,
             overlayModel: this.accessor.resolveDropOverlayModel?.('content'),
-            getPositionResolver: () => accessor.options.dropPositionResolver,
+            getPositionResolver: () => accessor.getDropPositionResolver?.(),
         });
 
         this.addDisposables(

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -805,6 +805,22 @@ export class DockviewComponent
         return this.gridview.element;
     }
 
+    /** IDropGuideHost — the frame the content drop target measures (mirrors the
+     *  `getOverlayOutline` rule in `content.ts`): the whole group when
+     *  `dndPanelOverlay === 'group'`, else just the content. The compass paints
+     *  in this frame so its cells align with where a drop resolves. */
+    getDropOverlayElement(group: DockviewGroupPanel): HTMLElement | undefined {
+        const content = group.element.querySelector<HTMLElement>(
+            '.dv-content-container'
+        );
+        if (!content) {
+            return undefined;
+        }
+        return this.options.theme?.dndPanelOverlay === 'group'
+            ? (content.parentElement ?? content)
+            : content;
+    }
+
     /**
      * The drop-position resolver installed on the group content drop targets —
      * the app's `dropPositionResolver` option if set, else the Drop Guide

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -788,6 +788,37 @@ export class DockviewComponent
         return this._moduleRegistry.services.dropGuideService;
     }
 
+    /** IDropGuideHost — whether a content drop at `position` on `group` is
+     *  allowed, for compass cell gating (only legal cells are shown). Mirrors the
+     *  content drop target's `canDisplayOverlay` (`content.ts`): a same-component
+     *  drag is always allowed; otherwise the per-position veto decides. */
+    canDropOnGroup(
+        group: DockviewGroupPanel,
+        position: Position,
+        event: DragEvent | PointerEvent
+    ): boolean {
+        const model = group.model;
+        if (
+            model.locked === 'no-drop-target' ||
+            (model.locked && position === 'center')
+        ) {
+            return false;
+        }
+        const data = getPanelData();
+        if (!data && event.shiftKey && model.location.type !== 'floating') {
+            return false;
+        }
+        if (data && data.viewId === this.id) {
+            return true;
+        }
+        return model.canDisplayOverlay(event, position, 'content');
+    }
+
+    /** IDropGuideHost — the layout root, the outer-cell edge preview's surface. */
+    getLayoutElement(): HTMLElement {
+        return this.gridview.element;
+    }
+
     /**
      * The drop-position resolver installed on the group content drop targets —
      * the app's `dropPositionResolver` option if set, else the Drop Guide

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -789,29 +789,15 @@ export class DockviewComponent
     }
 
     /** IDropGuideHost — whether a content drop at `position` on `group` is
-     *  allowed, for compass cell gating (only legal cells are shown). Mirrors the
-     *  content drop target's `canDisplayOverlay` (`content.ts`): a same-component
-     *  drag is always allowed; otherwise the per-position veto decides. */
+     *  allowed, for compass cell gating (only legal cells are shown). The same
+     *  predicate the content drop target uses, so the compass and the real drop
+     *  agree. */
     canDropOnGroup(
         group: DockviewGroupPanel,
         position: Position,
         event: DragEvent | PointerEvent
     ): boolean {
-        const model = group.model;
-        if (
-            model.locked === 'no-drop-target' ||
-            (model.locked && position === 'center')
-        ) {
-            return false;
-        }
-        const data = getPanelData();
-        if (!data && event.shiftKey && model.location.type !== 'floating') {
-            return false;
-        }
-        if (data && data.viewId === this.id) {
-            return true;
-        }
-        return model.canDisplayOverlay(event, position, 'content');
+        return group.model.canDisplayContentOverlay(event, position);
     }
 
     /** IDropGuideHost — the layout root, the outer-cell edge preview's surface. */

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -801,6 +801,60 @@ export class DockviewComponent
         );
     }
 
+    /**
+     * Dock the dragged item against the whole-layout edge at `position` (the
+     * orthogonalized root group), as the layout-edge drop zones do. Shared by
+     * the root drop target and by an `edge`-flagged drop on a group content
+     * target (a position resolver that marks an outer "dock to the layout edge"
+     * cell). No-op when there is no active drag data.
+     */
+    dockToLayoutEdge(
+        nativeEvent: DragEvent | PointerEvent,
+        position: Position
+    ): void {
+        const willDropEvent = new DockviewWillDropEvent({
+            nativeEvent,
+            position,
+            panel: undefined,
+            api: this._api,
+            group: undefined,
+            getData: getPanelData,
+            kind: 'edge',
+        });
+
+        this._onWillDrop.fire(willDropEvent);
+
+        if (willDropEvent.defaultPrevented) {
+            return;
+        }
+
+        const data = getPanelData();
+
+        if (data) {
+            this.moveGroupOrPanel({
+                from: {
+                    groupId: data.groupId,
+                    panelId: data.panelId ?? undefined,
+                },
+                to: {
+                    group: this.orthogonalize(position),
+                    position: 'center',
+                },
+            });
+        } else {
+            this._onDidDrop.fire(
+                new DockviewDidDropEvent({
+                    nativeEvent,
+                    position,
+                    panel: undefined,
+                    api: this._api,
+                    group: undefined,
+                    getData: getPanelData,
+                })
+            );
+        }
+    }
+
     get headerActionsService() {
         return this._moduleRegistry.services.headerActionsService;
     }
@@ -1295,49 +1349,9 @@ export class DockviewComponent
                         })
                     );
                 }),
-                rootDropTarget.onDrop((event) => {
-                    const willDropEvent = new DockviewWillDropEvent({
-                        nativeEvent: event.nativeEvent,
-                        position: event.position,
-                        panel: undefined,
-                        api: this._api,
-                        group: undefined,
-                        getData: getPanelData,
-                        kind: 'edge',
-                    });
-
-                    this._onWillDrop.fire(willDropEvent);
-
-                    if (willDropEvent.defaultPrevented) {
-                        return;
-                    }
-
-                    const data = getPanelData();
-
-                    if (data) {
-                        this.moveGroupOrPanel({
-                            from: {
-                                groupId: data.groupId,
-                                panelId: data.panelId ?? undefined,
-                            },
-                            to: {
-                                group: this.orthogonalize(event.position),
-                                position: 'center',
-                            },
-                        });
-                    } else {
-                        this._onDidDrop.fire(
-                            new DockviewDidDropEvent({
-                                nativeEvent: event.nativeEvent,
-                                position: event.position,
-                                panel: undefined,
-                                api: this._api,
-                                group: undefined,
-                                getData: getPanelData,
-                            })
-                        );
-                    }
-                })
+                rootDropTarget.onDrop((event) =>
+                    this.dockToLayoutEdge(event.nativeEvent, event.position)
+                )
             );
         }
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -800,11 +800,6 @@ export class DockviewComponent
         return group.model.canDisplayContentOverlay(event, position);
     }
 
-    /** IDropGuideHost — the layout root, the outer-cell edge preview's surface. */
-    getLayoutElement(): HTMLElement {
-        return this.gridview.element;
-    }
-
     /** IDropGuideHost — the frame the content drop target measures (mirrors the
      *  `getOverlayOutline` rule in `content.ts`): the whole group when
      *  `dndPanelOverlay === 'group'`, else just the content. The compass paints

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -816,6 +816,12 @@ export class DockviewComponent
             : content;
     }
 
+    /** IDropGuideHost — the layout root (`.dv-dockview`, a positioned element),
+     *  the surface the outer-cell landing preview is drawn over. */
+    getLayoutElement(): HTMLElement {
+        return this.gridview.element;
+    }
+
     /**
      * The drop-position resolver installed on the group content drop targets —
      * the app's `dropPositionResolver` option if set, else the Drop Guide

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -11,6 +11,7 @@ import {
     directionToPosition,
     DroptargetOverlayModel,
     Position,
+    PositionResolver,
 } from '../dnd/droptarget';
 import { tail, sequenceEquals } from '../array';
 import { DockviewPanel, IDockviewPanel } from './dockviewPanel';
@@ -90,6 +91,7 @@ import {
     IAdvancedDnDHost,
     IContextMenuHost,
     IContextMenuService,
+    IDropGuideHost,
     ILayoutHistoryHost,
     LayoutHistoryChangeEvent,
     ITabGroupChipsHost,
@@ -491,7 +493,8 @@ export class DockviewComponent
         IAdvancedDnDHost,
         ILiveRegionHost,
         IAccessibilityHost,
-        ILayoutHistoryHost
+        ILayoutHistoryHost,
+        IDropGuideHost
 {
     private readonly nextGroupId = sequentialNumberGenerator();
     private readonly _deserializer = new DefaultDockviewDeserialzier(this);
@@ -779,6 +782,23 @@ export class DockviewComponent
         // AllModules. Absent ⇒ the onWill* hooks simply don't fire (≡ no
         // subscriber), which is invisible to apps not customising DnD.
         return this._moduleRegistry.services.advancedDnDService;
+    }
+
+    private get _dropGuideService() {
+        return this._moduleRegistry.services.dropGuideService;
+    }
+
+    /**
+     * The drop-position resolver installed on the group content drop targets —
+     * the app's `dropPositionResolver` option if set, else the Drop Guide
+     * module's compass resolver (undefined when the compass is disabled). Read
+     * live by the content drop targets; undefined ⇒ default cursor-quadrant.
+     */
+    getDropPositionResolver(): PositionResolver | undefined {
+        return (
+            this.options.dropPositionResolver ??
+            this._dropGuideService?.resolver
+        );
     }
 
     get headerActionsService() {

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1710,6 +1710,36 @@ export class DockviewGroupPanelModel
         return firedEvent.isAccepted;
     }
 
+    /**
+     * Whether a content drop at `position` is allowed: the locked rules, the
+     * shift-to-not-drop gesture, the same-component shortcut, then the
+     * `canDisplayOverlay` veto. The single source of truth for the content drop
+     * target (`content.ts`) and the compass cell gating (`canDropOnGroup`).
+     */
+    canDisplayContentOverlay(
+        event: DragEvent | PointerEvent,
+        position: Position
+    ): boolean {
+        if (
+            this.locked === 'no-drop-target' ||
+            (this.locked && position === 'center')
+        ) {
+            return false;
+        }
+
+        const data = getPanelData();
+
+        if (!data && event.shiftKey && this.location.type !== 'floating') {
+            return false;
+        }
+
+        if (data && data.viewId === this.accessor.id) {
+            return true;
+        }
+
+        return this.canDisplayOverlay(event, position, 'content');
+    }
+
     private handleDropEvent(
         type: 'header' | 'content',
         event: DragEvent | PointerEvent,

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -611,14 +611,18 @@ export class DockviewGroupPanelModel
                 this.handleDropEvent(
                     'content',
                     event.nativeEvent,
-                    event.position
+                    event.position,
+                    undefined,
+                    event.edge
                 );
             }),
             this.contentContainer.pointerDropTarget.onDrop((event) => {
                 this.handleDropEvent(
                     'content',
                     event.nativeEvent,
-                    event.position
+                    event.position,
+                    undefined,
+                    event.edge
                 );
             }),
             this.tabsContainer.onWillShowOverlay((event) => {
@@ -1710,9 +1714,17 @@ export class DockviewGroupPanelModel
         type: 'header' | 'content',
         event: DragEvent | PointerEvent,
         position: Position,
-        index?: number
+        index?: number,
+        edge?: boolean
     ): void {
         if (this.locked === 'no-drop-target') {
+            return;
+        }
+
+        // An `edge` content drop (a resolver's outer "dock to the layout edge"
+        // cell) docks against the whole layout, not this group.
+        if (type === 'content' && edge) {
+            this.accessor.dockToLayoutEdge(event, position);
             return;
         }
 

--- a/packages/dockview-core/src/dockview/events.ts
+++ b/packages/dockview-core/src/dockview/events.ts
@@ -45,6 +45,12 @@ export class DockviewWillShowOverlayLocationEvent implements IDockviewEvent {
         return this.event.position;
     }
 
+    /** The resolved cell was marked `edge` (an outer "dock to the whole layout"
+     *  cell). See {@link DroptargetEvent.edge}. */
+    get edge(): boolean {
+        return this.event.edge;
+    }
+
     get defaultPrevented(): boolean {
         return this.event.defaultPrevented;
     }

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -6,7 +6,11 @@
  */
 import { IDisposable } from '../lifecycle';
 import { Event } from '../events';
-import { DroptargetOverlayModel, Position } from '../dnd/droptarget';
+import {
+    DroptargetOverlayModel,
+    Position,
+    PositionResolver,
+} from '../dnd/droptarget';
 import { IDragGhostSpec } from '../dnd/backend';
 import { DockviewApi } from '../api/component.api';
 import { DockviewGroupPanel } from './dockviewGroupPanel';
@@ -244,4 +248,32 @@ export interface ILayoutHistoryService extends IDisposable {
     redo(): void;
     /** Drop both stacks (e.g. on document switch). */
     clear(): void;
+}
+
+// --- DropGuide ---
+
+/**
+ * The narrow surface the Drop Guide ("compass") service needs from the host
+ * (`DockviewComponent`). The service owns the compass widget + the cell
+ * hit-test resolver; the component installs that resolver at the drop-target
+ * seam (`dropPositionResolver`) and surfaces the drag-over signal the widget
+ * follows. It never re-implements drop resolution or the commit path.
+ */
+export interface IDropGuideHost {
+    readonly options: DockviewComponentOptions;
+    /**
+     * Fires on each drag-over with the hovered group + native event — the
+     * signal the compass widget mounts/follows. The service filters for
+     * `kind === 'content'`.
+     */
+    readonly onWillShowOverlay: Event<DockviewWillShowOverlayLocationEvent>;
+}
+
+export interface IDropGuideService extends IDisposable {
+    /**
+     * The cell hit-test resolver, installed by the host at the drop-target seam
+     * in place of the default cursor-quadrant logic — or `undefined` when the
+     * compass is disabled (`dndGuide` unset), so the default behaviour runs.
+     */
+    readonly resolver: PositionResolver | undefined;
 }

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -284,6 +284,9 @@ export interface IDropGuideHost {
      * actually resolves, not a different box.
      */
     getDropOverlayElement(group: DockviewGroupPanel): HTMLElement | undefined;
+    /** The layout root element — the (positioned) surface the outer-cell
+     *  landing preview is drawn over (where a whole-layout-edge dock lands). */
+    getLayoutElement(): HTMLElement;
 }
 
 export interface IDropGuideService extends IDisposable {

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -267,6 +267,19 @@ export interface IDropGuideHost {
      * `kind === 'content'`.
      */
     readonly onWillShowOverlay: Event<DockviewWillShowOverlayLocationEvent>;
+    /**
+     * Whether a drop at `position` on `group`'s content is actually allowed
+     * (the per-position `canDisplayOverlay` veto) — used to gate which compass
+     * cells are shown, so only legal drops appear.
+     */
+    canDropOnGroup(
+        group: DockviewGroupPanel,
+        position: Position,
+        event: DragEvent | PointerEvent
+    ): boolean;
+    /** The layout root element — the surface the outer-cell edge preview is
+     *  drawn over (its coordinate space). */
+    getLayoutElement(): HTMLElement;
 }
 
 export interface IDropGuideService extends IDisposable {

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -280,6 +280,13 @@ export interface IDropGuideHost {
     /** The layout root element — the surface the outer-cell edge preview is
      *  drawn over (its coordinate space). */
     getLayoutElement(): HTMLElement;
+    /**
+     * The element the content drop target measures its quadrants against (the
+     * `dndPanelOverlay` outline — the whole group, or just its content). The
+     * compass paints its cells in this frame so they line up with where a drop
+     * actually resolves, not a different box.
+     */
+    getDropOverlayElement(group: DockviewGroupPanel): HTMLElement | undefined;
 }
 
 export interface IDropGuideService extends IDisposable {

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -277,9 +277,6 @@ export interface IDropGuideHost {
         position: Position,
         event: DragEvent | PointerEvent
     ): boolean;
-    /** The layout root element — the surface the outer-cell edge preview is
-     *  drawn over (its coordinate space). */
-    getLayoutElement(): HTMLElement;
     /**
      * The element the content drop target measures its quadrants against (the
      * `dndPanelOverlay` outline — the whole group, or just its content). The

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -21,6 +21,7 @@ import {
     IAccessibilityService,
     IAdvancedDnDService,
     IContextMenuService,
+    IDropGuideService,
     IKeyboardDockingService,
     ILayoutHistoryService,
     ITabGroupChipsService,
@@ -40,6 +41,7 @@ export interface ServiceCollection {
     accessibilityService?: IAccessibilityService;
     keyboardDockingService?: IKeyboardDockingService;
     layoutHistoryService?: ILayoutHistoryService;
+    dropGuideService?: IDropGuideService;
 }
 
 export interface DockviewModule<THost = unknown> {

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -260,9 +260,10 @@ export interface DockviewOptions {
      * Show an aim-at-a-cell "compass" drop guide over a group while dragging,
      * instead of resolving the drop by which quadrant the cursor is in. Default
      * off ⇒ the cursor-quadrant behaviour, unchanged. Provided by the Drop Guide
-     * module. Pass an object to restrict which inner cells appear (`zones`).
+     * module. Pass an object to restrict which inner cells appear (`zones`) or to
+     * hide the outer whole-layout-edge cells (`edges: false`, default on).
      */
-    dndGuide?: boolean | { zones?: Position[] };
+    dndGuide?: boolean | { zones?: Position[]; edges?: boolean };
     // #end dnd
     locked?: boolean;
     className?: string;

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -256,6 +256,13 @@ export interface DockviewOptions {
      * {@link DockviewApi.updateOptions}.
      */
     dropPositionResolver?: PositionResolver;
+    /**
+     * Show an aim-at-a-cell "compass" drop guide over a group while dragging,
+     * instead of resolving the drop by which quadrant the cursor is in. Default
+     * off ⇒ the cursor-quadrant behaviour, unchanged. Provided by the Drop Guide
+     * module. Pass an object to restrict which inner cells appear (`zones`).
+     */
+    dndGuide?: boolean | { zones?: Position[] };
     // #end dnd
     locked?: boolean;
     className?: string;
@@ -479,6 +486,7 @@ export const PROPERTY_KEYS_DOCKVIEW: (keyof DockviewOptions)[] = (() => {
         noPanelsOverlay: undefined,
         dndEdges: undefined,
         dropPositionResolver: undefined,
+        dndGuide: undefined,
         theme: undefined,
         disableTabsOverflowList: undefined,
         scrollbars: undefined,

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -199,6 +199,8 @@ export {
     IAdvancedDnDService,
     IContextMenuHost,
     IContextMenuService,
+    IDropGuideHost,
+    IDropGuideService,
     IKeyboardDockingService,
     ILayoutHistoryHost,
     ILayoutHistoryService,

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -45,14 +45,50 @@ describe('drop guide', () => {
 
     // 200x100 target: centre cell ≈ x[81,119] y[31,69]; left ≈ x[39,77];
     // right ≈ x[123,161]; top ≈ y[-11,27]; bottom ≈ y[73,111] (all x[81,119]).
-    test('hit-tests the pointer against the compass cells', () => {
+    test('hit-tests the pointer against the inner compass cells', () => {
         make(true);
         const r = service.resolver!;
-        expect(r.resolve(args(100, 50))).toEqual({ position: 'center' });
-        expect(r.resolve(args(58, 50))).toEqual({ position: 'left' });
-        expect(r.resolve(args(140, 50))).toEqual({ position: 'right' });
-        expect(r.resolve(args(100, 10))).toEqual({ position: 'top' });
-        expect(r.resolve(args(100, 90))).toEqual({ position: 'bottom' });
+        expect(r.resolve(args(100, 50))).toEqual({
+            position: 'center',
+            edge: false,
+        });
+        expect(r.resolve(args(58, 50))).toEqual({
+            position: 'left',
+            edge: false,
+        });
+        expect(r.resolve(args(140, 50))).toEqual({
+            position: 'right',
+            edge: false,
+        });
+        expect(r.resolve(args(100, 10))).toEqual({
+            position: 'top',
+            edge: false,
+        });
+        expect(r.resolve(args(100, 90))).toEqual({
+            position: 'bottom',
+            edge: false,
+        });
+    });
+
+    // 400x400 target: outer top cell ≈ x[181,219] y[97,135] (one ring beyond
+    // the inner top), flagged `edge` to dock against the whole layout.
+    test('outer cells resolve with the edge flag', () => {
+        make(true);
+        expect(
+            service.resolver!.resolve(args(200, 110, undefined, 400, 400))
+        ).toEqual({ position: 'top', edge: true });
+    });
+
+    test('`edges: false` hides the outer cells', () => {
+        make({ edges: false });
+        // the outer-top point is no longer a cell
+        expect(
+            service.resolver!.resolve(args(200, 110, undefined, 400, 400))
+        ).toBeNull();
+        // ...but the inner ring still resolves
+        expect(
+            service.resolver!.resolve(args(200, 200, undefined, 400, 400))
+        ).toEqual({ position: 'center', edge: false });
     });
 
     test('a dead corner (no cell) resolves to null', () => {
@@ -66,15 +102,17 @@ describe('drop guide', () => {
         expect(service.resolver!.resolve(args(58, 50, ['center']))).toBeNull();
         expect(service.resolver!.resolve(args(100, 50, ['center']))).toEqual({
             position: 'center',
+            edge: false,
         });
     });
 
-    test('`dndGuide.zones` restricts which cells the compass offers', () => {
+    test('`dndGuide.zones` restricts which inner cells the compass offers', () => {
         make({ zones: ['center'] });
         // left is in the target's zones but excluded by the option
         expect(service.resolver!.resolve(args(58, 50))).toBeNull();
         expect(service.resolver!.resolve(args(100, 50))).toEqual({
             position: 'center',
+            edge: false,
         });
     });
 
@@ -108,7 +146,11 @@ describe('drop guide', () => {
 
         const guide = content.querySelector('.dv-drop-guide');
         expect(guide).toBeTruthy();
-        expect(content.querySelectorAll('.dv-drop-guide-cell')).toHaveLength(5);
+        // 5 inner cells + 4 outer (edge) cells
+        expect(content.querySelectorAll('.dv-drop-guide-cell')).toHaveLength(9);
+        expect(
+            content.querySelectorAll('.dv-drop-guide-cell-edge')
+        ).toHaveLength(4);
 
         // the drag ending tears the widget down
         window.dispatchEvent(new Event('pointerup'));

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -1,0 +1,136 @@
+import { DockviewEmitter as Emitter } from 'dockview-core';
+import {
+    DockviewGroupPanel,
+    DockviewWillShowOverlayLocationEvent,
+    Position,
+    PositionResolverArgs,
+} from 'dockview-core';
+import { DropGuideService } from '../dropGuideService';
+
+/**
+ * Drop Guide ("compass") — Phase 1. The cell hit-test is pure geometry
+ * (container-relative px) so it's driven directly; the widget lifecycle is
+ * driven via a mock `onWillShowOverlay` host signal.
+ */
+describe('drop guide', () => {
+    let overlayEmitter: Emitter<DockviewWillShowOverlayLocationEvent>;
+    let service: DropGuideService;
+
+    const make = (
+        dndGuide: { zones?: Position[] } | boolean | undefined
+    ): void => {
+        overlayEmitter = new Emitter<DockviewWillShowOverlayLocationEvent>();
+        service = new DropGuideService({
+            options: { dndGuide } as any,
+            onWillShowOverlay: overlayEmitter.event,
+        });
+    };
+
+    const args = (
+        x: number,
+        y: number,
+        zones: Position[] = ['top', 'bottom', 'left', 'right', 'center'],
+        width = 200,
+        height = 100
+    ): PositionResolverArgs => ({
+        x,
+        y,
+        width,
+        height,
+        zones: new Set(zones),
+        event: {} as any,
+    });
+
+    afterEach(() => service?.dispose());
+
+    // 200x100 target: centre cell ≈ x[81,119] y[31,69]; left ≈ x[39,77];
+    // right ≈ x[123,161]; top ≈ y[-11,27]; bottom ≈ y[73,111] (all x[81,119]).
+    test('hit-tests the pointer against the compass cells', () => {
+        make(true);
+        const r = service.resolver!;
+        expect(r.resolve(args(100, 50))).toEqual({ position: 'center' });
+        expect(r.resolve(args(58, 50))).toEqual({ position: 'left' });
+        expect(r.resolve(args(140, 50))).toEqual({ position: 'right' });
+        expect(r.resolve(args(100, 10))).toEqual({ position: 'top' });
+        expect(r.resolve(args(100, 90))).toEqual({ position: 'bottom' });
+    });
+
+    test('a dead corner (no cell) resolves to null', () => {
+        make(true);
+        expect(service.resolver!.resolve(args(10, 10))).toBeNull();
+    });
+
+    test("honours the target's accepted zones", () => {
+        make(true);
+        // left cell is not offered when the target only accepts center
+        expect(service.resolver!.resolve(args(58, 50, ['center']))).toBeNull();
+        expect(service.resolver!.resolve(args(100, 50, ['center']))).toEqual({
+            position: 'center',
+        });
+    });
+
+    test('`dndGuide.zones` restricts which cells the compass offers', () => {
+        make({ zones: ['center'] });
+        // left is in the target's zones but excluded by the option
+        expect(service.resolver!.resolve(args(58, 50))).toBeNull();
+        expect(service.resolver!.resolve(args(100, 50))).toEqual({
+            position: 'center',
+        });
+    });
+
+    test('the resolver is absent when `dndGuide` is unset (default quadrant)', () => {
+        make(undefined);
+        expect(service.resolver).toBeUndefined();
+    });
+
+    // --- widget lifecycle ---
+
+    const groupWithContent = (): {
+        group: DockviewGroupPanel;
+        content: HTMLElement;
+    } => {
+        const content = document.createElement('div');
+        content.className = 'dv-content-container';
+        const element = document.createElement('div');
+        element.appendChild(content);
+        document.body.appendChild(element);
+        return { group: { element } as DockviewGroupPanel, content };
+    };
+
+    test('paints the compass over the hovered group, torn down on drop', () => {
+        make(true);
+        const { group, content } = groupWithContent();
+
+        overlayEmitter.fire({
+            kind: 'content',
+            group,
+        } as DockviewWillShowOverlayLocationEvent);
+
+        const guide = content.querySelector('.dv-drop-guide');
+        expect(guide).toBeTruthy();
+        expect(content.querySelectorAll('.dv-drop-guide-cell')).toHaveLength(5);
+
+        // the drag ending tears the widget down
+        window.dispatchEvent(new Event('pointerup'));
+        expect(content.querySelector('.dv-drop-guide')).toBeNull();
+    });
+
+    test('does not paint a non-content overlay or when disabled', () => {
+        make(true);
+        const { group, content } = groupWithContent();
+        // a tab/header overlay is not the compass target
+        overlayEmitter.fire({
+            kind: 'tab',
+            group,
+        } as DockviewWillShowOverlayLocationEvent);
+        expect(content.querySelector('.dv-drop-guide')).toBeNull();
+
+        make(undefined);
+        const off = groupWithContent();
+        overlayEmitter.fire({
+            kind: 'content',
+            group: off.group,
+        } as DockviewWillShowOverlayLocationEvent);
+        expect(off.content.querySelector('.dv-drop-guide')).toBeNull();
+    });
+});

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -17,6 +17,7 @@ describe('drop guide', () => {
     let service: DropGuideService;
     let layoutEl: HTMLElement;
     let canDrop: (position: Position) => boolean;
+    let dropOverlayEl: (group: DockviewGroupPanel) => HTMLElement | undefined;
 
     const make = (
         dndGuide: { zones?: Position[]; edges?: boolean } | boolean | undefined
@@ -25,11 +26,17 @@ describe('drop guide', () => {
         layoutEl = document.createElement('div');
         document.body.appendChild(layoutEl);
         canDrop = () => true;
+        // the drop target measures the content container by default
+        dropOverlayEl = (group) =>
+            group.element.querySelector<HTMLElement>('.dv-content-container') ??
+            undefined;
         service = new DropGuideService({
             options: { dndGuide } as any,
             onWillShowOverlay: overlayEmitter.event,
             canDropOnGroup: (_group, position) => canDrop(position),
             getLayoutElement: () => layoutEl,
+            getDropOverlayElement: (group: DockviewGroupPanel) =>
+                dropOverlayEl(group),
         });
     };
 
@@ -162,6 +169,38 @@ describe('drop guide', () => {
         // the drag ending tears the widget down
         window.dispatchEvent(new Event('pointerup'));
         expect(content.querySelector('.dv-drop-guide')).toBeNull();
+    });
+
+    test('paints cells in the drop-target outline frame, translated into its box', () => {
+        make(true);
+        const { group, content } = groupWithContent();
+        // the drop target measures a frame offset from the content the widget
+        // mounts in (e.g. dndPanelOverlay: 'group' includes the tab header).
+        const outline = document.createElement('div');
+        jest.spyOn(outline, 'getBoundingClientRect').mockReturnValue({
+            left: 10,
+            top: 40,
+            width: 200,
+            height: 100,
+            right: 210,
+            bottom: 140,
+            x: 10,
+            y: 40,
+            toJSON: () => ({}),
+        } as DOMRect);
+        dropOverlayEl = () => outline;
+
+        overlayEmitter.fire({
+            kind: 'content',
+            group,
+        } as DockviewWillShowOverlayLocationEvent);
+
+        // centre cell: (200/2 - 19) + dx(10), (100/2 - 19) + dy(40)
+        const center = content.querySelector<HTMLElement>(
+            '.dv-drop-guide-cell-center'
+        )!;
+        expect(center.style.left).toBe('91px');
+        expect(center.style.top).toBe('71px');
     });
 
     test('per-cell gating hides cells the drop would reject', () => {

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -18,6 +18,7 @@ describe('drop guide', () => {
     let canDrop: (position: Position) => boolean;
     let dropOverlayEl: (group: DockviewGroupPanel) => HTMLElement | undefined;
     let layoutEl: HTMLElement;
+    let gateCalls: Position[];
 
     const make = (
         dndGuide: { zones?: Position[]; edges?: boolean } | boolean | undefined
@@ -26,6 +27,7 @@ describe('drop guide', () => {
         layoutEl = document.createElement('div');
         document.body.appendChild(layoutEl);
         canDrop = () => true;
+        gateCalls = [];
         // the drop target measures the content container by default
         dropOverlayEl = (group) =>
             group.element.querySelector<HTMLElement>('.dv-content-container') ??
@@ -33,7 +35,10 @@ describe('drop guide', () => {
         service = new DropGuideService({
             options: { dndGuide } as any,
             onWillShowOverlay: overlayEmitter.event,
-            canDropOnGroup: (_group, position) => canDrop(position),
+            canDropOnGroup: (_group, position) => {
+                gateCalls.push(position);
+                return canDrop(position);
+            },
             getDropOverlayElement: (group: DockviewGroupPanel) =>
                 dropOverlayEl(group),
             getLayoutElement: () => layoutEl,
@@ -275,6 +280,20 @@ describe('drop guide', () => {
         expect(
             layoutEl.querySelector('.dv-drop-guide-edge-preview')
         ).toBeNull();
+    });
+
+    test('queries the drop veto at most once per direction (no per-cell fan-out)', () => {
+        make(true);
+        const { group } = groupWithContent();
+        overlayEmitter.fire({
+            kind: 'content',
+            group,
+        } as DockviewWillShowOverlayLocationEvent);
+
+        // 9 cells but inner+outer of a direction share a position — the veto
+        // (which can fire onUnhandledDragOver) must run at most once per position.
+        expect(gateCalls.length).toBe(new Set(gateCalls).size);
+        expect(gateCalls.length).toBeLessThanOrEqual(5);
     });
 
     test('per-cell gating hides cells the drop would reject', () => {

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -230,6 +230,22 @@ describe('drop guide', () => {
         expect(active[0].classList).toContain('dv-drop-guide-cell-center');
     });
 
+    test('no orphan edge preview when the group has no content container', () => {
+        make(true);
+        const element = document.createElement('div'); // no .dv-content-container
+        document.body.appendChild(element);
+        overlayEmitter.fire({
+            kind: 'content',
+            group: { element } as DockviewGroupPanel,
+            edge: true,
+            position: 'right',
+        } as DockviewWillShowOverlayLocationEvent);
+        // the compass never mounted, so nothing should be drawn anywhere
+        expect(
+            layoutEl.querySelector('.dv-drop-guide-edge-preview')
+        ).toBeNull();
+    });
+
     test('an outer cell previews the layout-edge landing region', () => {
         make(true);
         const { group } = groupWithContent();

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -8,21 +8,28 @@ import {
 import { DropGuideService } from '../dropGuideService';
 
 /**
- * Drop Guide ("compass") — Phase 1. The cell hit-test is pure geometry
- * (container-relative px) so it's driven directly; the widget lifecycle is
+ * Drop Guide ("compass"). The cell hit-test is pure geometry (container-relative
+ * px) so it's driven directly; the widget + edge-preview + gating lifecycle is
  * driven via a mock `onWillShowOverlay` host signal.
  */
 describe('drop guide', () => {
     let overlayEmitter: Emitter<DockviewWillShowOverlayLocationEvent>;
     let service: DropGuideService;
+    let layoutEl: HTMLElement;
+    let canDrop: (position: Position) => boolean;
 
     const make = (
-        dndGuide: { zones?: Position[] } | boolean | undefined
+        dndGuide: { zones?: Position[]; edges?: boolean } | boolean | undefined
     ): void => {
         overlayEmitter = new Emitter<DockviewWillShowOverlayLocationEvent>();
+        layoutEl = document.createElement('div');
+        document.body.appendChild(layoutEl);
+        canDrop = () => true;
         service = new DropGuideService({
             options: { dndGuide } as any,
             onWillShowOverlay: overlayEmitter.event,
+            canDropOnGroup: (_group, position) => canDrop(position),
+            getLayoutElement: () => layoutEl,
         });
     };
 
@@ -155,6 +162,52 @@ describe('drop guide', () => {
         // the drag ending tears the widget down
         window.dispatchEvent(new Event('pointerup'));
         expect(content.querySelector('.dv-drop-guide')).toBeNull();
+    });
+
+    test('per-cell gating hides cells the drop would reject', () => {
+        make(true);
+        const { group, content } = groupWithContent();
+        canDrop = (p) => p !== 'center'; // the group rejects a tab-into
+
+        overlayEmitter.fire({
+            kind: 'content',
+            group,
+        } as DockviewWillShowOverlayLocationEvent);
+
+        // centre inner cell hidden → 4 inner + 4 outer; edge cells are unaffected
+        expect(content.querySelectorAll('.dv-drop-guide-cell')).toHaveLength(8);
+        expect(content.querySelector('.dv-drop-guide-cell-center')).toBeNull();
+    });
+
+    test('an outer cell previews the layout edge, cleared on inner / drop', () => {
+        make(true);
+        const { group } = groupWithContent();
+        const over = (edge: boolean, position: Position) =>
+            overlayEmitter.fire({
+                kind: 'content',
+                group,
+                edge,
+                position,
+            } as DockviewWillShowOverlayLocationEvent);
+
+        over(true, 'right'); // outer cell → a band over the layout's right edge
+        const band = layoutEl.querySelector<HTMLElement>(
+            '.dv-drop-guide-edge-preview'
+        );
+        expect(band).toBeTruthy();
+        expect(band!.style.width).toBe('50%');
+        expect(band!.style.height).toBe('100%');
+
+        over(false, 'center'); // inner cell → cleared
+        expect(
+            layoutEl.querySelector('.dv-drop-guide-edge-preview')
+        ).toBeNull();
+
+        over(true, 'top'); // re-show, then end the drag → cleared
+        window.dispatchEvent(new Event('pointerup'));
+        expect(
+            layoutEl.querySelector('.dv-drop-guide-edge-preview')
+        ).toBeNull();
     });
 
     test('does not paint a non-content overlay or when disabled', () => {

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -17,11 +17,14 @@ describe('drop guide', () => {
     let service: DropGuideService;
     let canDrop: (position: Position) => boolean;
     let dropOverlayEl: (group: DockviewGroupPanel) => HTMLElement | undefined;
+    let layoutEl: HTMLElement;
 
     const make = (
         dndGuide: { zones?: Position[]; edges?: boolean } | boolean | undefined
     ): void => {
         overlayEmitter = new Emitter<DockviewWillShowOverlayLocationEvent>();
+        layoutEl = document.createElement('div');
+        document.body.appendChild(layoutEl);
         canDrop = () => true;
         // the drop target measures the content container by default
         dropOverlayEl = (group) =>
@@ -33,6 +36,7 @@ describe('drop guide', () => {
             canDropOnGroup: (_group, position) => canDrop(position),
             getDropOverlayElement: (group: DockviewGroupPanel) =>
                 dropOverlayEl(group),
+            getLayoutElement: () => layoutEl,
         });
     };
 
@@ -224,6 +228,37 @@ describe('drop guide', () => {
         const active = content.querySelectorAll('.dv-drop-guide-cell-active');
         expect(active).toHaveLength(1);
         expect(active[0].classList).toContain('dv-drop-guide-cell-center');
+    });
+
+    test('an outer cell previews the layout-edge landing region', () => {
+        make(true);
+        const { group } = groupWithContent();
+        const over = (edge: boolean, position: Position) =>
+            overlayEmitter.fire({
+                kind: 'content',
+                group,
+                edge,
+                position,
+            } as DockviewWillShowOverlayLocationEvent);
+
+        over(true, 'right'); // outer-right → the layout's right-half region
+        const band = layoutEl.querySelector<HTMLElement>(
+            '.dv-drop-guide-edge-preview'
+        );
+        expect(band).toBeTruthy();
+        expect(band!.style.width).toBe('50%');
+        expect(band!.style.height).toBe('100%');
+
+        over(false, 'center'); // inner cell → preview cleared
+        expect(
+            layoutEl.querySelector('.dv-drop-guide-edge-preview')
+        ).toBeNull();
+
+        over(true, 'top'); // re-show, then end the drag → cleared
+        window.dispatchEvent(new Event('pointerup'));
+        expect(
+            layoutEl.querySelector('.dv-drop-guide-edge-preview')
+        ).toBeNull();
     });
 
     test('per-cell gating hides cells the drop would reject', () => {

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -199,6 +199,33 @@ describe('drop guide', () => {
         expect(center.style.top).toBe('71px');
     });
 
+    test('highlights the aimed cell (the only feedback for an outer cell)', () => {
+        make(true);
+        const { group, content } = groupWithContent();
+        const over = (edge: boolean, position: Position) =>
+            overlayEmitter.fire({
+                kind: 'content',
+                group,
+                edge,
+                position,
+            } as DockviewWillShowOverlayLocationEvent);
+
+        over(true, 'right'); // outer-right cell
+        expect(
+            content.querySelector(
+                '.dv-drop-guide-cell-right.dv-drop-guide-cell-edge.dv-drop-guide-cell-active'
+            )
+        ).toBeTruthy();
+        expect(
+            content.querySelectorAll('.dv-drop-guide-cell-active')
+        ).toHaveLength(1);
+
+        over(false, 'center'); // moves to the inner centre — only it is active
+        const active = content.querySelectorAll('.dv-drop-guide-cell-active');
+        expect(active).toHaveLength(1);
+        expect(active[0].classList).toContain('dv-drop-guide-cell-center');
+    });
+
     test('per-cell gating hides cells the drop would reject', () => {
         make(true);
         const { group, content } = groupWithContent();

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -220,6 +220,18 @@ describe('drop guide', () => {
 
     test('an outer cell previews the layout edge, cleared on inner / drop', () => {
         make(true);
+        // a 400x300 layout; the band is positioned in explicit px against it
+        jest.spyOn(layoutEl, 'getBoundingClientRect').mockReturnValue({
+            left: 0,
+            top: 0,
+            width: 400,
+            height: 300,
+            right: 400,
+            bottom: 300,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        } as DOMRect);
         const { group } = groupWithContent();
         const over = (edge: boolean, position: Position) =>
             overlayEmitter.fire({
@@ -229,13 +241,14 @@ describe('drop guide', () => {
                 position,
             } as DockviewWillShowOverlayLocationEvent);
 
-        over(true, 'right'); // outer cell → a band over the layout's right edge
+        over(true, 'right'); // outer cell → a band over the layout's right half
         const band = layoutEl.querySelector<HTMLElement>(
             '.dv-drop-guide-edge-preview'
         );
         expect(band).toBeTruthy();
-        expect(band!.style.width).toBe('50%');
-        expect(band!.style.height).toBe('100%');
+        expect(band!.style.left).toBe('200px');
+        expect(band!.style.width).toBe('200px');
+        expect(band!.style.height).toBe('300px');
 
         over(false, 'center'); // inner cell → cleared
         expect(

--- a/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-modules/src/__tests__/dropGuide.spec.ts
@@ -15,7 +15,6 @@ import { DropGuideService } from '../dropGuideService';
 describe('drop guide', () => {
     let overlayEmitter: Emitter<DockviewWillShowOverlayLocationEvent>;
     let service: DropGuideService;
-    let layoutEl: HTMLElement;
     let canDrop: (position: Position) => boolean;
     let dropOverlayEl: (group: DockviewGroupPanel) => HTMLElement | undefined;
 
@@ -23,8 +22,6 @@ describe('drop guide', () => {
         dndGuide: { zones?: Position[]; edges?: boolean } | boolean | undefined
     ): void => {
         overlayEmitter = new Emitter<DockviewWillShowOverlayLocationEvent>();
-        layoutEl = document.createElement('div');
-        document.body.appendChild(layoutEl);
         canDrop = () => true;
         // the drop target measures the content container by default
         dropOverlayEl = (group) =>
@@ -34,7 +31,6 @@ describe('drop guide', () => {
             options: { dndGuide } as any,
             onWillShowOverlay: overlayEmitter.event,
             canDropOnGroup: (_group, position) => canDrop(position),
-            getLayoutElement: () => layoutEl,
             getDropOverlayElement: (group: DockviewGroupPanel) =>
                 dropOverlayEl(group),
         });
@@ -216,50 +212,6 @@ describe('drop guide', () => {
         // centre inner cell hidden → 4 inner + 4 outer; edge cells are unaffected
         expect(content.querySelectorAll('.dv-drop-guide-cell')).toHaveLength(8);
         expect(content.querySelector('.dv-drop-guide-cell-center')).toBeNull();
-    });
-
-    test('an outer cell previews the layout edge, cleared on inner / drop', () => {
-        make(true);
-        // a 400x300 layout; the band is positioned in explicit px against it
-        jest.spyOn(layoutEl, 'getBoundingClientRect').mockReturnValue({
-            left: 0,
-            top: 0,
-            width: 400,
-            height: 300,
-            right: 400,
-            bottom: 300,
-            x: 0,
-            y: 0,
-            toJSON: () => ({}),
-        } as DOMRect);
-        const { group } = groupWithContent();
-        const over = (edge: boolean, position: Position) =>
-            overlayEmitter.fire({
-                kind: 'content',
-                group,
-                edge,
-                position,
-            } as DockviewWillShowOverlayLocationEvent);
-
-        over(true, 'right'); // outer cell → a band over the layout's right half
-        const band = layoutEl.querySelector<HTMLElement>(
-            '.dv-drop-guide-edge-preview'
-        );
-        expect(band).toBeTruthy();
-        expect(band!.style.left).toBe('200px');
-        expect(band!.style.width).toBe('200px');
-        expect(band!.style.height).toBe('300px');
-
-        over(false, 'center'); // inner cell → cleared
-        expect(
-            layoutEl.querySelector('.dv-drop-guide-edge-preview')
-        ).toBeNull();
-
-        over(true, 'top'); // re-show, then end the drag → cleared
-        window.dispatchEvent(new Event('pointerup'));
-        expect(
-            layoutEl.querySelector('.dv-drop-guide-edge-preview')
-        ).toBeNull();
     });
 
     test('does not paint a non-content overlay or when disabled', () => {

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -1,0 +1,256 @@
+import {
+    DockviewCompositeDisposable as CompositeDisposable,
+    DockviewIDisposable as IDisposable,
+} from 'dockview-core';
+import {
+    DockviewGroupPanel,
+    DockviewWillShowOverlayLocationEvent,
+    Position,
+    PositionResolver,
+    PositionResolverArgs,
+    PositionResolverResult,
+} from 'dockview-core';
+import { defineModule } from 'dockview-core';
+import { IDropGuideHost, IDropGuideService } from 'dockview-core';
+import { AdvancedDnDModule } from './advancedDnDService';
+
+/** Size (px) of each compass cell + the gap between them. */
+const CELL = 38;
+const GAP = 4;
+
+/** The inner drop cells, in render order. */
+const INNER_CELLS: Position[] = ['center', 'top', 'bottom', 'left', 'right'];
+
+interface CompassCell {
+    readonly position: Position;
+    readonly left: number;
+    readonly top: number;
+    readonly size: number;
+}
+
+/**
+ * The cross of cells centred in a `width`×`height` target, restricted to
+ * `zones`. The resolver hit-tests against these rects and the widget paints
+ * them — one geometry, so you aim at exactly the cell you see.
+ */
+function compassCells(
+    width: number,
+    height: number,
+    zones: ReadonlySet<Position>
+): CompassCell[] {
+    const half = CELL / 2;
+    const step = CELL + GAP;
+    const cx = width / 2 - half;
+    const cy = height / 2 - half;
+    const offset: Record<Position, { left: number; top: number }> = {
+        center: { left: cx, top: cy },
+        top: { left: cx, top: cy - step },
+        bottom: { left: cx, top: cy + step },
+        left: { left: cx - step, top: cy },
+        right: { left: cx + step, top: cy },
+    };
+    return INNER_CELLS.filter((p) => zones.has(p)).map((p) => ({
+        position: p,
+        left: offset[p].left,
+        top: offset[p].top,
+        size: CELL,
+    }));
+}
+
+function intersect(
+    a: ReadonlySet<Position>,
+    b: ReadonlySet<Position>
+): Set<Position> {
+    return new Set([...a].filter((p) => b.has(p)));
+}
+
+/** Small disposable DOM listener helper (core's is not exported). */
+function listen(
+    target: EventTarget,
+    type: string,
+    handler: (e: Event) => void
+): IDisposable {
+    target.addEventListener(type, handler, true);
+    return {
+        dispose: () => target.removeEventListener(type, handler, true),
+    };
+}
+
+/**
+ * The {@link PositionResolver} the host installs at the drop-target seam in
+ * place of the cursor-quadrant logic: hit-test the pointer against the compass
+ * cells (centred cross), gated by the target's accepted zones intersected with
+ * the configured `dndGuide.zones`. A miss (a dead corner) returns `null`.
+ */
+class CompassResolver implements PositionResolver {
+    constructor(
+        private readonly configuredZones: () =>
+            | ReadonlySet<Position>
+            | undefined
+    ) {}
+
+    resolve(args: PositionResolverArgs): PositionResolverResult | null {
+        const configured = this.configuredZones();
+        const zones = configured
+            ? intersect(args.zones, configured)
+            : args.zones;
+        for (const cell of compassCells(args.width, args.height, zones)) {
+            if (
+                args.x >= cell.left &&
+                args.x <= cell.left + cell.size &&
+                args.y >= cell.top &&
+                args.y <= cell.top + cell.size
+            ) {
+                return { position: cell.position };
+            }
+        }
+        return null;
+    }
+}
+
+/** The cross of cells painted over the hovered group's content area. */
+class CompassWidget {
+    private readonly _element: HTMLElement;
+
+    constructor(container: HTMLElement) {
+        const doc = container.ownerDocument;
+        const el = doc.createElement('div');
+        el.className = 'dv-drop-guide';
+        el.style.position = 'absolute';
+        el.style.left = '0';
+        el.style.top = '0';
+        el.style.width = '100%';
+        el.style.height = '100%';
+        el.style.pointerEvents = 'none';
+        el.style.overflow = 'hidden';
+        container.appendChild(el);
+        this._element = el;
+    }
+
+    render(zones: ReadonlySet<Position>): void {
+        const doc = this._element.ownerDocument;
+        const rect = this._element.getBoundingClientRect();
+        const cells = compassCells(rect.width, rect.height, zones);
+        this._element.replaceChildren();
+        for (const cell of cells) {
+            const el = doc.createElement('div');
+            el.className = `dv-drop-guide-cell dv-drop-guide-cell-${cell.position}`;
+            el.style.position = 'absolute';
+            el.style.left = `${cell.left}px`;
+            el.style.top = `${cell.top}px`;
+            el.style.width = `${cell.size}px`;
+            el.style.height = `${cell.size}px`;
+            this._element.appendChild(el);
+        }
+    }
+
+    dispose(): void {
+        this._element.remove();
+    }
+}
+
+/**
+ * Drop Guide ("compass") — a VS Code-style aim-at-a-cell drop overlay for group
+ * docking. While a panel/group is dragged over a group, a cross of cells is
+ * painted over it and the dragged item snaps to whichever cell the cursor is
+ * over (instead of the cursor-quadrant of the target). The actual drop
+ * resolution + commit stay in core: the service installs a {@link CompassResolver}
+ * at the drop-target seam and paints the widget; the existing overlay renders
+ * the aimed cell's preview. Opt-in via `dndGuide` (default off → unchanged).
+ *
+ * Phase 1: inner cells (split/merge this group) on the group content target.
+ */
+export class DropGuideService
+    extends CompositeDisposable
+    implements IDropGuideService
+{
+    private readonly _resolver: CompassResolver;
+    private _mounted:
+        | { group: DockviewGroupPanel; widget: CompassWidget }
+        | undefined;
+    private _endListeners: CompositeDisposable | undefined;
+
+    constructor(private readonly host: IDropGuideHost) {
+        super();
+
+        this._resolver = new CompassResolver(() => this._configuredZones());
+
+        this.addDisposables(
+            this.host.onWillShowOverlay((e) => this._onWillShowOverlay(e)),
+            { dispose: () => this._unmount() }
+        );
+    }
+
+    /** Installed by the host only while the compass is enabled. */
+    get resolver(): PositionResolver | undefined {
+        return this._enabled ? this._resolver : undefined;
+    }
+
+    private get _enabled(): boolean {
+        return !!this.host.options.dndGuide;
+    }
+
+    /** Cells the option restricts the compass to, or `undefined` for all. */
+    private _configuredZones(): ReadonlySet<Position> | undefined {
+        const guide = this.host.options.dndGuide;
+        if (guide && typeof guide === 'object' && guide.zones) {
+            return new Set(guide.zones);
+        }
+        return undefined;
+    }
+
+    private _onWillShowOverlay(e: DockviewWillShowOverlayLocationEvent): void {
+        // Phase 1 covers the group content target only.
+        if (!this._enabled || e.kind !== 'content' || !e.group) {
+            return;
+        }
+        this._mount(e.group);
+    }
+
+    private _mount(group: DockviewGroupPanel): void {
+        if (this._mounted?.group === group) {
+            return; // already showing on this group
+        }
+        this._unmount();
+
+        const content = group.element.querySelector<HTMLElement>(
+            '.dv-content-container'
+        );
+        if (!content) {
+            return;
+        }
+
+        const widget = new CompassWidget(content);
+        const all = new Set(INNER_CELLS);
+        const configured = this._configuredZones();
+        widget.render(configured ? intersect(all, configured) : all);
+        this._mounted = { group, widget };
+
+        // The drag has no "left everything" event; tear the widget down when the
+        // drag ends (drop / dragend / pointerup / cancel) in the group's window.
+        const win = group.element.ownerDocument.defaultView ?? window;
+        const end = (): void => this._unmount();
+        this._endListeners = new CompositeDisposable(
+            listen(win, 'drop', end),
+            listen(win, 'dragend', end),
+            listen(win, 'pointerup', end),
+            listen(win, 'pointercancel', end)
+        );
+    }
+
+    private _unmount(): void {
+        this._endListeners?.dispose();
+        this._endListeners = undefined;
+        this._mounted?.widget.dispose();
+        this._mounted = undefined;
+    }
+}
+
+export const DropGuideModule = defineModule<'dropGuideService', IDropGuideHost>(
+    {
+        name: 'DropGuide',
+        serviceKey: 'dropGuideService',
+        dependsOn: [AdvancedDnDModule],
+        create: (host) => new DropGuideService(host),
+    }
+);

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -20,7 +20,7 @@ const GAP = 4;
 
 /** The inner drop cells, in render order. */
 const INNER_CELLS: Position[] = ['center', 'top', 'bottom', 'left', 'right'];
-/** The four directional cells, used for both the inner ring and the outer ring. */
+/** The four directional cells (the inner ring's arms + the outer ring). */
 const DIRECTIONS: Exclude<Position, 'center'>[] = [
     'top',
     'bottom',
@@ -106,7 +106,8 @@ function listen(
  * The {@link PositionResolver} the host installs at the drop-target seam in
  * place of the cursor-quadrant logic: hit-test the pointer against the compass
  * cells (centred cross), gated by the target's accepted zones intersected with
- * the configured `dndGuide.zones`. A miss (a dead corner) returns `null`.
+ * the configured `dndGuide.zones`. A miss (a dead corner) returns `null`. A
+ * per-cell veto is enforced by the drop target itself (`canDisplayOverlay`).
  */
 class CompassResolver implements PositionResolver {
     constructor(
@@ -160,7 +161,12 @@ class CompassWidget {
         this._element = el;
     }
 
-    render(zones: ReadonlySet<Position>, includeEdges: boolean): void {
+    /** Paint the cells `gate` accepts, so only legal drops are shown. */
+    render(
+        zones: ReadonlySet<Position>,
+        includeEdges: boolean,
+        gate: (cell: { position: Position; edge: boolean }) => boolean
+    ): void {
         const doc = this._element.ownerDocument;
         const rect = this._element.getBoundingClientRect();
         const cells = compassCells(
@@ -168,7 +174,7 @@ class CompassWidget {
             rect.height,
             zones,
             includeEdges
-        );
+        ).filter(gate);
         this._element.replaceChildren();
         for (const cell of cells) {
             const el = doc.createElement('div');
@@ -193,13 +199,14 @@ class CompassWidget {
  * Drop Guide ("compass") — a VS Code-style aim-at-a-cell drop overlay for group
  * docking. While a panel/group is dragged over a group, a cross of cells is
  * painted over it and the dragged item snaps to whichever cell the cursor is
- * over (instead of the cursor-quadrant of the target). The actual drop
- * resolution + commit stay in core: the service installs a {@link CompassResolver}
- * at the drop-target seam and paints the widget; the existing overlay renders
- * the aimed cell's preview. Opt-in via `dndGuide` (default off → unchanged).
+ * over (instead of the cursor-quadrant of the target). Drop resolution + commit
+ * stay in core: the service installs a {@link CompassResolver} at the drop-target
+ * seam and paints the widget. Opt-in via `dndGuide` (default off → unchanged).
  *
  * Inner cells split/merge the hovered group; the outer ring (`edge` cells) docks
- * against the whole layout (core routes `edge`-flagged drops to the layout edge).
+ * against the whole layout (core routes `edge`-flagged drops to the layout edge),
+ * previewed by a band over the layout edge. Cells the drop would reject are
+ * hidden (per-cell gating).
  */
 export class DropGuideService
     extends CompositeDisposable
@@ -210,6 +217,7 @@ export class DropGuideService
         | { group: DockviewGroupPanel; widget: CompassWidget }
         | undefined;
     private _endListeners: CompositeDisposable | undefined;
+    private _edgePreview: HTMLElement | undefined;
 
     constructor(private readonly host: IDropGuideHost) {
         super();
@@ -253,14 +261,24 @@ export class DropGuideService
     }
 
     private _onWillShowOverlay(e: DockviewWillShowOverlayLocationEvent): void {
-        // Phase 1 covers the group content target only.
+        // The compass covers the group content target.
         if (!this._enabled || e.kind !== 'content' || !e.group) {
             return;
         }
-        this._mount(e.group);
+        this._mount(e.group, e.nativeEvent);
+        // An outer cell previews the whole-layout-edge dock; an inner cell uses
+        // the group's own overlay, so clear any edge preview.
+        if (e.edge) {
+            this._showEdgePreview(e.position);
+        } else {
+            this._clearEdgePreview();
+        }
     }
 
-    private _mount(group: DockviewGroupPanel): void {
+    private _mount(
+        group: DockviewGroupPanel,
+        event: DragEvent | PointerEvent
+    ): void {
         if (this._mounted?.group === group) {
             return; // already showing on this group
         }
@@ -278,7 +296,12 @@ export class DropGuideService
         const configured = this._configuredZones();
         widget.render(
             configured ? intersect(all, configured) : all,
-            this._edgesEnabled()
+            this._edgesEnabled(),
+            // Hide cells the drop would reject. Outer (edge) cells dock the whole
+            // layout, not this group, so the group veto doesn't apply to them.
+            (cell) =>
+                cell.edge ||
+                this.host.canDropOnGroup(group, cell.position, event)
         );
         this._mounted = { group, widget };
 
@@ -294,11 +317,38 @@ export class DropGuideService
         );
     }
 
+    /** Highlight the whole-layout edge the outer cell would dock against. */
+    private _showEdgePreview(position: Position): void {
+        const layout = this.host.getLayoutElement();
+        if (!this._edgePreview) {
+            const el = layout.ownerDocument.createElement('div');
+            el.className = 'dv-drop-guide-edge-preview';
+            el.style.position = 'absolute';
+            el.style.pointerEvents = 'none';
+            layout.appendChild(el);
+            this._edgePreview = el;
+        }
+        const el = this._edgePreview;
+        const edges: Record<string, Partial<CSSStyleDeclaration>> = {
+            top: { inset: '0 0 auto 0', width: '100%', height: '50%' },
+            bottom: { inset: 'auto 0 0 0', width: '100%', height: '50%' },
+            left: { inset: '0 auto 0 0', width: '50%', height: '100%' },
+            right: { inset: '0 0 0 auto', width: '50%', height: '100%' },
+        };
+        Object.assign(el.style, edges[position] ?? {});
+    }
+
+    private _clearEdgePreview(): void {
+        this._edgePreview?.remove();
+        this._edgePreview = undefined;
+    }
+
     private _unmount(): void {
         this._endListeners?.dispose();
         this._endListeners = undefined;
         this._mounted?.widget.dispose();
         this._mounted = undefined;
+        this._clearEdgePreview();
     }
 }
 

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -37,6 +37,15 @@ interface CompassCell {
     readonly edge: boolean;
 }
 
+/** Half-of-the-layout band along each edge, keyed by the outer cell's direction. */
+const EDGE_PREVIEW_INSETS: Record<Position, Partial<CSSStyleDeclaration>> = {
+    center: {},
+    top: { inset: '0 0 auto 0', width: '100%', height: '50%' },
+    bottom: { inset: 'auto 0 0 0', width: '100%', height: '50%' },
+    left: { inset: '0 auto 0 0', width: '50%', height: '100%' },
+    right: { inset: '0 0 0 auto', width: '50%', height: '100%' },
+};
+
 const UNIT: Record<Position, { dx: number; dy: number }> = {
     center: { dx: 0, dy: 0 },
     top: { dx: 0, dy: -1 },
@@ -256,6 +265,7 @@ export class DropGuideService
         | { group: DockviewGroupPanel; widget: CompassWidget }
         | undefined;
     private _endListeners: CompositeDisposable | undefined;
+    private _edgePreview: HTMLElement | undefined;
 
     constructor(private readonly host: IDropGuideHost) {
         super();
@@ -304,8 +314,38 @@ export class DropGuideService
             return;
         }
         this._mount(e.group, e.nativeEvent);
-        // Fires per drag-over frame: light up the cell being aimed at.
+        // Fires per drag-over frame: light up the cell being aimed at, and for
+        // an outer cell preview the layout-edge region the panel would land in.
         this._mounted?.widget.setActive(e.position, e.edge);
+        if (e.edge) {
+            this._showEdgePreview(e.position);
+        } else {
+            this._clearEdgePreview();
+        }
+    }
+
+    /**
+     * Preview the whole-layout-edge region an outer cell docks into — the half
+     * the panel will occupy — styled with the same theme variables as a real
+     * drop overlay so it reads identically. Drawn over the layout root (a
+     * positioned element), beneath the compass.
+     */
+    private _showEdgePreview(position: Position): void {
+        const layout = this.host.getLayoutElement();
+        if (!this._edgePreview) {
+            const el = layout.ownerDocument.createElement('div');
+            el.className = 'dv-drop-guide-edge-preview';
+            el.style.position = 'absolute';
+            el.style.pointerEvents = 'none';
+            layout.appendChild(el);
+            this._edgePreview = el;
+        }
+        Object.assign(this._edgePreview.style, EDGE_PREVIEW_INSETS[position]);
+    }
+
+    private _clearEdgePreview(): void {
+        this._edgePreview?.remove();
+        this._edgePreview = undefined;
     }
 
     private _mount(
@@ -360,6 +400,7 @@ export class DropGuideService
         this._endListeners = undefined;
         this._mounted?.widget.dispose();
         this._mounted = undefined;
+        this._clearEdgePreview();
     }
 }
 

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -170,17 +170,27 @@ class CompassWidget {
         this._element = el;
     }
 
-    /** Paint the cells `gate` accepts, so only legal drops are shown. */
+    /**
+     * Paint the cells `gate` accepts (so only legal drops show), centred on
+     * `outline` — the frame the drop target measures — and translated into this
+     * widget's own box so the cells line up with where a drop resolves even when
+     * the two boxes differ (e.g. `dndPanelOverlay: 'group'` measures the whole
+     * group, but the widget is mounted in the content container).
+     */
     render(
+        outline: HTMLElement,
         zones: ReadonlySet<Position>,
         includeEdges: boolean,
         gate: (cell: { position: Position; edge: boolean }) => boolean
     ): void {
         const doc = this._element.ownerDocument;
-        const rect = this._element.getBoundingClientRect();
+        const elRect = this._element.getBoundingClientRect();
+        const oRect = outline.getBoundingClientRect();
+        const dx = oRect.left - elRect.left;
+        const dy = oRect.top - elRect.top;
         const cells = compassCells(
-            rect.width,
-            rect.height,
+            oRect.width,
+            oRect.height,
             zones,
             includeEdges
         ).filter(gate);
@@ -191,8 +201,8 @@ class CompassWidget {
                 `dv-drop-guide-cell dv-drop-guide-cell-${cell.position}` +
                 (cell.edge ? ' dv-drop-guide-cell-edge' : '');
             el.style.position = 'absolute';
-            el.style.left = `${cell.left}px`;
-            el.style.top = `${cell.top}px`;
+            el.style.left = `${cell.left + dx}px`;
+            el.style.top = `${cell.top + dy}px`;
             el.style.width = `${cell.size}px`;
             el.style.height = `${cell.size}px`;
             this._element.appendChild(el);
@@ -303,7 +313,11 @@ export class DropGuideService
         const widget = new CompassWidget(content);
         const all = new Set(INNER_CELLS);
         const configured = this._configuredZones();
+        // The frame the drop target measures (the whole group or just the
+        // content, per `dndPanelOverlay`); fall back to the content container.
+        const outline = this.host.getDropOverlayElement(group) ?? content;
         widget.render(
+            outline,
             configured ? intersect(all, configured) : all,
             this._edgesEnabled(),
             // Hide cells the drop would reject. Outer (edge) cells are gated the

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -37,6 +37,15 @@ interface CompassCell {
     readonly edge: boolean;
 }
 
+/** Half-size band along each layout edge, keyed by the outer cell's direction. */
+const EDGE_PREVIEW_INSETS: Record<Position, Partial<CSSStyleDeclaration>> = {
+    center: {},
+    top: { inset: '0 0 auto 0', width: '100%', height: '50%' },
+    bottom: { inset: 'auto 0 0 0', width: '100%', height: '50%' },
+    left: { inset: '0 auto 0 0', width: '50%', height: '100%' },
+    right: { inset: '0 0 0 auto', width: '50%', height: '100%' },
+};
+
 const UNIT: Record<Position, { dx: number; dy: number }> = {
     center: { dx: 0, dy: 0 },
     top: { dx: 0, dy: -1 },
@@ -297,11 +306,12 @@ export class DropGuideService
         widget.render(
             configured ? intersect(all, configured) : all,
             this._edgesEnabled(),
-            // Hide cells the drop would reject. Outer (edge) cells dock the whole
-            // layout, not this group, so the group veto doesn't apply to them.
-            (cell) =>
-                cell.edge ||
-                this.host.canDropOnGroup(group, cell.position, event)
+            // Hide cells the drop would reject. Outer (edge) cells are gated the
+            // same way they commit: the drop target routes an edge drop to the
+            // layout edge only after the group's own content veto passes, so the
+            // compass must apply that veto here too or it would paint a cell that
+            // does nothing on drop.
+            (cell) => this.host.canDropOnGroup(group, cell.position, event)
         );
         this._mounted = { group, widget };
 
@@ -317,7 +327,12 @@ export class DropGuideService
         );
     }
 
-    /** Highlight the whole-layout edge the outer cell would dock against. */
+    /**
+     * Highlight the whole-layout edge the outer cell would dock against. The
+     * band is a half-size approximation — the real dock size is decided by the
+     * grid on commit, not known here — so it indicates the edge, not the exact
+     * resulting bounds.
+     */
     private _showEdgePreview(position: Position): void {
         const layout = this.host.getLayoutElement();
         if (!this._edgePreview) {
@@ -328,14 +343,7 @@ export class DropGuideService
             layout.appendChild(el);
             this._edgePreview = el;
         }
-        const el = this._edgePreview;
-        const edges: Record<string, Partial<CSSStyleDeclaration>> = {
-            top: { inset: '0 0 auto 0', width: '100%', height: '50%' },
-            bottom: { inset: 'auto 0 0 0', width: '100%', height: '50%' },
-            left: { inset: '0 auto 0 0', width: '50%', height: '100%' },
-            right: { inset: '0 0 0 auto', width: '50%', height: '100%' },
-        };
-        Object.assign(el.style, edges[position] ?? {});
+        Object.assign(this._edgePreview.style, EDGE_PREVIEW_INSETS[position]);
     }
 
     private _clearEdgePreview(): void {

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -314,9 +314,12 @@ export class DropGuideService
             return;
         }
         this._mount(e.group, e.nativeEvent);
+        if (!this._mounted) {
+            return; // no compass mounted (e.g. no content container) — nothing to drive
+        }
         // Fires per drag-over frame: light up the cell being aimed at, and for
         // an outer cell preview the layout-edge region the panel would land in.
-        this._mounted?.widget.setActive(e.position, e.edge);
+        this._mounted.widget.setActive(e.position, e.edge);
         if (e.edge) {
             this._showEdgePreview(e.position);
         } else {

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -20,41 +20,67 @@ const GAP = 4;
 
 /** The inner drop cells, in render order. */
 const INNER_CELLS: Position[] = ['center', 'top', 'bottom', 'left', 'right'];
+/** The four directional cells, used for both the inner ring and the outer ring. */
+const DIRECTIONS: Exclude<Position, 'center'>[] = [
+    'top',
+    'bottom',
+    'left',
+    'right',
+];
 
 interface CompassCell {
     readonly position: Position;
     readonly left: number;
     readonly top: number;
     readonly size: number;
+    /** An outer cell that docks against the whole layout, not this group. */
+    readonly edge: boolean;
 }
 
+const UNIT: Record<Position, { dx: number; dy: number }> = {
+    center: { dx: 0, dy: 0 },
+    top: { dx: 0, dy: -1 },
+    bottom: { dx: 0, dy: 1 },
+    left: { dx: -1, dy: 0 },
+    right: { dx: 1, dy: 0 },
+};
+
 /**
- * The cross of cells centred in a `width`×`height` target, restricted to
- * `zones`. The resolver hit-tests against these rects and the widget paints
- * them — one geometry, so you aim at exactly the cell you see.
+ * The cross of cells centred in a `width`×`height` target: the inner ring
+ * (split/merge this group, restricted to `zones`) plus, when `includeEdges`, an
+ * outer ring of directional cells that dock against the whole layout. The
+ * resolver hit-tests these rects and the widget paints them — one geometry, so
+ * you aim at exactly the cell you see.
  */
 function compassCells(
     width: number,
     height: number,
-    zones: ReadonlySet<Position>
+    zones: ReadonlySet<Position>,
+    includeEdges: boolean
 ): CompassCell[] {
     const half = CELL / 2;
     const step = CELL + GAP;
     const cx = width / 2 - half;
     const cy = height / 2 - half;
-    const offset: Record<Position, { left: number; top: number }> = {
-        center: { left: cx, top: cy },
-        top: { left: cx, top: cy - step },
-        bottom: { left: cx, top: cy + step },
-        left: { left: cx - step, top: cy },
-        right: { left: cx + step, top: cy },
-    };
-    return INNER_CELLS.filter((p) => zones.has(p)).map((p) => ({
+    const cell = (p: Position, ring: number, edge: boolean): CompassCell => ({
         position: p,
-        left: offset[p].left,
-        top: offset[p].top,
+        left: cx + UNIT[p].dx * step * ring,
+        top: cy + UNIT[p].dy * step * ring,
         size: CELL,
-    }));
+        edge,
+    });
+    const cells: CompassCell[] = [];
+    for (const p of INNER_CELLS) {
+        if (zones.has(p)) {
+            cells.push(cell(p, p === 'center' ? 0 : 1, false));
+        }
+    }
+    if (includeEdges) {
+        for (const p of DIRECTIONS) {
+            cells.push(cell(p, 2, true));
+        }
+    }
+    return cells;
 }
 
 function intersect(
@@ -86,7 +112,8 @@ class CompassResolver implements PositionResolver {
     constructor(
         private readonly configuredZones: () =>
             | ReadonlySet<Position>
-            | undefined
+            | undefined,
+        private readonly edgesEnabled: () => boolean
     ) {}
 
     resolve(args: PositionResolverArgs): PositionResolverResult | null {
@@ -94,14 +121,20 @@ class CompassResolver implements PositionResolver {
         const zones = configured
             ? intersect(args.zones, configured)
             : args.zones;
-        for (const cell of compassCells(args.width, args.height, zones)) {
+        const cells = compassCells(
+            args.width,
+            args.height,
+            zones,
+            this.edgesEnabled()
+        );
+        for (const cell of cells) {
             if (
                 args.x >= cell.left &&
                 args.x <= cell.left + cell.size &&
                 args.y >= cell.top &&
                 args.y <= cell.top + cell.size
             ) {
-                return { position: cell.position };
+                return { position: cell.position, edge: cell.edge };
             }
         }
         return null;
@@ -127,14 +160,21 @@ class CompassWidget {
         this._element = el;
     }
 
-    render(zones: ReadonlySet<Position>): void {
+    render(zones: ReadonlySet<Position>, includeEdges: boolean): void {
         const doc = this._element.ownerDocument;
         const rect = this._element.getBoundingClientRect();
-        const cells = compassCells(rect.width, rect.height, zones);
+        const cells = compassCells(
+            rect.width,
+            rect.height,
+            zones,
+            includeEdges
+        );
         this._element.replaceChildren();
         for (const cell of cells) {
             const el = doc.createElement('div');
-            el.className = `dv-drop-guide-cell dv-drop-guide-cell-${cell.position}`;
+            el.className =
+                `dv-drop-guide-cell dv-drop-guide-cell-${cell.position}` +
+                (cell.edge ? ' dv-drop-guide-cell-edge' : '');
             el.style.position = 'absolute';
             el.style.left = `${cell.left}px`;
             el.style.top = `${cell.top}px`;
@@ -158,7 +198,8 @@ class CompassWidget {
  * at the drop-target seam and paints the widget; the existing overlay renders
  * the aimed cell's preview. Opt-in via `dndGuide` (default off → unchanged).
  *
- * Phase 1: inner cells (split/merge this group) on the group content target.
+ * Inner cells split/merge the hovered group; the outer ring (`edge` cells) docks
+ * against the whole layout (core routes `edge`-flagged drops to the layout edge).
  */
 export class DropGuideService
     extends CompositeDisposable
@@ -173,7 +214,10 @@ export class DropGuideService
     constructor(private readonly host: IDropGuideHost) {
         super();
 
-        this._resolver = new CompassResolver(() => this._configuredZones());
+        this._resolver = new CompassResolver(
+            () => this._configuredZones(),
+            () => this._edgesEnabled()
+        );
 
         this.addDisposables(
             this.host.onWillShowOverlay((e) => this._onWillShowOverlay(e)),
@@ -197,6 +241,15 @@ export class DropGuideService
             return new Set(guide.zones);
         }
         return undefined;
+    }
+
+    /** Whether the outer whole-layout-edge cells are shown (default true). */
+    private _edgesEnabled(): boolean {
+        const guide = this.host.options.dndGuide;
+        if (guide && typeof guide === 'object') {
+            return guide.edges !== false;
+        }
+        return !!guide;
     }
 
     private _onWillShowOverlay(e: DockviewWillShowOverlayLocationEvent): void {
@@ -223,7 +276,10 @@ export class DropGuideService
         const widget = new CompassWidget(content);
         const all = new Set(INNER_CELLS);
         const configured = this._configuredZones();
-        widget.render(configured ? intersect(all, configured) : all);
+        widget.render(
+            configured ? intersect(all, configured) : all,
+            this._edgesEnabled()
+        );
         this._mounted = { group, widget };
 
         // The drag has no "left everything" event; tear the widget down when the

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -145,8 +145,19 @@ class CompassResolver implements PositionResolver {
 /** The cross of cells painted over the hovered group's content area. */
 class CompassWidget {
     private readonly _element: HTMLElement;
+    private readonly _container: HTMLElement;
+    private readonly _priorPosition: string;
 
     constructor(container: HTMLElement) {
+        this._container = container;
+        // Pin a stable containing block. The drop target sets `position:
+        // relative` on this element only while an inner-cell overlay shows (the
+        // `.dv-drop-target` class), and removes it for edge cells — without this
+        // the absolutely-positioned compass re-anchors to a higher ancestor on
+        // an outer cell and visibly jumps. Restored on dispose.
+        this._priorPosition = container.style.position;
+        container.style.position = 'relative';
+
         const doc = container.ownerDocument;
         const el = doc.createElement('div');
         el.className = 'dv-drop-guide';
@@ -202,6 +213,7 @@ class CompassWidget {
 
     dispose(): void {
         this._element.remove();
+        this._container.style.position = this._priorPosition;
     }
 }
 

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -147,6 +147,8 @@ class CompassWidget {
     private readonly _element: HTMLElement;
     private readonly _container: HTMLElement;
     private readonly _priorPosition: string;
+    private _cells: { position: Position; edge: boolean; el: HTMLElement }[] =
+        [];
 
     constructor(container: HTMLElement) {
         this._container = container;
@@ -197,6 +199,7 @@ class CompassWidget {
             includeEdges
         ).filter(gate);
         this._element.replaceChildren();
+        this._cells = [];
         for (const cell of cells) {
             const el = doc.createElement('div');
             el.className =
@@ -208,6 +211,21 @@ class CompassWidget {
             el.style.width = `${cell.size}px`;
             el.style.height = `${cell.size}px`;
             this._element.appendChild(el);
+            this._cells.push({ position: cell.position, edge: cell.edge, el });
+        }
+    }
+
+    /**
+     * Highlight the cell the cursor is aiming at — the only hover feedback an
+     * outer (edge) cell gets, since the drop target draws no overlay for it.
+     * `edge` disambiguates the inner vs outer cell that share a direction.
+     */
+    setActive(position: Position, edge: boolean): void {
+        for (const c of this._cells) {
+            c.el.classList.toggle(
+                'dv-drop-guide-cell-active',
+                c.position === position && c.edge === edge
+            );
         }
     }
 
@@ -286,6 +304,8 @@ export class DropGuideService
             return;
         }
         this._mount(e.group, e.nativeEvent);
+        // Fires per drag-over frame: light up the cell being aimed at.
+        this._mounted?.widget.setActive(e.position, e.edge);
     }
 
     private _mount(

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -37,15 +37,6 @@ interface CompassCell {
     readonly edge: boolean;
 }
 
-/** Half-size band along each layout edge, keyed by the outer cell's direction. */
-const EDGE_PREVIEW_INSETS: Record<Position, Partial<CSSStyleDeclaration>> = {
-    center: {},
-    top: { inset: '0 0 auto 0', width: '100%', height: '50%' },
-    bottom: { inset: 'auto 0 0 0', width: '100%', height: '50%' },
-    left: { inset: '0 auto 0 0', width: '50%', height: '100%' },
-    right: { inset: '0 0 0 auto', width: '50%', height: '100%' },
-};
-
 const UNIT: Record<Position, { dx: number; dy: number }> = {
     center: { dx: 0, dy: 0 },
     top: { dx: 0, dy: -1 },
@@ -346,6 +337,10 @@ export class DropGuideService
      * band is a half-size approximation — the real dock size is decided by the
      * grid on commit, not known here — so it indicates the edge, not the exact
      * resulting bounds.
+     *
+     * Positioned with explicit pixels against the band's offset parent (the
+     * layout element is not guaranteed to establish a containing block), so the
+     * band stays inside the layout box and never overflows / shifts the content.
      */
     private _showEdgePreview(position: Position): void {
         const layout = this.host.getLayoutElement();
@@ -357,7 +352,26 @@ export class DropGuideService
             layout.appendChild(el);
             this._edgePreview = el;
         }
-        Object.assign(this._edgePreview.style, EDGE_PREVIEW_INSETS[position]);
+        const el = this._edgePreview;
+        const lRect = layout.getBoundingClientRect();
+        const pRect = (el.offsetParent ?? layout).getBoundingClientRect();
+        const x = lRect.left - pRect.left;
+        const y = lRect.top - pRect.top;
+        const w = lRect.width;
+        const h = lRect.height;
+        const box: Record<Position, [number, number, number, number]> = {
+            // [left, top, width, height]
+            center: [x, y, w, h],
+            top: [x, y, w, h / 2],
+            bottom: [x, y + h / 2, w, h / 2],
+            left: [x, y, w / 2, h],
+            right: [x + w / 2, y, w / 2, h],
+        };
+        const [left, top, width, height] = box[position];
+        el.style.left = `${left}px`;
+        el.style.top = `${top}px`;
+        el.style.width = `${width}px`;
+        el.style.height = `${height}px`;
     }
 
     private _clearEdgePreview(): void {

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -238,6 +238,13 @@ class CompassWidget {
         }
     }
 
+    /** Clear the aimed-cell highlight (cursor is over no cell). */
+    clearActive(): void {
+        for (const c of this._cells) {
+            c.el.classList.remove('dv-drop-guide-cell-active');
+        }
+    }
+
     dispose(): void {
         this._element.remove();
         this._container.style.position = this._priorPosition;
@@ -262,7 +269,11 @@ export class DropGuideService
 {
     private readonly _resolver: CompassResolver;
     private _mounted:
-        | { group: DockviewGroupPanel; widget: CompassWidget }
+        | {
+              group: DockviewGroupPanel;
+              widget: CompassWidget;
+              outline: HTMLElement;
+          }
         | undefined;
     private _endListeners: CompositeDisposable | undefined;
     private _edgePreview: HTMLElement | undefined;
@@ -317,12 +328,39 @@ export class DropGuideService
         if (!this._mounted) {
             return; // no compass mounted (e.g. no content container) — nothing to drive
         }
-        // Fires per drag-over frame: light up the cell being aimed at, and for
-        // an outer cell preview the layout-edge region the panel would land in.
+        // Fires per drag-over frame while over a cell: light up the cell being
+        // aimed at, and for an outer cell preview the layout-edge region. A move
+        // off the cells is handled by `_clearFeedbackIfOffCells` (this event
+        // doesn't fire in a dead zone).
         this._mounted.widget.setActive(e.position, e.edge);
         if (e.edge) {
             this._showEdgePreview(e.position);
         } else {
+            this._clearEdgePreview();
+        }
+    }
+
+    /**
+     * Clear the feedback when the cursor is over no cell (a dead zone between
+     * cells, or off the group). `onWillShowOverlay` only fires on a cell, so
+     * without this the highlight + edge preview would linger. Only ever clears —
+     * setting stays with `onWillShowOverlay` — so the two never conflict.
+     */
+    private _clearFeedbackIfOffCells(event: DragEvent | PointerEvent): void {
+        if (!this._mounted) {
+            return;
+        }
+        const rect = this._mounted.outline.getBoundingClientRect();
+        const onCell = this._resolver.resolve({
+            x: event.clientX - rect.left,
+            y: event.clientY - rect.top,
+            width: rect.width,
+            height: rect.height,
+            zones: new Set(INNER_CELLS),
+            event,
+        });
+        if (!onCell) {
+            this._mounted.widget.clearActive();
             this._clearEdgePreview();
         }
     }
@@ -373,6 +411,10 @@ export class DropGuideService
         // The frame the drop target measures (the whole group or just the
         // content, per `dndPanelOverlay`); fall back to the content container.
         const outline = this.host.getDropOverlayElement(group) ?? content;
+        // Cache the veto per direction: the inner and outer cell of a direction
+        // share a position, and `canDropOnGroup` can fire `onUnhandledDragOver`
+        // for a cross-component drag — so resolve each position at most once.
+        const allowed = new Map<Position, boolean>();
         widget.render(
             outline,
             configured ? intersect(all, configured) : all,
@@ -382,19 +424,31 @@ export class DropGuideService
             // layout edge only after the group's own content veto passes, so the
             // compass must apply that veto here too or it would paint a cell that
             // does nothing on drop.
-            (cell) => this.host.canDropOnGroup(group, cell.position, event)
+            (cell) => {
+                let ok = allowed.get(cell.position);
+                if (ok === undefined) {
+                    ok = this.host.canDropOnGroup(group, cell.position, event);
+                    allowed.set(cell.position, ok);
+                }
+                return ok;
+            }
         );
-        this._mounted = { group, widget };
+        this._mounted = { group, widget, outline };
 
-        // The drag has no "left everything" event; tear the widget down when the
-        // drag ends (drop / dragend / pointerup / cancel) in the group's window.
+        // The drag has no "left everything" event. Tear the widget down when the
+        // drag ends (drop / dragend / pointerup / cancel); drive the feedback off
+        // every move so it tracks dead zones the overlay event skips.
         const win = group.element.ownerDocument.defaultView ?? window;
         const end = (): void => this._unmount();
+        const move = (ev: Event): void =>
+            this._clearFeedbackIfOffCells(ev as DragEvent | PointerEvent);
         this._endListeners = new CompositeDisposable(
             listen(win, 'drop', end),
             listen(win, 'dragend', end),
             listen(win, 'pointerup', end),
-            listen(win, 'pointercancel', end)
+            listen(win, 'pointercancel', end),
+            listen(win, 'pointermove', move),
+            listen(win, 'dragover', move)
         );
     }
 

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -214,9 +214,8 @@ class CompassWidget {
  * seam and paints the widget. Opt-in via `dndGuide` (default off → unchanged).
  *
  * Inner cells split/merge the hovered group; the outer ring (`edge` cells) docks
- * against the whole layout (core routes `edge`-flagged drops to the layout edge),
- * previewed by a band over the layout edge. Cells the drop would reject are
- * hidden (per-cell gating).
+ * against the whole layout (core routes `edge`-flagged drops to the layout edge).
+ * Cells the drop would reject are hidden (per-cell gating).
  */
 export class DropGuideService
     extends CompositeDisposable
@@ -227,7 +226,6 @@ export class DropGuideService
         | { group: DockviewGroupPanel; widget: CompassWidget }
         | undefined;
     private _endListeners: CompositeDisposable | undefined;
-    private _edgePreview: HTMLElement | undefined;
 
     constructor(private readonly host: IDropGuideHost) {
         super();
@@ -276,13 +274,6 @@ export class DropGuideService
             return;
         }
         this._mount(e.group, e.nativeEvent);
-        // An outer cell previews the whole-layout-edge dock; an inner cell uses
-        // the group's own overlay, so clear any edge preview.
-        if (e.edge) {
-            this._showEdgePreview(e.position);
-        } else {
-            this._clearEdgePreview();
-        }
     }
 
     private _mount(
@@ -332,59 +323,11 @@ export class DropGuideService
         );
     }
 
-    /**
-     * Highlight the whole-layout edge the outer cell would dock against. The
-     * band is a half-size approximation — the real dock size is decided by the
-     * grid on commit, not known here — so it indicates the edge, not the exact
-     * resulting bounds.
-     *
-     * Positioned with explicit pixels against the band's offset parent (the
-     * layout element is not guaranteed to establish a containing block), so the
-     * band stays inside the layout box and never overflows / shifts the content.
-     */
-    private _showEdgePreview(position: Position): void {
-        const layout = this.host.getLayoutElement();
-        if (!this._edgePreview) {
-            const el = layout.ownerDocument.createElement('div');
-            el.className = 'dv-drop-guide-edge-preview';
-            el.style.position = 'absolute';
-            el.style.pointerEvents = 'none';
-            layout.appendChild(el);
-            this._edgePreview = el;
-        }
-        const el = this._edgePreview;
-        const lRect = layout.getBoundingClientRect();
-        const pRect = (el.offsetParent ?? layout).getBoundingClientRect();
-        const x = lRect.left - pRect.left;
-        const y = lRect.top - pRect.top;
-        const w = lRect.width;
-        const h = lRect.height;
-        const box: Record<Position, [number, number, number, number]> = {
-            // [left, top, width, height]
-            center: [x, y, w, h],
-            top: [x, y, w, h / 2],
-            bottom: [x, y + h / 2, w, h / 2],
-            left: [x, y, w / 2, h],
-            right: [x + w / 2, y, w / 2, h],
-        };
-        const [left, top, width, height] = box[position];
-        el.style.left = `${left}px`;
-        el.style.top = `${top}px`;
-        el.style.width = `${width}px`;
-        el.style.height = `${height}px`;
-    }
-
-    private _clearEdgePreview(): void {
-        this._edgePreview?.remove();
-        this._edgePreview = undefined;
-    }
-
     private _unmount(): void {
         this._endListeners?.dispose();
         this._endListeners = undefined;
         this._mounted?.widget.dispose();
         this._mounted = undefined;
-        this._clearEdgePreview();
     }
 }
 

--- a/packages/dockview-modules/src/index.ts
+++ b/packages/dockview-modules/src/index.ts
@@ -4,6 +4,7 @@ import { ContextMenuModule } from './contextMenu';
 import { AdvancedDnDModule } from './advancedDnDService';
 import { AccessibilityModule } from './accessibilityService';
 import { LayoutHistoryModule } from './layoutHistoryService';
+import { DropGuideModule } from './dropGuideService';
 
 export {
     TabGroupChipsService,
@@ -19,6 +20,7 @@ export {
     LayoutHistoryService,
     LayoutHistoryModule,
 } from './layoutHistoryService';
+export { DropGuideService, DropGuideModule } from './dropGuideService';
 // Advanced keyboard docking is an optional module — exported for explicit
 // registration, but not part of the default `Modules` bundle below.
 export {
@@ -36,4 +38,5 @@ export const Modules: DockviewModule<any>[] = [
     AdvancedDnDModule,
     AccessibilityModule,
     LayoutHistoryModule,
+    DropGuideModule,
 ];

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -789,6 +789,7 @@ const DockviewDemo = (props: {
                                             onReady={onReady}
                                             theme={effectiveTheme}
                                             floatingGroupDragHandle="titlebar"
+                                            dndGuide={true}
                                             getTabContextMenuItems={
                                                 getTabContextMenuItems
                                             }


### PR DESCRIPTION
## Drop Guide ("compass")

A VS Code / Visual Studio–style **aim-at-a-cell** drop overlay for group docking. While a panel or group is dragged over a group, a cross of cells is painted over it and the drop snaps to whichever cell the cursor is on — instead of the cursor-quadrant of the target.

Opt-in via a single option; **off by default**, so existing drag behaviour is byte-for-byte unchanged.

```ts
new DockviewComponent(el, { dndGuide: true });
// or React: <DockviewReact dndGuide />
```

### Behaviour
- **Inner ring** — `center` tabs into the hovered group; `top/bottom/left/right` split it. These reuse the drop target's own overlay as the landing preview.
- **Outer ring** — `top/bottom/left/right` dock against the **whole layout edge**, with a translucent landing-region preview styled from the existing `--dv-drag-over-*` theme variables (reads identically to any other drop preview).
- **Per-cell gating** — only cells whose drop is actually legal are shown (same veto the drop target uses).
- **Aimed-cell highlight** — the cell under the cursor lights up; clears when the cursor enters a dead zone.

### Options
- `dndGuide: boolean | { zones?: Position[]; edges?: boolean }` — restrict the inner cells (`zones`) or hide the outer ring (`edges: false`).
- Themeable: `--dv-drop-guide-color`, `--dv-drop-guide-cell-color`, `--dv-drop-guide-edge-cell-color`, `--dv-drop-guide-active-cell-color`.

### Core seam
The feature is a module (`DropGuideModule`, depends on `AdvancedDnDModule`); the only core additions are reusable, neutral primitives:
- A pluggable `PositionResolver` at the drop-target seam (`dropPositionResolver` / lazy getter) — both DnD backends consult it; unset ⇒ the default quadrant logic, unchanged.
- An `edge` flag on the resolver result that core routes to a whole-layout-edge dock (factored into `dockToLayoutEdge`, shared with the existing root-edge drop).
- A shared `canDisplayContentOverlay` predicate on the group model (the content drop target and the compass gating now use one source of truth).

### Tests
- Module unit tests (resolver hit-test, gating, edge routing, active-cell + edge-preview lifecycle, containing-block pinning, once-per-direction veto).
- Core unit tests for the `edge` flag plumbing in both DnD backends.
- Playwright e2e: compass appears + cell drop docks, outer-cell layout-edge dock, the compass holds position inner→outer, and feedback clears in dead zones.

All green (core+modules unit + e2e). Enabled in the dockview demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)