### PR TITLE
chore: resolve low-severity SonarCloud maintainability issues

### DIFF
--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -185,7 +185,7 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
     getWindow(): Window {
         return this.location.type === 'popout'
             ? this.location.getWindow()
-            : window;
+            : globalThis.window;
     }
 
     setHeaderPosition(position: DockviewHeaderPosition): void {

--- a/packages/dockview-core/src/dnd/pointer/longPress.ts
+++ b/packages/dockview-core/src/dnd/pointer/longPress.ts
@@ -62,7 +62,7 @@ export class LongPressDetector extends CompositeDisposable {
 
         // Source's owning window — popout drags fire on their own window.
         const targetWindow: Window =
-            this.element.ownerDocument?.defaultView ?? window;
+            this.element.ownerDocument?.defaultView ?? globalThis.window;
 
         this._timer = setTimeout(() => {
             this._timer = undefined;

--- a/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
@@ -26,9 +26,7 @@ export class PointerDragController extends CompositeDisposable {
     private static _instance: PointerDragController | undefined;
 
     static getInstance(): PointerDragController {
-        if (!PointerDragController._instance) {
-            PointerDragController._instance = new PointerDragController();
-        }
+        PointerDragController._instance ??= new PointerDragController();
         return PointerDragController._instance;
     }
 
@@ -136,7 +134,7 @@ export class PointerDragController extends CompositeDisposable {
         // Source's owning window — popout drags fire on their own window,
         // not the main one.
         const targetWindow: Window =
-            source.ownerDocument?.defaultView ?? window;
+            source.ownerDocument?.defaultView ?? globalThis.window;
 
         this._moveListener = addDisposableListener(
             targetWindow,

--- a/packages/dockview-core/src/dnd/pointer/pointerDragSource.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragSource.ts
@@ -133,7 +133,11 @@ export class PointerDragSource extends CompositeDisposable {
                 ? initiationDelayOpt()
                 : initiationDelayOpt) ?? DEFAULT_TOUCH_INITIATION_DELAY;
         this._armed = !isTouch || initiationDelay <= 0;
-        if (isTouch && initiationDelay > 0 && isFinite(initiationDelay)) {
+        if (
+            isTouch &&
+            initiationDelay > 0 &&
+            Number.isFinite(initiationDelay)
+        ) {
             this._armTimer = setTimeout(() => {
                 this._armTimer = undefined;
                 this._armed = true;
@@ -149,7 +153,7 @@ export class PointerDragSource extends CompositeDisposable {
 
         // Source's owning window — popout drags fire on their own window.
         const targetWindow: Window =
-            this.element.ownerDocument?.defaultView ?? window;
+            this.element.ownerDocument?.defaultView ?? globalThis.window;
 
         this._pendingMoveListener = addDisposableListener(
             targetWindow,

--- a/packages/dockview-core/src/dockview/components/popupService.ts
+++ b/packages/dockview-core/src/dockview/components/popupService.ts
@@ -26,7 +26,7 @@ export class PopupService extends CompositeDisposable {
     // document so they render and dismiss correctly.
     private readonly _window: Window;
 
-    constructor(root: HTMLElement, win: Window = window) {
+    constructor(root: HTMLElement, win: Window = globalThis.window) {
         super();
 
         this._root = root;

--- a/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
@@ -97,7 +97,7 @@ export class GroupDragSource extends CompositeDisposable {
 
         const buildMultiPanelsGhost = (): HTMLElement => {
             const ghostEl = document.createElement('div');
-            const style = window.getComputedStyle(this._element);
+            const style = globalThis.getComputedStyle(this._element);
             const bgColor = style.getPropertyValue(
                 '--dv-activegroup-visiblepanel-tab-background-color'
             );

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -349,19 +349,16 @@ export class TabGroupManager {
             this._indicator = null;
         }
 
-        if (!this._indicator) {
-            this._indicator = new Ctor({
-                tabsList: this._ctx.tabsList,
-                getTabGroups: () => this._ctx.group.model.getTabGroups(),
-                getActivePanelId: () => this._ctx.group.activePanel?.id,
-                getTabMap: () => this._ctx.getTabMap(),
-                getChipElement: (id) =>
-                    this._chipRenderers.get(id)?.chip.element,
-                getDirection: () => this._ctx.getDirection(),
-                getHeaderPosition: () => this._ctx.group.model.headerPosition,
-                getColorPalette: () => this._ctx.accessor.tabGroupColorPalette,
-            });
-        }
+        this._indicator ??= new Ctor({
+            tabsList: this._ctx.tabsList,
+            getTabGroups: () => this._ctx.group.model.getTabGroups(),
+            getActivePanelId: () => this._ctx.group.activePanel?.id,
+            getTabMap: () => this._ctx.getTabMap(),
+            getChipElement: (id) => this._chipRenderers.get(id)?.chip.element,
+            getDirection: () => this._ctx.getDirection(),
+            getHeaderPosition: () => this._ctx.group.model.headerPosition,
+            getColorPalette: () => this._ctx.accessor.tabGroupColorPalette,
+        });
     }
 
     private _ensureChipForGroup(tabGroup: ITabGroup): void {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -781,18 +781,15 @@ export class Tabs extends CompositeDisposable {
                     return;
                 }
 
-                switch (event.button) {
-                    case 0:
-                        // Edge groups are skipped here: all their tab interaction
-                        // is handled by onTabClick to avoid race conditions with
-                        // active panel state.
-                        if (
-                            this.group.api.location.type !== 'edge' &&
-                            this.group.activePanel !== panel
-                        ) {
-                            this.group.model.openPanel(panel);
-                        }
-                        break;
+                // Edge groups are skipped here: all their tab interaction
+                // is handled by onTabClick to avoid race conditions with
+                // active panel state.
+                if (
+                    event.button === 0 &&
+                    this.group.api.location.type !== 'edge' &&
+                    this.group.activePanel !== panel
+                ) {
+                    this.group.model.openPanel(panel);
                 }
             }),
             tab.onDrop((event) => {
@@ -831,8 +828,9 @@ export class Tabs extends CompositeDisposable {
                             firstPositions,
                             animState.sourceTabId,
                             animState.sourceIndex === -1,
-                            animState.sourceIndex !== -1
-                                ? {
+                            animState.sourceIndex === -1
+                                ? undefined
+                                : {
                                       from: Math.min(
                                           animState.sourceIndex,
                                           dropIndex
@@ -842,7 +840,6 @@ export class Tabs extends CompositeDisposable {
                                           dropIndex
                                       ),
                                   }
-                                : undefined
                         );
                     }
                 } else {

--- a/packages/dockview-core/src/dockview/dndCapabilities.ts
+++ b/packages/dockview-core/src/dockview/dndCapabilities.ts
@@ -47,13 +47,13 @@ export function resolveDndCapabilities(
 }
 
 function isCoarsePrimaryInput(): boolean {
-    if (typeof window === 'undefined' || !window.matchMedia) {
+    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
         return false;
     }
     // Coarse pointer without any fine pointer = phone-class device. A laptop
     // touchscreen reports both, and we want HTML5 to remain available there
     // because a real mouse is also plugged in.
-    const coarse = window.matchMedia('(pointer: coarse)').matches;
-    const fine = window.matchMedia('(pointer: fine)').matches;
+    const coarse = globalThis.matchMedia('(pointer: coarse)').matches;
+    const fine = globalThis.matchMedia('(pointer: fine)').matches;
     return coarse && !fine;
 }

--- a/packages/dockview-core/src/dockview/dndCapabilities.ts
+++ b/packages/dockview-core/src/dockview/dndCapabilities.ts
@@ -47,7 +47,7 @@ export function resolveDndCapabilities(
 }
 
 function isCoarsePrimaryInput(): boolean {
-    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
+    if (globalThis.window === undefined || !globalThis.matchMedia) {
         return false;
     }
     // Coarse pointer without any fine pointer = phone-class device. A laptop

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1379,11 +1379,11 @@ export class DockviewComponent
                     return false;
                 }
 
-                const referenceGroup = options?.referenceGroup
-                    ? options.referenceGroup
-                    : itemToPopout instanceof DockviewPanel
-                      ? itemToPopout.group
-                      : itemToPopout;
+                const referenceGroup =
+                    options?.referenceGroup ??
+                    (itemToPopout instanceof DockviewPanel
+                        ? itemToPopout.group
+                        : itemToPopout);
 
                 const referenceLocation = itemToPopout.api.location.type;
 
@@ -2674,7 +2674,7 @@ export class DockviewComponent
                 } = data;
 
                 if (typeof id !== 'string') {
-                    throw new Error(
+                    throw new TypeError(
                         'dockview: group id must be of type string'
                     );
                 }
@@ -2913,8 +2913,7 @@ export class DockviewComponent
                     }
                 }
 
-                for (let i = 0; i < createdPanels.length; i++) {
-                    const panel = createdPanels[i];
+                for (const panel of createdPanels) {
                     const isActive = activeView === panel.id;
                     edgeGroup.model.openPanel(panel, {
                         skipSetActive: !isActive,
@@ -3115,7 +3114,7 @@ export class DockviewComponent
     private _doAddPanel<T extends object = Parameters>(
         options: AddPanelOptions<T>
     ): DockviewPanel {
-        if (this.panels.find((_) => _.id === options.id)) {
+        if (this.panels.some((_) => _.id === options.id)) {
             throw new Error(
                 `dockview: panel with id ${options.id} already exists`
             );
@@ -3145,8 +3144,12 @@ export class DockviewComponent
                 index = options.position.index;
 
                 if (!referencePanel) {
+                    const referenceId =
+                        typeof options.position.referencePanel === 'string'
+                            ? options.position.referencePanel
+                            : options.position.referencePanel?.id;
                     throw new Error(
-                        `dockview: referencePanel '${options.position.referencePanel}' does not exist`
+                        `dockview: referencePanel '${referenceId}' does not exist`
                     );
                 }
 
@@ -3160,8 +3163,12 @@ export class DockviewComponent
                 index = options.position.index;
 
                 if (!referenceGroup) {
+                    const referenceId =
+                        typeof options.position.referenceGroup === 'string'
+                            ? options.position.referenceGroup
+                            : options.position.referenceGroup?.id;
                     throw new Error(
-                        `dockview: referenceGroup '${options.position.referenceGroup}' does not exist`
+                        `dockview: referenceGroup '${referenceId}' does not exist`
                     );
                 }
             } else {
@@ -3380,9 +3387,14 @@ export class DockviewComponent
                           )
                         : options.referencePanel;
 
+                const referencePanelId =
+                    typeof options.referencePanel === 'string'
+                        ? options.referencePanel
+                        : options.referencePanel?.id;
+
                 if (!referencePanel) {
                     throw new Error(
-                        `dockview: reference panel ${options.referencePanel} does not exist`
+                        `dockview: reference panel ${referencePanelId} does not exist`
                     );
                 }
 
@@ -3390,7 +3402,7 @@ export class DockviewComponent
 
                 if (!referenceGroup) {
                     throw new Error(
-                        `dockview: reference group for reference panel ${options.referencePanel} does not exist`
+                        `dockview: reference group for reference panel ${referencePanelId} does not exist`
                     );
                 }
             } else if (isGroupOptionsWithGroup(options)) {
@@ -3400,8 +3412,12 @@ export class DockviewComponent
                         : options.referenceGroup;
 
                 if (!referenceGroup) {
+                    const referenceId =
+                        typeof options.referenceGroup === 'string'
+                            ? options.referenceGroup
+                            : options.referenceGroup?.id;
                     throw new Error(
-                        `dockview: reference group ${options.referenceGroup} does not exist`
+                        `dockview: reference group ${referenceId} does not exist`
                     );
                 }
             } else {
@@ -3573,12 +3589,12 @@ export class DockviewComponent
             if (this.detachFromNestedWindow(group)) {
                 // The floating window hosts other groups and stays alive —
                 // finalize just this group.
-                if (!options?.skipDispose) {
-                    this.disposeGroupRecord(group);
-                } else {
+                if (options?.skipDispose) {
                     // Relocation: reset location so the destination root can
                     // re-tag it.
                     group.model.location = { type: 'grid' };
+                } else {
+                    this.disposeGroupRecord(group);
                 }
 
                 this.activateFallbackGroupIfRemoved(group, options?.skipActive);
@@ -3607,12 +3623,12 @@ export class DockviewComponent
             if (this.detachFromNestedWindow(group)) {
                 // The popout window hosts other groups and stays alive —
                 // finalize just this group.
-                if (!options?.skipDispose) {
-                    this.disposeGroupRecord(group);
-                } else {
+                if (options?.skipDispose) {
                     // Relocation: reset location so the destination root can
                     // re-tag it.
                     group.model.location = { type: 'grid' };
+                } else {
+                    this.disposeGroupRecord(group);
                 }
 
                 this.activateFallbackGroupIfRemoved(group, options?.skipActive);
@@ -4539,9 +4555,7 @@ export class DockviewComponent
     }
 
     createGroup(options?: GroupOptions): DockviewGroupPanel {
-        if (!options) {
-            options = {};
-        }
+        options ??= {};
 
         let id = options?.id;
 
@@ -4811,7 +4825,12 @@ export class DockviewComponent
             theme.edgeGroupCollapsedSize ?? 35
         );
 
-        if (theme.dndOverlayBorder !== undefined) {
+        if (theme.dndOverlayBorder === undefined) {
+            this.element.style.removeProperty('--dv-drag-over-border');
+            this._shellManager?.element.style.removeProperty(
+                '--dv-drag-over-border'
+            );
+        } else {
             this.element.style.setProperty(
                 '--dv-drag-over-border',
                 theme.dndOverlayBorder
@@ -4819,11 +4838,6 @@ export class DockviewComponent
             this._shellManager?.element.style.setProperty(
                 '--dv-drag-over-border',
                 theme.dndOverlayBorder
-            );
-        } else {
-            this.element.style.removeProperty('--dv-drag-over-border');
-            this._shellManager?.element.style.removeProperty(
-                '--dv-drag-over-border'
             );
         }
 

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1134,9 +1134,9 @@ export class DockviewGroupPanelModel
     restoreTabGroups(serializedGroups: SerializedTabGroup[]): void {
         // Bump counter past any restored numeric suffixes to avoid ID collisions
         for (const data of serializedGroups) {
-            const match = data.id.match(/-(\d+)$/);
+            const match = /-(\d+)$/.exec(data.id);
             if (match) {
-                const num = parseInt(match[1], 10) + 1;
+                const num = Number.parseInt(match[1], 10) + 1;
                 if (num > this._tabGroupIdCounter) {
                     this._tabGroupIdCounter = num;
                 }
@@ -1288,12 +1288,8 @@ export class DockviewGroupPanelModel
         panel?: IDockviewPanel;
         suppressRoll?: boolean;
     }): void {
-        if (!options) {
-            options = {};
-        }
-        if (!options.panel) {
-            options.panel = this.activePanel;
-        }
+        options ??= {};
+        options.panel ??= this.activePanel;
 
         const index = options.panel ? this.panels.indexOf(options.panel) : -1;
 
@@ -1301,10 +1297,10 @@ export class DockviewGroupPanelModel
 
         if (index < this.panels.length - 1) {
             normalizedIndex = index + 1;
-        } else if (!options.suppressRoll) {
-            normalizedIndex = 0;
-        } else {
+        } else if (options.suppressRoll) {
             return;
+        } else {
+            normalizedIndex = 0;
         }
 
         this.openPanel(this.panels[normalizedIndex]);
@@ -1314,12 +1310,8 @@ export class DockviewGroupPanelModel
         panel?: IDockviewPanel;
         suppressRoll?: boolean;
     }): void {
-        if (!options) {
-            options = {};
-        }
-        if (!options.panel) {
-            options.panel = this.activePanel;
-        }
+        options ??= {};
+        options.panel ??= this.activePanel;
 
         if (!options.panel) {
             return;
@@ -1331,10 +1323,10 @@ export class DockviewGroupPanelModel
 
         if (index > 0) {
             normalizedIndex = index - 1;
-        } else if (!options.suppressRoll) {
-            normalizedIndex = this.panels.length - 1;
-        } else {
+        } else if (options.suppressRoll) {
             return;
+        } else {
+            normalizedIndex = this.panels.length - 1;
         }
 
         this.openPanel(this.panels[normalizedIndex]);

--- a/packages/dockview-core/src/dockview/dockviewPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewPanel.ts
@@ -195,7 +195,7 @@ export class DockviewPanel
     public update(event: PanelUpdateEvent): void {
         // merge the new parameters with the existing parameters
         this._params = {
-            ...(this._params ?? {}),
+            ...this._params,
             ...event.params,
         };
 

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -123,9 +123,7 @@ export class EdgeGroupView implements IView {
         // Otherwise fall back to collapsedSize + 50 so the expanded state is
         // visually distinguishable from the collapsed state.
         this._expandedMinimumSize =
-            options.minimumSize !== undefined
-                ? options.minimumSize
-                : this._collapsedSize + 50;
+            options.minimumSize ?? this._collapsedSize + 50;
 
         this._lastExpandedSize = options.initialSize ?? 200;
 
@@ -587,7 +585,7 @@ export class ShellManager implements IDisposable {
             const baseCS = baseCfg.collapsedSize ?? defaultCollapsedSize;
             const newCS = baseCS + gapAdd;
             const baseMS = baseCfg.minimumSize;
-            const newMS = baseMS !== undefined ? baseMS + gapAdd : newCS + 50;
+            const newMS = baseMS === undefined ? newCS + 50 : baseMS + gapAdd;
             view.updateCollapsedSize(newCS, newMS);
         };
 

--- a/packages/dockview-core/src/dockview/strictEventsSequencing.ts
+++ b/packages/dockview-core/src/dockview/strictEventsSequencing.ts
@@ -23,12 +23,12 @@ export class StrictEventsSequencing extends CompositeDisposable {
                 }
             }),
             this.accessor.onDidRemovePanel((panel) => {
-                if (!panels.has(panel.api.id)) {
+                if (panels.has(panel.api.id)) {
+                    panels.delete(panel.api.id);
+                } else {
                     throw new Error(
                         `dockview: Invalid event sequence. [onDidRemovePanel] called for panel ${panel.api.id} but panel does not exists`
                     );
-                } else {
-                    panels.delete(panel.api.id);
                 }
             }),
             this.accessor.onDidAddGroup((group) => {
@@ -41,12 +41,12 @@ export class StrictEventsSequencing extends CompositeDisposable {
                 }
             }),
             this.accessor.onDidRemoveGroup((group) => {
-                if (!groups.has(group.api.id)) {
+                if (groups.has(group.api.id)) {
+                    groups.delete(group.api.id);
+                } else {
                     throw new Error(
                         `dockview: Invalid event sequence. [onDidRemoveGroup] called for group ${group.api.id} but group does not exists`
                     );
-                } else {
-                    groups.delete(group.api.id);
                 }
             })
         );

--- a/packages/dockview-core/src/dockview/tabGroup.ts
+++ b/packages/dockview-core/src/dockview/tabGroup.ts
@@ -170,9 +170,9 @@ export class TabGroup extends CompositeDisposable implements ITabGroup {
         }
 
         const insertIndex =
-            index !== undefined
-                ? Math.max(0, Math.min(index, this._panelIds.length))
-                : this._panelIds.length;
+            index === undefined
+                ? this._panelIds.length
+                : Math.max(0, Math.min(index, this._panelIds.length));
 
         this._panelIds.splice(insertIndex, 0, panelId);
         this._onDidPanelChange.fire({ panelId, type: 'add' });

--- a/packages/dockview-core/src/dockview/tabGroupAccent.ts
+++ b/packages/dockview-core/src/dockview/tabGroupAccent.ts
@@ -121,12 +121,10 @@ let _fallbackPalette: TabGroupColorPalette | undefined;
  * palette through.
  */
 function getFallbackPalette(): TabGroupColorPalette {
-    if (!_fallbackPalette) {
-        _fallbackPalette = new TabGroupColorPalette(
-            DEFAULT_TAB_GROUP_COLORS,
-            true
-        );
-    }
+    _fallbackPalette ??= new TabGroupColorPalette(
+        DEFAULT_TAB_GROUP_COLORS,
+        true
+    );
     return _fallbackPalette;
 }
 

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -159,7 +159,7 @@ class FocusTracker extends CompositeDisposable implements IFocusTracker {
         const onBlur = () => {
             if (hasFocus) {
                 loosingFocus = true;
-                window.setTimeout(() => {
+                globalThis.setTimeout(() => {
                     if (loosingFocus) {
                         loosingFocus = false;
                         hasFocus = false;

--- a/packages/dockview-core/src/events.ts
+++ b/packages/dockview-core/src/events.ts
@@ -80,7 +80,7 @@ class LeakageMonitor {
 
 class Stacktrace {
     static create(): Stacktrace {
-        return new Stacktrace(new Error().stack ?? '');
+        return new Stacktrace(new Error('listener stacktrace').stack ?? '');
     }
 
     private constructor(readonly value: string) {}

--- a/packages/dockview-core/src/gridview/baseComponentGridview.ts
+++ b/packages/dockview-core/src/gridview/baseComponentGridview.ts
@@ -338,9 +338,7 @@ export abstract class BaseGrid<T extends IGridPanelView>
     }
 
     public moveToNext(options?: MovementOptions2): void {
-        if (!options) {
-            options = {};
-        }
+        options ??= {};
         if (!options.group) {
             if (!this.activeGroup) {
                 return;
@@ -354,9 +352,7 @@ export abstract class BaseGrid<T extends IGridPanelView>
     }
 
     public moveToPrevious(options?: MovementOptions2): void {
-        if (!options) {
-            options = {};
-        }
+        options ??= {};
         if (!options.group) {
             if (!this.activeGroup) {
                 return;

--- a/packages/dockview-core/src/gridview/branchNode.ts
+++ b/packages/dockview-core/src/gridview/branchNode.ts
@@ -119,13 +119,13 @@ export class BranchNode extends CompositeDisposable implements IView {
             return LayoutPriority.Normal;
         }
 
-        const priorities = this.children.map((c) =>
-            c.priority === undefined ? LayoutPriority.Normal : c.priority
+        const priorities = new Set(
+            this.children.map((c) => c.priority ?? LayoutPriority.Normal)
         );
 
-        if (priorities.includes(LayoutPriority.High)) {
+        if (priorities.has(LayoutPriority.High)) {
             return LayoutPriority.High;
-        } else if (priorities.includes(LayoutPriority.Low)) {
+        } else if (priorities.has(LayoutPriority.Low)) {
             return LayoutPriority.Low;
         }
 

--- a/packages/dockview-core/src/gridview/branchNode.ts
+++ b/packages/dockview-core/src/gridview/branchNode.ts
@@ -120,14 +120,12 @@ export class BranchNode extends CompositeDisposable implements IView {
         }
 
         const priorities = this.children.map((c) =>
-            typeof c.priority === 'undefined'
-                ? LayoutPriority.Normal
-                : c.priority
+            c.priority === undefined ? LayoutPriority.Normal : c.priority
         );
 
-        if (priorities.some((p) => p === LayoutPriority.High)) {
+        if (priorities.includes(LayoutPriority.High)) {
             return LayoutPriority.High;
-        } else if (priorities.some((p) => p === LayoutPriority.Low)) {
+        } else if (priorities.includes(LayoutPriority.Low)) {
             return LayoutPriority.Low;
         }
 
@@ -173,15 +171,7 @@ export class BranchNode extends CompositeDisposable implements IView {
         this.element = document.createElement('div');
         this.element.className = 'dv-branch-node';
 
-        if (!childDescriptors) {
-            this.splitview = new Splitview(this.element, {
-                orientation: this.orientation,
-                proportionalLayout,
-                styles,
-                margin,
-            });
-            this.splitview.layout(this.size, this.orthogonalSize);
-        } else {
+        if (childDescriptors) {
             const descriptor = {
                 views: childDescriptors.map((childDescriptor) => {
                     return {
@@ -205,6 +195,14 @@ export class BranchNode extends CompositeDisposable implements IView {
                 styles,
                 margin,
             });
+        } else {
+            this.splitview = new Splitview(this.element, {
+                orientation: this.orientation,
+                proportionalLayout,
+                styles,
+                margin,
+            });
+            this.splitview.layout(this.size, this.orthogonalSize);
         }
 
         this.disabled = disabled;

--- a/packages/dockview-core/src/gridview/gridview.ts
+++ b/packages/dockview-core/src/gridview/gridview.ts
@@ -834,7 +834,7 @@ export class Gridview implements IDisposable {
         const [path, node] = this.getNode(location);
 
         if (!(node instanceof LeafNode)) {
-            throw new Error('invalid location');
+            throw new TypeError('invalid location');
         }
 
         for (let i = path.length - 1; i > -1; i--) {
@@ -880,7 +880,7 @@ export class Gridview implements IDisposable {
         const [, parent] = this.getNode(rest);
 
         if (!(parent instanceof BranchNode)) {
-            throw new Error('Invalid from location');
+            throw new TypeError('Invalid from location');
         }
 
         return parent.isChildVisible(index);
@@ -895,7 +895,7 @@ export class Gridview implements IDisposable {
         const [, parent] = this.getNode(rest);
 
         if (!(parent instanceof BranchNode)) {
-            throw new Error('Invalid from location');
+            throw new TypeError('Invalid from location');
         }
 
         this._onDidViewVisibilityChange.fire();
@@ -911,7 +911,7 @@ export class Gridview implements IDisposable {
         const [, parent] = this.getNode(parentLocation);
 
         if (!(parent instanceof BranchNode)) {
-            throw new Error('Invalid location');
+            throw new TypeError('Invalid location');
         }
 
         parent.moveChild(from, to);
@@ -997,13 +997,13 @@ export class Gridview implements IDisposable {
         const [pathToParent, parent] = this.getNode(rest);
 
         if (!(parent instanceof BranchNode)) {
-            throw new Error('Invalid location');
+            throw new TypeError('Invalid location');
         }
 
         const nodeToRemove = parent.children[index];
 
         if (!(nodeToRemove instanceof LeafNode)) {
-            throw new Error('Invalid location');
+            throw new TypeError('Invalid location');
         }
 
         parent.removeChild(index, sizing);
@@ -1126,7 +1126,7 @@ export class Gridview implements IDisposable {
         }
 
         if (!(node instanceof BranchNode)) {
-            throw new Error('Invalid location');
+            throw new TypeError('Invalid location');
         }
 
         const [index, ...rest] = location;

--- a/packages/dockview-core/src/gridview/gridviewComponent.ts
+++ b/packages/dockview-core/src/gridview/gridviewComponent.ts
@@ -382,11 +382,7 @@ export class GridviewComponent
                 }
                 this._groups.forEach((groupItem) => {
                     const group = groupItem.value;
-                    if (group !== panel) {
-                        group.setActive(false);
-                    } else {
-                        group.setActive(true);
-                    }
+                    group.setActive(group === panel);
                 });
             })
         );

--- a/packages/dockview-core/src/overlay/overlay.ts
+++ b/packages/dockview-core/src/overlay/overlay.ts
@@ -286,17 +286,17 @@ export class Overlay extends CompositeDisposable {
         const result: any = {};
 
         if (this.verticalAlignment === 'top') {
-            result.top = parseFloat(this._element.style.top);
+            result.top = Number.parseFloat(this._element.style.top);
         } else if (this.verticalAlignment === 'bottom') {
-            result.bottom = parseFloat(this._element.style.bottom);
+            result.bottom = Number.parseFloat(this._element.style.bottom);
         } else {
             result.top = element.top - container.top;
         }
 
         if (this.horiziontalAlignment === 'left') {
-            result.left = parseFloat(this._element.style.left);
+            result.left = Number.parseFloat(this._element.style.left);
         } else if (this.horiziontalAlignment === 'right') {
-            result.right = parseFloat(this._element.style.right);
+            result.right = Number.parseFloat(this._element.style.right);
         } else {
             result.left = element.left - container.left;
         }
@@ -379,7 +379,7 @@ export class Overlay extends CompositeDisposable {
                         }
                     },
                 },
-                addDisposableListener(window, 'pointermove', (e) => {
+                addDisposableListener(globalThis.window, 'pointermove', (e) => {
                     if (this._dragCancelled) {
                         return;
                     }
@@ -395,12 +395,10 @@ export class Overlay extends CompositeDisposable {
                     );
 
                     const overlayRect = this._element.getBoundingClientRect();
-                    if (offset === null) {
-                        offset = {
-                            x: e.clientX - overlayRect.left,
-                            y: e.clientY - overlayRect.top,
-                        };
-                    }
+                    offset ??= {
+                        x: e.clientX - overlayRect.left,
+                        y: e.clientY - overlayRect.top,
+                    };
 
                     const xOffset = Math.max(
                         0,
@@ -483,8 +481,8 @@ export class Overlay extends CompositeDisposable {
                         this._onDidStartMoving.fire();
                     }
                 }),
-                addDisposableListener(window, 'pointerup', end),
-                addDisposableListener(window, 'pointercancel', end)
+                addDisposableListener(globalThis.window, 'pointerup', end),
+                addDisposableListener(globalThis.window, 'pointercancel', end)
             );
         };
 
@@ -585,182 +583,185 @@ export class Overlay extends CompositeDisposable {
                 };
 
                 move.value = new CompositeDisposable(
-                    addDisposableListener(window, 'pointermove', (e) => {
-                        const containerRect =
-                            this.options.container.getBoundingClientRect();
-                        const overlayRect =
-                            this._element.getBoundingClientRect();
+                    addDisposableListener(
+                        globalThis.window,
+                        'pointermove',
+                        (e) => {
+                            const containerRect =
+                                this.options.container.getBoundingClientRect();
+                            const overlayRect =
+                                this._element.getBoundingClientRect();
 
-                        const y = e.clientY - containerRect.top;
-                        const x = e.clientX - containerRect.left;
+                            const y = e.clientY - containerRect.top;
+                            const x = e.clientX - containerRect.left;
 
-                        if (startPosition === null) {
                             // record the initial dimensions since as all subsequence moves are relative to this
-                            startPosition = {
+                            startPosition ??= {
                                 originalY: y,
                                 originalHeight: overlayRect.height,
                                 originalX: x,
                                 originalWidth: overlayRect.width,
                             };
+
+                            let top: number | undefined = undefined;
+                            let bottom: number | undefined = undefined;
+                            let height: number | undefined = undefined;
+                            let left: number | undefined = undefined;
+                            let right: number | undefined = undefined;
+                            let width: number | undefined = undefined;
+
+                            const moveTop = () => {
+                                // When dragging top handle, constrain top position to prevent oversizing
+                                const maxTop =
+                                    startPosition!.originalY +
+                                        startPosition!.originalHeight >
+                                    containerRect.height
+                                        ? Math.max(
+                                              0,
+                                              containerRect.height -
+                                                  Overlay.MINIMUM_HEIGHT
+                                          )
+                                        : Math.max(
+                                              0,
+                                              startPosition!.originalY +
+                                                  startPosition!
+                                                      .originalHeight -
+                                                  Overlay.MINIMUM_HEIGHT
+                                          );
+                                top = clamp(y, 0, maxTop);
+
+                                height =
+                                    startPosition!.originalY +
+                                    startPosition!.originalHeight -
+                                    top;
+
+                                bottom = containerRect.height - top - height;
+                            };
+
+                            const moveBottom = () => {
+                                top =
+                                    startPosition!.originalY -
+                                    startPosition!.originalHeight;
+
+                                // When dragging bottom handle, constrain height to container height
+                                const minHeight =
+                                    top < 0 &&
+                                    typeof this.options
+                                        .minimumInViewportHeight === 'number'
+                                        ? -top +
+                                          this.options.minimumInViewportHeight
+                                        : Overlay.MINIMUM_HEIGHT;
+
+                                const maxHeight =
+                                    containerRect.height - Math.max(0, top);
+
+                                height = clamp(y - top, minHeight, maxHeight);
+
+                                bottom = containerRect.height - top - height;
+                            };
+
+                            const moveLeft = () => {
+                                const maxLeft =
+                                    startPosition!.originalX +
+                                        startPosition!.originalWidth >
+                                    containerRect.width
+                                        ? Math.max(
+                                              0,
+                                              containerRect.width -
+                                                  Overlay.MINIMUM_WIDTH
+                                          ) // Prevent extending beyong right edge
+                                        : Math.max(
+                                              0,
+                                              startPosition!.originalX +
+                                                  startPosition!.originalWidth -
+                                                  Overlay.MINIMUM_WIDTH
+                                          );
+
+                                left = clamp(x, 0, maxLeft); // min is 0 (Not -Infinity) to prevent dragging beyond left edge
+
+                                width =
+                                    startPosition!.originalX +
+                                    startPosition!.originalWidth -
+                                    left;
+
+                                right = containerRect.width - left - width;
+                            };
+
+                            const moveRight = () => {
+                                left =
+                                    startPosition!.originalX -
+                                    startPosition!.originalWidth;
+
+                                // When dragging right handle, constrain width to container width
+                                const minWidth =
+                                    left < 0 &&
+                                    typeof this.options
+                                        .minimumInViewportWidth === 'number'
+                                        ? -left +
+                                          this.options.minimumInViewportWidth
+                                        : Overlay.MINIMUM_WIDTH;
+
+                                const maxWidth =
+                                    containerRect.width - Math.max(0, left);
+
+                                width = clamp(x - left, minWidth, maxWidth);
+
+                                right = containerRect.width - left - width;
+                            };
+
+                            switch (direction) {
+                                case 'top':
+                                    moveTop();
+                                    break;
+                                case 'bottom':
+                                    moveBottom();
+                                    break;
+                                case 'left':
+                                    moveLeft();
+                                    break;
+                                case 'right':
+                                    moveRight();
+                                    break;
+                                case 'topleft':
+                                    moveTop();
+                                    moveLeft();
+                                    break;
+                                case 'topright':
+                                    moveTop();
+                                    moveRight();
+                                    break;
+                                case 'bottomleft':
+                                    moveBottom();
+                                    moveLeft();
+                                    break;
+                                case 'bottomright':
+                                    moveBottom();
+                                    moveRight();
+                                    break;
+                            }
+
+                            const bounds: any = {};
+
+                            // Anchor to top or to bottom depending on which one is closer
+                            if (top! <= bottom!) {
+                                bounds.top = top;
+                            } else {
+                                bounds.bottom = bottom;
+                            }
+
+                            // Anchor to left or to right depending on which one is closer
+                            if (left! <= right!) {
+                                bounds.left = left;
+                            } else {
+                                bounds.right = right;
+                            }
+
+                            bounds.height = height;
+                            bounds.width = width;
+
+                            this.setBounds(bounds);
                         }
-
-                        let top: number | undefined = undefined;
-                        let bottom: number | undefined = undefined;
-                        let height: number | undefined = undefined;
-                        let left: number | undefined = undefined;
-                        let right: number | undefined = undefined;
-                        let width: number | undefined = undefined;
-
-                        const moveTop = () => {
-                            // When dragging top handle, constrain top position to prevent oversizing
-                            const maxTop =
-                                startPosition!.originalY +
-                                    startPosition!.originalHeight >
-                                containerRect.height
-                                    ? Math.max(
-                                          0,
-                                          containerRect.height -
-                                              Overlay.MINIMUM_HEIGHT
-                                      )
-                                    : Math.max(
-                                          0,
-                                          startPosition!.originalY +
-                                              startPosition!.originalHeight -
-                                              Overlay.MINIMUM_HEIGHT
-                                      );
-                            top = clamp(y, 0, maxTop);
-
-                            height =
-                                startPosition!.originalY +
-                                startPosition!.originalHeight -
-                                top;
-
-                            bottom = containerRect.height - top - height;
-                        };
-
-                        const moveBottom = () => {
-                            top =
-                                startPosition!.originalY -
-                                startPosition!.originalHeight;
-
-                            // When dragging bottom handle, constrain height to container height
-                            const minHeight =
-                                top < 0 &&
-                                typeof this.options.minimumInViewportHeight ===
-                                    'number'
-                                    ? -top +
-                                      this.options.minimumInViewportHeight
-                                    : Overlay.MINIMUM_HEIGHT;
-
-                            const maxHeight =
-                                containerRect.height - Math.max(0, top);
-
-                            height = clamp(y - top, minHeight, maxHeight);
-
-                            bottom = containerRect.height - top - height;
-                        };
-
-                        const moveLeft = () => {
-                            const maxLeft =
-                                startPosition!.originalX +
-                                    startPosition!.originalWidth >
-                                containerRect.width
-                                    ? Math.max(
-                                          0,
-                                          containerRect.width -
-                                              Overlay.MINIMUM_WIDTH
-                                      ) // Prevent extending beyong right edge
-                                    : Math.max(
-                                          0,
-                                          startPosition!.originalX +
-                                              startPosition!.originalWidth -
-                                              Overlay.MINIMUM_WIDTH
-                                      );
-
-                            left = clamp(x, 0, maxLeft); // min is 0 (Not -Infinity) to prevent dragging beyond left edge
-
-                            width =
-                                startPosition!.originalX +
-                                startPosition!.originalWidth -
-                                left;
-
-                            right = containerRect.width - left - width;
-                        };
-
-                        const moveRight = () => {
-                            left =
-                                startPosition!.originalX -
-                                startPosition!.originalWidth;
-
-                            // When dragging right handle, constrain width to container width
-                            const minWidth =
-                                left < 0 &&
-                                typeof this.options.minimumInViewportWidth ===
-                                    'number'
-                                    ? -left +
-                                      this.options.minimumInViewportWidth
-                                    : Overlay.MINIMUM_WIDTH;
-
-                            const maxWidth =
-                                containerRect.width - Math.max(0, left);
-
-                            width = clamp(x - left, minWidth, maxWidth);
-
-                            right = containerRect.width - left - width;
-                        };
-
-                        switch (direction) {
-                            case 'top':
-                                moveTop();
-                                break;
-                            case 'bottom':
-                                moveBottom();
-                                break;
-                            case 'left':
-                                moveLeft();
-                                break;
-                            case 'right':
-                                moveRight();
-                                break;
-                            case 'topleft':
-                                moveTop();
-                                moveLeft();
-                                break;
-                            case 'topright':
-                                moveTop();
-                                moveRight();
-                                break;
-                            case 'bottomleft':
-                                moveBottom();
-                                moveLeft();
-                                break;
-                            case 'bottomright':
-                                moveBottom();
-                                moveRight();
-                                break;
-                        }
-
-                        const bounds: any = {};
-
-                        // Anchor to top or to bottom depending on which one is closer
-                        if (top! <= bottom!) {
-                            bounds.top = top;
-                        } else {
-                            bounds.bottom = bottom;
-                        }
-
-                        // Anchor to left or to right depending on which one is closer
-                        if (left! <= right!) {
-                            bounds.left = left;
-                        } else {
-                            bounds.right = right;
-                        }
-
-                        bounds.height = height;
-                        bounds.width = width;
-
-                        this.setBounds(bounds);
-                    }),
+                    ),
                     {
                         dispose: () => {
                             iframes.release();
@@ -778,8 +779,12 @@ export class Overlay extends CompositeDisposable {
                             }
                         },
                     },
-                    addDisposableListener(window, 'pointerup', end),
-                    addDisposableListener(window, 'pointercancel', end)
+                    addDisposableListener(globalThis.window, 'pointerup', end),
+                    addDisposableListener(
+                        globalThis.window,
+                        'pointercancel',
+                        end
+                    )
                 );
             })
         );

--- a/packages/dockview-core/src/paneview/paneviewComponent.ts
+++ b/packages/dockview-core/src/paneview/paneviewComponent.ts
@@ -275,9 +275,7 @@ export class PaneviewComponent extends Resizable implements IPaneviewComponent {
             });
         }
 
-        if (!header) {
-            header = new DefaultHeader();
-        }
+        header ??= new DefaultHeader();
 
         const view = new PaneFramework({
             id: options.id,
@@ -405,9 +403,7 @@ export class PaneviewComponent extends Resizable implements IPaneviewComponent {
                         });
                     }
 
-                    if (!header) {
-                        header = new DefaultHeader();
-                    }
+                    header ??= new DefaultHeader();
 
                     const panel = new PaneFramework({
                         id: data.id,

--- a/packages/dockview-core/src/popoutWindow.ts
+++ b/packages/dockview-core/src/popoutWindow.ts
@@ -19,14 +19,14 @@ export type PopoutWindowOptions = {
 export function assertSameOriginPopoutUrl(url: string): void {
     let resolved: URL;
     try {
-        resolved = new URL(url, window.location.href);
+        resolved = new URL(url, globalThis.location.href);
     } catch {
         throw new Error(`dockview: invalid popout URL: ${url}`);
     }
 
     const protocolOk =
         resolved.protocol === 'http:' || resolved.protocol === 'https:';
-    if (!protocolOk || resolved.origin !== window.location.origin) {
+    if (!protocolOk || resolved.origin !== globalThis.location.origin) {
         throw new Error(
             `dockview: popout URL must be same-origin http(s); got: ${url}`
         );
@@ -126,7 +126,7 @@ export class PopoutWindow extends CompositeDisposable {
             Disposable.from(() => {
                 externalWindow.close();
             }),
-            addDisposableListener(window, 'beforeunload', () => {
+            addDisposableListener(globalThis.window, 'beforeunload', () => {
                 /**
                  * before the main window closes we should close this popup too
                  * to be good citizens
@@ -165,9 +165,13 @@ export class PopoutWindow extends CompositeDisposable {
 
                     externalDocument.body.appendChild(container);
 
-                    addStyles(externalDocument, window.document.styleSheets, {
-                        nonce: this.options.nonce,
-                    });
+                    addStyles(
+                        externalDocument,
+                        globalThis.document.styleSheets,
+                        {
+                            nonce: this.options.nonce,
+                        }
+                    );
 
                     /**
                      * beforeunload must be registered after load for reasons I could not determine

--- a/packages/dockview-core/src/scrollbar.ts
+++ b/packages/dockview-core/src/scrollbar.ts
@@ -14,7 +14,7 @@ export class Scrollbar extends CompositeDisposable {
     private _scrollOffset: number = 0;
     private _animationTimer: any;
     private _orientation: 'horizontal' | 'vertical' = 'horizontal';
-    public static MouseWheelSpeed = 1;
+    public static readonly MouseWheelSpeed = 1;
 
     get element(): HTMLElement {
         return this._element;

--- a/packages/dockview-core/src/splitview/splitview.ts
+++ b/packages/dockview-core/src/splitview/splitview.ts
@@ -664,7 +664,7 @@ export class Splitview {
     public moveView(from: number, to: number): void {
         const cachedVisibleSize = this.getViewCachedVisibleSize(from);
         const sizing =
-            typeof cachedVisibleSize === 'undefined'
+            cachedVisibleSize === undefined
                 ? this.getViewSize(from)
                 : Sizing.Invisible(cachedVisibleSize);
         const view = this.removeView(from, undefined, true);
@@ -676,23 +676,7 @@ export class Splitview {
         this.size = size;
         this.orthogonalSize = orthogonalSize;
 
-        if (!this.proportions) {
-            const indexes = range(this.viewItems.length);
-            const lowPriorityIndexes = indexes.filter(
-                (i) => this.viewItems[i].priority === LayoutPriority.Low
-            );
-            const highPriorityIndexes = indexes.filter(
-                (i) => this.viewItems[i].priority === LayoutPriority.High
-            );
-
-            this.resize(
-                this.viewItems.length - 1,
-                size - previousSize,
-                undefined,
-                lowPriorityIndexes,
-                highPriorityIndexes
-            );
-        } else {
+        if (this.proportions) {
             let total = 0;
 
             for (let i = 0; i < this.viewItems.length; i++) {
@@ -718,6 +702,22 @@ export class Splitview {
                     );
                 }
             }
+        } else {
+            const indexes = range(this.viewItems.length);
+            const lowPriorityIndexes = indexes.filter(
+                (i) => this.viewItems[i].priority === LayoutPriority.Low
+            );
+            const highPriorityIndexes = indexes.filter(
+                (i) => this.viewItems[i].priority === LayoutPriority.High
+            );
+
+            this.resize(
+                this.viewItems.length - 1,
+                size - previousSize,
+                undefined,
+                lowPriorityIndexes,
+                highPriorityIndexes
+            );
         }
 
         this.distributeEmptySpace();

--- a/packages/dockview-core/src/splitview/viewItem.ts
+++ b/packages/dockview-core/src/splitview/viewItem.ts
@@ -19,7 +19,7 @@ export class ViewItem {
     }
 
     get visible(): boolean {
-        return typeof this._cachedVisibleSize === 'undefined';
+        return this._cachedVisibleSize === undefined;
     }
 
     get minimumSize(): number {

--- a/packages/dockview-modules/src/contextMenu.ts
+++ b/packages/dockview-modules/src/contextMenu.ts
@@ -66,11 +66,11 @@ function buildSeparator(): HTMLElement {
 }
 
 function isCoarsePrimaryInput(): boolean {
-    if (typeof window === 'undefined' || !window.matchMedia) {
+    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
         return false;
     }
-    const coarse = window.matchMedia('(pointer: coarse)').matches;
-    const fine = window.matchMedia('(pointer: fine)').matches;
+    const coarse = globalThis.matchMedia('(pointer: coarse)').matches;
+    const fine = globalThis.matchMedia('(pointer: fine)').matches;
     return coarse && !fine;
 }
 

--- a/packages/dockview-modules/src/contextMenu.ts
+++ b/packages/dockview-modules/src/contextMenu.ts
@@ -66,7 +66,7 @@ function buildSeparator(): HTMLElement {
 }
 
 function isCoarsePrimaryInput(): boolean {
-    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
+    if (globalThis.window === undefined || !globalThis.matchMedia) {
         return false;
     }
     const coarse = globalThis.matchMedia('(pointer: coarse)').matches;

--- a/packages/dockview-react/src/react.ts
+++ b/packages/dockview-react/src/react.ts
@@ -99,11 +99,11 @@ export class ReactPart<
             throw new Error('invalid operation: resource is already disposed');
         }
 
-        if (!this.componentInstance) {
+        if (this.componentInstance) {
+            this.componentInstance.update(props);
+        } else {
             // if the component is yet to be mounted store the props
             this._initialProps = { ...this._initialProps, ...props };
-        } else {
-            this.componentInstance.update(props);
         }
     }
 

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -114,13 +114,13 @@ describe('GridviewVue Component', () => {
             component: 'test-component',
         });
 
-        expect(api.panels.length).toBe(1);
+        expect(api.panels).toHaveLength(1);
         expect(api.panels[0].id).toBe('grid-panel-1');
         expect(initSpy).toHaveBeenCalled();
 
         // Remove the panel
         api.removePanel(api.panels[0]);
-        expect(api.panels.length).toBe(0);
+        expect(api.panels).toHaveLength(0);
 
         initSpy.mockRestore();
         api.dispose();


### PR DESCRIPTION
## Description

Addresses the open **LOW-severity MAINTAINABILITY** SonarCloud code smells for `mathuo_dockview` (~90 of 102). All changes are mechanical modernizations with no behavioural impact. A minority are intentionally left as-is because the Sonar suggestion is a false positive or would change behaviour — see below.

**Fixed:**

| Rule | Count | Change |
|---|---|---|
| S7764 | 25 | `window` → `globalThis` (`globalThis.window` where an actual `Window` value is required, to stay type-safe) |
| S6606 | 16 | `??=` / `??` instead of if-null assignments and ternaries |
| S7735 | 15 | invert unexpected negated conditions |
| S7786 | 8 | `TypeError` (not `Error`) from type-guard checks |
| S7773 / S6594 | 7 | `Number.parseFloat/parseInt/isFinite`, `RegExp.exec` |
| S6551 | 5 | interpolate reference **ids** (not objects) into error messages |
| S7765 / S7741 / S7754 | 6 | `includes` over `some`, direct `=== undefined`, `some` over `find` |
| S1301 / S7744 / S7722 / S1444 / S5906 / S4138 | 8 | switch→if, drop useless `{}` spread, `Error` message, `readonly` static, specific jest matcher, `for-of` |

**Intentionally not changed (false positives / would break behaviour):**

- **S7747 ×7** — the `[...collection]` spreads are required snapshots; each loop disposes/removes from the very collection it iterates (`group.panels` returns the live `_panels`; Sets/arrays get `.delete`/`.splice`/`remove()` during disposal), so removing the copy would skip elements.
- **S7765** (`tabsContainer.indexOf`) — the custom `ITabsContainer` has `indexOf()` but no `includes()`.
- **S6598** (`Event`) — the interface merges with `namespace Event`; a type alias can't.
- **S1444** (`ENABLE_TRACKING`) — reassigned at runtime (`events.ts`).
- **S2094** (`TransferObject`) — intentional empty base class for DnD transfer types.
- **S6848** (default-tab close-button a11y) and **S6754** (useState in the React bridge) — genuine but need a UX/keyboard design decision rather than a mechanical fix.

## Type of change

- [x] Refactor / cleanup

## Affected packages

- [x] `dockview-core`
- [x] `dockview-react`
- [x] `dockview-vue`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-angular`
- [ ] `docs`

(also `dockview-modules` — `contextMenu.ts`)

## How to test

Covered by the existing suites — no behavioural change is intended:

- `dockview-core`: 1073 tests pass
- `dockview-react`: 44 tests pass
- `dockview-modules`: 99 tests pass
- `dockview-vue`: 121 tests pass (vitest, via `nx test dockview-vue`)
- `dockview-core` typechecks clean; `dockview-core`, `dockview-modules`, `dockview-react` build successfully

## Checklist

- [x] `yarn lint:fix` passes (no errors; only pre-existing warnings)
- [x] `yarn format` passes (changed files run through prettier)
- [ ] `npm run gen` has been run and generated files are up to date (n/a — no generated sources affected)
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable (one existing vue assertion made more specific per S5906)
- [ ] Breaking changes are documented (n/a — no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiZ9eADKvMUzPp7JLa6cXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiZ9eADKvMUzPp7JLa6cXy)_