### PR TITLE
refactor(core): move the AdvancedDnD module into dockview-core

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -7,6 +7,8 @@ AddPanelOptions
 AddPanelPositionOptions
 AddPaneviewComponentOptions
 AddSplitviewComponentOptions
+AdvancedDnDModule
+AdvancedDnDService
 AnchorPosition
 AnchoredBox
 AnnouncementEvent

--- a/packages/dockview-core/src/__tests__/dockview/advancedDnDDrag.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/advancedDnDDrag.spec.ts
@@ -4,7 +4,7 @@ import {
     IContentRenderer,
     TabDragEvent,
     GroupDragEvent,
-} from 'dockview-core';
+} from '../../index';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');

--- a/packages/dockview-core/src/__tests__/dockview/advancedDnDPreview.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/advancedDnDPreview.spec.ts
@@ -1,6 +1,6 @@
-import { DockviewComponent } from 'dockview-core';
-import { IContentRenderer } from 'dockview-core';
-import { IAdvancedDnDService } from 'dockview-core';
+import { DockviewComponent } from '../../index';
+import { IContentRenderer } from '../../index';
+import { IAdvancedDnDService } from '../../index';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');

--- a/packages/dockview-core/src/__tests__/dockview/advancedDnDService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/advancedDnDService.spec.ts
@@ -1,10 +1,10 @@
-import { AdvancedDnDService } from '../advancedDnDService';
-import { IAdvancedDnDHost } from 'dockview-core';
-import { DockviewComponentOptions } from 'dockview-core';
-import { DockviewApi } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
-import { DockviewComponent } from 'dockview-core';
-import { IContentRenderer } from 'dockview-core';
+import { AdvancedDnDService } from '../../index';
+import { IAdvancedDnDHost } from '../../index';
+import { DockviewComponentOptions } from '../../index';
+import { DockviewApi } from '../../index';
+import { DockviewGroupPanel } from '../../index';
+import { DockviewComponent } from '../../index';
+import { IContentRenderer } from '../../index';
 
 describe('AdvancedDnDService', () => {
     function createHost(

--- a/packages/dockview-core/src/dockview/advancedDnDService.ts
+++ b/packages/dockview-core/src/dockview/advancedDnDService.ts
@@ -1,18 +1,18 @@
+import { Disposable, IDisposable } from '../lifecycle';
+import { IDragGhostSpec } from '../dnd/backend';
+import { DroptargetOverlayModel, Position } from '../dnd/droptarget';
 import {
-    DockviewDisposable as Disposable,
-    DockviewIDisposable as IDisposable,
-} from 'dockview-core';
-import { IDragGhostSpec } from 'dockview-core';
-import { DroptargetOverlayModel, Position } from 'dockview-core';
-import { GroupDragEvent, TabDragEvent } from 'dockview-core';
-import { DockviewWillDropEvent } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
+    GroupDragEvent,
+    TabDragEvent,
+} from './components/titlebar/tabsContainer';
+import { DockviewWillDropEvent } from './dockviewGroupPanelModel';
+import { DockviewGroupPanel } from './dockviewGroupPanel';
 import {
     DockviewGroupDropLocation,
     DockviewWillShowOverlayLocationEvent,
-} from 'dockview-core';
-import { defineModule } from 'dockview-core';
-import { IAdvancedDnDHost, IAdvancedDnDService } from 'dockview-core';
+} from './events';
+import { defineModule } from './modules';
+import { IAdvancedDnDHost, IAdvancedDnDService } from './moduleContracts';
 
 /** Cursor offset of the group drag ghost, matched to the long-shipped default. */
 const GROUP_DRAG_GHOST_OFFSET_X = 30;

--- a/packages/dockview-core/src/dockview/allModules.ts
+++ b/packages/dockview-core/src/dockview/allModules.ts
@@ -6,6 +6,7 @@ import { EdgeGroupModule } from './edgeGroupService';
 import { RootDropTargetModule } from './rootDropTargetService';
 import { HeaderActionsModule } from './headerActionsService';
 import { LiveRegionModule } from './liveRegionService';
+import { AdvancedDnDModule } from './advancedDnDService';
 
 /**
  * Internal list of the built-in modules that ship with the core. Registered
@@ -21,4 +22,5 @@ export const AllModules: DockviewModule<any>[] = [
     RootDropTargetModule,
     HeaderActionsModule,
     LiveRegionModule,
+    AdvancedDnDModule,
 ];

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -229,6 +229,10 @@ export {
 } from './dismissableLayer';
 export { IDragGhostSpec } from './dnd/backend';
 export { LiveRegionModule } from './dockview/liveRegionService';
+export {
+    AdvancedDnDModule,
+    AdvancedDnDService,
+} from './dockview/advancedDnDService';
 export { FloatingGroupModule } from './dockview/floatingGroupService';
 export { EdgeGroupModule } from './dockview/edgeGroupService';
 export { createCloseButton, createPinButton } from './svg';

--- a/packages/dockview-modules/src/dropGuideService.ts
+++ b/packages/dockview-modules/src/dropGuideService.ts
@@ -12,7 +12,7 @@ import {
 } from 'dockview-core';
 import { defineModule } from 'dockview-core';
 import { IDropGuideHost, IDropGuideService } from 'dockview-core';
-import { AdvancedDnDModule } from './advancedDnDService';
+import { AdvancedDnDModule } from 'dockview-core';
 
 /** Size (px) of each compass cell + the gap between them. */
 const CELL = 38;

--- a/packages/dockview-modules/src/index.ts
+++ b/packages/dockview-modules/src/index.ts
@@ -1,7 +1,6 @@
 import { DockviewModule } from 'dockview-core';
 import { TabGroupChipsModule } from './tabGroupChipsService';
 import { ContextMenuModule } from './contextMenu';
-import { AdvancedDnDModule } from './advancedDnDService';
 import { AccessibilityModule } from './accessibilityService';
 import { LayoutHistoryModule } from './layoutHistoryService';
 import { DropGuideModule } from './dropGuideService';
@@ -13,7 +12,6 @@ export {
     TabGroupChipsModule,
 } from './tabGroupChipsService';
 export { ContextMenuController, ContextMenuModule } from './contextMenu';
-export { AdvancedDnDService, AdvancedDnDModule } from './advancedDnDService';
 export {
     AccessibilityService,
     AccessibilityModule,
@@ -42,7 +40,6 @@ export {
 export const Modules: DockviewModule<any>[] = [
     TabGroupChipsModule,
     ContextMenuModule,
-    AdvancedDnDModule,
     AccessibilityModule,
     LayoutHistoryModule,
     DropGuideModule,

--- a/packages/dockview-modules/src/keyboardDockingService.ts
+++ b/packages/dockview-modules/src/keyboardDockingService.ts
@@ -7,7 +7,7 @@ import { DockviewGroupPanel } from 'dockview-core';
 import { IDockviewPanel } from 'dockview-core';
 import { resolveMessages } from 'dockview-core';
 import { defineModule } from 'dockview-core';
-import { AdvancedDnDModule } from './advancedDnDService';
+import { AdvancedDnDModule } from 'dockview-core';
 import { LiveRegionModule } from 'dockview-core';
 import { IAccessibilityHost, IKeyboardDockingService } from 'dockview-core';
 import {


### PR DESCRIPTION
## What

Relocates the **AdvancedDnD** module from `dockview-modules` into `dockview-core`.

- Moves `advancedDnDService.ts` (implementation) and its three test specs into core.
- Registers `AdvancedDnDModule` via core's `allModules.ts` (so it auto-registers from core), and exports `AdvancedDnDModule` / `AdvancedDnDService` from the core entrypoint.
- Repoints the two modules that `dependsOn` it — drop guide and keyboard docking — to import `AdvancedDnDModule` from `dockview-core`.

The service's contract (`IAdvancedDnDHost` / `IAdvancedDnDService`) already lived in core's `moduleContracts.ts`; only the implementation and tests needed to move.

## Why

AdvancedDnD's `onWill*` hooks have shipped in core for years, so it belongs with the built-in core modules rather than the separately-distributed package. Moving it into core also resolves an existing coupling where core reached into the sibling package to call the service.

## Behaviour / API

Unchanged. The `dockview` meta-package re-exports core (`export * from 'dockview-core'`), so `AdvancedDnDModule` / `AdvancedDnDService` remain importable from `dockview`, and `DockviewComponent` auto-registers `AllModules` exactly as before.

## Verification

- `dockview-core`: 1117 tests green (incl. the relocated specs), `tsc --noEmit` clean, full build clean.
- `dockview-modules`: 184 tests green, `tsc --noEmit` clean against the rebuilt core types.
- Formatted (prettier), no dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)