### PR TITLE
Merge master into v8-branch

### DIFF
--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -80,7 +80,7 @@ export interface DockviewAngularOptions extends DockviewOptions {
 })
 export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @ViewChild('dockviewContainer', { static: true })
-    private containerRef!: ElementRef<HTMLDivElement>;
+    private readonly containerRef!: ElementRef<HTMLDivElement>;
 
     @Input() components!: Record<string, Type<any> | TemplateRef<any>>;
     @Input() tabComponents?: Record<string, Type<any> | TemplateRef<any>>;
@@ -133,9 +133,9 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Output() willDrop = new EventEmitter<DockviewWillDropEvent>();
 
     private dockviewApi?: DockviewApi;
-    private lifecycleManager = new AngularLifecycleManager();
-    private injector = inject(Injector);
-    private environmentInjector = inject(EnvironmentInjector);
+    private readonly lifecycleManager = new AngularLifecycleManager();
+    private readonly injector = inject(Injector);
+    private readonly environmentInjector = inject(EnvironmentInjector);
 
     ngOnInit(): void {
         this.initializeDockview();

--- a/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
@@ -54,7 +54,7 @@ export interface GridviewAngularOptions extends GridviewOptions {
 })
 export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @ViewChild('gridviewContainer', { static: true })
-    private containerRef!: ElementRef<HTMLDivElement>;
+    private readonly containerRef!: ElementRef<HTMLDivElement>;
 
     @Input() components!: Record<string, Type<any> | TemplateRef<any>>;
 
@@ -69,9 +69,9 @@ export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Output() ready = new EventEmitter<GridviewAngularReadyEvent>();
 
     private gridviewApi?: GridviewApi;
-    private lifecycleManager = new AngularLifecycleManager();
-    private injector = inject(Injector);
-    private environmentInjector = inject(EnvironmentInjector);
+    private readonly lifecycleManager = new AngularLifecycleManager();
+    private readonly injector = inject(Injector);
+    private readonly environmentInjector = inject(EnvironmentInjector);
 
     ngOnInit(): void {
         this.initializeGridview();

--- a/packages/dockview-angular/src/lib/paneview/angular-pane-part.ts
+++ b/packages/dockview-angular/src/lib/paneview/angular-pane-part.ts
@@ -12,7 +12,7 @@ import {
 import { AngularRenderer } from '../utils/angular-renderer';
 
 export class AngularPanePart implements IPanePart {
-    private renderer: AngularRenderer;
+    private readonly renderer: AngularRenderer;
 
     constructor(
         private readonly angularComponent: Type<any> | TemplateRef<any>,

--- a/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
@@ -57,7 +57,7 @@ export interface PaneviewAngularOptions extends PaneviewOptions {
 })
 export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @ViewChild('paneviewContainer', { static: true })
-    private containerRef!: ElementRef<HTMLDivElement>;
+    private readonly containerRef!: ElementRef<HTMLDivElement>;
 
     @Input() components!: Record<string, Type<any> | TemplateRef<any>>;
     @Input() headerComponents?: Record<string, Type<any> | TemplateRef<any>>;
@@ -73,9 +73,9 @@ export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Output() drop = new EventEmitter<PaneviewDidDropEvent>();
 
     private paneviewApi?: PaneviewApi;
-    private lifecycleManager = new AngularLifecycleManager();
-    private injector = inject(Injector);
-    private environmentInjector = inject(EnvironmentInjector);
+    private readonly lifecycleManager = new AngularLifecycleManager();
+    private readonly injector = inject(Injector);
+    private readonly environmentInjector = inject(EnvironmentInjector);
 
     ngOnInit(): void {
         this.initializePaneview();

--- a/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
@@ -54,7 +54,7 @@ export interface SplitviewAngularOptions extends SplitviewOptions {
 })
 export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @ViewChild('splitviewContainer', { static: true })
-    private containerRef!: ElementRef<HTMLDivElement>;
+    private readonly containerRef!: ElementRef<HTMLDivElement>;
 
     @Input() components!: Record<string, Type<any> | TemplateRef<any>>;
 
@@ -69,9 +69,9 @@ export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Output() ready = new EventEmitter<SplitviewAngularReadyEvent>();
 
     private splitviewApi?: SplitviewApi;
-    private lifecycleManager = new AngularLifecycleManager();
-    private injector = inject(Injector);
-    private environmentInjector = inject(EnvironmentInjector);
+    private readonly lifecycleManager = new AngularLifecycleManager();
+    private readonly injector = inject(Injector);
+    private readonly environmentInjector = inject(EnvironmentInjector);
 
     ngOnInit(): void {
         this.initializeSplitview();

--- a/packages/dockview-angular/src/lib/utils/angular-renderer.ts
+++ b/packages/dockview-angular/src/lib/utils/angular-renderer.ts
@@ -22,9 +22,9 @@ export class AngularRenderer<T = unknown>
     private componentRef: ComponentRef<T> | null = null;
     private viewRef: EmbeddedViewRef<T> | null = null;
     private _element: HTMLElement | null = null;
-    private appRef: ApplicationRef;
+    private readonly appRef: ApplicationRef;
 
-    constructor(private options: AngularRendererOptions<T>) {
+    constructor(private readonly options: AngularRendererOptions<T>) {
         this.appRef = options.injector.get(ApplicationRef);
     }
 

--- a/packages/dockview-angular/src/lib/utils/component-factory.ts
+++ b/packages/dockview-angular/src/lib/utils/component-factory.ts
@@ -23,16 +23,22 @@ import { AngularPanePart } from '../paneview/angular-pane-part';
 
 export class AngularFrameworkComponentFactory {
     constructor(
-        private components: Record<string, Type<any> | TemplateRef<any>>,
-        private injector: Injector,
-        private environmentInjector?: EnvironmentInjector,
-        private tabComponents?: Record<string, Type<any> | TemplateRef<any>>,
-        private watermarkComponent?: Type<any> | TemplateRef<any>,
-        private headerActionsComponents?: Record<
+        private readonly components: Record<
             string,
             Type<any> | TemplateRef<any>
         >,
-        private defaultTabComponent?: Type<any> | TemplateRef<any>
+        private readonly injector: Injector,
+        private readonly environmentInjector?: EnvironmentInjector,
+        private readonly tabComponents?: Record<
+            string,
+            Type<any> | TemplateRef<any>
+        >,
+        private readonly watermarkComponent?: Type<any> | TemplateRef<any>,
+        private readonly headerActionsComponents?: Record<
+            string,
+            Type<any> | TemplateRef<any>
+        >,
+        private readonly defaultTabComponent?: Type<any> | TemplateRef<any>
     ) {}
 
     // For DockviewComponent

--- a/packages/dockview-angular/src/lib/utils/lifecycle-utils.ts
+++ b/packages/dockview-angular/src/lib/utils/lifecycle-utils.ts
@@ -36,7 +36,7 @@ export class AngularDisposable implements DockviewIDisposable {
 }
 
 export class AngularLifecycleManager {
-    private destroySubject = new Subject<void>();
+    private readonly destroySubject = new Subject<void>();
     private disposables: DockviewIDisposable[] = [];
 
     get destroy$(): Observable<void> {

--- a/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
@@ -157,7 +157,7 @@ describe('droptarget', () => {
         let viewQuery = element.querySelectorAll(
             '.dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection'
         );
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
 
         const target = element.querySelector(
             '.dv-drop-target-dropzone'
@@ -192,7 +192,7 @@ describe('droptarget', () => {
         viewQuery = element.querySelectorAll(
             '.dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection'
         );
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
         expect(droptarget.state).toBe('left');
         check(
             element
@@ -214,7 +214,7 @@ describe('droptarget', () => {
         viewQuery = element.querySelectorAll(
             '.dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection'
         );
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
         expect(droptarget.state).toBe('top');
         check(
             element
@@ -236,7 +236,7 @@ describe('droptarget', () => {
         viewQuery = element.querySelectorAll(
             '.dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection'
         );
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
         expect(droptarget.state).toBe('bottom');
         check(
             element
@@ -258,7 +258,7 @@ describe('droptarget', () => {
         viewQuery = element.querySelectorAll(
             '.dv-drop-target > .dv-drop-target-dropzone > .dv-drop-target-selection'
         );
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
         expect(droptarget.state).toBe('right');
         check(
             element
@@ -288,7 +288,7 @@ describe('droptarget', () => {
         fireEvent.dragLeave(target);
         expect(droptarget.state).toBe('center');
         viewQuery = element.querySelectorAll('.dv-drop-target');
-        expect(viewQuery.length).toBe(0);
+        expect(viewQuery).toHaveLength(0);
     });
 
     describe('calculateQuadrantAsPercentage', () => {

--- a/packages/dockview-core/src/__tests__/dnd/ghost.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/ghost.spec.ts
@@ -26,6 +26,6 @@ describe('ghost', () => {
         jest.runAllTimers();
 
         expect(element.className).toBe('');
-        expect(element.parentElement).toBe(null);
+        expect(element.parentElement).toBeNull();
     });
 });

--- a/packages/dockview-core/src/__tests__/dnd/pointer/pointerDropTarget.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/pointer/pointerDropTarget.spec.ts
@@ -49,7 +49,7 @@ describe('PointerDropTarget', () => {
         const dropzones = element.getElementsByClassName(
             'dv-drop-target-dropzone'
         );
-        expect(dropzones.length).toBe(1);
+        expect(dropzones).toHaveLength(1);
         expect(target.state).toBe('left');
 
         target.dispose();
@@ -82,8 +82,8 @@ describe('PointerDropTarget', () => {
         (target as any)._onDragOver(makeDragEvent(10, 20));
 
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
 
         target.dispose();
         document.body.removeChild(element);
@@ -114,13 +114,13 @@ describe('PointerDropTarget', () => {
 
         (target as any)._onDragOver(makeDragEvent(10, 20));
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
 
         (target as any)._removeOverlay();
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
 
         target.dispose();
         document.body.removeChild(element);
@@ -163,8 +163,8 @@ describe('PointerDropTarget', () => {
             expect.objectContaining({ position: 'right' })
         );
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
 
         target.dispose();
         document.body.removeChild(element);
@@ -195,18 +195,18 @@ describe('PointerDropTarget', () => {
 
         (target as any)._onDragOver(makeDragEvent(10, 20));
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
 
         target.disabled = true;
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
 
         (target as any)._onDragOver(makeDragEvent(10, 20));
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
 
         target.dispose();
         document.body.removeChild(element);

--- a/packages/dockview-core/src/__tests__/dnd/pointer/pointerDropTargetAnchor.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/pointer/pointerDropTargetAnchor.spec.ts
@@ -85,8 +85,8 @@ describe('PointerDropTarget — anchor / override target path', () => {
 
         // No in-place dropzone should have been added to the drop element.
         expect(
-            dropEl.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            dropEl.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
         // The anchor overlay should have been positioned (any non-empty
         // dimensions are fine — we just want to confirm the anchor path ran).
         expect(overlay.style.width).not.toBe('');

--- a/packages/dockview-core/src/__tests__/dockview/activePanelOrigin.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/activePanelOrigin.spec.ts
@@ -98,7 +98,7 @@ describe('active panel change origin', () => {
 
         p1.api.setActive();
 
-        expect(events.length).toBe(1);
+        expect(events).toHaveLength(1);
         expect(events[0].panel).toBe(p1);
         expect(events[0].origin).toBe('api');
     });

--- a/packages/dockview-core/src/__tests__/dockview/components/panel/content.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/panel/content.spec.ts
@@ -244,12 +244,12 @@ describe('contentContainer', () => {
         cut.openPanel(panel1);
 
         expect(panel1.view.content.element.parentElement).toBe(cut.element);
-        expect(cut.element.childNodes.length).toBe(1);
+        expect(cut.element.childNodes).toHaveLength(1);
 
         cut.openPanel(panel2);
 
         expect(panel1.view.content.element.parentElement).toBeNull();
         expect(panel2.view.content.element.parentElement).toBe(cut.element);
-        expect(cut.element.childNodes.length).toBe(1);
+        expect(cut.element.childNodes).toHaveLength(1);
     });
 });

--- a/packages/dockview-core/src/__tests__/dockview/components/tab.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/tab.spec.ts
@@ -89,8 +89,8 @@ describe('tab', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalled();
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
     });
 
     test('that if you drag over yourself a drop target is shown', () => {
@@ -135,8 +135,8 @@ describe('tab', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalledTimes(0);
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
     });
 
     test('that if you drag over another tab a drop target is shown', () => {
@@ -181,8 +181,8 @@ describe('tab', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalledTimes(0);
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
     });
 
     test('that dropping on a tab with the same id but from a different component should not render a drop over and call through to the group model', () => {
@@ -233,8 +233,8 @@ describe('tab', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalledTimes(1);
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
     });
 
     test('that dropping on a tab from a different component should not render a drop over and call through to the group model', () => {
@@ -285,8 +285,8 @@ describe('tab', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalledTimes(1);
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
     });
 
     describe('pointer (touch) drag', () => {

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroupIndicator.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroupIndicator.spec.ts
@@ -239,10 +239,10 @@ describe('indicator type identity', () => {
         const none = new NoneTabGroupIndicator(ctx);
         const wrap = new WrapTabGroupIndicator(ctx);
 
-        expect(none instanceof NoneTabGroupIndicator).toBe(true);
-        expect(none instanceof WrapTabGroupIndicator).toBe(false);
-        expect(wrap instanceof WrapTabGroupIndicator).toBe(true);
-        expect(wrap instanceof NoneTabGroupIndicator).toBe(false);
+        expect(none).toBeInstanceOf(NoneTabGroupIndicator);
+        expect(none).not.toBeInstanceOf(WrapTabGroupIndicator);
+        expect(wrap).toBeInstanceOf(WrapTabGroupIndicator);
+        expect(wrap).not.toBeInstanceOf(NoneTabGroupIndicator);
 
         none.dispose();
         wrap.dispose();

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
@@ -104,8 +104,8 @@ describe('tabs', () => {
             expect(
                 cut.element.querySelectorAll(
                     '.dv-scrollable > .dv-tabs-container'
-                ).length
-            ).toBe(1);
+                )
+            ).toHaveLength(1);
         });
 
         test('enabled when disabled flag is false', () => {
@@ -124,8 +124,8 @@ describe('tabs', () => {
             expect(
                 cut.element.querySelectorAll(
                     '.dv-scrollable > .dv-tabs-container'
-                ).length
-            ).toBe(1);
+                )
+            ).toHaveLength(1);
         });
 
         test('disabled when disabled flag is true', () => {
@@ -144,8 +144,8 @@ describe('tabs', () => {
             expect(
                 cut.element.querySelectorAll(
                     '.dv-scrollable > .dv-tabs-container'
-                ).length
-            ).toBe(0);
+                )
+            ).toHaveLength(0);
         });
     });
 
@@ -419,7 +419,7 @@ describe('tabs', () => {
 
             // drop should now fire and emit the correct index
             fireEvent.drop(tabsList);
-            expect(drops.length).toBe(1);
+            expect(drops).toHaveLength(1);
         });
     });
 
@@ -600,7 +600,7 @@ describe('tabs', () => {
 
             fireEvent.drop(dropzone!);
 
-            expect(drops.length).toBe(1);
+            expect(drops).toHaveLength(1);
             expect(drops[0].index).toBe(0);
             expect(drops[0].targetTabGroupId).toBeNull();
         });
@@ -659,7 +659,7 @@ describe('tabs', () => {
 
             fireEvent.drop(dropzone!);
 
-            expect(drops.length).toBe(1);
+            expect(drops).toHaveLength(1);
             expect(drops[0].index).toBe(1);
             expect(drops[0].targetTabGroupId).toBeNull();
         });
@@ -698,7 +698,7 @@ describe('tabs', () => {
 
             cut.openPanel(panel1);
             cut.delete('panel1');
-            expect(cut.tabs.length).toBe(0);
+            expect(cut.tabs).toHaveLength(0);
 
             expect(() => cut.delete('panel1')).not.toThrow();
         });

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -467,7 +467,7 @@ describe('tabs - animation', () => {
             expect(elements[1].style.transform).toBe('');
 
             // No rAF should be queued
-            expect(rAFCallbacks.length).toBe(0);
+            expect(rAFCallbacks).toHaveLength(0);
         });
     });
 

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
@@ -68,8 +68,8 @@ describe('tabsContainer', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalled();
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
     });
 
     test('that a drag over event from another tab should render a drop target', () => {
@@ -140,8 +140,8 @@ describe('tabsContainer', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalledTimes(0);
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
         // expect(
         //     dropTargetContainer.getElementsByClassName('dv-drop-target-anchor')
         //         .length
@@ -214,8 +214,8 @@ describe('tabsContainer', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalledTimes(0);
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
     });
 
     test.each([true, 'no-drop-target' as const])(
@@ -284,8 +284,7 @@ describe('tabsContainer', () => {
 
             expect(
                 cut.element.getElementsByClassName('dv-drop-target-dropzone')
-                    .length
-            ).toBe(0);
+            ).toHaveLength(0);
         }
     );
 
@@ -355,8 +354,8 @@ describe('tabsContainer', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalledTimes(0);
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
     });
 
     test('that dropping a tab from another component should not render a drop target', () => {
@@ -430,8 +429,8 @@ describe('tabsContainer', () => {
         expect(groupView.canDisplayOverlay).toHaveBeenCalledTimes(1);
 
         expect(
-            cut.element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            cut.element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
     });
 
     test('left actions', () => {
@@ -458,8 +457,8 @@ describe('tabsContainer', () => {
             '.dv-tabs-and-actions-container > .dv-left-actions-container'
         );
 
-        expect(query.length).toBe(1);
-        expect(query[0].children.length).toBe(0);
+        expect(query).toHaveLength(1);
+        expect(query[0].children).toHaveLength(0);
 
         // add left action
 
@@ -470,11 +469,11 @@ describe('tabsContainer', () => {
         query = cut.element.querySelectorAll(
             '.dv-tabs-and-actions-container > .dv-left-actions-container'
         );
-        expect(query.length).toBe(1);
+        expect(query).toHaveLength(1);
         expect(query[0].children.item(0)?.className).toBe(
             'test-left-actions-element'
         );
-        expect(query[0].children.length).toBe(1);
+        expect(query[0].children).toHaveLength(1);
 
         // add left action
 
@@ -485,11 +484,11 @@ describe('tabsContainer', () => {
         query = cut.element.querySelectorAll(
             '.dv-tabs-and-actions-container > .dv-left-actions-container'
         );
-        expect(query.length).toBe(1);
+        expect(query).toHaveLength(1);
         expect(query[0].children.item(0)?.className).toBe(
             'test-left-actions-element-2'
         );
-        expect(query[0].children.length).toBe(1);
+        expect(query[0].children).toHaveLength(1);
 
         // remove left action
 
@@ -498,8 +497,8 @@ describe('tabsContainer', () => {
             '.dv-tabs-and-actions-container > .dv-left-actions-container'
         );
 
-        expect(query.length).toBe(1);
-        expect(query[0].children.length).toBe(0);
+        expect(query).toHaveLength(1);
+        expect(query[0].children).toHaveLength(0);
     });
 
     test('right actions', () => {
@@ -526,8 +525,8 @@ describe('tabsContainer', () => {
             '.dv-tabs-and-actions-container > .dv-right-actions-container'
         );
 
-        expect(query.length).toBe(1);
-        expect(query[0].children.length).toBe(0);
+        expect(query).toHaveLength(1);
+        expect(query[0].children).toHaveLength(0);
 
         // add right action
 
@@ -538,11 +537,11 @@ describe('tabsContainer', () => {
         query = cut.element.querySelectorAll(
             '.dv-tabs-and-actions-container > .dv-right-actions-container'
         );
-        expect(query.length).toBe(1);
+        expect(query).toHaveLength(1);
         expect(query[0].children.item(0)?.className).toBe(
             'test-right-actions-element'
         );
-        expect(query[0].children.length).toBe(1);
+        expect(query[0].children).toHaveLength(1);
 
         // add right action
 
@@ -553,11 +552,11 @@ describe('tabsContainer', () => {
         query = cut.element.querySelectorAll(
             '.dv-tabs-and-actions-container > .dv-right-actions-container'
         );
-        expect(query.length).toBe(1);
+        expect(query).toHaveLength(1);
         expect(query[0].children.item(0)?.className).toBe(
             'test-right-actions-element-2'
         );
-        expect(query[0].children.length).toBe(1);
+        expect(query[0].children).toHaveLength(1);
 
         // remove right action
 
@@ -566,8 +565,8 @@ describe('tabsContainer', () => {
             '.dv-tabs-and-actions-container > .dv-right-actions-container'
         );
 
-        expect(query.length).toBe(1);
-        expect(query[0].children.length).toBe(0);
+        expect(query).toHaveLength(1);
+        expect(query[0].children).toHaveLength(0);
     });
 
     test('that a tab will become floating when clicked if not floating and shift is selected', () => {
@@ -841,14 +840,14 @@ describe('tabsContainer', () => {
 
         let result = cut.element.querySelector('.dv-pre-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(0);
+        expect(result!.childNodes).toHaveLength(0);
 
         const actions = document.createElement('div');
         cut.setPrefixActionsElement(actions);
 
         result = cut.element.querySelector('.dv-pre-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(1);
+        expect(result!.childNodes).toHaveLength(1);
         expect(result!.childNodes.item(0)).toBe(actions);
 
         const updatedActions = document.createElement('div');
@@ -856,14 +855,14 @@ describe('tabsContainer', () => {
 
         result = cut.element.querySelector('.dv-pre-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(1);
+        expect(result!.childNodes).toHaveLength(1);
         expect(result!.childNodes.item(0)).toBe(updatedActions);
 
         cut.setPrefixActionsElement(undefined);
 
         result = cut.element.querySelector('.dv-pre-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(0);
+        expect(result!.childNodes).toHaveLength(0);
     });
 
     test('left header actions', () => {
@@ -912,14 +911,14 @@ describe('tabsContainer', () => {
 
         let result = cut.element.querySelector('.dv-left-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(0);
+        expect(result!.childNodes).toHaveLength(0);
 
         const actions = document.createElement('div');
         cut.setLeftActionsElement(actions);
 
         result = cut.element.querySelector('.dv-left-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(1);
+        expect(result!.childNodes).toHaveLength(1);
         expect(result!.childNodes.item(0)).toBe(actions);
 
         const updatedActions = document.createElement('div');
@@ -927,14 +926,14 @@ describe('tabsContainer', () => {
 
         result = cut.element.querySelector('.dv-left-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(1);
+        expect(result!.childNodes).toHaveLength(1);
         expect(result!.childNodes.item(0)).toBe(updatedActions);
 
         cut.setLeftActionsElement(undefined);
 
         result = cut.element.querySelector('.dv-left-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(0);
+        expect(result!.childNodes).toHaveLength(0);
     });
 
     test('right header actions', () => {
@@ -983,14 +982,14 @@ describe('tabsContainer', () => {
 
         let result = cut.element.querySelector('.dv-right-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(0);
+        expect(result!.childNodes).toHaveLength(0);
 
         const actions = document.createElement('div');
         cut.setRightActionsElement(actions);
 
         result = cut.element.querySelector('.dv-right-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(1);
+        expect(result!.childNodes).toHaveLength(1);
         expect(result!.childNodes.item(0)).toBe(actions);
 
         const updatedActions = document.createElement('div');
@@ -998,14 +997,14 @@ describe('tabsContainer', () => {
 
         result = cut.element.querySelector('.dv-right-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(1);
+        expect(result!.childNodes).toHaveLength(1);
         expect(result!.childNodes.item(0)).toBe(updatedActions);
 
         cut.setRightActionsElement(undefined);
 
         result = cut.element.querySelector('.dv-right-actions-container');
         expect(result).toBeTruthy();
-        expect(result!.childNodes.length).toBe(0);
+        expect(result!.childNodes).toHaveLength(0);
     });
 
     test('class dv-single-tab is present when only one tab exists`', () => {

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
@@ -580,8 +580,7 @@ describe('voidContainer', () => {
 
             expect(
                 cut.element.getElementsByClassName('dv-drop-target-dropzone')
-                    .length
-            ).toBe(1);
+            ).toHaveLength(1);
 
             cut.dispose();
         });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -608,8 +608,8 @@ describe('dockviewComponent', () => {
             await dockview.addPopoutGroup(panel1.api.group);
 
             expect(panel1.api.location.type).toBe('popout');
-            expect(dockview.groups.length).toBe(4);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(4);
+            expect(dockview.panels).toHaveLength(3);
 
             panel1.api.group.api.moveTo({
                 group: panel2.api.group,
@@ -617,11 +617,11 @@ describe('dockviewComponent', () => {
             });
 
             expect(panel1.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(3);
 
             const query = dockview.element.querySelectorAll('.dv-view');
-            expect(query.length).toBe(3);
+            expect(query).toHaveLength(3);
         });
 
         test('that moving a popout group to specific position works correctly', async () => {
@@ -655,7 +655,7 @@ describe('dockviewComponent', () => {
 
             await dockview.addPopoutGroup(panel1.api.group);
             expect(panel1.api.location.type).toBe('popout');
-            expect(dockview.groups.length).toBe(3); // panel2 + hidden reference + popout
+            expect(dockview.groups).toHaveLength(3); // panel2 + hidden reference + popout
 
             // Move popout group to left of panel2
             panel1.api.group.api.moveTo({
@@ -665,8 +665,8 @@ describe('dockviewComponent', () => {
 
             // Core assertions: should be back in grid and positioned correctly
             expect(panel1.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2); // Should clean up properly
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2); // Should clean up properly
+            expect(dockview.panels).toHaveLength(2);
 
             // Verify both panels are visible and accessible
             expect(panel1.api.isVisible).toBe(true);
@@ -717,7 +717,7 @@ describe('dockviewComponent', () => {
                 expect(panel1.api.isVisible).toBe(true);
                 expect(panel2.api.isVisible).toBe(true);
                 expect(dockview.groups.length).toBeGreaterThanOrEqual(2);
-                expect(dockview.panels.length).toBe(2);
+                expect(dockview.panels).toHaveLength(2);
             });
         });
 
@@ -755,7 +755,7 @@ describe('dockviewComponent', () => {
 
             await dockview.addPopoutGroup(panel1.api.group);
             expect(panel1.api.location.type).toBe('popout');
-            expect(dockview.groups.length).toBe(3); // panel2 + hidden reference + popout
+            expect(dockview.groups).toHaveLength(3); // panel2 + hidden reference + popout
 
             // Move to new position - should clean up reference group
             panel1.api.group.api.moveTo({
@@ -764,7 +764,7 @@ describe('dockviewComponent', () => {
             });
 
             expect(panel1.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2); // Just panel2 + panel1 in new position
+            expect(dockview.groups).toHaveLength(2); // Just panel2 + panel1 in new position
 
             // Reference group should be cleaned up (no longer exist)
             const referenceGroupStillExists = dockview.groups.some(
@@ -1137,11 +1137,11 @@ describe('dockviewComponent', () => {
         expect(panel2.group).toBe(destGroup);
 
         // Source group should be removed (was empty after move)
-        expect(dockview.groups.length).toBe(1);
+        expect(dockview.groups).toHaveLength(1);
 
         // Tab group should be recreated in destination
         const destTabGroups = destGroup.model.getTabGroups();
-        expect(destTabGroups.length).toBe(1);
+        expect(destTabGroups).toHaveLength(1);
         expect(destTabGroups[0].label).toBe('Feature');
         expect(destTabGroups[0].color).toBe('blue');
         expect(destTabGroups[0].panelIds).toContain('panel1');
@@ -1193,7 +1193,7 @@ describe('dockviewComponent', () => {
         });
 
         const destTabGroups = destGroup.model.getTabGroups();
-        expect(destTabGroups.length).toBe(1);
+        expect(destTabGroups).toHaveLength(1);
         expect(destTabGroups[0].collapsed).toBe(true);
         expect(destTabGroups[0].color).toBe('red');
 
@@ -1253,7 +1253,7 @@ describe('dockviewComponent', () => {
         expect(destCollapseEvents).toHaveLength(0);
 
         const destTabGroups = destGroup.model.getTabGroups();
-        expect(destTabGroups.length).toBe(1);
+        expect(destTabGroups).toHaveLength(1);
         expect(destTabGroups[0].collapsed).toBe(true);
 
         // Force synchronous chip rendering (updateTabGroups is normally
@@ -1314,7 +1314,7 @@ describe('dockviewComponent', () => {
         });
 
         // Should have 2 groups now
-        expect(dockview.groups.length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
 
         // panel3 stays in source
         expect(panel3.group).toBe(sourceGroup);
@@ -1327,7 +1327,7 @@ describe('dockviewComponent', () => {
         expect(newGroup.model.size).toBe(2);
 
         const newTabGroups = newGroup.model.getTabGroups();
-        expect(newTabGroups.length).toBe(1);
+        expect(newTabGroups).toHaveLength(1);
         expect(newTabGroups[0].label).toBe('Split');
         expect(newTabGroups[0].color).toBe('green');
 
@@ -1445,7 +1445,7 @@ describe('dockviewComponent', () => {
 
         // Tab group should have come along with its panels and metadata.
         const movedTabGroups = destGroup.model.getTabGroups();
-        expect(movedTabGroups.length).toBe(1);
+        expect(movedTabGroups).toHaveLength(1);
         const moved = movedTabGroups[0];
         expect(moved.label).toBe('Feature');
         expect(moved.color).toBe('blue');
@@ -1512,7 +1512,7 @@ describe('dockviewComponent', () => {
 
         // Tab group recreated and still collapsed.
         const tgs = destGroup.model.getTabGroups();
-        expect(tgs.length).toBe(1);
+        expect(tgs).toHaveLength(1);
         expect(tgs[0].collapsed).toBe(true);
         expect([...tgs[0].panelIds]).toEqual(['panel1', 'panel2']);
 
@@ -1559,14 +1559,14 @@ describe('dockviewComponent', () => {
 
         // Source group should be removed (it became empty); only the new
         // group at the right contains the panels.
-        expect(dockview.groups.length).toBe(1);
+        expect(dockview.groups).toHaveLength(1);
         const newGroup = panel1.group;
         expect(newGroup).not.toBe(sourceGroup);
         expect(panel2.group).toBe(newGroup);
         expect(newGroup.model.size).toBe(2);
 
         const newTabGroups = newGroup.model.getTabGroups();
-        expect(newTabGroups.length).toBe(1);
+        expect(newTabGroups).toHaveLength(1);
         expect(newTabGroups[0].label).toBe('All');
         expect(newTabGroups[0].color).toBe('red');
 
@@ -1869,13 +1869,13 @@ describe('dockviewComponent', () => {
             '.dv-branch-node > .dv-split-view-container > .dv-view-container > .dv-view'
         );
 
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
 
         viewQuery = container.querySelectorAll(
             '.dv-branch-node > .dv-split-view-container > .dv-view-container > .dv-view:nth-child(1) >.dv-groupview > .dv-content-container > .testpanel-panel2'
         );
 
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
 
         const group = dockview.getGroupPanel('panel1')!.group;
         dockview.moveGroupOrPanel({
@@ -1887,19 +1887,19 @@ describe('dockviewComponent', () => {
             '.dv-branch-node > .dv-split-view-container > .dv-view-container > .dv-view'
         );
 
-        expect(viewQuery.length).toBe(2);
+        expect(viewQuery).toHaveLength(2);
 
         viewQuery = container.querySelectorAll(
             '.dv-branch-node > .dv-split-view-container > .dv-view-container > .dv-view:nth-child(1) >.dv-groupview > .dv-content-container > .testpanel-panel2'
         );
 
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
 
         viewQuery = container.querySelectorAll(
             '.dv-branch-node > .dv-split-view-container > .dv-view-container > .dv-view:nth-child(2) >.dv-groupview > .dv-content-container > .testpanel-panel1'
         );
 
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
     });
 
     describe('serialization', () => {
@@ -1928,7 +1928,7 @@ describe('dockviewComponent', () => {
             dockview.addPanel({ id: 'panel2', component: 'default' });
             dockview.addPanel({ id: 'panel7', component: 'default' });
 
-            expect(parts.length).toBe(3);
+            expect(parts).toHaveLength(3);
 
             expect(parts.map((part) => part.isDisposed)).toEqual([
                 false,
@@ -2044,7 +2044,7 @@ describe('dockviewComponent', () => {
             dockview.addPanel({ id: 'panel2', component: 'default' });
             dockview.addPanel({ id: 'panel7', component: 'default' });
 
-            expect(parts.length).toBe(3);
+            expect(parts).toHaveLength(3);
 
             expect(parts.map((part) => part.isDisposed)).toEqual([
                 false,
@@ -2349,8 +2349,8 @@ describe('dockviewComponent', () => {
             expect(panel4.api.isMaximized()).toBeTruthy();
 
             api.clear();
-            expect(api.groups.length).toBe(0);
-            expect(api.panels.length).toBe(0);
+            expect(api.groups).toHaveLength(0);
+            expect(api.panels).toHaveLength(0);
 
             api.fromJSON(state);
             const newPanel4 = api.getPanel('panel4')!;
@@ -3002,7 +3002,7 @@ describe('dockviewComponent', () => {
         events = [];
         disposable.dispose();
 
-        expect(events.length).toBe(0);
+        expect(events).toHaveLength(0);
     });
 
     test('that removing a panel from a group reflects in the dockviewcomponent when searching for a panel', () => {
@@ -3104,8 +3104,8 @@ describe('dockviewComponent', () => {
             },
         });
 
-        expect(removedGroups.length).toBe(2);
-        expect(removedPanels.length).toBe(3);
+        expect(removedGroups).toHaveLength(2);
+        expect(removedPanels).toHaveLength(3);
 
         disposable.dispose();
     });
@@ -3130,11 +3130,11 @@ describe('dockviewComponent', () => {
             component: 'default',
         });
 
-        expect(container.childNodes.length).toBe(1);
+        expect(container.childNodes).toHaveLength(1);
 
         dockview.dispose();
 
-        expect(container.childNodes.length).toBe(0);
+        expect(container.childNodes).toHaveLength(0);
     });
 
     test('panel is disposed of when closed', () => {
@@ -3648,14 +3648,14 @@ describe('dockviewComponent', () => {
 
         const panel1Spy = jest.spyOn(panel1.group, 'dispose');
 
-        expect(dockview.groups.length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
 
         dockview.moveGroupOrPanel({
             from: { groupId: panel1.group.id },
             to: { group: panel3.group, position: 'center' },
         });
 
-        expect(dockview.groups.length).toBe(1);
+        expect(dockview.groups).toHaveLength(1);
         expect(panel1Spy).toHaveBeenCalledTimes(1);
     });
 
@@ -3781,13 +3781,13 @@ describe('dockviewComponent', () => {
 
         jest.runAllTimers();
 
-        expect(addGroup.length).toBe(4);
-        expect(removeGroup.length).toBe(0);
-        expect(activeGroup.length).toBe(1);
-        expect(addPanel.length).toBe(5);
-        expect(removePanel.length).toBe(0);
-        expect(activePanel.length).toBe(1);
-        expect(movedPanels.length).toBe(0);
+        expect(addGroup).toHaveLength(4);
+        expect(removeGroup).toHaveLength(0);
+        expect(activeGroup).toHaveLength(1);
+        expect(addPanel).toHaveLength(5);
+        expect(removePanel).toHaveLength(0);
+        expect(activePanel).toHaveLength(1);
+        expect(movedPanels).toHaveLength(0);
         expect(layoutChange).toBe(1);
         expect(layoutChangeFromJson).toBe(1);
 
@@ -3816,13 +3816,13 @@ describe('dockviewComponent', () => {
 
         jest.runAllTimers();
 
-        expect(addGroup.length).toBe(0);
-        expect(removeGroup.length).toBe(4);
-        expect(activeGroup.length).toBe(1);
-        expect(addPanel.length).toBe(0);
-        expect(removePanel.length).toBe(5);
-        expect(activePanel.length).toBe(1);
-        expect(movedPanels.length).toBe(0);
+        expect(addGroup).toHaveLength(0);
+        expect(removeGroup).toHaveLength(4);
+        expect(activeGroup).toHaveLength(1);
+        expect(addPanel).toHaveLength(0);
+        expect(removePanel).toHaveLength(5);
+        expect(activePanel).toHaveLength(1);
+        expect(movedPanels).toHaveLength(0);
         expect(layoutChange).toBe(1);
         expect(layoutChangeFromJson).toBe(1);
 
@@ -4125,17 +4125,17 @@ describe('dockviewComponent', () => {
         const viewQuery = group.element.querySelectorAll(
             '.dv-groupview > .dv-tabs-and-actions-container > .dv-scrollable > .dv-tabs-container > .dv-tab'
         );
-        expect(viewQuery.length).toBe(2);
+        expect(viewQuery).toHaveLength(2);
 
         const viewQuery2 = group.element.querySelectorAll(
             '.dv-groupview > .dv-tabs-and-actions-container > .dv-scrollable > .dv-tabs-container > .dv-tab > .dv-default-tab'
         );
-        expect(viewQuery2.length).toBe(1);
+        expect(viewQuery2).toHaveLength(1);
 
         const viewQuery3 = group.element.querySelectorAll(
             '.dv-groupview > .dv-tabs-and-actions-container > .dv-scrollable > .dv-tabs-container > .dv-tab > .panel-tab-part-panel2'
         );
-        expect(viewQuery3.length).toBe(1);
+        expect(viewQuery3).toHaveLength(1);
     });
 
     // load a layout with a default tab identifier when react default is present
@@ -4609,7 +4609,7 @@ describe('dockviewComponent', () => {
             },
         });
 
-        expect(dockview.groups.length).toBe(0);
+        expect(dockview.groups).toHaveLength(0);
     });
 
     test('updateOptions({ createWatermarkComponent }) swaps live watermarks', () => {
@@ -4631,13 +4631,13 @@ describe('dockviewComponent', () => {
 
         // No groups → dockview-level watermark mounted with the default renderer.
         expect(
-            dockview.element.querySelectorAll('.dv-watermark-container').length
-        ).toBe(1);
+            dockview.element.querySelectorAll('.dv-watermark-container')
+        ).toHaveLength(1);
         expect(
             dockview.element.querySelectorAll(
                 '.dv-watermark-container .dv-watermark-custom'
-            ).length
-        ).toBe(0);
+            )
+        ).toHaveLength(0);
 
         const customRenderers: HTMLElement[] = [];
 
@@ -4657,13 +4657,13 @@ describe('dockviewComponent', () => {
 
         // Same dockview-level container, but now wrapping the custom element.
         expect(
-            dockview.element.querySelectorAll('.dv-watermark-container').length
-        ).toBe(1);
+            dockview.element.querySelectorAll('.dv-watermark-container')
+        ).toHaveLength(1);
         expect(
             dockview.element.querySelectorAll(
                 '.dv-watermark-container .dv-watermark-custom'
-            ).length
-        ).toBe(1);
+            )
+        ).toHaveLength(1);
         expect(customRenderers).toHaveLength(1);
 
         // Toggling back to the default factory disposes the custom one and
@@ -4671,13 +4671,13 @@ describe('dockviewComponent', () => {
         dockview.updateOptions({ createWatermarkComponent: undefined });
 
         expect(
-            dockview.element.querySelectorAll('.dv-watermark-container').length
-        ).toBe(1);
+            dockview.element.querySelectorAll('.dv-watermark-container')
+        ).toHaveLength(1);
         expect(
             dockview.element.querySelectorAll(
                 '.dv-watermark-container .dv-watermark-custom'
-            ).length
-        ).toBe(0);
+            )
+        ).toHaveLength(0);
     });
 
     test('that deserializing an empty layout has zero groups and a watermark', () => {
@@ -4697,11 +4697,11 @@ describe('dockviewComponent', () => {
             },
         });
 
-        expect(dockview.groups.length).toBe(0);
+        expect(dockview.groups).toHaveLength(0);
 
         expect(
-            dockview.element.querySelectorAll('.dv-watermark-container').length
-        ).toBe(1);
+            dockview.element.querySelectorAll('.dv-watermark-container')
+        ).toHaveLength(1);
 
         dockview.fromJSON({
             grid: {
@@ -4716,11 +4716,11 @@ describe('dockviewComponent', () => {
             panels: {},
         });
 
-        expect(dockview.groups.length).toBe(0);
+        expect(dockview.groups).toHaveLength(0);
 
         expect(
-            dockview.element.querySelectorAll('.dv-watermark-container').length
-        ).toBe(1);
+            dockview.element.querySelectorAll('.dv-watermark-container')
+        ).toHaveLength(1);
     });
 
     test('that deserializing a populated layout removes the watermark', () => {
@@ -4747,8 +4747,8 @@ describe('dockviewComponent', () => {
 
         // No groups yet → watermark mounted.
         expect(
-            dockview.element.querySelectorAll('.dv-watermark-container').length
-        ).toBe(1);
+            dockview.element.querySelectorAll('.dv-watermark-container')
+        ).toHaveLength(1);
 
         dockview.fromJSON({
             grid: {
@@ -4779,12 +4779,12 @@ describe('dockviewComponent', () => {
             },
         });
 
-        expect(dockview.groups.length).toBe(1);
+        expect(dockview.groups).toHaveLength(1);
 
         // Restored layout has a visible grid group → watermark removed.
         expect(
-            dockview.element.querySelectorAll('.dv-watermark-container').length
-        ).toBe(0);
+            dockview.element.querySelectorAll('.dv-watermark-container')
+        ).toHaveLength(0);
     });
 
     test('empty', () => {
@@ -4935,46 +4935,46 @@ describe('dockviewComponent', () => {
             component: 'default',
         });
 
-        expect(dockview.element.querySelectorAll('.dv-view').length).toBe(1);
+        expect(dockview.element.querySelectorAll('.dv-view')).toHaveLength(1);
 
         const panel2 = dockview.addPanel({
             id: 'panel2',
             component: 'default',
         });
 
-        expect(dockview.element.querySelectorAll('.dv-view').length).toBe(1);
+        expect(dockview.element.querySelectorAll('.dv-view')).toHaveLength(1);
 
         const panel3 = dockview.addPanel({
             id: 'panel3',
             component: 'default',
         });
 
-        expect(dockview.element.querySelectorAll('.dv-view').length).toBe(1);
+        expect(dockview.element.querySelectorAll('.dv-view')).toHaveLength(1);
 
         dockview.moveGroupOrPanel({
             from: { groupId: panel3.group.id, panelId: panel3.id },
             to: { group: panel3.group, position: 'right' },
         });
 
-        expect(dockview.groups.length).toBe(2);
-        expect(dockview.element.querySelectorAll('.dv-view').length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
+        expect(dockview.element.querySelectorAll('.dv-view')).toHaveLength(2);
 
         dockview.moveGroupOrPanel({
             from: { groupId: panel2.group.id, panelId: panel2.id },
             to: { group: panel3.group, position: 'bottom' },
         });
 
-        expect(dockview.groups.length).toBe(3);
-        expect(dockview.element.querySelectorAll('.dv-view').length).toBe(4);
+        expect(dockview.groups).toHaveLength(3);
+        expect(dockview.element.querySelectorAll('.dv-view')).toHaveLength(4);
 
         dockview.moveGroupOrPanel({
             from: { groupId: panel1.group.id, panelId: panel1.id },
             to: { group: panel2.group, position: 'center' },
         });
 
-        expect(dockview.groups.length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
 
-        expect(dockview.element.querySelectorAll('.dv-view').length).toBe(2);
+        expect(dockview.element.querySelectorAll('.dv-view')).toHaveLength(2);
     });
 
     test('that fromJSON layouts are resized to the current dimensions', async () => {
@@ -5097,15 +5097,13 @@ describe('dockviewComponent', () => {
 
         expect(
             dockview.element.querySelectorAll('.dv-view-container > .dv-view')
-                .length
-        ).toBe(1);
+        ).toHaveLength(1);
 
         dockview.addFloatingGroup(panel1);
 
         expect(
             dockview.element.querySelectorAll('.dv-view-container > .dv-view')
-                .length
-        ).toBe(0);
+        ).toHaveLength(0);
     });
 
     test('that api.setSize applies to the overlay for floating panels', () => {
@@ -5136,7 +5134,7 @@ describe('dockviewComponent', () => {
         panel1.api.setSize({ height: 123, width: 256 });
 
         const items = container.querySelectorAll('.dv-resize-container');
-        expect(items.length).toBe(1);
+        expect(items).toHaveLength(1);
 
         const el = items[0] as HTMLElement;
 
@@ -5255,7 +5253,7 @@ describe('dockviewComponent', () => {
         expect(events[0].position).toBe('left');
         expect(events[0].target).toBe('edge');
         expect(events[0].getData).toBe(getPanelData);
-        expect(events.length).toBe(1);
+        expect(events).toHaveLength(1);
 
         // right
 
@@ -5272,7 +5270,7 @@ describe('dockviewComponent', () => {
         expect(events[1].position).toBe('right');
         expect(events[1].target).toBe('edge');
         expect(events[1].getData).toBe(getPanelData);
-        expect(events.length).toBe(2);
+        expect(events).toHaveLength(2);
 
         // top
 
@@ -5289,7 +5287,7 @@ describe('dockviewComponent', () => {
         expect(events[2].position).toBe('top');
         expect(events[2].target).toBe('edge');
         expect(events[2].getData).toBe(getPanelData);
-        expect(events.length).toBe(3);
+        expect(events).toHaveLength(3);
 
         // top
 
@@ -5306,7 +5304,7 @@ describe('dockviewComponent', () => {
         expect(events[3].position).toBe('bottom');
         expect(events[3].target).toBe('edge');
         expect(events[3].getData).toBe(getPanelData);
-        expect(events.length).toBe(4);
+        expect(events).toHaveLength(4);
 
         // center
 
@@ -5320,7 +5318,7 @@ describe('dockviewComponent', () => {
         fireEvent(dockview.element, eventCenter);
 
         // expect not to be called for center
-        expect(events.length).toBe(4);
+        expect(events).toHaveLength(4);
 
         dockview.removePanel(panel1);
         dockview.removePanel(panel2);
@@ -5340,7 +5338,7 @@ describe('dockviewComponent', () => {
         expect(events[4].position).toBe('center');
         expect(events[4].target).toBe('edge');
         expect(events[4].getData).toBe(getPanelData);
-        expect(events.length).toBe(5);
+        expect(events).toHaveLength(5);
     });
 
     test('corrupt layout: bad inline view', () => {
@@ -5365,15 +5363,15 @@ describe('dockviewComponent', () => {
 
         let el = dockview.element.querySelector('.dv-view-container');
         expect(el).toBeTruthy();
-        expect(el!.childNodes.length).toBe(0);
+        expect(el!.childNodes).toHaveLength(0);
 
         dockview.addPanel({
             id: 'panel_1',
             component: 'panelA',
         });
 
-        expect(dockview.groups.length).toBe(1);
-        expect(dockview.panels.length).toBe(1);
+        expect(dockview.groups).toHaveLength(1);
+        expect(dockview.panels).toHaveLength(1);
 
         el = dockview.element.querySelector('.dv-view-container');
         expect(el).toBeTruthy();
@@ -5426,12 +5424,12 @@ describe('dockviewComponent', () => {
             });
         }).toThrow("unsupported panel 'somethingBad'");
 
-        expect(dockview.groups.length).toBe(0);
-        expect(dockview.panels.length).toBe(0);
+        expect(dockview.groups).toHaveLength(0);
+        expect(dockview.panels).toHaveLength(0);
 
         el = dockview.element.querySelector('.dv-view-container');
         expect(el).toBeTruthy();
-        expect(el!.childNodes.length).toBe(0);
+        expect(el!.childNodes).toHaveLength(0);
     });
 
     test('corrupt layout: bad floating view', () => {
@@ -5456,7 +5454,7 @@ describe('dockviewComponent', () => {
 
         let el = dockview.element.querySelector('.dv-view-container');
         expect(el).toBeTruthy();
-        expect(el!.childNodes.length).toBe(0);
+        expect(el!.childNodes).toHaveLength(0);
 
         dockview.addPanel({
             id: 'panel_1',
@@ -5469,8 +5467,8 @@ describe('dockviewComponent', () => {
             floating: true,
         });
 
-        expect(dockview.groups.length).toBe(2);
-        expect(dockview.panels.length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
+        expect(dockview.panels).toHaveLength(2);
 
         el = container.querySelector('.dv-resize-container');
         expect(el).toBeTruthy();
@@ -5549,15 +5547,15 @@ describe('dockviewComponent', () => {
             });
         }).toThrow("unsupported panel 'panelC'");
 
-        expect(dockview.groups.length).toBe(0);
-        expect(dockview.panels.length).toBe(0);
+        expect(dockview.groups).toHaveLength(0);
+        expect(dockview.panels).toHaveLength(0);
 
         el = container.querySelector('.dv-resize-container');
         expect(el).toBeFalsy();
 
         el = dockview.element.querySelector('.dv-view-container');
         expect(el).toBeTruthy();
-        expect(el!.childNodes.length).toBe(0);
+        expect(el!.childNodes).toHaveLength(0);
     });
 
     test('that disableResizing is always true because the shell manages resizing', () => {
@@ -5625,16 +5623,16 @@ describe('dockviewComponent', () => {
 
             dockview.layout(1000, 500);
 
-            expect(dockview.groups.length).toBe(0);
+            expect(dockview.groups).toHaveLength(0);
             const panel = dockview.addPanel({
                 id: 'panel_1',
                 component: 'default',
                 floating: true,
             });
-            expect(dockview.groups.length).toBe(1);
+            expect(dockview.groups).toHaveLength(1);
 
             dockview.removePanel(panel);
-            expect(dockview.groups.length).toBe(0);
+            expect(dockview.groups).toHaveLength(0);
         });
 
         const createDockview = () =>
@@ -5760,8 +5758,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id },
@@ -5770,8 +5768,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
         });
 
         test('move a floating group of one tab to an existing fixed group', () => {
@@ -5806,8 +5804,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id },
@@ -5816,8 +5814,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(1);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(1);
+            expect(dockview.panels).toHaveLength(2);
         });
 
         test('move a floating group of one tab to an existing floating group', () => {
@@ -5859,8 +5857,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel3.group.id },
@@ -5870,8 +5868,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         describe('nested floating layout (multi-root)', () => {
@@ -5904,7 +5902,7 @@ describe('dockviewComponent', () => {
                     floating: true,
                 });
 
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
 
                 // drag the whole grid group to the right of the floating group
                 dockview.moveGroupOrPanel({
@@ -5913,7 +5911,7 @@ describe('dockviewComponent', () => {
                 });
 
                 // still a single floating window, now hosting both groups
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
                 expect(panel1.group.api.location.type).toBe('floating');
                 expect(panel2.group.api.location.type).toBe('floating');
                 expect(dockview.getGridviewForGroup(panel1.group)).toBe(
@@ -5959,7 +5957,7 @@ describe('dockviewComponent', () => {
                 expect(dockview.getGridviewForGroup(movedPanel.group)).toBe(
                     dockview.getGridviewForGroup(panel2.group)
                 );
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
             });
 
             test('moving a group out of a multi-group window keeps the window alive', () => {
@@ -5986,7 +5984,7 @@ describe('dockviewComponent', () => {
                     from: { groupId: panel3.group.id },
                     to: { group: panel2.group, position: 'right' },
                 });
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
                 expect(dockview.getGridviewForGroup(panel3.group)).toBe(
                     dockview.getGridviewForGroup(panel2.group)
                 );
@@ -6000,7 +5998,7 @@ describe('dockviewComponent', () => {
                 expect(panel3.group.api.location.type).toBe('grid');
                 expect(panel2.group.api.location.type).toBe('floating');
                 // the window survived because panel2's group still lives in it
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
             });
 
             test('floating-to-floating move merges windows (source window closes)', () => {
@@ -6019,7 +6017,7 @@ describe('dockviewComponent', () => {
                     floating: true,
                 });
 
-                expect(dockview.floatingGroups.length).toBe(2);
+                expect(dockview.floatingGroups).toHaveLength(2);
 
                 dockview.moveGroupOrPanel({
                     from: { groupId: panel3.group.id },
@@ -6028,7 +6026,7 @@ describe('dockviewComponent', () => {
 
                 // panel3's single-group window closed; both groups now share
                 // panel2's window
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
                 expect(panel2.group.api.location.type).toBe('floating');
                 expect(panel3.group.api.location.type).toBe('floating');
                 expect(dockview.getGridviewForGroup(panel3.group)).toBe(
@@ -6163,11 +6161,11 @@ describe('dockviewComponent', () => {
                 mockWindow.close();
 
                 expect(panel2.api.location.type).toBe('grid');
-                expect(dockview.panels.length).toBe(3);
+                expect(dockview.panels).toHaveLength(3);
 
                 // an orphaned group would trip clear() with 'Invalid grid element'
                 expect(() => dockview.clear()).not.toThrow();
-                expect(dockview.groups.length).toBe(0);
+                expect(dockview.groups).toHaveLength(0);
 
                 dockview.dispose();
             });
@@ -6215,7 +6213,7 @@ describe('dockviewComponent', () => {
                 // docked to the grid, splitting the window across two roots.
                 expect(panel2.api.location.type).toBe('grid');
                 expect(panel3.api.location.type).toBe('grid');
-                expect(dockview.floatingGroups.length).toBe(0);
+                expect(dockview.floatingGroups).toHaveLength(0);
                 expect(panel1.api.location.type).toBe('grid');
 
                 dockview.dispose();
@@ -6362,7 +6360,7 @@ describe('dockviewComponent', () => {
                 expect(loc('p1')).toBe('grid');
                 expect(loc('p2')).toBe('floating');
                 expect(loc('p3')).toBe('popout');
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
 
                 jest.useRealTimers();
                 dockview.dispose();
@@ -6389,7 +6387,7 @@ describe('dockviewComponent', () => {
                     from: { groupId: panel3.group.id },
                     to: { group: panel2.group, position: 'right' },
                 });
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
 
                 const json = dockview.toJSON();
                 // a multi-group window serializes as a nested grid
@@ -6400,12 +6398,12 @@ describe('dockviewComponent', () => {
                 restored.layout(1000, 500);
                 restored.fromJSON(json);
 
-                expect(restored.panels.length).toBe(3);
-                expect(restored.floatingGroups.length).toBe(1);
+                expect(restored.panels).toHaveLength(3);
+                expect(restored.floatingGroups).toHaveLength(1);
                 const floatingGroups = restored.groups.filter(
                     (g) => g.api.location.type === 'floating'
                 );
-                expect(floatingGroups.length).toBe(2);
+                expect(floatingGroups).toHaveLength(2);
                 expect(restored.getGridviewForGroup(floatingGroups[0])).toBe(
                     restored.getGridviewForGroup(floatingGroups[1])
                 );
@@ -6453,7 +6451,7 @@ describe('dockviewComponent', () => {
                     from: { groupId: panel2.group.id },
                     to: { group: panel1.group, position: 'right' },
                 });
-                expect(dockview.floatingGroups.length).toBe(1);
+                expect(dockview.floatingGroups).toHaveLength(1);
                 expect(fg.group).toBe(panel3.group);
 
                 // dragging the title bar now targets the promoted anchor, not
@@ -6469,7 +6467,7 @@ describe('dockviewComponent', () => {
                 Object.defineProperty(event, 'shiftKey', { value: true });
                 fireEvent(titlebar, event);
 
-                expect(groupDragEvents.length).toBe(1);
+                expect(groupDragEvents).toHaveLength(1);
                 expect(groupDragEvents[0].group).toBe(panel3.group);
 
                 dockview.dispose();
@@ -6518,8 +6516,8 @@ describe('dockviewComponent', () => {
                 expect(
                     dockview.groups.filter(
                         (g) => g.api.location.type === 'popout'
-                    ).length
-                ).toBe(0);
+                    )
+                ).toHaveLength(0);
                 // both members landed in the main grid (a hidden reference
                 // ghost group may also linger, as with single-group restore)
                 expect(
@@ -6529,7 +6527,7 @@ describe('dockviewComponent', () => {
                 ).toBeGreaterThanOrEqual(2);
 
                 expect(() => dockview.clear()).not.toThrow();
-                expect(dockview.groups.length).toBe(0);
+                expect(dockview.groups).toHaveLength(0);
 
                 jest.useRealTimers();
             });
@@ -6574,8 +6572,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id },
@@ -6585,8 +6583,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a floating group of many tabs to an existing fixed group', () => {
@@ -6628,8 +6626,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id },
@@ -6639,8 +6637,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(1);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(1);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a floating group of many tabs to an existing floating group', () => {
@@ -6689,8 +6687,8 @@ describe('dockviewComponent', () => {
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
             expect(panel4.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(4);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(4);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id },
@@ -6701,8 +6699,8 @@ describe('dockviewComponent', () => {
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
             expect(panel4.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(4);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(4);
         });
 
         test('move a floating tab of one tab to a new fixed group', () => {
@@ -6737,8 +6735,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id, panelId: panel2.id },
@@ -6747,8 +6745,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
         });
 
         test('move a floating tab of one tab to an existing fixed group', () => {
@@ -6783,8 +6781,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id, panelId: panel2.id },
@@ -6793,8 +6791,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(1);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(1);
+            expect(dockview.panels).toHaveLength(2);
         });
 
         test('move a floating tab of one tab to an existing floating group', () => {
@@ -6836,8 +6834,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel3.group.id, panelId: panel3.id },
@@ -6847,8 +6845,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a floating tab of many tabs to a new fixed group', () => {
@@ -6890,8 +6888,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id, panelId: panel2.id },
@@ -6901,8 +6899,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a floating tab of many tabs to an existing fixed group', () => {
@@ -6944,8 +6942,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id, panelId: panel2.id },
@@ -6955,8 +6953,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a floating tab of many tabs to an existing floating group', () => {
@@ -7005,8 +7003,8 @@ describe('dockviewComponent', () => {
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
             expect(panel4.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(4);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(4);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id, panelId: panel2.id },
@@ -7017,8 +7015,8 @@ describe('dockviewComponent', () => {
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
             expect(panel4.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(4);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(4);
         });
 
         test('move a fixed tab of one tab to an existing floating group', () => {
@@ -7060,8 +7058,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel1.group.id, panelId: panel1.id },
@@ -7071,8 +7069,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('floating');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a fixed tab of many tabs to an existing floating group', () => {
@@ -7113,8 +7111,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel1.group.id, panelId: panel1.id },
@@ -7124,8 +7122,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('floating');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a fixed group of one tab to an existing floating group', () => {
@@ -7167,8 +7165,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel1.group.id },
@@ -7178,8 +7176,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('floating');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a fixed group of many tabs to an existing floating group', () => {
@@ -7220,8 +7218,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel1.group.id },
@@ -7231,8 +7229,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('floating');
             expect(panel2.group.api.location.type).toBe('floating');
             expect(panel3.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(1);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(1);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('move a fixed tab of one tab to a new floating group', () => {
@@ -7267,15 +7265,15 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
 
             dockview.addFloatingGroup(panel2);
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
         });
 
         test('move a fixed tab of many tabs to a new floating group', () => {
@@ -7309,15 +7307,15 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(1);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(1);
+            expect(dockview.panels).toHaveLength(2);
 
             dockview.addFloatingGroup(panel2);
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
         });
 
         test('move a fixed group of one tab to a new floating group', () => {
@@ -7352,15 +7350,15 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
 
             dockview.addFloatingGroup(panel2.group);
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
         });
 
         test('move a fixed group of many tabs to a new floating group', () => {
@@ -7394,15 +7392,15 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(1);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(1);
+            expect(dockview.panels).toHaveLength(2);
 
             dockview.addFloatingGroup(panel2.group);
 
             expect(panel1.group.api.location.type).toBe('floating');
             expect(panel2.group.api.location.type).toBe('floating');
-            expect(dockview.groups.length).toBe(1);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(1);
+            expect(dockview.panels).toHaveLength(2);
         });
 
         test('component should remain visible when moving from floating back to new grid group (GitHub issue #996)', () => {
@@ -7859,8 +7857,8 @@ describe('dockviewComponent', () => {
             expect(
                 panel2.group.element.querySelectorAll(
                     '.dv-content-container > .testpanel-panel_2'
-                ).length
-            ).toBe(1);
+                )
+            ).toHaveLength(1);
 
             await dockview.addPopoutGroup(panel3);
             panel3.api.moveTo({ group: panel1.api.group, position: 'right' });
@@ -7871,13 +7869,13 @@ describe('dockviewComponent', () => {
             expect(
                 container.querySelectorAll(
                     '.dv-render-overlay > .testpanel-panel_3'
-                ).length
-            ).toBe(1);
+                )
+            ).toHaveLength(1);
             expect(
                 panel2.group.element.querySelectorAll(
                     '.dv-content-container > .testpanel-panel_3'
-                ).length
-            ).toBe(0);
+                )
+            ).toHaveLength(0);
         });
 
         test('move popout group of 1 panel inside grid', async () => {
@@ -7921,8 +7919,8 @@ describe('dockviewComponent', () => {
 
             panel2.api.moveTo({ position: 'top', group: panel3.group });
 
-            expect(dockview.panels.length).toBe(3);
-            expect(dockview.groups.length).toBe(3);
+            expect(dockview.panels).toHaveLength(3);
+            expect(dockview.groups).toHaveLength(3);
         });
 
         // Regression test for issue #1004: when a single-panel popout group is
@@ -8005,9 +8003,9 @@ describe('dockviewComponent', () => {
             });
 
             expect(panel2.api.location.type).toBe('grid');
-            expect(dockview.panels.length).toBe(4);
+            expect(dockview.panels).toHaveLength(4);
             // The empty popout reference group should have been cleaned up.
-            expect(dockview.groups.length).toBe(4);
+            expect(dockview.groups).toHaveLength(4);
 
             const gridOrder = collectGridPanelOrder(
                 JSON.parse(JSON.stringify(dockview.toJSON())).grid.root
@@ -8075,8 +8073,8 @@ describe('dockviewComponent', () => {
             ).not.toThrow();
 
             expect(panel2.api.location.type).toBe('grid');
-            expect(dockview.panels.length).toBe(4);
-            expect(dockview.groups.length).toBe(4);
+            expect(dockview.panels).toHaveLength(4);
+            expect(dockview.groups).toHaveLength(4);
 
             const gridOrder = collectGridPanelOrder(
                 JSON.parse(JSON.stringify(dockview.toJSON())).grid.root
@@ -8122,8 +8120,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(1);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(1);
+            expect(dockview.panels).toHaveLength(2);
 
             const events: SizeEvent[] = [];
 
@@ -8142,8 +8140,8 @@ describe('dockviewComponent', () => {
 
             expect(panel1.group.api.location.type).toBe('popout');
             expect(panel2.group.api.location.type).toBe('popout');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(2);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(2);
 
             if (panel2.api.location.type !== 'popout') {
                 fail('unexpected');
@@ -8228,7 +8226,7 @@ describe('dockviewComponent', () => {
              */
             await dockview.popoutRestorationPromise;
 
-            expect(dockview.panels.length).toBe(4);
+            expect(dockview.panels).toHaveLength(4);
 
             panel1 = dockview.api.getPanel('panel_1') as DockviewPanel;
             panel2 = dockview.api.getPanel('panel_2') as DockviewPanel;
@@ -8241,8 +8239,8 @@ describe('dockviewComponent', () => {
             expect(panel4.api.location.type).toBe('popout');
 
             dockview.clear();
-            expect(dockview.groups.length).toBe(0);
-            expect(dockview.panels.length).toBe(0);
+            expect(dockview.groups).toHaveLength(0);
+            expect(dockview.panels).toHaveLength(0);
         });
 
         test('close popout window object', async () => {
@@ -8297,8 +8295,8 @@ describe('dockviewComponent', () => {
             expect(panel3.group.api.location.type).toBe('grid');
 
             dockview.clear();
-            expect(dockview.groups.length).toBe(0);
-            expect(dockview.panels.length).toBe(0);
+            expect(dockview.groups).toHaveLength(0);
+            expect(dockview.panels).toHaveLength(0);
         });
 
         test('remove all panels from popout group', async () => {
@@ -8343,16 +8341,16 @@ describe('dockviewComponent', () => {
             expect(panel2.group.api.location.type).toBe('popout');
             expect(panel3.group.api.location.type).toBe('popout');
 
-            expect(dockview.panels.length).toBe(3);
-            expect(dockview.groups.length).toBe(3); // includes one hidden group
+            expect(dockview.panels).toHaveLength(3);
+            expect(dockview.groups).toHaveLength(3); // includes one hidden group
 
             panel2.api.moveTo({ group: panel1.group, position: 'left' });
-            expect(dockview.panels.length).toBe(3);
-            expect(dockview.groups.length).toBe(4);
+            expect(dockview.panels).toHaveLength(3);
+            expect(dockview.groups).toHaveLength(4);
 
             panel3.api.moveTo({ group: panel1.group, position: 'left' });
-            expect(dockview.panels.length).toBe(3);
-            expect(dockview.groups.length).toBe(3);
+            expect(dockview.panels).toHaveLength(3);
+            expect(dockview.groups).toHaveLength(3);
         });
 
         test('that can remove a popout group', async () => {
@@ -8381,14 +8379,14 @@ describe('dockviewComponent', () => {
 
             expect(await dockview.addPopoutGroup(panel1)).toBeTruthy();
 
-            expect(dockview.panels.length).toBe(1);
-            expect(dockview.groups.length).toBe(2);
+            expect(dockview.panels).toHaveLength(1);
+            expect(dockview.groups).toHaveLength(2);
             expect(panel1.api.group.api.location.type).toBe('popout');
 
             dockview.removePanel(panel1);
 
-            expect(dockview.panels.length).toBe(0);
-            expect(dockview.groups.length).toBe(0);
+            expect(dockview.panels).toHaveLength(0);
+            expect(dockview.groups).toHaveLength(0);
         });
 
         test('getPopupServiceForGroup returns a per-popout service rooted in the popout window', async () => {
@@ -8482,13 +8480,13 @@ describe('dockviewComponent', () => {
                 position: { direction: 'right' },
             });
 
-            expect(dockview.panels.length).toBe(4);
-            expect(dockview.groups.length).toBe(2);
+            expect(dockview.panels).toHaveLength(4);
+            expect(dockview.groups).toHaveLength(2);
 
             expect(await dockview.addPopoutGroup(panel1)).toBeTruthy();
 
-            expect(dockview.panels.length).toBe(4);
-            expect(dockview.groups.length).toBe(3);
+            expect(dockview.panels).toHaveLength(4);
+            expect(dockview.groups).toHaveLength(3);
 
             expect(panel1.api.location.type).toBe('popout');
 
@@ -8496,8 +8494,8 @@ describe('dockviewComponent', () => {
 
             await new Promise((resolve) => setTimeout(resolve, 0)); // popout views are completed as a promise so must complete microtask-queue
 
-            expect(dockview.panels.length).toBe(4);
-            expect(dockview.groups.length).toBe(3);
+            expect(dockview.panels).toHaveLength(4);
+            expect(dockview.groups).toHaveLength(3);
             expect(dockview.groups.every((g) => g.api.isVisible)).toBeTruthy();
         });
 
@@ -8541,16 +8539,16 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
 
             expect(await dockview.addPopoutGroup(panel2.group)).toBeTruthy();
 
             expect(panel1.group.api.location.type).toBe('popout');
             expect(panel2.group.api.location.type).toBe('popout');
             expect(panel3.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(3);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(3);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel2.group.id, panelId: panel2.id },
@@ -8560,8 +8558,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('popout');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(4);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(4);
+            expect(dockview.panels).toHaveLength(3);
 
             dockview.moveGroupOrPanel({
                 from: { groupId: panel1.group.id, panelId: panel1.id },
@@ -8571,8 +8569,8 @@ describe('dockviewComponent', () => {
             expect(panel1.group.api.location.type).toBe('grid');
             expect(panel2.group.api.location.type).toBe('grid');
             expect(panel3.group.api.location.type).toBe('grid');
-            expect(dockview.groups.length).toBe(2);
-            expect(dockview.panels.length).toBe(3);
+            expect(dockview.groups).toHaveLength(2);
+            expect(dockview.panels).toHaveLength(3);
         });
 
         test('persistance with custom url', async () => {
@@ -8657,7 +8655,7 @@ describe('dockviewComponent', () => {
             ]);
 
             dockview.clear();
-            expect(dockview.groups.length).toBe(0);
+            expect(dockview.groups).toHaveLength(0);
 
             dockview.fromJSON(state);
 
@@ -8744,12 +8742,11 @@ describe('dockviewComponent', () => {
             ]);
             expect(
                 dockview.groups.filter((g) => g.api.location.type === 'popout')
-                    .length
-            ).toBe(0);
+            ).toHaveLength(0);
 
             // and clearing the restored layout doesn't throw on orphaned groups
             expect(() => dockview.clear()).not.toThrow();
-            expect(dockview.groups.length).toBe(0);
+            expect(dockview.groups).toHaveLength(0);
 
             jest.useRealTimers();
         });
@@ -9201,7 +9198,7 @@ describe('dockviewComponent', () => {
                 position: { referencePanel: panel3, direction: 'within' },
             });
 
-            expect(api.groups.length).toBe(2);
+            expect(api.groups).toHaveLength(2);
             expect(panel1.group).toBe(panel2.group);
             expect(panel3.group).toBe(panel4.group);
 
@@ -9307,7 +9304,7 @@ describe('dockviewComponent', () => {
                 position: { referencePanel: panel1, direction: 'below' },
             });
 
-            expect(api.groups.length).toBe(3);
+            expect(api.groups).toHaveLength(3);
 
             panel1.group.api.setVisible(false);
             panel2.group.api.setVisible(false);
@@ -9431,7 +9428,7 @@ describe('dockviewComponent', () => {
                 group: panel1.group,
                 position: 'left',
             });
-            expect(api.groups.length).toBe(3);
+            expect(api.groups).toHaveLength(3);
             expect(panel2.api.isVisible).toBeFalsy();
             expect(panel2.api.group.api.isVisible).toBeFalsy();
 
@@ -10112,13 +10109,13 @@ describe('dockviewComponent', () => {
             position: { direction: 'right' },
         });
 
-        expect(api.panels.length).toBe(3);
-        expect(api.groups.length).toBe(2);
+        expect(api.panels).toHaveLength(3);
+        expect(api.groups).toHaveLength(2);
 
         api.addGroup({ direction: 'left' });
 
-        expect(api.panels.length).toBe(3);
-        expect(api.groups.length).toBe(3);
+        expect(api.panels).toHaveLength(3);
+        expect(api.groups).toHaveLength(3);
     });
 
     test('addGroup calls normalize method on gridview', () => {
@@ -10160,8 +10157,8 @@ describe('dockviewComponent', () => {
         expect(normalizeSpy).toHaveBeenCalled();
 
         // Should have the new empty group plus the existing group with panels
-        expect(api.panels.length).toBe(1);
-        expect(api.groups.length).toBe(2);
+        expect(api.panels).toHaveLength(1);
+        expect(api.groups).toHaveLength(2);
 
         normalizeSpy.mockRestore();
     });
@@ -10846,8 +10843,8 @@ describe('dockviewComponent', () => {
 
             // Tab group should have been auto-destroyed (isEmpty triggers dispose)
             expect(
-                dockview.api.getTabGroups({ groupId: panel2.group.id }).length
-            ).toBe(0);
+                dockview.api.getTabGroups({ groupId: panel2.group.id })
+            ).toHaveLength(0);
         });
 
         test('no-label group chip renders with empty label class', () => {
@@ -10943,7 +10940,7 @@ describe('dockviewComponent', () => {
             const restored = dockview.api.getTabGroups({
                 groupId: restoredGroup.id,
             });
-            expect(restored.length).toBe(2);
+            expect(restored).toHaveLength(2);
 
             const r1 = restored.find((tg) => tg.label === 'Alpha')!;
             expect(r1).toBeDefined();
@@ -11456,7 +11453,7 @@ describe('dockviewComponent', () => {
             // Shell is always created even with no edge panels
             expect(c.childNodes.length).toBeGreaterThan(0);
             dv.dispose();
-            expect(c.childNodes.length).toBe(0);
+            expect(c.childNodes).toHaveLength(0);
         });
 
         test('removeEdgeGroup removes the group and disposes its panels', () => {
@@ -11688,7 +11685,7 @@ describe('dockviewComponent', () => {
             });
             edgeP1.api.setActive();
 
-            expect(edgeGroup.panels.length).toBe(2);
+            expect(edgeGroup.panels).toHaveLength(2);
             expect(edgeGroup.activePanel?.id).toBe('edge-p1');
 
             dv.moveGroup({
@@ -11699,7 +11696,7 @@ describe('dockviewComponent', () => {
             // Edge group still exists at its position, now empty
             expect(dv.getEdgeGroup('left')).toBeDefined();
             expect(edgeGroup.api.location.type).toBe('edge');
-            expect(edgeGroup.panels.length).toBe(0);
+            expect(edgeGroup.panels).toHaveLength(0);
             // ...and auto-collapsed via the addEdgeGroup listener
             expect((dv as any)._shellManager.isEdgeGroupCollapsed('left')).toBe(
                 true

--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
@@ -379,7 +379,7 @@ describe('dockviewGroupPanelModel', () => {
         const panel2 = new TestPanel('panel2', panelApi);
         const panel3 = new TestPanel('panel3', panelApi);
 
-        expect(events.length).toBe(0);
+        expect(events).toHaveLength(0);
 
         groupview.model.openPanel(panel1);
         expect(events).toEqual([
@@ -828,23 +828,23 @@ describe('dockviewGroupPanelModel', () => {
         const panel1 = new TestPanel('id_1', panelApi);
 
         cut.openPanel(panel1);
-        expect(contentContainer.length).toBe(1);
+        expect(contentContainer).toHaveLength(1);
         expect(contentContainer.item(0)).toBe(panel1.view.content.element);
 
         const panel2 = new TestPanel('id_2', panelApi);
 
         cut.openPanel(panel2);
-        expect(contentContainer.length).toBe(1);
+        expect(contentContainer).toHaveLength(1);
         expect(contentContainer.item(0)).toBe(panel2.view.content.element);
 
         const panel3 = new TestPanel('id_2', panelApi);
 
         cut.openPanel(panel3, { skipSetActive: true });
-        expect(contentContainer.length).toBe(1);
+        expect(contentContainer).toHaveLength(1);
         expect(contentContainer.item(0)).toBe(panel2.view.content.element);
 
         cut.openPanel(panel3);
-        expect(contentContainer.length).toBe(1);
+        expect(contentContainer).toHaveLength(1);
         expect(contentContainer.item(0)).toBe(panel3.view.content.element);
     });
 
@@ -907,8 +907,8 @@ describe('dockviewGroupPanelModel', () => {
         expect(counter).toBe(1);
 
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
     });
 
     test('that the .locked behaviour is as', () => {
@@ -974,32 +974,32 @@ describe('dockviewGroupPanelModel', () => {
         cut.locked = false;
         run(10);
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
         fireEvent.dragEnd(element);
 
         // special case - locked with no possible target
         cut.locked = 'no-drop-target';
         run(10);
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
         fireEvent.dragEnd(element);
 
         // standard locked - only show if not center target
         cut.locked = true;
         run(10);
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
         fireEvent.dragEnd(element);
 
         // standard locked but for center target - expect not shown
         cut.locked = true;
         run(25);
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
         fireEvent.dragEnd(element);
     });
 
@@ -1066,8 +1066,8 @@ describe('dockviewGroupPanelModel', () => {
         expect(counter).toBe(0);
 
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
     });
 
     test('that should allow drop when dropping on self for same component id', () => {
@@ -1140,8 +1140,8 @@ describe('dockviewGroupPanelModel', () => {
         expect(counter).toBe(0);
 
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(1);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(1);
     });
 
     // Regression test for #1242: dropping a tab-group chip on the edge of
@@ -1244,7 +1244,7 @@ describe('dockviewGroupPanelModel', () => {
         );
         fireEvent.drop(target);
 
-        expect(moveEvents.length).toBe(1);
+        expect(moveEvents).toHaveLength(1);
         expect(moveEvents[0].target).toBe('right');
         expect(moveEvents[0].tabGroupId).toBe('tg-1');
         expect(moveEvents[0].itemId).toBeUndefined();
@@ -1340,7 +1340,7 @@ describe('dockviewGroupPanelModel', () => {
             fireEvent.drop(target);
         }
 
-        expect(moveEvents.length).toBe(0);
+        expect(moveEvents).toHaveLength(0);
 
         LocalSelectionTransfer.getInstance().clearData(PanelTransfer.prototype);
     });
@@ -1415,8 +1415,8 @@ describe('dockviewGroupPanelModel', () => {
         expect(counter).toBe(1);
 
         expect(
-            element.getElementsByClassName('dv-drop-target-dropzone').length
-        ).toBe(0);
+            element.getElementsByClassName('dv-drop-target-dropzone')
+        ).toHaveLength(0);
     });
 
     test('that the watermark is removed when dispose is called', () => {
@@ -1450,14 +1450,14 @@ describe('dockviewGroupPanelModel', () => {
         cut.initialize();
 
         expect(
-            container.getElementsByClassName('watermark-test-container').length
-        ).toBe(1);
+            container.getElementsByClassName('watermark-test-container')
+        ).toHaveLength(1);
 
         cut.dispose();
 
         expect(
-            container.getElementsByClassName('watermark-test-container').length
-        ).toBe(0);
+            container.getElementsByClassName('watermark-test-container')
+        ).toHaveLength(0);
     });
 
     test('that watermark is added', () => {
@@ -1491,42 +1491,41 @@ describe('dockviewGroupPanelModel', () => {
         cut.initialize();
 
         expect(
-            container.getElementsByClassName('watermark-test-container').length
-        ).toBe(1);
+            container.getElementsByClassName('watermark-test-container')
+        ).toHaveLength(1);
 
         cut.openPanel(new TestPanel('panel1', panelApi));
 
         expect(
-            container.getElementsByClassName('watermark-test-container').length
-        ).toBe(0);
+            container.getElementsByClassName('watermark-test-container')
+        ).toHaveLength(0);
         expect(
             container.getElementsByClassName('dv-tabs-and-actions-container')
-                .length
-        ).toBe(1);
+        ).toHaveLength(1);
 
         cut.openPanel(new TestPanel('panel2', panelApi));
 
         expect(
-            container.getElementsByClassName('watermark-test-container').length
-        ).toBe(0);
+            container.getElementsByClassName('watermark-test-container')
+        ).toHaveLength(0);
 
         cut.removePanel('panel1');
 
         expect(
-            container.getElementsByClassName('watermark-test-container').length
-        ).toBe(0);
+            container.getElementsByClassName('watermark-test-container')
+        ).toHaveLength(0);
 
         cut.removePanel('panel2');
 
         expect(
-            container.getElementsByClassName('watermark-test-container').length
-        ).toBe(1);
+            container.getElementsByClassName('watermark-test-container')
+        ).toHaveLength(1);
 
         cut.openPanel(new TestPanel('panel1', panelApi));
 
         expect(
-            container.getElementsByClassName('watermark-test-container').length
-        ).toBe(0);
+            container.getElementsByClassName('watermark-test-container')
+        ).toHaveLength(0);
     });
 
     describe('tab groups', () => {
@@ -1777,7 +1776,7 @@ describe('dockviewGroupPanelModel', () => {
 
             const json = groupview.model.toJSON();
             expect(json.tabGroups).toBeDefined();
-            expect(json.tabGroups!.length).toBe(1);
+            expect(json.tabGroups!).toHaveLength(1);
             expect(json.tabGroups![0].id).toBe(tabGroup.id);
             expect(json.tabGroups![0].label).toBe('Group A');
             expect(json.tabGroups![0].color).toBe('blue');
@@ -1812,7 +1811,7 @@ describe('dockviewGroupPanelModel', () => {
             ]);
 
             const groups = groupview.model.getTabGroups();
-            expect(groups.length).toBe(1);
+            expect(groups).toHaveLength(1);
             expect(groups[0].id).toBe('tg-restored');
             expect(groups[0].label).toBe('Restored');
             expect(groups[0].color).toBe('red');
@@ -1834,7 +1833,7 @@ describe('dockviewGroupPanelModel', () => {
             ]);
 
             const groups = groupview.model.getTabGroups();
-            expect(groups.length).toBe(1);
+            expect(groups).toHaveLength(1);
             expect(groups[0].panelIds).toEqual(['panel1']);
         });
 
@@ -1852,7 +1851,7 @@ describe('dockviewGroupPanelModel', () => {
             ]);
 
             const groups = groupview.model.getTabGroups();
-            expect(groups.length).toBe(0);
+            expect(groups).toHaveLength(0);
         });
 
         test('collapsing all tab groups shows watermark', () => {
@@ -2024,17 +2023,17 @@ describe('dockviewGroupPanelModel', () => {
             tg2.collapse();
 
             const json = groupview.model.toJSON();
-            expect(json.tabGroups!.length).toBe(2);
+            expect(json.tabGroups!).toHaveLength(2);
 
             // Dissolve existing groups
             groupview.model.dissolveTabGroup(tg1.id);
             groupview.model.dissolveTabGroup(tg2.id);
-            expect(groupview.model.getTabGroups().length).toBe(0);
+            expect(groupview.model.getTabGroups()).toHaveLength(0);
 
             // Restore from JSON
             groupview.model.restoreTabGroups(json.tabGroups!);
             const restored = groupview.model.getTabGroups();
-            expect(restored.length).toBe(2);
+            expect(restored).toHaveLength(2);
             expect(restored[0].label).toBe('G1');
             expect(restored[0].color).toBe('purple');
             expect(restored[0].collapsed).toBe(false);

--- a/packages/dockview-core/src/__tests__/dockview/dockviewPanel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewPanel.spec.ts
@@ -167,7 +167,7 @@ describe('dockviewPanel', () => {
             }
         );
 
-        expect(cut.params).toEqual(undefined);
+        expect(cut.params).toBeUndefined();
 
         cut.update({ params: { variableA: 'A', variableB: 'B' } });
 

--- a/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
@@ -49,7 +49,7 @@ describe('popout lifecycle', () => {
 
         await dockview.addPopoutGroup(panel);
 
-        expect(events.length).toBe(1);
+        expect(events).toHaveLength(1);
         expect(events[0].hasGroup).toBe(true);
         expect(events[0].hasWindow).toBe(true);
         // the event id matches the now-enumerable popout
@@ -63,7 +63,7 @@ describe('popout lifecycle', () => {
         await dockview.addPopoutGroup(panel);
 
         const popouts = dockview.getPopouts();
-        expect(popouts.length).toBe(1);
+        expect(popouts).toHaveLength(1);
         expect(typeof popouts[0].id).toBe('string');
         expect(popouts[0].group).toBeDefined();
         expect(popouts[0].window).toBeDefined();
@@ -76,14 +76,14 @@ describe('popout lifecycle', () => {
         const panel = dockview.addPanel({ id: 'p1', component: 'default' });
         await dockview.addPopoutGroup(panel);
 
-        expect(fired.length).toBe(1);
+        expect(fired).toHaveLength(1);
         expect(dockview.api.getPopouts().map((p) => p.id)).toEqual(fired);
     });
 
     test('closing the popout window returns the panel, fires onDidRemovePopoutGroup, and clears getPopouts', async () => {
         const panel = dockview.addPanel({ id: 'p1', component: 'default' });
         await dockview.addPopoutGroup(panel);
-        expect(dockview.getPopouts().length).toBe(1);
+        expect(dockview.getPopouts()).toHaveLength(1);
 
         const popoutId = dockview.getPopouts()[0].id;
         const popoutWindow = dockview.getPopouts()[0].window;

--- a/packages/dockview-core/src/__tests__/dockview/tabGroup.test.ts
+++ b/packages/dockview-core/src/__tests__/dockview/tabGroup.test.ts
@@ -162,10 +162,10 @@ describe('TabGroup', () => {
         const changes: void[] = [];
         group.onDidChange(() => changes.push(undefined));
         group.setLabel('New Label');
-        expect(changes.length).toBe(1);
+        expect(changes).toHaveLength(1);
         // Setting same label should not fire
         group.setLabel('New Label');
-        expect(changes.length).toBe(1);
+        expect(changes).toHaveLength(1);
         group.dispose();
     });
 
@@ -174,10 +174,10 @@ describe('TabGroup', () => {
         const changes: void[] = [];
         group.onDidChange(() => changes.push(undefined));
         group.setColor('blue');
-        expect(changes.length).toBe(1);
+        expect(changes).toHaveLength(1);
         // Setting same color should not fire
         group.setColor('blue');
-        expect(changes.length).toBe(1);
+        expect(changes).toHaveLength(1);
         group.dispose();
     });
 
@@ -187,10 +187,10 @@ describe('TabGroup', () => {
         group.onDidChange(() => changes.push(undefined));
         group.setComponentParams({ icon: 'star' });
         expect(group.componentParams).toEqual({ icon: 'star' });
-        expect(changes.length).toBe(1);
+        expect(changes).toHaveLength(1);
         group.setComponentParams(undefined);
         expect(group.componentParams).toBeUndefined();
-        expect(changes.length).toBe(2);
+        expect(changes).toHaveLength(2);
         group.dispose();
     });
 

--- a/packages/dockview-core/src/__tests__/dom.spec.ts
+++ b/packages/dockview-core/src/__tests__/dom.spec.ts
@@ -138,7 +138,7 @@ describe('dom', () => {
             addStyles(targetDoc, sheets, { nonce: 'abc123' });
 
             const styles = targetDoc.head.querySelectorAll('style');
-            expect(styles.length).toBe(2);
+            expect(styles).toHaveLength(2);
             expect(styles[0].getAttribute('nonce')).toBe('abc123');
             expect(styles[1].getAttribute('nonce')).toBe('abc123');
             expect(styles[0].textContent).toBe('.a { color: red; }');
@@ -176,7 +176,7 @@ describe('dom', () => {
             );
             // The <link> already loads the sheet in the target document;
             // we must not also inject inline <style> for the same rules.
-            expect(targetDoc.head.querySelectorAll('style').length).toBe(0);
+            expect(targetDoc.head.querySelectorAll('style')).toHaveLength(0);
         });
 
         test('preserves source order when mixing href-bearing and inline sheets', () => {
@@ -192,7 +192,7 @@ describe('dom', () => {
             const appended = Array.from(targetDoc.head.children).filter(
                 (el) => el.tagName === 'STYLE' || el.tagName === 'LINK'
             );
-            expect(appended.length).toBe(3);
+            expect(appended).toHaveLength(3);
             expect(appended[0].tagName).toBe('STYLE');
             expect(appended[0].textContent).toBe('.first { color: red; }');
             expect(appended[1].tagName).toBe('LINK');
@@ -224,7 +224,7 @@ describe('dom', () => {
 
             expect(warn).toHaveBeenCalledTimes(1);
             const styles = targetDoc.head.querySelectorAll('style');
-            expect(styles.length).toBe(1);
+            expect(styles).toHaveLength(1);
             expect(styles[0].textContent).toBe('.after { color: green; }');
 
             warn.mockRestore();

--- a/packages/dockview-core/src/__tests__/gridview/baseComponentGridview.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/baseComponentGridview.spec.ts
@@ -177,7 +177,7 @@ describe('baseComponentGridview', () => {
 
         cut.doAddGroup(panel1);
 
-        expect(events.length).toBe(1);
+        expect(events).toHaveLength(1);
         expect(events[0]).toEqual({ type: 'add', panel: panel1 });
 
         const panel2 = new TestPanel(
@@ -193,11 +193,11 @@ describe('baseComponentGridview', () => {
 
         cut.doAddGroup(panel2);
 
-        expect(events.length).toBe(2);
+        expect(events).toHaveLength(2);
         expect(events[1]).toEqual({ type: 'add', panel: panel2 });
 
         cut.doRemoveGroup(panel1);
-        expect(events.length).toBe(3);
+        expect(events).toHaveLength(3);
         expect(events[2]).toEqual({ type: 'remove', panel: panel1 });
 
         disposable.dispose();

--- a/packages/dockview-core/src/__tests__/gridview/gridview.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridview.spec.ts
@@ -49,7 +49,7 @@ describe('gridview', () => {
     });
 
     test('dispose of gridview', () => {
-        expect(container.childNodes.length).toBe(0);
+        expect(container.childNodes).toHaveLength(0);
 
         const gridview = new Gridview(
             false,
@@ -59,11 +59,11 @@ describe('gridview', () => {
 
         container.appendChild(gridview.element);
 
-        expect(container.childNodes.length).toBe(1);
+        expect(container.childNodes).toHaveLength(1);
 
         gridview.dispose();
 
-        expect(container.childNodes.length).toBe(0);
+        expect(container.childNodes).toHaveLength(0);
     });
 
     test('insertOrthogonalSplitviewAtRoot #1', () => {
@@ -177,8 +177,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(3);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(3);
 
         gridview.removeView([1, 0], Sizing.Distribute);
 
@@ -204,8 +204,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(2);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(2);
     });
 
     test('removeView: remove leaf from branch where branch remains branch and parent is root', () => {
@@ -260,8 +260,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(4);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(4);
 
         gridview.removeView([1, 0], Sizing.Distribute);
 
@@ -298,8 +298,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(3);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(3);
     });
 
     test('removeView: remove leaf where parent is root', () => {
@@ -348,8 +348,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(3);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(3);
 
         gridview.removeView([0], Sizing.Distribute);
 
@@ -375,8 +375,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(2);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(2);
     });
 
     test('removeView: remove leaf from branch where branch becomes leaf and parent is not root', () => {
@@ -437,8 +437,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(4);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(4);
 
         gridview.removeView([1, 0, 0], Sizing.Distribute);
 
@@ -475,8 +475,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(3);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(3);
     });
 
     test('removeView: remove leaf from branch where branch remains branch and parent is not root', () => {
@@ -543,8 +543,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(5);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(5);
 
         gridview.removeView([1, 0, 1], Sizing.Distribute);
 
@@ -592,8 +592,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(4);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(4);
     });
 
     test('removeView: remove leaf where parent is root', () => {
@@ -660,8 +660,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(5);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(5);
 
         gridview.removeView([1, 1], Sizing.Distribute);
 
@@ -697,8 +697,8 @@ describe('gridview', () => {
             width: 1000,
         });
         expect(
-            gridview.element.querySelectorAll('.mock-grid-view').length
-        ).toBe(4);
+            gridview.element.querySelectorAll('.mock-grid-view')
+        ).toHaveLength(4);
     });
 
     test('that calling insertOrthogonalSplitviewAtRoot() for an empty view doesnt add any nodes', () => {
@@ -758,12 +758,12 @@ describe('gridview', () => {
         gridview.addView(view6, Sizing.Distribute, [1, 1, 0, 0, 0]);
 
         let el = gridview.element.querySelectorAll('.mock-grid-view');
-        expect(el.length).toBe(6);
+        expect(el).toHaveLength(6);
 
         gridview.remove(view2);
 
         el = gridview.element.querySelectorAll('.mock-grid-view');
-        expect(el.length).toBe(5);
+        expect(el).toHaveLength(5);
     });
 
     test('gridview nested proportional layouts', () => {
@@ -1232,8 +1232,8 @@ describe('gridview', () => {
             const afterNormalize = gridview.serialize();
             expect(afterNormalize).toEqual(beforeNormalize);
             expect(
-                gridview.element.querySelectorAll('.mock-grid-view').length
-            ).toBe(2);
+                gridview.element.querySelectorAll('.mock-grid-view')
+            ).toHaveLength(2);
         });
 
         test('should not normalize when root has single leaf child', () => {
@@ -1299,8 +1299,8 @@ describe('gridview', () => {
             gridview.addView(view1, Sizing.Distribute, [0]);
 
             expect(
-                gridview.element.querySelectorAll('.mock-grid-view').length
-            ).toBe(1);
+                gridview.element.querySelectorAll('.mock-grid-view')
+            ).toHaveLength(1);
         });
 
         test('normalize method exists and is callable', () => {

--- a/packages/dockview-core/src/__tests__/gridview/gridviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridviewComponent.spec.ts
@@ -198,7 +198,7 @@ describe('gridview', () => {
             },
         });
 
-        expect(container.querySelectorAll('.dv-grid-view').length).toBe(1);
+        expect(container.querySelectorAll('.dv-grid-view')).toHaveLength(1);
 
         gridview.layout(800, 400);
         gridview.fromJSON({
@@ -245,7 +245,7 @@ describe('gridview', () => {
             activePanel: 'panel_1',
         });
 
-        expect(container.querySelectorAll('.dv-grid-view').length).toBe(1);
+        expect(container.querySelectorAll('.dv-grid-view')).toHaveLength(1);
 
         gridview.layout(800, 400, true);
 
@@ -495,7 +495,7 @@ describe('gridview', () => {
     });
 
     test('dispose of gridviewComponent', () => {
-        expect(container.childNodes.length).toBe(0);
+        expect(container.childNodes).toHaveLength(0);
 
         const gridview = new GridviewComponent(container, {
             proportionalLayout: false,
@@ -529,7 +529,7 @@ describe('gridview', () => {
 
         gridview.dispose();
 
-        expect(container.children.length).toBe(0);
+        expect(container.children).toHaveLength(0);
     });
 
     test('#1/VERTICAL', () => {
@@ -2054,9 +2054,9 @@ describe('gridview', () => {
 
         jest.runAllTimers();
 
-        expect(addGroup.length).toBe(4);
-        expect(removeGroup.length).toBe(0);
-        expect(activeGroup.length).toBe(1);
+        expect(addGroup).toHaveLength(4);
+        expect(removeGroup).toHaveLength(0);
+        expect(activeGroup).toHaveLength(1);
         expect(activeGroup[0]).toEqual(gridview.getPanel('panel_1'));
         expect(layoutChange).toBe(1);
         expect(layoutChangeFromJson).toBe(1);
@@ -2075,9 +2075,9 @@ describe('gridview', () => {
 
         jest.runAllTimers();
 
-        expect(addGroup.length).toBe(0);
-        expect(removeGroup.length).toBe(4);
-        expect(activeGroup.length).toBe(1);
+        expect(addGroup).toHaveLength(0);
+        expect(removeGroup).toHaveLength(4);
+        expect(activeGroup).toHaveLength(1);
         expect(layoutChange).toBe(2);
         expect(layoutChangeFromJson).toBe(2);
 
@@ -2797,7 +2797,7 @@ describe('gridview', () => {
 
         let el = gridview.element.querySelector('.dv-view-container');
         expect(el).toBeTruthy();
-        expect(el!.childNodes.length).toBe(0);
+        expect(el!.childNodes).toHaveLength(0);
 
         expect(() => {
             gridview.fromJSON({
@@ -2858,11 +2858,11 @@ describe('gridview', () => {
             });
         }).toThrow("unsupported panel 'somethingBad'");
 
-        expect(gridview.groups.length).toBe(0);
+        expect(gridview.groups).toHaveLength(0);
 
         el = gridview.element.querySelector('.dv-view-container');
         expect(el).toBeTruthy();
-        expect(el!.childNodes.length).toBe(0);
+        expect(el!.childNodes).toHaveLength(0);
     });
 
     test('that disableAutoResizing is false by default', () => {

--- a/packages/dockview-core/src/__tests__/gridview/gridviewPanel.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridviewPanel.spec.ts
@@ -16,7 +16,7 @@ describe('gridviewPanel', () => {
 
         const cut = new DockviewGroupPanel(accessor, 'id', {});
 
-        expect(cut.params).toEqual(undefined);
+        expect(cut.params).toBeUndefined();
 
         cut.update({ params: { variableA: 'A', variableB: 'B' } });
 

--- a/packages/dockview-core/src/__tests__/paneview/paneview.spec.ts
+++ b/packages/dockview-core/src/__tests__/paneview/paneview.spec.ts
@@ -79,34 +79,34 @@ describe('paneview', () => {
             maximumBodySize: Number.MAX_SAFE_INTEGER,
         });
 
-        expect(added.length).toBe(0);
-        expect(removed.length).toBe(0);
+        expect(added).toHaveLength(0);
+        expect(removed).toHaveLength(0);
 
         paneview.addPane(view1);
-        expect(added.length).toBe(1);
-        expect(removed.length).toBe(0);
+        expect(added).toHaveLength(1);
+        expect(removed).toHaveLength(0);
         expect(added[0]).toBe(view1);
 
         paneview.addPane(view2);
-        expect(added.length).toBe(2);
-        expect(removed.length).toBe(0);
+        expect(added).toHaveLength(2);
+        expect(removed).toHaveLength(0);
         expect(added[1]).toBe(view2);
 
         paneview.removePane(0);
-        expect(added.length).toBe(2);
-        expect(removed.length).toBe(1);
+        expect(added).toHaveLength(2);
+        expect(removed).toHaveLength(1);
         expect(removed[0]).toBe(view1);
 
         paneview.removePane(0);
-        expect(added.length).toBe(2);
-        expect(removed.length).toBe(2);
+        expect(added).toHaveLength(2);
+        expect(removed).toHaveLength(2);
         expect(removed[1]).toBe(view2);
 
         disposable.dispose();
     });
 
     test('dispose of paneview', () => {
-        expect(container.childNodes.length).toBe(0);
+        expect(container.childNodes).toHaveLength(0);
 
         const paneview = new Paneview(container, {
             orientation: Orientation.HORIZONTAL,
@@ -142,6 +142,6 @@ describe('paneview', () => {
 
         paneview.dispose();
 
-        expect(container.childNodes.length).toBe(0);
+        expect(container.childNodes).toHaveLength(0);
     });
 });

--- a/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
@@ -96,7 +96,7 @@ describe('paneviewComponent', () => {
         paneview.dispose();
 
         expect(container.parentElement).toBe(root);
-        expect(container.children.length).toBe(0);
+        expect(container.children).toHaveLength(0);
     });
 
     test('vertical panels', () => {
@@ -190,7 +190,9 @@ describe('paneviewComponent', () => {
             },
         });
 
-        expect(container.querySelectorAll('.dv-pane-container').length).toBe(1);
+        expect(container.querySelectorAll('.dv-pane-container')).toHaveLength(
+            1
+        );
 
         paneview.fromJSON({
             size: 6,
@@ -224,7 +226,9 @@ describe('paneviewComponent', () => {
             ],
         });
 
-        expect(container.querySelectorAll('.dv-pane-container').length).toBe(1);
+        expect(container.querySelectorAll('.dv-pane-container')).toHaveLength(
+            1
+        );
 
         paneview.layout(400, 800);
 

--- a/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
+++ b/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
@@ -130,48 +130,48 @@ describe('splitview', () => {
         let viewQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-view-container > .dv-view'
         );
-        expect(viewQuery.length).toBe(3);
+        expect(viewQuery).toHaveLength(3);
 
         let sashQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-sash-container > .dv-sash'
         );
-        expect(sashQuery.length).toBe(2);
+        expect(sashQuery).toHaveLength(2);
 
         splitview.removeView(2);
 
         viewQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-view-container > .dv-view'
         );
-        expect(viewQuery.length).toBe(2);
+        expect(viewQuery).toHaveLength(2);
 
         sashQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-sash-container > .dv-sash'
         );
-        expect(sashQuery.length).toBe(1);
+        expect(sashQuery).toHaveLength(1);
 
         splitview.removeView(0);
 
         viewQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-view-container > .dv-view'
         );
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
 
         sashQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-sash-container > .dv-sash'
         );
-        expect(sashQuery.length).toBe(0);
+        expect(sashQuery).toHaveLength(0);
 
         splitview.removeView(0);
 
         viewQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-view-container > .dv-view'
         );
-        expect(viewQuery.length).toBe(0);
+        expect(viewQuery).toHaveLength(0);
 
         sashQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-sash-container > .dv-sash'
         );
-        expect(sashQuery.length).toBe(0);
+        expect(sashQuery).toHaveLength(0);
 
         splitview.dispose();
     });
@@ -190,14 +190,14 @@ describe('splitview', () => {
         let viewQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-view-container > .dv-view.visible'
         );
-        expect(viewQuery.length).toBe(2);
+        expect(viewQuery).toHaveLength(2);
 
         splitview.setViewVisible(1, false);
 
         viewQuery = container.querySelectorAll(
             '.dv-split-view-container > .dv-view-container > .dv-view.visible'
         );
-        expect(viewQuery.length).toBe(1);
+        expect(viewQuery).toHaveLength(1);
 
         splitview.dispose();
     });
@@ -545,34 +545,34 @@ describe('splitview', () => {
         const view1 = new Testview(0, 100);
         const view2 = new Testview(0, 100);
 
-        expect(added.length).toBe(0);
-        expect(removed.length).toBe(0);
+        expect(added).toHaveLength(0);
+        expect(removed).toHaveLength(0);
 
         splitview.addView(view1);
-        expect(added.length).toBe(1);
-        expect(removed.length).toBe(0);
+        expect(added).toHaveLength(1);
+        expect(removed).toHaveLength(0);
         expect(added[0]).toBe(view1);
 
         splitview.addView(view2);
-        expect(added.length).toBe(2);
-        expect(removed.length).toBe(0);
+        expect(added).toHaveLength(2);
+        expect(removed).toHaveLength(0);
         expect(added[1]).toBe(view2);
 
         splitview.removeView(0);
-        expect(added.length).toBe(2);
-        expect(removed.length).toBe(1);
+        expect(added).toHaveLength(2);
+        expect(removed).toHaveLength(1);
         expect(removed[0]).toBe(view1);
 
         splitview.removeView(0);
-        expect(added.length).toBe(2);
-        expect(removed.length).toBe(2);
+        expect(added).toHaveLength(2);
+        expect(removed).toHaveLength(2);
         expect(removed[1]).toBe(view2);
 
         disposable.dispose();
     });
 
     test('dispose of splitview', () => {
-        expect(container.childNodes.length).toBe(0);
+        expect(container.childNodes).toHaveLength(0);
 
         const splitview = new Splitview(container, {
             orientation: Orientation.HORIZONTAL,
@@ -596,7 +596,7 @@ describe('splitview', () => {
         listener.dispose();
 
         expect(anyEvents).toBeFalsy();
-        expect(container.childNodes.length).toBe(0);
+        expect(container.childNodes).toHaveLength(0);
     });
 
     test('dnd: pointer events to move sash', () => {

--- a/packages/dockview-core/src/__tests__/splitview/splitviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/splitview/splitviewComponent.spec.ts
@@ -46,7 +46,7 @@ describe('componentSplitview', () => {
         splitview.dispose();
 
         expect(container.parentElement).toBe(root);
-        expect(container.children.length).toBe(0);
+        expect(container.children).toHaveLength(0);
     });
 
     test('event leakage', () => {
@@ -122,14 +122,14 @@ describe('componentSplitview', () => {
 
         expect(panel1.api.isActive).toBeFalsy();
         expect(panel2.api.isActive).toBeTruthy();
-        expect(splitview.length).toBe(2);
+        expect(splitview).toHaveLength(2);
 
         splitview.removePanel(panel1);
         expect(panel2.api.isActive).toBeTruthy();
-        expect(splitview.length).toBe(1);
+        expect(splitview).toHaveLength(1);
 
         splitview.removePanel(panel2);
-        expect(splitview.length).toBe(0);
+        expect(splitview).toHaveLength(0);
     });
 
     test('horizontal dimensions', () => {
@@ -396,8 +396,8 @@ describe('componentSplitview', () => {
         splitview.layout(400, 6);
 
         expect(
-            container.querySelectorAll('.dv-split-view-container').length
-        ).toBe(1);
+            container.querySelectorAll('.dv-split-view-container')
+        ).toHaveLength(1);
 
         splitview.fromJSON({
             views: [
@@ -419,10 +419,10 @@ describe('componentSplitview', () => {
         });
 
         expect(
-            container.querySelectorAll('.dv-split-view-container').length
-        ).toBe(1);
+            container.querySelectorAll('.dv-split-view-container')
+        ).toHaveLength(1);
 
-        expect(splitview.length).toBe(3);
+        expect(splitview).toHaveLength(3);
 
         expect(JSON.parse(JSON.stringify(splitview.toJSON()))).toEqual({
             views: [

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -185,7 +185,7 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
     getWindow(): Window {
         return this.location.type === 'popout'
             ? this.location.getWindow()
-            : window;
+            : globalThis.window;
     }
 
     setHeaderPosition(position: DockviewHeaderPosition): void {

--- a/packages/dockview-core/src/dnd/pointer/longPress.ts
+++ b/packages/dockview-core/src/dnd/pointer/longPress.ts
@@ -62,7 +62,7 @@ export class LongPressDetector extends CompositeDisposable {
 
         // Source's owning window — popout drags fire on their own window.
         const targetWindow: Window =
-            this.element.ownerDocument?.defaultView ?? window;
+            this.element.ownerDocument?.defaultView ?? globalThis.window;
 
         this._timer = setTimeout(() => {
             this._timer = undefined;

--- a/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
@@ -26,9 +26,7 @@ export class PointerDragController extends CompositeDisposable {
     private static _instance: PointerDragController | undefined;
 
     static getInstance(): PointerDragController {
-        if (!PointerDragController._instance) {
-            PointerDragController._instance = new PointerDragController();
-        }
+        PointerDragController._instance ??= new PointerDragController();
         return PointerDragController._instance;
     }
 
@@ -136,7 +134,7 @@ export class PointerDragController extends CompositeDisposable {
         // Source's owning window — popout drags fire on their own window,
         // not the main one.
         const targetWindow: Window =
-            source.ownerDocument?.defaultView ?? window;
+            source.ownerDocument?.defaultView ?? globalThis.window;
 
         this._moveListener = addDisposableListener(
             targetWindow,

--- a/packages/dockview-core/src/dnd/pointer/pointerDragSource.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragSource.ts
@@ -133,7 +133,11 @@ export class PointerDragSource extends CompositeDisposable {
                 ? initiationDelayOpt()
                 : initiationDelayOpt) ?? DEFAULT_TOUCH_INITIATION_DELAY;
         this._armed = !isTouch || initiationDelay <= 0;
-        if (isTouch && initiationDelay > 0 && isFinite(initiationDelay)) {
+        if (
+            isTouch &&
+            initiationDelay > 0 &&
+            Number.isFinite(initiationDelay)
+        ) {
             this._armTimer = setTimeout(() => {
                 this._armTimer = undefined;
                 this._armed = true;
@@ -149,7 +153,7 @@ export class PointerDragSource extends CompositeDisposable {
 
         // Source's owning window — popout drags fire on their own window.
         const targetWindow: Window =
-            this.element.ownerDocument?.defaultView ?? window;
+            this.element.ownerDocument?.defaultView ?? globalThis.window;
 
         this._pendingMoveListener = addDisposableListener(
             targetWindow,

--- a/packages/dockview-core/src/dockview/components/popupService.ts
+++ b/packages/dockview-core/src/dockview/components/popupService.ts
@@ -26,7 +26,7 @@ export class PopupService extends CompositeDisposable {
     // document so they render and dismiss correctly.
     private readonly _window: Window;
 
-    constructor(root: HTMLElement, win: Window = window) {
+    constructor(root: HTMLElement, win: Window = globalThis.window) {
         super();
 
         this._root = root;

--- a/packages/dockview-core/src/dockview/components/titlebar/floatingTitleBar.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/floatingTitleBar.ts
@@ -1,5 +1,5 @@
 import { DockviewComponent } from '../../dockviewComponent';
-import { addDisposableListener, Emitter, Event } from '../../../events';
+import { addDisposableListener, Emitter } from '../../../events';
 import { CompositeDisposable } from '../../../lifecycle';
 import { DockviewGroupPanel } from '../../dockviewGroupPanel';
 import { quasiPreventDefault } from '../../../dom';

--- a/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
@@ -10,7 +10,7 @@ import {
     pointerBackend,
 } from '../../../dnd/backend';
 import { DockviewComponent } from '../../dockviewComponent';
-import { Emitter, Event } from '../../../events';
+import { Emitter } from '../../../events';
 import {
     CompositeDisposable,
     Disposable,

--- a/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/groupDragSource.ts
@@ -97,7 +97,7 @@ export class GroupDragSource extends CompositeDisposable {
 
         const buildMultiPanelsGhost = (): HTMLElement => {
             const ghostEl = document.createElement('div');
-            const style = window.getComputedStyle(this._element);
+            const style = globalThis.getComputedStyle(this._element);
             const bgColor = style.getPropertyValue(
                 '--dv-activegroup-visiblepanel-tab-background-color'
             );

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -1,6 +1,7 @@
 import { toggleClass } from '../../../dom';
 import { addDisposableListener } from '../../../events';
 import {
+    getPanelData,
     LocalSelectionTransfer,
     PanelTransfer,
 } from '../../../dnd/dataTransfer';
@@ -25,7 +26,6 @@ import { applyTabGroupAccent } from '../../tabGroupAccent';
 import { TabGroupChip } from './tabGroupChip';
 import { ITabGroupChipRenderer } from '../../framework';
 import { Droptarget, DroptargetEvent } from '../../../dnd/droptarget';
-import { getPanelData } from '../../../dnd/dataTransfer';
 import {
     ITabGroupIndicator,
     NoneTabGroupIndicator,

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -349,19 +349,16 @@ export class TabGroupManager {
             this._indicator = null;
         }
 
-        if (!this._indicator) {
-            this._indicator = new Ctor({
-                tabsList: this._ctx.tabsList,
-                getTabGroups: () => this._ctx.group.model.getTabGroups(),
-                getActivePanelId: () => this._ctx.group.activePanel?.id,
-                getTabMap: () => this._ctx.getTabMap(),
-                getChipElement: (id) =>
-                    this._chipRenderers.get(id)?.chip.element,
-                getDirection: () => this._ctx.getDirection(),
-                getHeaderPosition: () => this._ctx.group.model.headerPosition,
-                getColorPalette: () => this._ctx.accessor.tabGroupColorPalette,
-            });
-        }
+        this._indicator ??= new Ctor({
+            tabsList: this._ctx.tabsList,
+            getTabGroups: () => this._ctx.group.model.getTabGroups(),
+            getActivePanelId: () => this._ctx.group.activePanel?.id,
+            getTabMap: () => this._ctx.getTabMap(),
+            getChipElement: (id) => this._chipRenderers.get(id)?.chip.element,
+            getDirection: () => this._ctx.getDirection(),
+            getHeaderPosition: () => this._ctx.group.model.headerPosition,
+            getColorPalette: () => this._ctx.accessor.tabGroupColorPalette,
+        });
     }
 
     private _ensureChipForGroup(tabGroup: ITabGroup): void {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -781,18 +781,15 @@ export class Tabs extends CompositeDisposable {
                     return;
                 }
 
-                switch (event.button) {
-                    case 0:
-                        // Edge groups are skipped here: all their tab interaction
-                        // is handled by onTabClick to avoid race conditions with
-                        // active panel state.
-                        if (
-                            this.group.api.location.type !== 'edge' &&
-                            this.group.activePanel !== panel
-                        ) {
-                            this.group.model.openPanel(panel);
-                        }
-                        break;
+                // Edge groups are skipped here: all their tab interaction
+                // is handled by onTabClick to avoid race conditions with
+                // active panel state.
+                if (
+                    event.button === 0 &&
+                    this.group.api.location.type !== 'edge' &&
+                    this.group.activePanel !== panel
+                ) {
+                    this.group.model.openPanel(panel);
                 }
             }),
             tab.onDrop((event) => {
@@ -831,8 +828,9 @@ export class Tabs extends CompositeDisposable {
                             firstPositions,
                             animState.sourceTabId,
                             animState.sourceIndex === -1,
-                            animState.sourceIndex !== -1
-                                ? {
+                            animState.sourceIndex === -1
+                                ? undefined
+                                : {
                                       from: Math.min(
                                           animState.sourceIndex,
                                           dropIndex
@@ -842,7 +840,6 @@ export class Tabs extends CompositeDisposable {
                                           dropIndex
                                       ),
                                   }
-                                : undefined
                         );
                     }
                 } else {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -1,11 +1,6 @@
-import {
-    getPanelData,
-    LocalSelectionTransfer,
-    PanelTransfer,
-} from '../../../dnd/dataTransfer';
+import { getPanelData } from '../../../dnd/dataTransfer';
 import {
     addClasses,
-    disableIframePointEvents,
     isChildEntirelyVisibleWithinParent,
     OverflowObserver,
     removeClasses,
@@ -29,7 +24,6 @@ import { DockviewHeaderDirection } from '../../options';
 import { Tab } from '../tab/tab';
 import { TabDragEvent, TabDropIndexEvent } from './tabsContainer';
 import { ITabGroup } from '../../tabGroup';
-import { TabGroupChip } from './tabGroupChip';
 import { TabGroupManager } from './tabGroups';
 import { ITabGroupChipRenderer } from '../../framework';
 import { DroptargetEvent } from '../../../dnd/droptarget';
@@ -647,14 +641,12 @@ export class Tabs extends CompositeDisposable {
                     ) {
                         parentElement.scrollTop = running;
                     }
-                } else {
-                    if (
-                        running < parentElement.scrollLeft ||
-                        running + element.clientWidth >
-                            parentElement.scrollLeft + parentElement.clientWidth
-                    ) {
-                        parentElement.scrollLeft = running;
-                    }
+                } else if (
+                    running < parentElement.scrollLeft ||
+                    running + element.clientWidth >
+                        parentElement.scrollLeft + parentElement.clientWidth
+                ) {
+                    parentElement.scrollLeft = running;
                 }
             }
 
@@ -791,13 +783,14 @@ export class Tabs extends CompositeDisposable {
 
                 switch (event.button) {
                     case 0:
-                        if (this.group.api.location.type === 'edge') {
-                            // All tab interaction for edge groups is handled by
-                            // onTabClick to avoid race conditions with active panel state
-                        } else {
-                            if (this.group.activePanel !== panel) {
-                                this.group.model.openPanel(panel);
-                            }
+                        // Edge groups are skipped here: all their tab interaction
+                        // is handled by onTabClick to avoid race conditions with
+                        // active panel state.
+                        if (
+                            this.group.api.location.type !== 'edge' &&
+                            this.group.activePanel !== panel
+                        ) {
+                            this.group.model.openPanel(panel);
                         }
                         break;
                 }

--- a/packages/dockview-core/src/dockview/dndCapabilities.ts
+++ b/packages/dockview-core/src/dockview/dndCapabilities.ts
@@ -47,13 +47,13 @@ export function resolveDndCapabilities(
 }
 
 function isCoarsePrimaryInput(): boolean {
-    if (typeof window === 'undefined' || !window.matchMedia) {
+    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
         return false;
     }
     // Coarse pointer without any fine pointer = phone-class device. A laptop
     // touchscreen reports both, and we want HTML5 to remain available there
     // because a real mouse is also plugged in.
-    const coarse = window.matchMedia('(pointer: coarse)').matches;
-    const fine = window.matchMedia('(pointer: fine)').matches;
+    const coarse = globalThis.matchMedia('(pointer: coarse)').matches;
+    const fine = globalThis.matchMedia('(pointer: fine)').matches;
     return coarse && !fine;
 }

--- a/packages/dockview-core/src/dockview/dndCapabilities.ts
+++ b/packages/dockview-core/src/dockview/dndCapabilities.ts
@@ -47,7 +47,7 @@ export function resolveDndCapabilities(
 }
 
 function isCoarsePrimaryInput(): boolean {
-    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
+    if (globalThis.window === undefined || !globalThis.matchMedia) {
         return false;
     }
     // Coarse pointer without any fine pointer = phone-class device. A laptop

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -478,8 +478,8 @@ export class DockviewComponent
     private readonly _api: DockviewApi;
     private readonly _moduleRegistry = new ModuleRegistry<DockviewComponent>();
     private _options: Exclude<DockviewComponentOptions, 'orientation'>;
-    private _tabGroupColorPalette: TabGroupColorPalette;
-    private _shellThemeClassnames: Classnames | undefined;
+    private readonly _tabGroupColorPalette: TabGroupColorPalette;
+    private readonly _shellThemeClassnames: Classnames | undefined;
 
     readonly overlayRenderContainer: OverlayRenderContainer;
     readonly popupService: PopupService;
@@ -630,8 +630,8 @@ export class DockviewComponent
         new Emitter<DockviewMaximizedGroupChangeEvent>();
     readonly onDidMaximizedGroupChange = this._onDidMaximizedGroupChange.event;
 
-    private _shellManager: ShellManager | undefined;
-    private _floatingOverlayHost: HTMLDivElement | undefined;
+    private readonly _shellManager: ShellManager | undefined;
+    private readonly _floatingOverlayHost: HTMLDivElement | undefined;
     private _inShellLayout = false;
 
     private readonly _onDidRemoveGroup = new Emitter<DockviewGroupPanel>();

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1379,11 +1379,11 @@ export class DockviewComponent
                     return false;
                 }
 
-                const referenceGroup = options?.referenceGroup
-                    ? options.referenceGroup
-                    : itemToPopout instanceof DockviewPanel
-                      ? itemToPopout.group
-                      : itemToPopout;
+                const referenceGroup =
+                    options?.referenceGroup ??
+                    (itemToPopout instanceof DockviewPanel
+                        ? itemToPopout.group
+                        : itemToPopout);
 
                 const referenceLocation = itemToPopout.api.location.type;
 
@@ -2674,7 +2674,7 @@ export class DockviewComponent
                 } = data;
 
                 if (typeof id !== 'string') {
-                    throw new Error(
+                    throw new TypeError(
                         'dockview: group id must be of type string'
                     );
                 }
@@ -2913,8 +2913,7 @@ export class DockviewComponent
                     }
                 }
 
-                for (let i = 0; i < createdPanels.length; i++) {
-                    const panel = createdPanels[i];
+                for (const panel of createdPanels) {
                     const isActive = activeView === panel.id;
                     edgeGroup.model.openPanel(panel, {
                         skipSetActive: !isActive,
@@ -3115,7 +3114,7 @@ export class DockviewComponent
     private _doAddPanel<T extends object = Parameters>(
         options: AddPanelOptions<T>
     ): DockviewPanel {
-        if (this.panels.find((_) => _.id === options.id)) {
+        if (this.panels.some((_) => _.id === options.id)) {
             throw new Error(
                 `dockview: panel with id ${options.id} already exists`
             );
@@ -3145,8 +3144,12 @@ export class DockviewComponent
                 index = options.position.index;
 
                 if (!referencePanel) {
+                    const referenceId =
+                        typeof options.position.referencePanel === 'string'
+                            ? options.position.referencePanel
+                            : options.position.referencePanel?.id;
                     throw new Error(
-                        `dockview: referencePanel '${options.position.referencePanel}' does not exist`
+                        `dockview: referencePanel '${referenceId}' does not exist`
                     );
                 }
 
@@ -3160,8 +3163,12 @@ export class DockviewComponent
                 index = options.position.index;
 
                 if (!referenceGroup) {
+                    const referenceId =
+                        typeof options.position.referenceGroup === 'string'
+                            ? options.position.referenceGroup
+                            : options.position.referenceGroup?.id;
                     throw new Error(
-                        `dockview: referenceGroup '${options.position.referenceGroup}' does not exist`
+                        `dockview: referenceGroup '${referenceId}' does not exist`
                     );
                 }
             } else {
@@ -3380,9 +3387,14 @@ export class DockviewComponent
                           )
                         : options.referencePanel;
 
+                const referencePanelId =
+                    typeof options.referencePanel === 'string'
+                        ? options.referencePanel
+                        : options.referencePanel?.id;
+
                 if (!referencePanel) {
                     throw new Error(
-                        `dockview: reference panel ${options.referencePanel} does not exist`
+                        `dockview: reference panel ${referencePanelId} does not exist`
                     );
                 }
 
@@ -3390,7 +3402,7 @@ export class DockviewComponent
 
                 if (!referenceGroup) {
                     throw new Error(
-                        `dockview: reference group for reference panel ${options.referencePanel} does not exist`
+                        `dockview: reference group for reference panel ${referencePanelId} does not exist`
                     );
                 }
             } else if (isGroupOptionsWithGroup(options)) {
@@ -3400,8 +3412,12 @@ export class DockviewComponent
                         : options.referenceGroup;
 
                 if (!referenceGroup) {
+                    const referenceId =
+                        typeof options.referenceGroup === 'string'
+                            ? options.referenceGroup
+                            : options.referenceGroup?.id;
                     throw new Error(
-                        `dockview: reference group ${options.referenceGroup} does not exist`
+                        `dockview: reference group ${referenceId} does not exist`
                     );
                 }
             } else {
@@ -3573,12 +3589,12 @@ export class DockviewComponent
             if (this.detachFromNestedWindow(group)) {
                 // The floating window hosts other groups and stays alive —
                 // finalize just this group.
-                if (!options?.skipDispose) {
-                    this.disposeGroupRecord(group);
-                } else {
+                if (options?.skipDispose) {
                     // Relocation: reset location so the destination root can
                     // re-tag it.
                     group.model.location = { type: 'grid' };
+                } else {
+                    this.disposeGroupRecord(group);
                 }
 
                 this.activateFallbackGroupIfRemoved(group, options?.skipActive);
@@ -3607,12 +3623,12 @@ export class DockviewComponent
             if (this.detachFromNestedWindow(group)) {
                 // The popout window hosts other groups and stays alive —
                 // finalize just this group.
-                if (!options?.skipDispose) {
-                    this.disposeGroupRecord(group);
-                } else {
+                if (options?.skipDispose) {
                     // Relocation: reset location so the destination root can
                     // re-tag it.
                     group.model.location = { type: 'grid' };
+                } else {
+                    this.disposeGroupRecord(group);
                 }
 
                 this.activateFallbackGroupIfRemoved(group, options?.skipActive);
@@ -4539,9 +4555,7 @@ export class DockviewComponent
     }
 
     createGroup(options?: GroupOptions): DockviewGroupPanel {
-        if (!options) {
-            options = {};
-        }
+        options ??= {};
 
         let id = options?.id;
 
@@ -4811,7 +4825,12 @@ export class DockviewComponent
             theme.edgeGroupCollapsedSize ?? 35
         );
 
-        if (theme.dndOverlayBorder !== undefined) {
+        if (theme.dndOverlayBorder === undefined) {
+            this.element.style.removeProperty('--dv-drag-over-border');
+            this._shellManager?.element.style.removeProperty(
+                '--dv-drag-over-border'
+            );
+        } else {
             this.element.style.setProperty(
                 '--dv-drag-over-border',
                 theme.dndOverlayBorder
@@ -4819,11 +4838,6 @@ export class DockviewComponent
             this._shellManager?.element.style.setProperty(
                 '--dv-drag-over-border',
                 theme.dndOverlayBorder
-            );
-        } else {
-            this.element.style.removeProperty('--dv-drag-over-border');
-            this._shellManager?.element.style.removeProperty(
-                '--dv-drag-over-border'
             );
         }
 

--- a/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
@@ -36,7 +36,7 @@ export class DockviewGroupPanel
     private readonly _model: DockviewGroupPanelModel;
 
     // Track explicitly set constraints to override panel constraints
-    private _explicitConstraints: Partial<Constraints> = {};
+    private readonly _explicitConstraints: Partial<Constraints> = {};
 
     override get minimumWidth(): number {
         // Check for explicitly set group constraint first

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1134,9 +1134,9 @@ export class DockviewGroupPanelModel
     restoreTabGroups(serializedGroups: SerializedTabGroup[]): void {
         // Bump counter past any restored numeric suffixes to avoid ID collisions
         for (const data of serializedGroups) {
-            const match = data.id.match(/-(\d+)$/);
+            const match = /-(\d+)$/.exec(data.id);
             if (match) {
-                const num = parseInt(match[1], 10) + 1;
+                const num = Number.parseInt(match[1], 10) + 1;
                 if (num > this._tabGroupIdCounter) {
                     this._tabGroupIdCounter = num;
                 }
@@ -1288,12 +1288,8 @@ export class DockviewGroupPanelModel
         panel?: IDockviewPanel;
         suppressRoll?: boolean;
     }): void {
-        if (!options) {
-            options = {};
-        }
-        if (!options.panel) {
-            options.panel = this.activePanel;
-        }
+        options ??= {};
+        options.panel ??= this.activePanel;
 
         const index = options.panel ? this.panels.indexOf(options.panel) : -1;
 
@@ -1301,10 +1297,10 @@ export class DockviewGroupPanelModel
 
         if (index < this.panels.length - 1) {
             normalizedIndex = index + 1;
-        } else if (!options.suppressRoll) {
-            normalizedIndex = 0;
-        } else {
+        } else if (options.suppressRoll) {
             return;
+        } else {
+            normalizedIndex = 0;
         }
 
         this.openPanel(this.panels[normalizedIndex]);
@@ -1314,12 +1310,8 @@ export class DockviewGroupPanelModel
         panel?: IDockviewPanel;
         suppressRoll?: boolean;
     }): void {
-        if (!options) {
-            options = {};
-        }
-        if (!options.panel) {
-            options.panel = this.activePanel;
-        }
+        options ??= {};
+        options.panel ??= this.activePanel;
 
         if (!options.panel) {
             return;
@@ -1331,10 +1323,10 @@ export class DockviewGroupPanelModel
 
         if (index > 0) {
             normalizedIndex = index - 1;
-        } else if (!options.suppressRoll) {
-            normalizedIndex = this.panels.length - 1;
-        } else {
+        } else if (options.suppressRoll) {
             return;
+        } else {
+            normalizedIndex = this.panels.length - 1;
         }
 
         this.openPanel(this.panels[normalizedIndex]);

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -8,12 +8,10 @@ import {
     DockviewEvent,
     Emitter,
     Event,
-    IDockviewEvent,
 } from '../events';
 import {
     DockviewGroupDropLocation,
     DockviewWillShowOverlayLocationEvent,
-    DockviewWillShowOverlayLocationEventOptions,
 } from './events';
 import { IViewSize } from '../gridview/gridview';
 import { CompositeDisposable, IDisposable } from '../lifecycle';

--- a/packages/dockview-core/src/dockview/dockviewPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewPanel.ts
@@ -195,7 +195,7 @@ export class DockviewPanel
     public update(event: PanelUpdateEvent): void {
         // merge the new parameters with the existing parameters
         this._params = {
-            ...(this._params ?? {}),
+            ...this._params,
             ...event.params,
         };
 

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -123,9 +123,7 @@ export class EdgeGroupView implements IView {
         // Otherwise fall back to collapsedSize + 50 so the expanded state is
         // visually distinguishable from the collapsed state.
         this._expandedMinimumSize =
-            options.minimumSize !== undefined
-                ? options.minimumSize
-                : this._collapsedSize + 50;
+            options.minimumSize ?? this._collapsedSize + 50;
 
         this._lastExpandedSize = options.initialSize ?? 200;
 
@@ -587,7 +585,7 @@ export class ShellManager implements IDisposable {
             const baseCS = baseCfg.collapsedSize ?? defaultCollapsedSize;
             const newCS = baseCS + gapAdd;
             const baseMS = baseCfg.minimumSize;
-            const newMS = baseMS !== undefined ? baseMS + gapAdd : newCS + 50;
+            const newMS = baseMS === undefined ? newCS + 50 : baseMS + gapAdd;
             view.updateCollapsedSize(newCS, newMS);
         };
 

--- a/packages/dockview-core/src/dockview/strictEventsSequencing.ts
+++ b/packages/dockview-core/src/dockview/strictEventsSequencing.ts
@@ -23,12 +23,12 @@ export class StrictEventsSequencing extends CompositeDisposable {
                 }
             }),
             this.accessor.onDidRemovePanel((panel) => {
-                if (!panels.has(panel.api.id)) {
+                if (panels.has(panel.api.id)) {
+                    panels.delete(panel.api.id);
+                } else {
                     throw new Error(
                         `dockview: Invalid event sequence. [onDidRemovePanel] called for panel ${panel.api.id} but panel does not exists`
                     );
-                } else {
-                    panels.delete(panel.api.id);
                 }
             }),
             this.accessor.onDidAddGroup((group) => {
@@ -41,12 +41,12 @@ export class StrictEventsSequencing extends CompositeDisposable {
                 }
             }),
             this.accessor.onDidRemoveGroup((group) => {
-                if (!groups.has(group.api.id)) {
+                if (groups.has(group.api.id)) {
+                    groups.delete(group.api.id);
+                } else {
                     throw new Error(
                         `dockview: Invalid event sequence. [onDidRemoveGroup] called for group ${group.api.id} but group does not exists`
                     );
-                } else {
-                    groups.delete(group.api.id);
                 }
             })
         );

--- a/packages/dockview-core/src/dockview/tabGroup.ts
+++ b/packages/dockview-core/src/dockview/tabGroup.ts
@@ -170,9 +170,9 @@ export class TabGroup extends CompositeDisposable implements ITabGroup {
         }
 
         const insertIndex =
-            index !== undefined
-                ? Math.max(0, Math.min(index, this._panelIds.length))
-                : this._panelIds.length;
+            index === undefined
+                ? this._panelIds.length
+                : Math.max(0, Math.min(index, this._panelIds.length));
 
         this._panelIds.splice(insertIndex, 0, panelId);
         this._onDidPanelChange.fire({ panelId, type: 'add' });

--- a/packages/dockview-core/src/dockview/tabGroupAccent.ts
+++ b/packages/dockview-core/src/dockview/tabGroupAccent.ts
@@ -121,12 +121,10 @@ let _fallbackPalette: TabGroupColorPalette | undefined;
  * palette through.
  */
 function getFallbackPalette(): TabGroupColorPalette {
-    if (!_fallbackPalette) {
-        _fallbackPalette = new TabGroupColorPalette(
-            DEFAULT_TAB_GROUP_COLORS,
-            true
-        );
-    }
+    _fallbackPalette ??= new TabGroupColorPalette(
+        DEFAULT_TAB_GROUP_COLORS,
+        true
+    );
     return _fallbackPalette;
 }
 

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -159,7 +159,7 @@ class FocusTracker extends CompositeDisposable implements IFocusTracker {
         const onBlur = () => {
             if (hasFocus) {
                 loosingFocus = true;
-                window.setTimeout(() => {
+                globalThis.setTimeout(() => {
                     if (loosingFocus) {
                         loosingFocus = false;
                         hasFocus = false;

--- a/packages/dockview-core/src/events.ts
+++ b/packages/dockview-core/src/events.ts
@@ -80,7 +80,7 @@ class LeakageMonitor {
 
 class Stacktrace {
     static create(): Stacktrace {
-        return new Stacktrace(new Error().stack ?? '');
+        return new Stacktrace(new Error('listener stacktrace').stack ?? '');
     }
 
     private constructor(readonly value: string) {}

--- a/packages/dockview-core/src/gridview/baseComponentGridview.ts
+++ b/packages/dockview-core/src/gridview/baseComponentGridview.ts
@@ -338,9 +338,7 @@ export abstract class BaseGrid<T extends IGridPanelView>
     }
 
     public moveToNext(options?: MovementOptions2): void {
-        if (!options) {
-            options = {};
-        }
+        options ??= {};
         if (!options.group) {
             if (!this.activeGroup) {
                 return;
@@ -354,9 +352,7 @@ export abstract class BaseGrid<T extends IGridPanelView>
     }
 
     public moveToPrevious(options?: MovementOptions2): void {
-        if (!options) {
-            options = {};
-        }
+        options ??= {};
         if (!options.group) {
             if (!this.activeGroup) {
                 return;

--- a/packages/dockview-core/src/gridview/branchNode.ts
+++ b/packages/dockview-core/src/gridview/branchNode.ts
@@ -119,13 +119,13 @@ export class BranchNode extends CompositeDisposable implements IView {
             return LayoutPriority.Normal;
         }
 
-        const priorities = this.children.map((c) =>
-            c.priority === undefined ? LayoutPriority.Normal : c.priority
+        const priorities = new Set(
+            this.children.map((c) => c.priority ?? LayoutPriority.Normal)
         );
 
-        if (priorities.includes(LayoutPriority.High)) {
+        if (priorities.has(LayoutPriority.High)) {
             return LayoutPriority.High;
-        } else if (priorities.includes(LayoutPriority.Low)) {
+        } else if (priorities.has(LayoutPriority.Low)) {
             return LayoutPriority.Low;
         }
 

--- a/packages/dockview-core/src/gridview/branchNode.ts
+++ b/packages/dockview-core/src/gridview/branchNode.ts
@@ -120,14 +120,12 @@ export class BranchNode extends CompositeDisposable implements IView {
         }
 
         const priorities = this.children.map((c) =>
-            typeof c.priority === 'undefined'
-                ? LayoutPriority.Normal
-                : c.priority
+            c.priority === undefined ? LayoutPriority.Normal : c.priority
         );
 
-        if (priorities.some((p) => p === LayoutPriority.High)) {
+        if (priorities.includes(LayoutPriority.High)) {
             return LayoutPriority.High;
-        } else if (priorities.some((p) => p === LayoutPriority.Low)) {
+        } else if (priorities.includes(LayoutPriority.Low)) {
             return LayoutPriority.Low;
         }
 
@@ -173,15 +171,7 @@ export class BranchNode extends CompositeDisposable implements IView {
         this.element = document.createElement('div');
         this.element.className = 'dv-branch-node';
 
-        if (!childDescriptors) {
-            this.splitview = new Splitview(this.element, {
-                orientation: this.orientation,
-                proportionalLayout,
-                styles,
-                margin,
-            });
-            this.splitview.layout(this.size, this.orthogonalSize);
-        } else {
+        if (childDescriptors) {
             const descriptor = {
                 views: childDescriptors.map((childDescriptor) => {
                     return {
@@ -205,6 +195,14 @@ export class BranchNode extends CompositeDisposable implements IView {
                 styles,
                 margin,
             });
+        } else {
+            this.splitview = new Splitview(this.element, {
+                orientation: this.orientation,
+                proportionalLayout,
+                styles,
+                margin,
+            });
+            this.splitview.layout(this.size, this.orthogonalSize);
         }
 
         this.disabled = disabled;

--- a/packages/dockview-core/src/gridview/gridview.ts
+++ b/packages/dockview-core/src/gridview/gridview.ts
@@ -834,7 +834,7 @@ export class Gridview implements IDisposable {
         const [path, node] = this.getNode(location);
 
         if (!(node instanceof LeafNode)) {
-            throw new Error('invalid location');
+            throw new TypeError('invalid location');
         }
 
         for (let i = path.length - 1; i > -1; i--) {
@@ -880,7 +880,7 @@ export class Gridview implements IDisposable {
         const [, parent] = this.getNode(rest);
 
         if (!(parent instanceof BranchNode)) {
-            throw new Error('Invalid from location');
+            throw new TypeError('Invalid from location');
         }
 
         return parent.isChildVisible(index);
@@ -895,7 +895,7 @@ export class Gridview implements IDisposable {
         const [, parent] = this.getNode(rest);
 
         if (!(parent instanceof BranchNode)) {
-            throw new Error('Invalid from location');
+            throw new TypeError('Invalid from location');
         }
 
         this._onDidViewVisibilityChange.fire();
@@ -911,7 +911,7 @@ export class Gridview implements IDisposable {
         const [, parent] = this.getNode(parentLocation);
 
         if (!(parent instanceof BranchNode)) {
-            throw new Error('Invalid location');
+            throw new TypeError('Invalid location');
         }
 
         parent.moveChild(from, to);
@@ -997,13 +997,13 @@ export class Gridview implements IDisposable {
         const [pathToParent, parent] = this.getNode(rest);
 
         if (!(parent instanceof BranchNode)) {
-            throw new Error('Invalid location');
+            throw new TypeError('Invalid location');
         }
 
         const nodeToRemove = parent.children[index];
 
         if (!(nodeToRemove instanceof LeafNode)) {
-            throw new Error('Invalid location');
+            throw new TypeError('Invalid location');
         }
 
         parent.removeChild(index, sizing);
@@ -1126,7 +1126,7 @@ export class Gridview implements IDisposable {
         }
 
         if (!(node instanceof BranchNode)) {
-            throw new Error('Invalid location');
+            throw new TypeError('Invalid location');
         }
 
         const [index, ...rest] = location;

--- a/packages/dockview-core/src/gridview/gridviewComponent.ts
+++ b/packages/dockview-core/src/gridview/gridviewComponent.ts
@@ -382,11 +382,7 @@ export class GridviewComponent
                 }
                 this._groups.forEach((groupItem) => {
                     const group = groupItem.value;
-                    if (group !== panel) {
-                        group.setActive(false);
-                    } else {
-                        group.setActive(true);
-                    }
+                    group.setActive(group === panel);
                 });
             })
         );

--- a/packages/dockview-core/src/overlay/overlay.ts
+++ b/packages/dockview-core/src/overlay/overlay.ts
@@ -286,17 +286,17 @@ export class Overlay extends CompositeDisposable {
         const result: any = {};
 
         if (this.verticalAlignment === 'top') {
-            result.top = parseFloat(this._element.style.top);
+            result.top = Number.parseFloat(this._element.style.top);
         } else if (this.verticalAlignment === 'bottom') {
-            result.bottom = parseFloat(this._element.style.bottom);
+            result.bottom = Number.parseFloat(this._element.style.bottom);
         } else {
             result.top = element.top - container.top;
         }
 
         if (this.horiziontalAlignment === 'left') {
-            result.left = parseFloat(this._element.style.left);
+            result.left = Number.parseFloat(this._element.style.left);
         } else if (this.horiziontalAlignment === 'right') {
-            result.right = parseFloat(this._element.style.right);
+            result.right = Number.parseFloat(this._element.style.right);
         } else {
             result.left = element.left - container.left;
         }
@@ -379,7 +379,7 @@ export class Overlay extends CompositeDisposable {
                         }
                     },
                 },
-                addDisposableListener(window, 'pointermove', (e) => {
+                addDisposableListener(globalThis.window, 'pointermove', (e) => {
                     if (this._dragCancelled) {
                         return;
                     }
@@ -395,12 +395,10 @@ export class Overlay extends CompositeDisposable {
                     );
 
                     const overlayRect = this._element.getBoundingClientRect();
-                    if (offset === null) {
-                        offset = {
-                            x: e.clientX - overlayRect.left,
-                            y: e.clientY - overlayRect.top,
-                        };
-                    }
+                    offset ??= {
+                        x: e.clientX - overlayRect.left,
+                        y: e.clientY - overlayRect.top,
+                    };
 
                     const xOffset = Math.max(
                         0,
@@ -483,8 +481,8 @@ export class Overlay extends CompositeDisposable {
                         this._onDidStartMoving.fire();
                     }
                 }),
-                addDisposableListener(window, 'pointerup', end),
-                addDisposableListener(window, 'pointercancel', end)
+                addDisposableListener(globalThis.window, 'pointerup', end),
+                addDisposableListener(globalThis.window, 'pointercancel', end)
             );
         };
 
@@ -585,182 +583,185 @@ export class Overlay extends CompositeDisposable {
                 };
 
                 move.value = new CompositeDisposable(
-                    addDisposableListener(window, 'pointermove', (e) => {
-                        const containerRect =
-                            this.options.container.getBoundingClientRect();
-                        const overlayRect =
-                            this._element.getBoundingClientRect();
+                    addDisposableListener(
+                        globalThis.window,
+                        'pointermove',
+                        (e) => {
+                            const containerRect =
+                                this.options.container.getBoundingClientRect();
+                            const overlayRect =
+                                this._element.getBoundingClientRect();
 
-                        const y = e.clientY - containerRect.top;
-                        const x = e.clientX - containerRect.left;
+                            const y = e.clientY - containerRect.top;
+                            const x = e.clientX - containerRect.left;
 
-                        if (startPosition === null) {
                             // record the initial dimensions since as all subsequence moves are relative to this
-                            startPosition = {
+                            startPosition ??= {
                                 originalY: y,
                                 originalHeight: overlayRect.height,
                                 originalX: x,
                                 originalWidth: overlayRect.width,
                             };
+
+                            let top: number | undefined = undefined;
+                            let bottom: number | undefined = undefined;
+                            let height: number | undefined = undefined;
+                            let left: number | undefined = undefined;
+                            let right: number | undefined = undefined;
+                            let width: number | undefined = undefined;
+
+                            const moveTop = () => {
+                                // When dragging top handle, constrain top position to prevent oversizing
+                                const maxTop =
+                                    startPosition!.originalY +
+                                        startPosition!.originalHeight >
+                                    containerRect.height
+                                        ? Math.max(
+                                              0,
+                                              containerRect.height -
+                                                  Overlay.MINIMUM_HEIGHT
+                                          )
+                                        : Math.max(
+                                              0,
+                                              startPosition!.originalY +
+                                                  startPosition!
+                                                      .originalHeight -
+                                                  Overlay.MINIMUM_HEIGHT
+                                          );
+                                top = clamp(y, 0, maxTop);
+
+                                height =
+                                    startPosition!.originalY +
+                                    startPosition!.originalHeight -
+                                    top;
+
+                                bottom = containerRect.height - top - height;
+                            };
+
+                            const moveBottom = () => {
+                                top =
+                                    startPosition!.originalY -
+                                    startPosition!.originalHeight;
+
+                                // When dragging bottom handle, constrain height to container height
+                                const minHeight =
+                                    top < 0 &&
+                                    typeof this.options
+                                        .minimumInViewportHeight === 'number'
+                                        ? -top +
+                                          this.options.minimumInViewportHeight
+                                        : Overlay.MINIMUM_HEIGHT;
+
+                                const maxHeight =
+                                    containerRect.height - Math.max(0, top);
+
+                                height = clamp(y - top, minHeight, maxHeight);
+
+                                bottom = containerRect.height - top - height;
+                            };
+
+                            const moveLeft = () => {
+                                const maxLeft =
+                                    startPosition!.originalX +
+                                        startPosition!.originalWidth >
+                                    containerRect.width
+                                        ? Math.max(
+                                              0,
+                                              containerRect.width -
+                                                  Overlay.MINIMUM_WIDTH
+                                          ) // Prevent extending beyong right edge
+                                        : Math.max(
+                                              0,
+                                              startPosition!.originalX +
+                                                  startPosition!.originalWidth -
+                                                  Overlay.MINIMUM_WIDTH
+                                          );
+
+                                left = clamp(x, 0, maxLeft); // min is 0 (Not -Infinity) to prevent dragging beyond left edge
+
+                                width =
+                                    startPosition!.originalX +
+                                    startPosition!.originalWidth -
+                                    left;
+
+                                right = containerRect.width - left - width;
+                            };
+
+                            const moveRight = () => {
+                                left =
+                                    startPosition!.originalX -
+                                    startPosition!.originalWidth;
+
+                                // When dragging right handle, constrain width to container width
+                                const minWidth =
+                                    left < 0 &&
+                                    typeof this.options
+                                        .minimumInViewportWidth === 'number'
+                                        ? -left +
+                                          this.options.minimumInViewportWidth
+                                        : Overlay.MINIMUM_WIDTH;
+
+                                const maxWidth =
+                                    containerRect.width - Math.max(0, left);
+
+                                width = clamp(x - left, minWidth, maxWidth);
+
+                                right = containerRect.width - left - width;
+                            };
+
+                            switch (direction) {
+                                case 'top':
+                                    moveTop();
+                                    break;
+                                case 'bottom':
+                                    moveBottom();
+                                    break;
+                                case 'left':
+                                    moveLeft();
+                                    break;
+                                case 'right':
+                                    moveRight();
+                                    break;
+                                case 'topleft':
+                                    moveTop();
+                                    moveLeft();
+                                    break;
+                                case 'topright':
+                                    moveTop();
+                                    moveRight();
+                                    break;
+                                case 'bottomleft':
+                                    moveBottom();
+                                    moveLeft();
+                                    break;
+                                case 'bottomright':
+                                    moveBottom();
+                                    moveRight();
+                                    break;
+                            }
+
+                            const bounds: any = {};
+
+                            // Anchor to top or to bottom depending on which one is closer
+                            if (top! <= bottom!) {
+                                bounds.top = top;
+                            } else {
+                                bounds.bottom = bottom;
+                            }
+
+                            // Anchor to left or to right depending on which one is closer
+                            if (left! <= right!) {
+                                bounds.left = left;
+                            } else {
+                                bounds.right = right;
+                            }
+
+                            bounds.height = height;
+                            bounds.width = width;
+
+                            this.setBounds(bounds);
                         }
-
-                        let top: number | undefined = undefined;
-                        let bottom: number | undefined = undefined;
-                        let height: number | undefined = undefined;
-                        let left: number | undefined = undefined;
-                        let right: number | undefined = undefined;
-                        let width: number | undefined = undefined;
-
-                        const moveTop = () => {
-                            // When dragging top handle, constrain top position to prevent oversizing
-                            const maxTop =
-                                startPosition!.originalY +
-                                    startPosition!.originalHeight >
-                                containerRect.height
-                                    ? Math.max(
-                                          0,
-                                          containerRect.height -
-                                              Overlay.MINIMUM_HEIGHT
-                                      )
-                                    : Math.max(
-                                          0,
-                                          startPosition!.originalY +
-                                              startPosition!.originalHeight -
-                                              Overlay.MINIMUM_HEIGHT
-                                      );
-                            top = clamp(y, 0, maxTop);
-
-                            height =
-                                startPosition!.originalY +
-                                startPosition!.originalHeight -
-                                top;
-
-                            bottom = containerRect.height - top - height;
-                        };
-
-                        const moveBottom = () => {
-                            top =
-                                startPosition!.originalY -
-                                startPosition!.originalHeight;
-
-                            // When dragging bottom handle, constrain height to container height
-                            const minHeight =
-                                top < 0 &&
-                                typeof this.options.minimumInViewportHeight ===
-                                    'number'
-                                    ? -top +
-                                      this.options.minimumInViewportHeight
-                                    : Overlay.MINIMUM_HEIGHT;
-
-                            const maxHeight =
-                                containerRect.height - Math.max(0, top);
-
-                            height = clamp(y - top, minHeight, maxHeight);
-
-                            bottom = containerRect.height - top - height;
-                        };
-
-                        const moveLeft = () => {
-                            const maxLeft =
-                                startPosition!.originalX +
-                                    startPosition!.originalWidth >
-                                containerRect.width
-                                    ? Math.max(
-                                          0,
-                                          containerRect.width -
-                                              Overlay.MINIMUM_WIDTH
-                                      ) // Prevent extending beyong right edge
-                                    : Math.max(
-                                          0,
-                                          startPosition!.originalX +
-                                              startPosition!.originalWidth -
-                                              Overlay.MINIMUM_WIDTH
-                                      );
-
-                            left = clamp(x, 0, maxLeft); // min is 0 (Not -Infinity) to prevent dragging beyond left edge
-
-                            width =
-                                startPosition!.originalX +
-                                startPosition!.originalWidth -
-                                left;
-
-                            right = containerRect.width - left - width;
-                        };
-
-                        const moveRight = () => {
-                            left =
-                                startPosition!.originalX -
-                                startPosition!.originalWidth;
-
-                            // When dragging right handle, constrain width to container width
-                            const minWidth =
-                                left < 0 &&
-                                typeof this.options.minimumInViewportWidth ===
-                                    'number'
-                                    ? -left +
-                                      this.options.minimumInViewportWidth
-                                    : Overlay.MINIMUM_WIDTH;
-
-                            const maxWidth =
-                                containerRect.width - Math.max(0, left);
-
-                            width = clamp(x - left, minWidth, maxWidth);
-
-                            right = containerRect.width - left - width;
-                        };
-
-                        switch (direction) {
-                            case 'top':
-                                moveTop();
-                                break;
-                            case 'bottom':
-                                moveBottom();
-                                break;
-                            case 'left':
-                                moveLeft();
-                                break;
-                            case 'right':
-                                moveRight();
-                                break;
-                            case 'topleft':
-                                moveTop();
-                                moveLeft();
-                                break;
-                            case 'topright':
-                                moveTop();
-                                moveRight();
-                                break;
-                            case 'bottomleft':
-                                moveBottom();
-                                moveLeft();
-                                break;
-                            case 'bottomright':
-                                moveBottom();
-                                moveRight();
-                                break;
-                        }
-
-                        const bounds: any = {};
-
-                        // Anchor to top or to bottom depending on which one is closer
-                        if (top! <= bottom!) {
-                            bounds.top = top;
-                        } else {
-                            bounds.bottom = bottom;
-                        }
-
-                        // Anchor to left or to right depending on which one is closer
-                        if (left! <= right!) {
-                            bounds.left = left;
-                        } else {
-                            bounds.right = right;
-                        }
-
-                        bounds.height = height;
-                        bounds.width = width;
-
-                        this.setBounds(bounds);
-                    }),
+                    ),
                     {
                         dispose: () => {
                             iframes.release();
@@ -778,8 +779,12 @@ export class Overlay extends CompositeDisposable {
                             }
                         },
                     },
-                    addDisposableListener(window, 'pointerup', end),
-                    addDisposableListener(window, 'pointercancel', end)
+                    addDisposableListener(globalThis.window, 'pointerup', end),
+                    addDisposableListener(
+                        globalThis.window,
+                        'pointercancel',
+                        end
+                    )
                 );
             })
         );

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -11,7 +11,7 @@ import { IDockviewPanel } from '../dockview/dockviewPanel';
 import { DockviewComponent } from '../dockview/dockviewComponent';
 
 class PositionCache {
-    private cache = new Map<
+    private readonly cache = new Map<
         Element,
         {
             rect: { left: number; top: number; width: number; height: number };

--- a/packages/dockview-core/src/paneview/paneviewComponent.ts
+++ b/packages/dockview-core/src/paneview/paneviewComponent.ts
@@ -275,9 +275,7 @@ export class PaneviewComponent extends Resizable implements IPaneviewComponent {
             });
         }
 
-        if (!header) {
-            header = new DefaultHeader();
-        }
+        header ??= new DefaultHeader();
 
         const view = new PaneFramework({
             id: options.id,
@@ -405,9 +403,7 @@ export class PaneviewComponent extends Resizable implements IPaneviewComponent {
                         });
                     }
 
-                    if (!header) {
-                        header = new DefaultHeader();
-                    }
+                    header ??= new DefaultHeader();
 
                     const panel = new PaneFramework({
                         id: data.id,

--- a/packages/dockview-core/src/popoutWindow.ts
+++ b/packages/dockview-core/src/popoutWindow.ts
@@ -19,14 +19,14 @@ export type PopoutWindowOptions = {
 export function assertSameOriginPopoutUrl(url: string): void {
     let resolved: URL;
     try {
-        resolved = new URL(url, window.location.href);
+        resolved = new URL(url, globalThis.location.href);
     } catch {
         throw new Error(`dockview: invalid popout URL: ${url}`);
     }
 
     const protocolOk =
         resolved.protocol === 'http:' || resolved.protocol === 'https:';
-    if (!protocolOk || resolved.origin !== window.location.origin) {
+    if (!protocolOk || resolved.origin !== globalThis.location.origin) {
         throw new Error(
             `dockview: popout URL must be same-origin http(s); got: ${url}`
         );
@@ -126,7 +126,7 @@ export class PopoutWindow extends CompositeDisposable {
             Disposable.from(() => {
                 externalWindow.close();
             }),
-            addDisposableListener(window, 'beforeunload', () => {
+            addDisposableListener(globalThis.window, 'beforeunload', () => {
                 /**
                  * before the main window closes we should close this popup too
                  * to be good citizens
@@ -165,9 +165,13 @@ export class PopoutWindow extends CompositeDisposable {
 
                     externalDocument.body.appendChild(container);
 
-                    addStyles(externalDocument, window.document.styleSheets, {
-                        nonce: this.options.nonce,
-                    });
+                    addStyles(
+                        externalDocument,
+                        globalThis.document.styleSheets,
+                        {
+                            nonce: this.options.nonce,
+                        }
+                    );
 
                     /**
                      * beforeunload must be registered after load for reasons I could not determine

--- a/packages/dockview-core/src/scrollbar.ts
+++ b/packages/dockview-core/src/scrollbar.ts
@@ -14,7 +14,7 @@ export class Scrollbar extends CompositeDisposable {
     private _scrollOffset: number = 0;
     private _animationTimer: any;
     private _orientation: 'horizontal' | 'vertical' = 'horizontal';
-    public static MouseWheelSpeed = 1;
+    public static readonly MouseWheelSpeed = 1;
 
     get element(): HTMLElement {
         return this._element;

--- a/packages/dockview-core/src/splitview/splitview.ts
+++ b/packages/dockview-core/src/splitview/splitview.ts
@@ -664,7 +664,7 @@ export class Splitview {
     public moveView(from: number, to: number): void {
         const cachedVisibleSize = this.getViewCachedVisibleSize(from);
         const sizing =
-            typeof cachedVisibleSize === 'undefined'
+            cachedVisibleSize === undefined
                 ? this.getViewSize(from)
                 : Sizing.Invisible(cachedVisibleSize);
         const view = this.removeView(from, undefined, true);
@@ -676,23 +676,7 @@ export class Splitview {
         this.size = size;
         this.orthogonalSize = orthogonalSize;
 
-        if (!this.proportions) {
-            const indexes = range(this.viewItems.length);
-            const lowPriorityIndexes = indexes.filter(
-                (i) => this.viewItems[i].priority === LayoutPriority.Low
-            );
-            const highPriorityIndexes = indexes.filter(
-                (i) => this.viewItems[i].priority === LayoutPriority.High
-            );
-
-            this.resize(
-                this.viewItems.length - 1,
-                size - previousSize,
-                undefined,
-                lowPriorityIndexes,
-                highPriorityIndexes
-            );
-        } else {
+        if (this.proportions) {
             let total = 0;
 
             for (let i = 0; i < this.viewItems.length; i++) {
@@ -718,6 +702,22 @@ export class Splitview {
                     );
                 }
             }
+        } else {
+            const indexes = range(this.viewItems.length);
+            const lowPriorityIndexes = indexes.filter(
+                (i) => this.viewItems[i].priority === LayoutPriority.Low
+            );
+            const highPriorityIndexes = indexes.filter(
+                (i) => this.viewItems[i].priority === LayoutPriority.High
+            );
+
+            this.resize(
+                this.viewItems.length - 1,
+                size - previousSize,
+                undefined,
+                lowPriorityIndexes,
+                highPriorityIndexes
+            );
         }
 
         this.distributeEmptySpace();

--- a/packages/dockview-core/src/splitview/splitview.ts
+++ b/packages/dockview-core/src/splitview/splitview.ts
@@ -1002,7 +1002,7 @@ export class Splitview {
         toggleClass(sash.container, 'dv-minimum', state === SashState.MINIMUM);
     }
 
-    private resize = (
+    private readonly resize = (
         index: number,
         delta: number,
         sizes: number[] = this.viewItems.map((x) => x.size),

--- a/packages/dockview-core/src/splitview/viewItem.ts
+++ b/packages/dockview-core/src/splitview/viewItem.ts
@@ -19,7 +19,7 @@ export class ViewItem {
     }
 
     get visible(): boolean {
-        return typeof this._cachedVisibleSize === 'undefined';
+        return this._cachedVisibleSize === undefined;
     }
 
     get minimumSize(): number {

--- a/packages/dockview-modules/src/__tests__/accessibility.spec.ts
+++ b/packages/dockview-modules/src/__tests__/accessibility.spec.ts
@@ -75,7 +75,7 @@ describe('accessibility: WAI-ARIA tabs baseline', () => {
         expect(tabpanel.id).toBeTruthy();
 
         const tabs = realTabs();
-        expect(tabs.length).toBe(1);
+        expect(tabs).toHaveLength(1);
         expect(tabs[0].getAttribute('role')).toBe('tab');
         expect(tabs[0].id).toBeTruthy();
     });
@@ -86,7 +86,7 @@ describe('accessibility: WAI-ARIA tabs baseline', () => {
 
         const tabpanel = container.querySelector('.dv-content-container')!;
         const tabs = realTabs();
-        expect(tabs.length).toBe(2);
+        expect(tabs).toHaveLength(2);
 
         // aria-controls: every tab references the single group tabpanel.
         for (const tab of tabs) {
@@ -97,7 +97,7 @@ describe('accessibility: WAI-ARIA tabs baseline', () => {
         const selected = tabs.filter(
             (t) => t.getAttribute('aria-selected') === 'true'
         );
-        expect(selected.length).toBe(1);
+        expect(selected).toHaveLength(1);
         expect(tabpanel.getAttribute('aria-labelledby')).toBe(selected[0].id);
     });
 
@@ -114,7 +114,7 @@ describe('accessibility: WAI-ARIA tabs baseline', () => {
         const selectedBefore = realTabs().filter(
             (t) => t.getAttribute('aria-selected') === 'true'
         );
-        expect(selectedBefore.length).toBe(1);
+        expect(selectedBefore).toHaveLength(1);
         const activeTabId2 = selectedBefore[0].id;
         expect(tabpanel.getAttribute('aria-labelledby')).toBe(activeTabId2);
 
@@ -124,7 +124,7 @@ describe('accessibility: WAI-ARIA tabs baseline', () => {
         const selectedAfter = realTabs().filter(
             (t) => t.getAttribute('aria-selected') === 'true'
         );
-        expect(selectedAfter.length).toBe(1);
+        expect(selectedAfter).toHaveLength(1);
         expect(selectedAfter[0].id).not.toBe(activeTabId2);
         expect(tabpanel.getAttribute('aria-labelledby')).toBe(
             selectedAfter[0].id
@@ -142,7 +142,7 @@ describe('accessibility: WAI-ARIA tabs baseline', () => {
         const tabpanels = Array.from(
             container.querySelectorAll('.dv-content-container')
         ) as HTMLElement[];
-        expect(tabpanels.length).toBe(2);
+        expect(tabpanels).toHaveLength(2);
         expect(tabpanels[0].id).not.toBe(tabpanels[1].id);
 
         const ids = realTabs().map((t) => t.id);

--- a/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
+++ b/packages/dockview-modules/src/__tests__/accessibilityDocking.spec.ts
@@ -62,7 +62,7 @@ describe('accessibility: keyboard docking', () => {
     test('target another group, centre, Enter → tab-into (groups merge)', () => {
         make(true);
         twoGroups(); // p1, p2 in separate groups; p2 active, targeting its own group
-        expect(dockview.groups.length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
 
         fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
         expect(region().textContent).toContain('Moving P2');
@@ -74,14 +74,14 @@ describe('accessibility: keyboard docking', () => {
 
         // commit centre (tab-into)
         fireEvent.keyDown(dockview.element, { key: 'Enter' });
-        expect(dockview.groups.length).toBe(1);
+        expect(dockview.groups).toHaveLength(1);
     });
 
     test('split a tab out of a single group to an edge (creates a group)', () => {
         make(true);
         dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
         dockview.addPanel({ id: 'p2', component: 'default', title: 'P2' });
-        expect(dockview.groups.length).toBe(1); // p1, p2 are tabs in one group
+        expect(dockview.groups).toHaveLength(1); // p1, p2 are tabs in one group
 
         fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
         fireEvent.keyDown(dockview.element, { key: 'Enter' }); // pick the (only) group
@@ -89,7 +89,7 @@ describe('accessibility: keyboard docking', () => {
         expect(region().textContent).toContain('Split left of');
 
         fireEvent.keyDown(dockview.element, { key: 'Enter' });
-        expect(dockview.groups.length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
     });
 
     test('Escape cancels without changing the layout', () => {
@@ -101,7 +101,7 @@ describe('accessibility: keyboard docking', () => {
 
         fireEvent.keyDown(dockview.element, { key: 'Escape' });
         expect(region().textContent).toBe('Move cancelled.');
-        expect(dockview.groups.length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
     });
 
     test('does nothing when keyboardNavigation is off (default)', () => {
@@ -110,7 +110,7 @@ describe('accessibility: keyboard docking', () => {
 
         fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
         expect(region().textContent).not.toContain('Moving');
-        expect(dockview.groups.length).toBe(2);
+        expect(dockview.groups).toHaveLength(2);
     });
 });
 
@@ -435,7 +435,7 @@ describe('accessibility: spatial group focus', () => {
     test('Ctrl+Shift+Right / Down focus the neighbouring group', () => {
         make();
         grid2x2();
-        expect(dockview.groups.length).toBe(4);
+        expect(dockview.groups).toHaveLength(4);
         groupOf('tl').api.setActive();
         expect(dockview.activeGroup).toBe(groupOf('tl'));
 

--- a/packages/dockview-modules/src/__tests__/advancedDnDDrag.spec.ts
+++ b/packages/dockview-modules/src/__tests__/advancedDnDDrag.spec.ts
@@ -48,8 +48,8 @@ describe('advanced dnd: onWillDrag hooks', () => {
 
         fireEvent.dragStart(el);
 
-        expect(tabDragEvents.length).toBe(1);
-        expect(groupDragEvents.length).toBe(0);
+        expect(tabDragEvents).toHaveLength(1);
+        expect(groupDragEvents).toHaveLength(0);
 
         dockview.dispose();
     });
@@ -78,8 +78,8 @@ describe('advanced dnd: onWillDrag hooks', () => {
 
         fireEvent.dragStart(el);
 
-        expect(tabDragEvents.length).toBe(0);
-        expect(groupDragEvents.length).toBe(1);
+        expect(tabDragEvents).toHaveLength(0);
+        expect(groupDragEvents).toHaveLength(1);
 
         dockview.dispose();
     });

--- a/packages/dockview-modules/src/__tests__/contextMenu.spec.ts
+++ b/packages/dockview-modules/src/__tests__/contextMenu.spec.ts
@@ -728,7 +728,7 @@ describe('ContextMenuController', () => {
             const swatches = picker.querySelectorAll(
                 '.dv-context-menu-color-swatch'
             );
-            expect(swatches.length).toBe(DEFAULT_TAB_GROUP_COLORS.length);
+            expect(swatches).toHaveLength(DEFAULT_TAB_GROUP_COLORS.length);
 
             const first = swatches[0] as HTMLElement;
             expect(first.style.getPropertyValue('--dv-tab-group-color')).toBe(
@@ -766,7 +766,7 @@ describe('ContextMenuController', () => {
             const swatches = menuEl.querySelectorAll(
                 '.dv-context-menu-color-swatch'
             );
-            expect(swatches.length).toBe(2);
+            expect(swatches).toHaveLength(2);
             expect((swatches[0] as HTMLElement).title).toBe('Brand');
             expect(
                 (swatches[0] as HTMLElement).style.getPropertyValue(
@@ -796,8 +796,8 @@ describe('ContextMenuController', () => {
             )!;
             expect(picker).toBeTruthy();
             expect(
-                picker.querySelectorAll('.dv-context-menu-color-swatch').length
-            ).toBe(0);
+                picker.querySelectorAll('.dv-context-menu-color-swatch')
+            ).toHaveLength(0);
         });
     });
 

--- a/packages/dockview-modules/src/__tests__/tabGroupChips.spec.ts
+++ b/packages/dockview-modules/src/__tests__/tabGroupChips.spec.ts
@@ -122,8 +122,8 @@ describe('tab group events (TabGroupChipsModule)', () => {
             panelId: 'panel1',
         });
         // One removal from the restored group, one addition to newTg
-        expect(panelsRemoved.length).toBe(1);
-        expect(panelsAdded.length).toBe(1);
+        expect(panelsRemoved).toHaveLength(1);
+        expect(panelsAdded).toHaveLength(1);
         expect(panelsAdded[0]).toEqual({
             tgId: newTg.id,
             panelId: 'panel1',
@@ -139,7 +139,7 @@ describe('tab group events (TabGroupChipsModule)', () => {
             groupId: restoredGroup.id,
             panelId: 'panel1',
         });
-        expect(panelsRemoved.length).toBe(1);
+        expect(panelsRemoved).toHaveLength(1);
         expect(panelsRemoved[0]).toEqual({
             tgId: newTg.id,
             panelId: 'panel1',
@@ -231,7 +231,7 @@ describe('tab group events (TabGroupChipsModule)', () => {
         changes.length = 0;
         tg.setLabel('Updated');
         tg.setColor('red');
-        expect(changes.length).toBe(2);
+        expect(changes).toHaveLength(2);
 
         // 4. Collapse and expand
         tg.collapse();

--- a/packages/dockview-modules/src/accessibilityService.ts
+++ b/packages/dockview-modules/src/accessibilityService.ts
@@ -1,11 +1,12 @@
 import {
     DockviewCompositeDisposable as CompositeDisposable,
-    DockviewIDisposable as IDisposable,
+    DockviewGroupPanel,
+    DockviewKeybindings,
+    KeyboardNavigationOptions,
+    defineModule,
+    IAccessibilityHost,
+    IAccessibilityService,
 } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
-import { DockviewKeybindings, KeyboardNavigationOptions } from 'dockview-core';
-import { defineModule } from 'dockview-core';
-import { IAccessibilityHost, IAccessibilityService } from 'dockview-core';
 import {
     KEYBOARD_MOVE_ATTRIBUTE,
     matchesBinding,

--- a/packages/dockview-modules/src/advancedDnDService.ts
+++ b/packages/dockview-modules/src/advancedDnDService.ts
@@ -1,18 +1,19 @@
 import {
     DockviewDisposable as Disposable,
     DockviewIDisposable as IDisposable,
-} from 'dockview-core';
-import { IDragGhostSpec } from 'dockview-core';
-import { DroptargetOverlayModel, Position } from 'dockview-core';
-import { GroupDragEvent, TabDragEvent } from 'dockview-core';
-import { DockviewWillDropEvent } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
-import {
+    IDragGhostSpec,
+    DroptargetOverlayModel,
+    Position,
+    GroupDragEvent,
+    TabDragEvent,
+    DockviewWillDropEvent,
+    DockviewGroupPanel,
     DockviewGroupDropLocation,
     DockviewWillShowOverlayLocationEvent,
+    defineModule,
+    IAdvancedDnDHost,
+    IAdvancedDnDService,
 } from 'dockview-core';
-import { defineModule } from 'dockview-core';
-import { IAdvancedDnDHost, IAdvancedDnDService } from 'dockview-core';
 
 /** Cursor offset of the group drag ghost, matched to the long-shipped default. */
 const GROUP_DRAG_GHOST_OFFSET_X = 30;

--- a/packages/dockview-modules/src/contextMenu.ts
+++ b/packages/dockview-modules/src/contextMenu.ts
@@ -1,15 +1,16 @@
-import { findRelativeZIndexParent } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
-import { IDockviewPanel } from 'dockview-core';
 import {
+    findRelativeZIndexParent,
+    DockviewGroupPanel,
+    IDockviewPanel,
     BuiltInChipContextMenuItem,
     ContextMenuItemConfig,
     ContextMenuItem,
+    ITabGroup,
+    TabGroupColorPalette,
+    defineModule,
+    IContextMenuHost,
+    IContextMenuService,
 } from 'dockview-core';
-import { ITabGroup } from 'dockview-core';
-import { TabGroupColorPalette } from 'dockview-core';
-import { defineModule } from 'dockview-core';
-import { IContextMenuHost, IContextMenuService } from 'dockview-core';
 
 function popoverZIndexFor(target: EventTarget | null): string | undefined {
     if (!(target instanceof HTMLElement)) {

--- a/packages/dockview-modules/src/contextMenu.ts
+++ b/packages/dockview-modules/src/contextMenu.ts
@@ -66,11 +66,11 @@ function buildSeparator(): HTMLElement {
 }
 
 function isCoarsePrimaryInput(): boolean {
-    if (typeof window === 'undefined' || !window.matchMedia) {
+    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
         return false;
     }
-    const coarse = window.matchMedia('(pointer: coarse)').matches;
-    const fine = window.matchMedia('(pointer: fine)').matches;
+    const coarse = globalThis.matchMedia('(pointer: coarse)').matches;
+    const fine = globalThis.matchMedia('(pointer: fine)').matches;
     return coarse && !fine;
 }
 

--- a/packages/dockview-modules/src/contextMenu.ts
+++ b/packages/dockview-modules/src/contextMenu.ts
@@ -66,7 +66,7 @@ function buildSeparator(): HTMLElement {
 }
 
 function isCoarsePrimaryInput(): boolean {
-    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
+    if (globalThis.window === undefined || !globalThis.matchMedia) {
         return false;
     }
     const coarse = globalThis.matchMedia('(pointer: coarse)').matches;

--- a/packages/dockview-modules/src/keyboardDockingService.ts
+++ b/packages/dockview-modules/src/keyboardDockingService.ts
@@ -1,15 +1,16 @@
 import {
     DockviewCompositeDisposable as CompositeDisposable,
     DockviewIDisposable as IDisposable,
+    Position,
+    DockviewGroupPanel,
+    IDockviewPanel,
+    resolveMessages,
+    defineModule,
+    LiveRegionModule,
+    IAccessibilityHost,
+    IKeyboardDockingService,
 } from 'dockview-core';
-import { Position } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
-import { IDockviewPanel } from 'dockview-core';
-import { resolveMessages } from 'dockview-core';
-import { defineModule } from 'dockview-core';
 import { AdvancedDnDModule } from './advancedDnDService';
-import { LiveRegionModule } from 'dockview-core';
-import { IAccessibilityHost, IKeyboardDockingService } from 'dockview-core';
 import {
     KEYBOARD_MOVE_ATTRIBUTE,
     matchesBinding,

--- a/packages/dockview-modules/src/tabGroupChipsService.ts
+++ b/packages/dockview-modules/src/tabGroupChipsService.ts
@@ -1,10 +1,11 @@
 import {
     DockviewCompositeDisposable as CompositeDisposable,
     DockviewIDisposable as IDisposable,
+    DockviewGroupPanel,
+    defineModule,
+    ITabGroupChipsHost,
+    ITabGroupChipsService,
 } from 'dockview-core';
-import { DockviewGroupPanel } from 'dockview-core';
-import { defineModule } from 'dockview-core';
-import { ITabGroupChipsHost, ITabGroupChipsService } from 'dockview-core';
 
 export class TabGroupChipsService implements ITabGroupChipsService {
     private readonly _host: ITabGroupChipsHost;

--- a/packages/dockview-react/src/__tests__/dockview/headerActionsRenderer.spec.ts
+++ b/packages/dockview-react/src/__tests__/dockview/headerActionsRenderer.spec.ts
@@ -36,7 +36,7 @@ describe('headerActionsRenderer', () => {
             groupPanel
         );
 
-        expect(cut.element.childNodes.length).toBe(0);
+        expect(cut.element.childNodes).toHaveLength(0);
         expect(cut.element.className).toBe('dv-react-part');
         expect(cut.part).toBeUndefined();
 

--- a/packages/dockview-react/src/react.ts
+++ b/packages/dockview-react/src/react.ts
@@ -99,11 +99,11 @@ export class ReactPart<
             throw new Error('invalid operation: resource is already disposed');
         }
 
-        if (!this.componentInstance) {
+        if (this.componentInstance) {
+            this.componentInstance.update(props);
+        } else {
             // if the component is yet to be mounted store the props
             this._initialProps = { ...this._initialProps, ...props };
-        } else {
-            this.componentInstance.update(props);
         }
     }
 

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -114,13 +114,13 @@ describe('GridviewVue Component', () => {
             component: 'test-component',
         });
 
-        expect(api.panels.length).toBe(1);
+        expect(api.panels).toHaveLength(1);
         expect(api.panels[0].id).toBe('grid-panel-1');
         expect(initSpy).toHaveBeenCalled();
 
         // Remove the panel
         api.removePanel(api.panels[0]);
-        expect(api.panels.length).toBe(0);
+        expect(api.panels).toHaveLength(0);
 
         initSpy.mockRestore();
         api.dispose();

--- a/packages/dockview-vue/src/__tests__/keepalive.spec.ts
+++ b/packages/dockview-vue/src/__tests__/keepalive.spec.ts
@@ -1,0 +1,219 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import {
+    defineComponent,
+    h,
+    inject,
+    KeepAlive,
+    onActivated,
+    onDeactivated,
+    nextTick,
+    provide,
+} from 'vue';
+import DockviewVue from '../dockview/dockview.vue';
+import SplitviewVue from '../splitview/splitview.vue';
+import GridviewVue from '../gridview/gridview.vue';
+import PaneviewVue from '../paneview/paneview.vue';
+import { Orientation } from 'dockview';
+
+/**
+ * Regression coverage for https://github.com/mathuo/dockview/issues/1369
+ *
+ * Panels are mounted via `<Teleport>` (rendered by `<DockviewPortals>`), which
+ * keeps them as real descendants of the host component in the Vue component
+ * tree. That ancestry is what lets framework features that walk the tree reach
+ * panels: KeepAlive (`onActivated`/`onDeactivated`) and `provide`/`inject`.
+ *
+ * Before the teleport migration, panels were detached `render()` roots with no
+ * tree ancestry, so KeepAlive could never reach them and these hooks never ran.
+ */
+
+interface ViewCase {
+    name: string;
+    view: ReturnType<typeof defineComponent>;
+    viewProps: Record<string, any>;
+    addPanel: (api: any) => void;
+}
+
+/** Wrap any view component in `<keep-alive>` behind a `show` toggle. */
+function createHost(view: ReturnType<typeof defineComponent>, viewProps: any) {
+    return defineComponent({
+        name: 'KeepAliveHost',
+        props: { show: { type: Boolean, default: true } },
+        emits: ['ready'],
+        setup(props, { emit }) {
+            return () =>
+                h(KeepAlive, null, {
+                    default: () =>
+                        props.show
+                            ? h(view, {
+                                  ...viewProps,
+                                  onReady: (event: { api: any }) =>
+                                      emit('ready', event),
+                              })
+                            : null,
+                });
+        },
+    });
+}
+
+function makePanel(
+    cssClass: string,
+    hooks?: { activated?: () => void; deactivated?: () => void }
+) {
+    return defineComponent({
+        name: `Panel_${cssClass}`,
+        props: ['params', 'api', 'containerApi', 'title'],
+        setup() {
+            if (hooks?.activated) {
+                onActivated(hooks.activated);
+            }
+            if (hooks?.deactivated) {
+                onDeactivated(hooks.deactivated);
+            }
+            return () => h('div', { class: cssClass }, 'Panel');
+        },
+    });
+}
+
+describe('Vue components under <keep-alive> (issue #1369)', () => {
+    let wrapper: ReturnType<typeof mount>;
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    const cases: ViewCase[] = [
+        {
+            name: 'DockviewVue',
+            view: DockviewVue,
+            viewProps: {},
+            addPanel: (api) =>
+                api.addPanel({ id: 'p1', component: 'Panel', title: 'P1' }),
+        },
+        {
+            name: 'SplitviewVue',
+            view: SplitviewVue,
+            viewProps: { orientation: Orientation.HORIZONTAL },
+            addPanel: (api) => api.addPanel({ id: 'p1', component: 'Panel' }),
+        },
+        {
+            name: 'GridviewVue',
+            view: GridviewVue,
+            viewProps: {},
+            addPanel: (api) => api.addPanel({ id: 'p1', component: 'Panel' }),
+        },
+        {
+            name: 'PaneviewVue',
+            view: PaneviewVue,
+            viewProps: {},
+            addPanel: (api) =>
+                api.addPanel({ id: 'p1', component: 'Panel', title: 'P1' }),
+        },
+    ];
+
+    for (const c of cases) {
+        test(`${c.name}: panel renders into the DOM via teleport`, async () => {
+            const cssClass = `teleport-${c.name}`;
+            const Panel = makePanel(cssClass);
+
+            wrapper = mount(
+                createHost(c.view, { ...c.viewProps, components: { Panel } }),
+                { attachTo: document.body, props: { show: true } }
+            );
+            await flushPromises();
+
+            const api = (wrapper.emitted('ready')![0][0] as any).api;
+            c.addPanel(api);
+            await flushPromises();
+            await nextTick();
+
+            expect(document.querySelector(`.${cssClass}`)).not.toBeNull();
+        });
+
+        test(`${c.name}: onActivated/onDeactivated fire across keep-alive toggles`, async () => {
+            const activated = vi.fn();
+            const deactivated = vi.fn();
+            const Panel = makePanel(`ka-${c.name}`, { activated, deactivated });
+
+            wrapper = mount(
+                createHost(c.view, { ...c.viewProps, components: { Panel } }),
+                { attachTo: document.body, props: { show: true } }
+            );
+            await flushPromises();
+
+            const api = (wrapper.emitted('ready')![0][0] as any).api;
+            c.addPanel(api);
+            await flushPromises();
+            await nextTick();
+
+            // Deactivate (e.g. router navigates away): the panel is cached, not
+            // unmounted, so onDeactivated fires. This was entirely missing
+            // before the teleport migration.
+            await wrapper.setProps({ show: false });
+            await flushPromises();
+            expect(deactivated).toHaveBeenCalledTimes(1);
+
+            // Reactivate: the cached panel is re-inserted and onActivated fires.
+            await wrapper.setProps({ show: true });
+            await flushPromises();
+            expect(activated).toHaveBeenCalledTimes(1);
+
+            // The cycle keeps working on subsequent toggles.
+            await wrapper.setProps({ show: false });
+            await flushPromises();
+            expect(deactivated).toHaveBeenCalledTimes(2);
+
+            await wrapper.setProps({ show: true });
+            await flushPromises();
+            expect(activated).toHaveBeenCalledTimes(2);
+        });
+    }
+});
+
+describe('provide/inject reaches teleported panels', () => {
+    let wrapper: ReturnType<typeof mount>;
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    test('a value provided above the host is injectable inside a panel', async () => {
+        const injected = vi.fn();
+
+        const Panel = defineComponent({
+            name: 'InjectPanel',
+            props: ['params'],
+            setup() {
+                injected(inject('shared-token'));
+                return () => h('div', { class: 'inject-panel' }, 'Panel');
+            },
+        });
+
+        // The host provides a value; the panel — a teleported descendant —
+        // must resolve it through the component tree.
+        const Host = defineComponent({
+            name: 'ProvideHost',
+            emits: ['ready'],
+            setup(_, { emit }) {
+                provide('shared-token', 'from-host');
+                return () =>
+                    h(DockviewVue, {
+                        components: { Panel },
+                        onReady: (event: { api: any }) => emit('ready', event),
+                    });
+            },
+        });
+
+        wrapper = mount(Host, { attachTo: document.body });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api;
+        api.addPanel({ id: 'p1', component: 'Panel', title: 'P1' });
+        await flushPromises();
+        await nextTick();
+
+        expect(document.querySelector('.inject-panel')).not.toBeNull();
+        expect(injected).toHaveBeenCalledWith('from-host');
+    });
+});

--- a/packages/dockview-vue/src/__tests__/teleport-render.spec.ts
+++ b/packages/dockview-vue/src/__tests__/teleport-render.spec.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { defineComponent, h, nextTick, onMounted, onUnmounted } from 'vue';
+import DockviewVue from '../dockview/dockview.vue';
+
+/**
+ * Render-behaviour coverage for the teleport mount path beyond the happy
+ * single-panel case: the `onlyWhenVisible` detach/reattach cycle (tab
+ * switching) and panel prop updates flowing through the reactive props ref.
+ */
+describe('teleport render behaviour', () => {
+    let wrapper: ReturnType<typeof mount>;
+
+    afterEach(() => {
+        wrapper?.unmount();
+    });
+
+    function mountDockview(components: Record<string, any>) {
+        return mount(DockviewVue, {
+            props: { components },
+            attachTo: document.body,
+        });
+    }
+
+    test('tab switching detaches/reattaches without destroying the panel instance', async () => {
+        const mounted = vi.fn();
+        const unmounted = vi.fn();
+
+        const Panel = defineComponent({
+            name: 'TabPanel',
+            props: ['params'],
+            setup(props) {
+                onMounted(mounted);
+                onUnmounted(unmounted);
+                return () =>
+                    h(
+                        'div',
+                        { class: `tab-panel-${props.params.params.which}` },
+                        'Panel'
+                    );
+            },
+        });
+
+        wrapper = mountDockview({ Panel });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api;
+        api.addPanel({
+            id: 'p1',
+            component: 'Panel',
+            params: { which: '1' },
+        });
+        api.addPanel({
+            id: 'p2',
+            component: 'Panel',
+            params: { which: '2' },
+            position: { referencePanel: 'p1', direction: 'within' },
+        });
+        await flushPromises();
+        await nextTick();
+
+        // Two panels in one group -> two component instances, both kept alive.
+        expect(mounted).toHaveBeenCalledTimes(2);
+        expect(unmounted).not.toHaveBeenCalled();
+
+        // Switch active tab back to p1 a few times; the default 'onlyWhenVisible'
+        // renderer detaches/reattaches the teleport target element. The Vue
+        // instances must survive (no remount, no unmount).
+        api.getPanel('p1')!.api.setActive();
+        await flushPromises();
+        api.getPanel('p2')!.api.setActive();
+        await flushPromises();
+        api.getPanel('p1')!.api.setActive();
+        await flushPromises();
+        await nextTick();
+
+        expect(mounted).toHaveBeenCalledTimes(2);
+        expect(unmounted).not.toHaveBeenCalled();
+        expect(document.querySelector('.tab-panel-1')).not.toBeNull();
+    });
+
+    test('panel param updates flow through to the rendered component', async () => {
+        const Panel = defineComponent({
+            name: 'UpdatePanel',
+            props: ['params'],
+            setup: (props) => () =>
+                h(
+                    'div',
+                    { class: 'update-panel' },
+                    String(props.params.params.value)
+                ),
+        });
+
+        wrapper = mountDockview({ Panel });
+        await flushPromises();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api;
+        api.addPanel({
+            id: 'p1',
+            component: 'Panel',
+            params: { value: 'before' },
+        });
+        await flushPromises();
+        await nextTick();
+
+        expect(document.querySelector('.update-panel')!.textContent).toBe(
+            'before'
+        );
+
+        api.getPanel('p1')!.api.updateParameters({ value: 'after' });
+        await flushPromises();
+        await nextTick();
+
+        expect(document.querySelector('.update-panel')!.textContent).toBe(
+            'after'
+        );
+    });
+});

--- a/packages/dockview-vue/src/composables/useViewComponent.ts
+++ b/packages/dockview-vue/src/composables/useViewComponent.ts
@@ -8,7 +8,7 @@ import {
     type ComponentInternalInstance,
 } from 'vue';
 import type { DockviewIDisposable } from 'dockview';
-import { findComponent } from '../utils';
+import { findComponent, VueRendererRegistry } from '../utils';
 
 export interface ViewComponentConfig<
     TApi,
@@ -28,7 +28,8 @@ export interface ViewComponentConfig<
         id: string,
         name: string | undefined,
         component: any,
-        instance: ComponentInternalInstance
+        instance: ComponentInternalInstance,
+        registry: VueRendererRegistry
     ) => TView;
     extractCoreOptions: (props: TProps) => TOptions;
     onApiCreated?: (api: TApi) => DockviewIDisposable[];
@@ -60,6 +61,13 @@ export function useViewComponent<
     const el = ref<HTMLElement | null>(null);
     const instance = ref<TApi | null>(null);
     const eventDisposables: DockviewIDisposable[] = [];
+
+    /**
+     * Components are teleported into the view's DOM (rendered by
+     * `<DockviewPortals>` in the host template) so panels stay in the Vue
+     * component tree. See {@link VueRendererRegistry}.
+     */
+    const registry = new VueRendererRegistry();
 
     config.propertyKeys.forEach((coreOptionKey) => {
         watch(
@@ -99,7 +107,8 @@ export function useViewComponent<
                             options.id,
                             options.name,
                             component! as any,
-                            inst
+                            inst,
+                            registry
                         );
                     },
                 } as unknown as Partial<TOptions>);
@@ -131,7 +140,8 @@ export function useViewComponent<
                     options.id,
                     options.name,
                     component! as any,
-                    inst
+                    inst,
+                    registry
                 );
             },
         } as TFrameworkOptions;
@@ -164,5 +174,6 @@ export function useViewComponent<
     return {
         el,
         instance,
+        registry,
     };
 }

--- a/packages/dockview-vue/src/dockview/dockview.vue
+++ b/packages/dockview-vue/src/dockview/dockview.vue
@@ -21,10 +21,12 @@ import {
     VueContextMenuItemRenderer,
     VueTabGroupChipRenderer,
     VueRenderer,
+    VueRendererRegistry,
     VueWatermarkRenderer,
     findComponent,
     resolveComponent,
 } from '../utils';
+import DockviewPortals from '../dockviewPortals.vue';
 import type { IDockviewVueProps, VueEvents } from './types';
 
 const DEFAULT_VUE_TAB = 'props.defaultTabComponent';
@@ -61,6 +63,13 @@ PROPERTY_KEYS_DOCKVIEW.forEach((coreOptionKey) => {
 
 const inst = getCurrentInstance()!;
 
+/**
+ * Components are mounted into dockview's DOM via `<Teleport>` (rendered by
+ * `<DockviewPortals>` below) rather than detached `render()` roots, keeping
+ * panels in the Vue component tree. See {@link VueRendererRegistry}.
+ */
+const registry = new VueRendererRegistry();
+
 watch(
     () => props.tabGroupChipComponent,
     (newValue) => {
@@ -69,7 +78,11 @@ watch(
                 createTabGroupChipComponent: newValue
                     ? () => {
                           const component = resolveComponent(newValue, inst);
-                          return new VueTabGroupChipRenderer(component!, inst);
+                          return new VueTabGroupChipRenderer(
+                              component!,
+                              inst,
+                              registry
+                          );
                       }
                     : undefined,
             });
@@ -87,7 +100,8 @@ watch(
                           const component = resolveComponent(newValue, inst);
                           return new VueGroupDragGhostRenderer(
                               component!,
-                              inst
+                              inst,
+                              registry
                           );
                       }
                     : undefined,
@@ -123,7 +137,7 @@ watch(
                     }
 
                     if (component) {
-                        return new VueRenderer(component, inst);
+                        return new VueRenderer(component, inst, registry);
                     }
                     return undefined;
                 },
@@ -140,7 +154,11 @@ watch(
                 createWatermarkComponent: newValue
                     ? () => {
                           const component = resolveComponent(newValue, inst);
-                          return new VueWatermarkRenderer(component!, inst);
+                          return new VueWatermarkRenderer(
+                              component!,
+                              inst,
+                              registry
+                          );
                       }
                     : undefined,
             });
@@ -159,7 +177,8 @@ watch(
                           return new VueHeaderActionsRenderer(
                               component!,
                               inst,
-                              group
+                              group,
+                              registry
                           );
                       }
                     : undefined,
@@ -179,7 +198,8 @@ watch(
                           return new VueHeaderActionsRenderer(
                               component!,
                               inst,
-                              group
+                              group,
+                              registry
                           );
                       }
                     : undefined,
@@ -199,7 +219,8 @@ watch(
                           return new VueHeaderActionsRenderer(
                               component!,
                               inst,
-                              group
+                              group,
+                              registry
                           );
                       }
                     : undefined,
@@ -224,7 +245,7 @@ onMounted(() => {
                 options.name,
                 props.components
             );
-            return new VueRenderer(component!, inst);
+            return new VueRenderer(component!, inst, registry);
         },
         createTabComponent(options) {
             let component =
@@ -238,7 +259,7 @@ onMounted(() => {
             }
 
             if (component) {
-                return new VueRenderer(component, inst);
+                return new VueRenderer(component, inst, registry);
             }
             return undefined;
         },
@@ -249,7 +270,7 @@ onMounted(() => {
                       inst
                   );
 
-                  return new VueWatermarkRenderer(component!, inst);
+                  return new VueWatermarkRenderer(component!, inst, registry);
               }
             : undefined,
         createLeftHeaderActionComponent: props.leftHeaderActionsComponent
@@ -258,7 +279,12 @@ onMounted(() => {
                       props.leftHeaderActionsComponent,
                       inst
                   );
-                  return new VueHeaderActionsRenderer(component!, inst, group);
+                  return new VueHeaderActionsRenderer(
+                      component!,
+                      inst,
+                      group,
+                      registry
+                  );
               }
             : undefined,
         createPrefixHeaderActionComponent: props.prefixHeaderActionsComponent
@@ -267,7 +293,12 @@ onMounted(() => {
                       props.prefixHeaderActionsComponent,
                       inst
                   );
-                  return new VueHeaderActionsRenderer(component!, inst, group);
+                  return new VueHeaderActionsRenderer(
+                      component!,
+                      inst,
+                      group,
+                      registry
+                  );
               }
             : undefined,
         createRightHeaderActionComponent: props.rightHeaderActionsComponent
@@ -276,7 +307,12 @@ onMounted(() => {
                       props.rightHeaderActionsComponent,
                       inst
                   );
-                  return new VueHeaderActionsRenderer(component!, inst, group);
+                  return new VueHeaderActionsRenderer(
+                      component!,
+                      inst,
+                      group,
+                      registry
+                  );
               }
             : undefined,
         createContextMenuItemComponent: (options) => {
@@ -288,7 +324,7 @@ onMounted(() => {
                 options.component as string,
                 props.components
             );
-            return new VueContextMenuItemRenderer(component!, inst);
+            return new VueContextMenuItemRenderer(component!, inst, registry);
         },
     };
 
@@ -304,7 +340,7 @@ onMounted(() => {
         const chipValue = props.tabGroupChipComponent;
         coreOptions.createTabGroupChipComponent = () => {
             const component = resolveComponent(chipValue, inst);
-            return new VueTabGroupChipRenderer(component!, inst);
+            return new VueTabGroupChipRenderer(component!, inst, registry);
         };
     }
 
@@ -312,7 +348,7 @@ onMounted(() => {
         const ghostValue = props.groupDragGhostComponent;
         coreOptions.createGroupDragGhostComponent = () => {
             const component = resolveComponent(ghostValue, inst);
-            return new VueGroupDragGhostRenderer(component!, inst);
+            return new VueGroupDragGhostRenderer(component!, inst, registry);
         };
     }
 
@@ -358,4 +394,5 @@ onBeforeUnmount(() => {
 
 <template>
     <div ref="el" />
+    <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/dockviewPortals.vue
+++ b/packages/dockview-vue/src/dockviewPortals.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { VueMountEntry } from './utils';
+
+/**
+ * Renders every registered component into its target element via `<Teleport>`.
+ *
+ * Hosts (`dockview.vue`, `splitview.vue`, ...) render this component as a child
+ * so each teleported panel stays a true descendant in the Vue component tree.
+ * That ancestry is what makes `<keep-alive>` (`onActivated`/`onDeactivated`),
+ * `provide`/`inject`, `<Suspense>` and error boundaries work for panels, while
+ * dockview keeps full control of where the DOM physically lives (including
+ * across popout windows).
+ */
+defineProps<{ entries: VueMountEntry[] }>();
+</script>
+
+<template>
+    <template v-for="entry in entries" :key="entry.id">
+        <Teleport :to="entry.target">
+            <component :is="entry.component" v-bind="entry.props.value" />
+        </Teleport>
+    </template>
+</template>

--- a/packages/dockview-vue/src/gridview/gridview.vue
+++ b/packages/dockview-vue/src/gridview/gridview.vue
@@ -8,6 +8,7 @@ import {
 } from 'dockview';
 import { useViewComponent } from '../composables/useViewComponent';
 import { VueGridviewPanelView } from './view';
+import DockviewPortals from '../dockviewPortals.vue';
 import type { IGridviewVueProps, GridviewVueEvents } from './types';
 
 function extractCoreOptions(props: IGridviewVueProps): GridviewOptions {
@@ -24,13 +25,13 @@ function extractCoreOptions(props: IGridviewVueProps): GridviewOptions {
 const emit = defineEmits<GridviewVueEvents>();
 const props = defineProps<IGridviewVueProps>();
 
-const { el } = useViewComponent(
+const { el, registry } = useViewComponent(
     {
         componentName: 'gridview-vue',
         propertyKeys: PROPERTY_KEYS_GRIDVIEW,
         createApi: createGridview,
-        createView: (id, name, component, instance) =>
-            new VueGridviewPanelView(id, name, component, instance),
+        createView: (id, name, component, instance, registry) =>
+            new VueGridviewPanelView(id, name, component, instance, registry),
         extractCoreOptions,
     },
     props,
@@ -40,4 +41,5 @@ const { el } = useViewComponent(
 
 <template>
     <div ref="el" style="height: 100%; width: 100%" />
+    <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/gridview/gridview.vue
+++ b/packages/dockview-vue/src/gridview/gridview.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import {
-    GridviewApi,
     type GridviewOptions,
     PROPERTY_KEYS_GRIDVIEW,
-    type GridviewFrameworkOptions,
     createGridview,
 } from 'dockview';
 import { useViewComponent } from '../composables/useViewComponent';

--- a/packages/dockview-vue/src/gridview/view.ts
+++ b/packages/dockview-vue/src/gridview/view.ts
@@ -1,6 +1,6 @@
 import { GridviewApi, GridviewPanel, IFrameworkPart } from 'dockview';
 import { type ComponentInternalInstance } from 'vue';
-import { VuePart, type VueComponent } from '../utils';
+import { VuePart, VueRendererRegistry, type VueComponent } from '../utils';
 import type { IGridviewVuePanelProps } from './types';
 
 export class VueGridviewPanelView extends GridviewPanel {
@@ -8,17 +8,24 @@ export class VueGridviewPanelView extends GridviewPanel {
         id: string,
         component: string,
         private readonly vueComponent: VueComponent<IGridviewVuePanelProps>,
-        private readonly parent: ComponentInternalInstance
+        private readonly parent: ComponentInternalInstance,
+        private readonly registry?: VueRendererRegistry
     ) {
         super(id, component);
     }
 
     getComponent(): IFrameworkPart {
-        const part = new VuePart(this.element, this.vueComponent, this.parent, {
-            params: this._params?.params ?? {},
-            api: this.api,
-            containerApi: new GridviewApi((this._params as any).accessor),
-        });
+        const part = new VuePart(
+            this.element,
+            this.vueComponent,
+            this.parent,
+            {
+                params: this._params?.params ?? {},
+                api: this.api,
+                containerApi: new GridviewApi((this._params as any).accessor),
+            },
+            this.registry
+        );
         part.init();
         return part;
     }

--- a/packages/dockview-vue/src/paneview/paneview.vue
+++ b/packages/dockview-vue/src/paneview/paneview.vue
@@ -8,6 +8,7 @@ import {
 } from 'dockview';
 import { useViewComponent } from '../composables/useViewComponent';
 import { VuePaneviewPanelView } from './view';
+import DockviewPortals from '../dockviewPortals.vue';
 import type { IPaneviewVueProps, PaneviewVueEvents } from './types';
 
 function extractCoreOptions(props: IPaneviewVueProps): PaneviewOptions {
@@ -24,13 +25,13 @@ function extractCoreOptions(props: IPaneviewVueProps): PaneviewOptions {
 const emit = defineEmits<PaneviewVueEvents>();
 const props = defineProps<IPaneviewVueProps>();
 
-const { el } = useViewComponent(
+const { el, registry } = useViewComponent(
     {
         componentName: 'paneview-vue',
         propertyKeys: PROPERTY_KEYS_PANEVIEW,
         createApi: createPaneview,
-        createView: (id, name, component, instance) =>
-            new VuePaneviewPanelView(id, component, instance),
+        createView: (id, name, component, instance, registry) =>
+            new VuePaneviewPanelView(id, component, instance, registry),
         extractCoreOptions,
         onApiCreated: (api) => [
             api.onDidDrop((event) => emit('didDrop', event)),
@@ -43,4 +44,5 @@ const { el } = useViewComponent(
 
 <template>
     <div ref="el" style="height: 100%; width: 100%" />
+    <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/paneview/paneview.vue
+++ b/packages/dockview-vue/src/paneview/paneview.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import {
-    PaneviewApi,
     type PaneviewOptions,
     PROPERTY_KEYS_PANEVIEW,
-    type PaneviewFrameworkOptions,
     createPaneview,
 } from 'dockview';
 import { useViewComponent } from '../composables/useViewComponent';

--- a/packages/dockview-vue/src/paneview/view.ts
+++ b/packages/dockview-vue/src/paneview/view.ts
@@ -4,7 +4,7 @@ import {
     PanelUpdateEvent,
 } from 'dockview';
 import { type ComponentInternalInstance } from 'vue';
-import { VuePart, type VueComponent } from '../utils';
+import { VuePart, VueRendererRegistry, type VueComponent } from '../utils';
 import type { IPaneviewVuePanelProps } from './types';
 
 export class VuePaneviewPanelView implements IPanePart {
@@ -18,7 +18,8 @@ export class VuePaneviewPanelView implements IPanePart {
     constructor(
         public readonly id: string,
         private readonly vueComponent: VueComponent<IPaneviewVuePanelProps>,
-        private readonly parent: ComponentInternalInstance
+        private readonly parent: ComponentInternalInstance,
+        private readonly registry?: VueRendererRegistry
     ) {
         this._element = document.createElement('div');
         this._element.style.height = '100%';
@@ -26,12 +27,18 @@ export class VuePaneviewPanelView implements IPanePart {
     }
 
     public init(parameters: PanePanelComponentInitParameter): void {
-        this.part = new VuePart(this.element, this.vueComponent, this.parent, {
-            params: parameters.params,
-            api: parameters.api,
-            title: parameters.title,
-            containerApi: parameters.containerApi,
-        });
+        this.part = new VuePart(
+            this.element,
+            this.vueComponent,
+            this.parent,
+            {
+                params: parameters.params,
+                api: parameters.api,
+                title: parameters.title,
+                containerApi: parameters.containerApi,
+            },
+            this.registry
+        );
         this.part.init();
     }
 

--- a/packages/dockview-vue/src/splitview/splitview.vue
+++ b/packages/dockview-vue/src/splitview/splitview.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import {
-    SplitviewApi,
     type SplitviewOptions,
     PROPERTY_KEYS_SPLITVIEW,
-    type SplitviewFrameworkOptions,
     createSplitview,
 } from 'dockview';
 import { useViewComponent } from '../composables/useViewComponent';

--- a/packages/dockview-vue/src/splitview/splitview.vue
+++ b/packages/dockview-vue/src/splitview/splitview.vue
@@ -8,6 +8,7 @@ import {
 } from 'dockview';
 import { useViewComponent } from '../composables/useViewComponent';
 import { VueSplitviewPanelView } from './view';
+import DockviewPortals from '../dockviewPortals.vue';
 import type { ISplitviewVueProps, SplitviewVueEvents } from './types';
 
 function extractCoreOptions(props: ISplitviewVueProps): SplitviewOptions {
@@ -24,13 +25,13 @@ function extractCoreOptions(props: ISplitviewVueProps): SplitviewOptions {
 const emit = defineEmits<SplitviewVueEvents>();
 const props = defineProps<ISplitviewVueProps>();
 
-const { el } = useViewComponent(
+const { el, registry } = useViewComponent(
     {
         componentName: 'splitview-vue',
         propertyKeys: PROPERTY_KEYS_SPLITVIEW,
         createApi: createSplitview,
-        createView: (id, name, component, instance) =>
-            new VueSplitviewPanelView(id, name, component, instance),
+        createView: (id, name, component, instance, registry) =>
+            new VueSplitviewPanelView(id, name, component, instance, registry),
         extractCoreOptions,
     },
     props,
@@ -40,4 +41,5 @@ const { el } = useViewComponent(
 
 <template>
     <div ref="el" style="height: 100%; width: 100%" />
+    <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/splitview/view.ts
+++ b/packages/dockview-vue/src/splitview/view.ts
@@ -1,9 +1,4 @@
-import {
-    SplitviewApi,
-    PanelViewInitParameters,
-    SplitviewPanel,
-    IFrameworkPart,
-} from 'dockview';
+import { SplitviewApi, SplitviewPanel, IFrameworkPart } from 'dockview';
 import { type ComponentInternalInstance } from 'vue';
 import { VuePart, VueRendererRegistry, type VueComponent } from '../utils';
 import type { ISplitviewVuePanelProps } from './types';

--- a/packages/dockview-vue/src/splitview/view.ts
+++ b/packages/dockview-vue/src/splitview/view.ts
@@ -5,7 +5,7 @@ import {
     IFrameworkPart,
 } from 'dockview';
 import { type ComponentInternalInstance } from 'vue';
-import { VuePart, type VueComponent } from '../utils';
+import { VuePart, VueRendererRegistry, type VueComponent } from '../utils';
 import type { ISplitviewVuePanelProps } from './types';
 
 export class VueSplitviewPanelView extends SplitviewPanel {
@@ -13,17 +13,24 @@ export class VueSplitviewPanelView extends SplitviewPanel {
         id: string,
         component: string,
         private readonly vueComponent: VueComponent<ISplitviewVuePanelProps>,
-        private readonly parent: ComponentInternalInstance
+        private readonly parent: ComponentInternalInstance,
+        private readonly registry?: VueRendererRegistry
     ) {
         super(id, component);
     }
 
     getComponent(): IFrameworkPart {
-        const part = new VuePart(this.element, this.vueComponent, this.parent, {
-            params: this._params?.params ?? {},
-            api: this.api,
-            containerApi: new SplitviewApi((this._params as any).accessor),
-        });
+        const part = new VuePart(
+            this.element,
+            this.vueComponent,
+            this.parent,
+            {
+                params: this._params?.params ?? {},
+                api: this.api,
+                containerApi: new SplitviewApi((this._params as any).accessor),
+            },
+            this.registry
+        );
         part.init();
         return part;
     }

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -31,6 +31,10 @@ import {
     type ComponentOptionsBase,
     render,
     cloneVNode,
+    markRaw,
+    shallowReactive,
+    shallowRef,
+    type ShallowRef,
     type DefineComponent,
     type ComponentInternalInstance,
 } from 'vue';
@@ -124,8 +128,70 @@ export function mountVueComponent<T extends Record<string, any>>(
     };
 }
 
+export interface VueMountDisposable {
+    update: (props: Record<string, any>) => void;
+    dispose: () => void;
+}
+
+/**
+ * A single component to be teleported by the host's `<DockviewPortals>`.
+ *
+ * `props` is a {@link ShallowRef} so reassigning it triggers a re-render
+ * without Vue deeply proxying the value — the params object carries raw
+ * dockview API instances that must NOT be made reactive.
+ */
+export interface VueMountEntry {
+    readonly id: number;
+    readonly component: VueComponent;
+    readonly target: HTMLElement;
+    readonly props: ShallowRef<Record<string, any>>;
+}
+
+let nextMountEntryId = 0;
+
+/**
+ * Shared, reactive registry of components that a host (`dockview.vue`,
+ * `splitview.vue`, ...) renders via `<Teleport>` instead of the detached
+ * `render()` root used by {@link mountVueComponent}.
+ *
+ * Teleporting keeps each panel a true descendant of the host in the Vue
+ * component tree, so framework features that walk the tree work natively:
+ * KeepAlive (`onActivated`/`onDeactivated`), `provide`/`inject`, `<Suspense>`
+ * and error boundaries.
+ */
+export class VueRendererRegistry {
+    readonly entries = shallowReactive<VueMountEntry[]>([]);
+
+    mount(
+        component: VueComponent,
+        target: HTMLElement,
+        props: Record<string, any>
+    ): VueMountDisposable {
+        const entry: VueMountEntry = {
+            id: nextMountEntryId++,
+            component: markRaw(component),
+            target,
+            props: shallowRef(props),
+        };
+        this.entries.push(entry);
+
+        return {
+            update: (newProps: Record<string, any>) => {
+                entry.props.value = { ...entry.props.value, ...newProps };
+            },
+            dispose: () => {
+                const index = this.entries.indexOf(entry);
+                if (index !== -1) {
+                    this.entries.splice(index, 1);
+                }
+            },
+        };
+    }
+}
+
 abstract class AbstractVueRenderer {
     protected readonly _element: HTMLElement;
+    protected _renderDisposable: VueMountDisposable | undefined;
 
     get element(): HTMLElement {
         return this._element;
@@ -133,12 +199,31 @@ abstract class AbstractVueRenderer {
 
     constructor(
         protected readonly component: VueComponent,
-        protected readonly parent: ComponentInternalInstance
+        protected readonly parent: ComponentInternalInstance,
+        protected readonly registry?: VueRendererRegistry
     ) {
         this._element = document.createElement('div');
         this.element.className = 'dv-vue-part';
         this.element.style.height = '100%';
         this.element.style.width = '100%';
+    }
+
+    /**
+     * Mount `component` into `this.element`. When a {@link VueRendererRegistry}
+     * is provided the component is teleported by the host (keeping it in the
+     * Vue component tree); otherwise it falls back to the detached
+     * {@link mountVueComponent} render root.
+     */
+    protected mount(props: Record<string, any>): void {
+        this._renderDisposable?.dispose();
+        this._renderDisposable = this.registry
+            ? this.registry.mount(this.component, this.element, props)
+            : mountVueComponent(
+                  this.component,
+                  this.parent,
+                  props,
+                  this.element
+              );
     }
 }
 
@@ -146,9 +231,6 @@ export class VueRenderer
     extends AbstractVueRenderer
     implements ITabRenderer, IContentRenderer
 {
-    private _renderDisposable:
-        | { update: (props: any) => void; dispose: () => void }
-        | undefined;
     private _api: DockviewPanelApi | undefined;
     private _containerApi: DockviewApi | undefined;
 
@@ -163,13 +245,7 @@ export class VueRenderer
             tabLocation: parameters.tabLocation,
         };
 
-        this._renderDisposable?.dispose();
-        this._renderDisposable = mountVueComponent(
-            this.component,
-            this.parent,
-            { params: props },
-            this.element
-        );
+        this.mount({ params: props });
     }
 
     update(event: PanelUpdateEvent<Parameters>): void {
@@ -196,10 +272,6 @@ export class VueWatermarkRenderer
     extends AbstractVueRenderer
     implements IWatermarkRenderer
 {
-    private _renderDisposable:
-        | { update: (props: any) => void; dispose: () => void }
-        | undefined;
-
     get element(): HTMLElement {
         return this._element;
     }
@@ -210,13 +282,7 @@ export class VueWatermarkRenderer
             containerApi: parameters.containerApi,
         };
 
-        this._renderDisposable?.dispose();
-        this._renderDisposable = mountVueComponent(
-            this.component,
-            this.parent,
-            { params: props },
-            this.element
-        );
+        this.mount({ params: props });
     }
 
     update(event: PanelUpdateEvent<Parameters>): void {
@@ -232,9 +298,6 @@ export class VueHeaderActionsRenderer
     extends AbstractVueRenderer
     implements IHeaderActionsRenderer
 {
-    private _renderDisposable:
-        | { update: (props: any) => void; dispose: () => void }
-        | undefined;
     private readonly _mutableDisposable = new DockviewMutableDisposable();
     private _baseProps: IGroupHeaderProps | undefined;
 
@@ -245,9 +308,10 @@ export class VueHeaderActionsRenderer
     constructor(
         component: VueComponent,
         parent: ComponentInternalInstance,
-        private readonly group: DockviewGroupPanel
+        private readonly group: DockviewGroupPanel,
+        registry?: VueRendererRegistry
     ) {
-        super(component, parent);
+        super(component, parent, registry);
     }
 
     init(props: IGroupHeaderProps): void {
@@ -271,13 +335,7 @@ export class VueHeaderActionsRenderer
             })
         );
 
-        this._renderDisposable?.dispose();
-        this._renderDisposable = mountVueComponent(
-            this.component,
-            this.parent,
-            { params: this.buildEnrichedProps() },
-            this.element
-        );
+        this.mount({ params: this.buildEnrichedProps() });
     }
 
     dispose(): void {
@@ -310,18 +368,8 @@ export class VueContextMenuItemRenderer
     extends AbstractVueRenderer
     implements IContextMenuItemRenderer
 {
-    private _renderDisposable:
-        | { update: (props: any) => void; dispose: () => void }
-        | undefined;
-
     init(props: IContextMenuItemComponentProps): void {
-        this._renderDisposable?.dispose();
-        this._renderDisposable = mountVueComponent(
-            this.component,
-            this.parent,
-            { params: props },
-            this.element
-        );
+        this.mount({ params: props });
     }
 
     dispose(): void {
@@ -333,34 +381,28 @@ export class VueTabGroupChipRenderer
     extends AbstractVueRenderer
     implements ITabGroupChipRenderer
 {
-    private _renderDisposable:
-        | { update: (props: any) => void; dispose: () => void }
-        | undefined;
-
     get element(): HTMLElement {
         return this._element;
     }
 
-    constructor(component: VueComponent, parent: ComponentInternalInstance) {
-        super(component, parent);
+    constructor(
+        component: VueComponent,
+        parent: ComponentInternalInstance,
+        registry?: VueRendererRegistry
+    ) {
+        super(component, parent, registry);
         this.element.style.height = '';
         this.element.style.width = '';
         this.element.style.display = 'inline-flex';
     }
 
     init(params: { tabGroup: ITabGroup; api: DockviewApi }): void {
-        this._renderDisposable?.dispose();
-        this._renderDisposable = mountVueComponent(
-            this.component,
-            this.parent,
-            {
-                params: {
-                    tabGroup: params.tabGroup,
-                    api: params.api,
-                },
+        this.mount({
+            params: {
+                tabGroup: params.tabGroup,
+                api: params.api,
             },
-            this.element
-        );
+        });
     }
 
     update(params: { tabGroup: ITabGroup }): void {
@@ -378,30 +420,24 @@ export class VueGroupDragGhostRenderer
     extends AbstractVueRenderer
     implements IGroupDragGhostRenderer
 {
-    private _renderDisposable:
-        | { update: (props: any) => void; dispose: () => void }
-        | undefined;
-
-    constructor(component: VueComponent, parent: ComponentInternalInstance) {
-        super(component, parent);
+    constructor(
+        component: VueComponent,
+        parent: ComponentInternalInstance,
+        registry?: VueRendererRegistry
+    ) {
+        super(component, parent, registry);
         this.element.style.height = '';
         this.element.style.width = '';
         this.element.style.display = 'inline-flex';
     }
 
     init(params: { group: IDockviewGroupPanel; api: DockviewApi }): void {
-        this._renderDisposable?.dispose();
-        this._renderDisposable = mountVueComponent(
-            this.component,
-            this.parent,
-            {
-                params: {
-                    group: params.group,
-                    api: params.api,
-                },
+        this.mount({
+            params: {
+                group: params.group,
+                api: params.api,
             },
-            this.element
-        );
+        });
     }
 
     dispose(): void {
@@ -410,25 +446,26 @@ export class VueGroupDragGhostRenderer
 }
 
 export class VuePart<T extends Record<string, any> = any> {
-    private _renderDisposable:
-        | { update: (props: any) => void; dispose: () => void }
-        | undefined;
+    private _renderDisposable: VueMountDisposable | undefined;
 
     constructor(
         private readonly element: HTMLElement,
         private readonly vueComponent: VueComponent<T>,
         private readonly parent: ComponentInternalInstance,
-        private props: T
+        private props: T,
+        private readonly registry?: VueRendererRegistry
     ) {}
 
     init(): void {
         this._renderDisposable?.dispose();
-        this._renderDisposable = mountVueComponent(
-            this.vueComponent,
-            this.parent,
-            this.props,
-            this.element
-        );
+        this._renderDisposable = this.registry
+            ? this.registry.mount(this.vueComponent, this.element, this.props)
+            : mountVueComponent(
+                  this.vueComponent,
+                  this.parent,
+                  this.props,
+                  this.element
+              );
     }
 
     update(props: T): void {


### PR DESCRIPTION
## Description

Merges the latest `master` (`e4c0f7a`) into `v8-branch` to keep the v8 line current. Master had advanced with two batches of SonarCloud maintainability cleanups (PRs #1394, #1395) plus the earlier Vue Teleport mount fix (#1380).

Five files conflicted, all from the same root cause: v8 relocated these modules (`dockview-modules` → `dockview-core` / `dockview-enterprise`) and renamed `AccessibilityModule` → `KeyboardNavigation`, while master applied mechanical import-consolidation to the old file locations. Only the import blocks conflicted:

- `dockview-core/src/dockview/advancedDnDService.ts` — kept the v8 version (file lives in core now with relative imports)
- `dockview-enterprise/src/contextMenu.ts` — kept v8 imports (`from 'dockview'`) **and preserved master's `window` → `globalThis` body fix** that auto-merged
- `dockview-enterprise/src/keyboardDockingService.ts` — kept v8 (preserves the KeyboardNavigation rename)
- `dockview-enterprise/src/keyboardNavigationService.ts` — kept v8 (master's copy was still `accessibilityService.ts`)
- `dockview-enterprise/src/tabGroupChipsService.ts` — kept v8

Master's changes to these files were import-only apart from the `globalThis` fix, which was retained, so no behavioral changes from master were dropped. Confirmed `origin/master` is now a full ancestor of the merge commit.

## Type of change

- [x] Refactor / cleanup

## Affected packages

- [x] `dockview-core`
- [x] `dockview` (vanilla JS)

## How to test

Ran locally on the merged tree:

- `dockview-core` + `dockview` + `dockview-enterprise` build clean (type-check passes)
- `nx test dockview-core` — 1126 passing
- `nx test dockview-enterprise` — 275 passing
- `npm run gen:check` — generated files in sync

## Checklist

- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [ ] I have added or updated tests where applicable (merge only — no new behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUDm943vwiVCqmAa5BrsEh)_