### PR TITLE
feat(core): header-aware content sizing seam

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -80,7 +80,12 @@
                         return {
                             element,
                             init() {},
-                            layout() {},
+                            // Record the content-area dimensions the group hands
+                            // each panel so the content-sizing seam (group box
+                            // minus header) is observable to the harness.
+                            layout(width, height) {
+                                panelDimensions[options.id] = { width, height };
+                            },
                             dispose() {},
                         };
                     },
@@ -89,6 +94,9 @@
 
                 // Test-facing handle.
                 const panels = {};
+                // Last content-area dimensions each panel was laid out with,
+                // keyed by panel id (written by the panel's layout() above).
+                const panelDimensions = {};
                 window.__dv = {
                     addPanel: (id) => {
                         panels[id] = dockview.addPanel({
@@ -97,6 +105,9 @@
                             title: id,
                         });
                     },
+                    // The content-area dimensions a panel was last laid out
+                    // with — the seam reports the group box minus the header.
+                    panelDimensions: (id) => panelDimensions[id],
                     closePanel: (id) => panels[id] && panels[id].api.close(),
                     // Create a new panel and move it to the right of the
                     // popped-out group — the move lands in the popout's own

--- a/e2e/tests/content-sizing.spec.ts
+++ b/e2e/tests/content-sizing.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Header-aware content sizing — the group lays panels out with the content-area
+ * dimensions (group box minus the header along its axis), not the
+ * header-inclusive group box. Real-browser only: it depends on the header
+ * actually having a measured size, which jsdom (no layout) can't produce.
+ */
+test.describe('content sizing (header-aware)', () => {
+    const setup = async (page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.addPanel('main'));
+    };
+
+    test('panel is laid out with the content box, not the header-inclusive group box', async ({
+        page,
+    }) => {
+        await setup(page);
+
+        const reported = await page.evaluate(() =>
+            (window as any).__dv.panelDimensions('main')
+        );
+        expect(reported).toBeTruthy();
+
+        const groupBox = (await page
+            .locator('.dv-groupview')
+            .first()
+            .boundingBox())!;
+        const headerBox = (await page
+            .locator('.dv-tabs-and-actions-container')
+            .first()
+            .boundingBox())!;
+        const contentBox = (await page
+            .locator('.dv-content-container')
+            .first()
+            .boundingBox())!;
+
+        // the header has real height (a single tab row)
+        expect(headerBox.height).toBeGreaterThan(0);
+
+        // the reported height matches the content area, i.e. the group height
+        // minus the header — NOT the full group box (the latent over-report).
+        expect(reported.height).toBeCloseTo(contentBox.height, 0);
+        expect(reported.height).toBeCloseTo(
+            groupBox.height - headerBox.height,
+            0
+        );
+        expect(reported.height).toBeLessThan(groupBox.height);
+
+        // width is unaffected by a horizontal (top) header
+        expect(reported.width).toBeCloseTo(contentBox.width, 0);
+        expect(reported.width).toBeCloseTo(groupBox.width, 0);
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/groupContentSizing.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/groupContentSizing.spec.ts
@@ -1,0 +1,177 @@
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { IContentRenderer } from '../../dockview/types';
+import { GroupPanelPartInitParameters } from '../../dockview/types';
+import { PanelUpdateEvent } from '../../panel/types';
+
+class TestContentPart implements IContentRenderer {
+    public element = document.createElement('div');
+
+    constructor(public readonly id: string) {
+        this.element.className = `content-part-${id}`;
+    }
+
+    init(_params: GroupPanelPartInitParameters): void {
+        //
+    }
+
+    layout(_width: number, _height: number): void {
+        //
+    }
+
+    update(_event: PanelUpdateEvent): void {
+        //
+    }
+
+    dispose(): void {
+        //
+    }
+}
+
+/**
+ * The group lays panels out with the *content-area* dimensions — the group box
+ * minus the header along its axis — so panels (and `onDidDimensionsChange`)
+ * receive the real space they occupy, not the header-inclusive group box.
+ *
+ * jsdom performs no layout, so `offset*` is 0 by default and nothing is
+ * subtracted; these tests stub the header element's `offsetHeight`/`offsetWidth`
+ * to simulate a measured header.
+ */
+describe('group content sizing (header-aware)', () => {
+    function createComponent() {
+        return new DockviewComponent(document.createElement('div'), {
+            createComponent(options) {
+                switch (options.name) {
+                    case 'component':
+                        return new TestContentPart(options.id);
+                    default:
+                        throw new Error(`unsupported ${options.name}`);
+                }
+            },
+        });
+    }
+
+    function stubOffset(
+        element: HTMLElement,
+        prop: 'offsetWidth' | 'offsetHeight',
+        value: number
+    ): void {
+        Object.defineProperty(element, prop, {
+            configurable: true,
+            get: () => value,
+        });
+    }
+
+    function getHeaderElement(group: { element: HTMLElement }): HTMLElement {
+        const header = group.element.querySelector<HTMLElement>(
+            '.dv-tabs-and-actions-container'
+        );
+        if (!header) {
+            throw new Error('header element not found');
+        }
+        return header;
+    }
+
+    test('horizontal header (top): content height = group height - header height', () => {
+        const cut = createComponent();
+        const panel = cut.addPanel({ id: 'panel1', component: 'component' });
+        const group = panel.group;
+
+        stubOffset(getHeaderElement(group), 'offsetHeight', 35);
+
+        const dimensions: { width: number; height: number }[] = [];
+        const disposable = panel.api.onDidDimensionsChange((event) =>
+            dimensions.push({ width: event.width, height: event.height })
+        );
+
+        group.layout(200, 100);
+
+        expect(dimensions).toContainEqual({ width: 200, height: 65 });
+
+        disposable.dispose();
+        cut.dispose();
+    });
+
+    test('vertical header (left): content width = group width - header width', () => {
+        const cut = createComponent();
+        const panel = cut.addPanel({ id: 'panel1', component: 'component' });
+        const group = panel.group;
+
+        group.model.headerPosition = 'left';
+        stubOffset(getHeaderElement(group), 'offsetWidth', 40);
+
+        const dimensions: { width: number; height: number }[] = [];
+        const disposable = panel.api.onDidDimensionsChange((event) =>
+            dimensions.push({ width: event.width, height: event.height })
+        );
+
+        group.layout(200, 100);
+
+        expect(dimensions).toContainEqual({ width: 160, height: 100 });
+
+        disposable.dispose();
+        cut.dispose();
+    });
+
+    test('no measurable header (hidden / zero offset): content gets the full box', () => {
+        const cut = createComponent();
+        const panel = cut.addPanel({ id: 'panel1', component: 'component' });
+        const group = panel.group;
+
+        // header offset stays 0 (jsdom default ≈ display:none header)
+        const dimensions: { width: number; height: number }[] = [];
+        const disposable = panel.api.onDidDimensionsChange((event) =>
+            dimensions.push({ width: event.width, height: event.height })
+        );
+
+        group.layout(200, 100);
+
+        expect(dimensions).toContainEqual({ width: 200, height: 100 });
+
+        disposable.dispose();
+        cut.dispose();
+    });
+
+    test('subtraction is floored at 0 when the header is taller than the box', () => {
+        const cut = createComponent();
+        const panel = cut.addPanel({ id: 'panel1', component: 'component' });
+        const group = panel.group;
+
+        stubOffset(getHeaderElement(group), 'offsetHeight', 150);
+
+        const dimensions: { width: number; height: number }[] = [];
+        const disposable = panel.api.onDidDimensionsChange((event) =>
+            dimensions.push({ width: event.width, height: event.height })
+        );
+
+        group.layout(200, 100);
+
+        expect(dimensions).toContainEqual({ width: 200, height: 0 });
+
+        disposable.dispose();
+        cut.dispose();
+    });
+
+    test('relayout() re-applies current dimensions with the latest header size', () => {
+        const cut = createComponent();
+        const panel = cut.addPanel({ id: 'panel1', component: 'component' });
+        const group = panel.group;
+
+        const header = getHeaderElement(group);
+        stubOffset(header, 'offsetHeight', 30);
+        group.layout(200, 100);
+
+        const dimensions: { width: number; height: number }[] = [];
+        const disposable = panel.api.onDidDimensionsChange((event) =>
+            dimensions.push({ width: event.width, height: event.height })
+        );
+
+        // header grows (e.g. a second tab row) without the group box changing
+        stubOffset(header, 'offsetHeight', 60);
+        group.relayout();
+
+        expect(dimensions).toContainEqual({ width: 200, height: 40 });
+
+        disposable.dispose();
+        cut.dispose();
+    });
+});

--- a/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
@@ -205,6 +205,14 @@ export class DockviewGroupPanel
         this.model.layout(width, height);
     }
 
+    /**
+     * Re-run the group's layout with its current dimensions, propagating a
+     * header-size change down to the content + active panel.
+     */
+    relayout(): void {
+        this.model.relayout();
+    }
+
     getComponent(): IFrameworkPart {
         return this._model;
     }

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -192,6 +192,7 @@ export interface IDockviewGroupPanelModel extends IPanel {
     headerPosition: DockviewHeaderPosition;
     setActive(isActive: boolean): void;
     initialize(): void;
+    relayout(): void;
     // state
     isPanelActive: (panel: IDockviewPanel) => boolean;
     indexOf(panel: IDockviewPanel): number;
@@ -457,7 +458,8 @@ export class DockviewGroupPanelModel
         // resize the active panel to fit the new header direction
         // if not, the panel will overflow the tabs container
         if (this._activePanel?.layout) {
-            this._activePanel.layout(this._width, this._height);
+            const { width, height } = this.contentDimensions();
+            this._activePanel.layout(width, height);
         }
 
         this.updateHeaderActions();
@@ -1508,11 +1510,45 @@ export class DockviewGroupPanelModel
         this._width = width;
         this._height = height;
 
-        this.contentContainer.layout(this._width, this._height);
+        const { width: contentWidth, height: contentHeight } =
+            this.contentDimensions();
+
+        this.contentContainer.layout(contentWidth, contentHeight);
 
         if (this._activePanel?.layout) {
-            this._activePanel.layout(this._width, this._height);
+            this._activePanel.layout(contentWidth, contentHeight);
         }
+    }
+
+    /**
+     * Re-run the group's layout with its current dimensions. Used to propagate a
+     * header-size change (e.g. a header that grew/shrank without the group box
+     * changing) down to the content + active panel.
+     */
+    public relayout(): void {
+        this.layout(this._width, this._height);
+    }
+
+    /**
+     * The dimensions available to the content/panel: the group box minus the
+     * header along its axis. The header (`dv-tabs-and-actions-container`) is
+     * laid out top/bottom (subtract its height) or left/right (subtract its
+     * width); a hidden header has `display:none` so its `offset*` is 0 and
+     * nothing is subtracted.
+     */
+    private contentDimensions(): { width: number; height: number } {
+        const headerEl = this.tabsContainer.element;
+        const horizontal =
+            this.headerPosition === 'top' || this.headerPosition === 'bottom';
+
+        return {
+            width: horizontal
+                ? this._width
+                : Math.max(0, this._width - headerEl.offsetWidth),
+            height: horizontal
+                ? Math.max(0, this._height - headerEl.offsetHeight)
+                : this._height,
+        };
     }
 
     private _removePanel(
@@ -1633,7 +1669,8 @@ export class DockviewGroupPanelModel
 
             this.contentContainer.openPanel(panel);
 
-            panel.layout(this._width, this._height);
+            const { width, height } = this.contentDimensions();
+            panel.layout(width, height);
 
             this.updateMru(panel);
 

--- a/packages/dockview-core/src/dockview/dockviewPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewPanel.ts
@@ -273,7 +273,8 @@ export class DockviewPanel
     }
 
     public layout(width: number, height: number): void {
-        // TODO: Can we somehow do height without header height or indicate what the header height is?
+        // `width`/`height` are the content-area dimensions (the group box minus
+        // the header), computed by DockviewGroupPanelModel.contentDimensions().
         this.api._onDidDimensionChange.fire({
             width,
             height: height,


### PR DESCRIPTION
## What

Free-core correctness fix: `DockviewGroupPanelModel` now lays panels out with the **content-area** dimensions (group box minus the header along its axis) instead of the header-inclusive group box.

Today `DockviewGroupPanelModel.layout(w, h)` forwarded the full group box straight to `panel.layout(w, h)` — the header was never subtracted (there was a literal `TODO` to this effect in `dockviewPanel.ts`). `ContentContainer.layout` is a no-op and `always`-overlays position off `getBoundingClientRect`, so the *visual* box was already correct; only the **reported numbers** (`panel.layout` args / `onDidDimensionsChange`) were wrong — harmless for CSS-fill renderers, but over-reporting height for canvas / virtualised / embed consumers.

## Changes

- `contentDimensions()` helper subtracts the header along its axis (`offsetHeight` for top/bottom, `offsetWidth` for left/right; a hidden header measures 0 → no subtraction, floored at 0). All three panel-sizing sites route through it.
- Generic no-arg `relayout()` on the model + `DockviewGroupPanel` wrapper — re-applies the stored dimensions so a header-size change can propagate without the group box changing.
- Removed the resolved `dockviewPanel.ts` TODO.

## Why now

This is the free seam that unblocks the planned **multi-row / advanced-overflow** modules (a variable-height header makes the over-report grow per row). It's a standalone correctness fix that benefits everyone and lands in free core; the wrap *mode* that needs it stays pro.

## Back-compat

⚠️ **BREAKING (v8):** panels and `onDidDimensionsChange` now receive the content-area height (group box minus header) instead of the header-inclusive group box. Within core nothing consumes the reported height, so the only observable change is more-correct numbers to apps that read panel dimensions. CSS-fill renderers are unaffected. Applied always (not gated) — gating would leave the latent bug in the default path.

## Tests

- **Unit** (`groupContentSizing.spec.ts`): stubs header offsets (jsdom has no layout) — content height/width subtraction for top/bottom + left/right headers, full box when unmeasured, floor at 0, `relayout()` re-application. jsdom reports `offsetHeight === 0` so the seam is inert by default → all existing layout tests stay green unchanged.
- **e2e** (`content-sizing.spec.ts`): real Chromium geometry — panel laid out with the content box (group height − real header height), not the full group box. Fixture instrumented to record panel layout dims via `__dv.panelDimensions`.
- core: 1103 passed · e2e: 26 passed · lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)