### PR TITLE
ci: build, bundle and publish fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
                       ${{ runner.os }}-modules-
 
             - run: yarn
-            - run: npx nx run-many -t build --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular
+            - run: npx nx run-many -t build --projects=dockview-core,dockview,dockview-enterprise,dockview-vue,dockview-react,dockview-angular
 
             - uses: actions/upload-artifact@v4
               with:
@@ -177,7 +177,7 @@ jobs:
                   name: build-output
                   path: packages/
 
-            - run: npx nx run-many -t build:bundle --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular
+            - run: npx nx run-many -t build:bundle --projects=dockview-core,dockview,dockview-enterprise,dockview-vue,dockview-react,dockview-angular
 
     test:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,11 @@ jobs:
             - run: npm install -g npm@latest
 
             - run: yarn
-            - run: npx nx run-many -t build --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular
-            - run: npx nx run-many -t build:bundle --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular
+            - run: npx nx run-many -t build --projects=dockview-core,dockview,dockview-enterprise,dockview-vue,dockview-react,dockview-angular
+            - run: npx nx run-many -t build:bundle --projects=dockview-core,dockview,dockview-enterprise,dockview-vue,dockview-react,dockview-angular
             - name: Publish to npm
               run: |
-                  for pkg in dockview-core dockview dockview-vue dockview-react dockview-angular; do
+                  for pkg in dockview-core dockview dockview-enterprise dockview-vue dockview-react dockview-angular; do
                     npm publish ./packages/$pkg --provenance --access public
                   done
     publish-experimental:
@@ -52,11 +52,11 @@ jobs:
             - run: npm install -g npm@latest
 
             - run: yarn
-            - run: npx nx run-many -t build --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular
-            - run: npx nx run-many -t build:bundle --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular
+            - run: npx nx run-many -t build --projects=dockview-core,dockview,dockview-enterprise,dockview-vue,dockview-react,dockview-angular
+            - run: npx nx run-many -t build:bundle --projects=dockview-core,dockview,dockview-enterprise,dockview-vue,dockview-react,dockview-angular
             - run: npx nx release version 0.0.0-experimental-$(git rev-parse --short HEAD)-$(date +%Y%m%d) --git-commit=false --git-tag=false
             - name: Publish to npm
               run: |
-                  for pkg in dockview-core dockview dockview-vue dockview-react dockview-angular; do
+                  for pkg in dockview-core dockview dockview-enterprise dockview-vue dockview-react dockview-angular; do
                     npm publish ./packages/$pkg --provenance --access public --tag experimental ${{ inputs.dry-run && '--dry-run' || '' }}
                   done


### PR DESCRIPTION
## Description

The `dockview-enterprise` package was already wired into nx release versioning (`nx.json` release `projects`, fixed relationship) and its tests already run in CI via the root jest glob (`packages/*/jest.config.ts`) — but the CI and publish workflows omitted it from the build/bundle project lists and the `npm publish` loop. That meant each release bumped its version yet nothing ever built its bundle or published it to npm.

This adds `dockview-enterprise` (placed right after its `dockview` dependency) to:

- **`main.yml`** — the `build` and `bundle` jobs
- **`publish.yml`** — `build`, `build:bundle`, and the `npm publish` loop, in both the release-triggered `publish` job and the `workflow_dispatch` `publish-experimental` job

## Type of change

- [x] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

(`dockview-enterprise` — CI/publish wiring only, no source changes)

## How to test

- `npx nx build:bundle dockview-enterprise` succeeds locally, producing `dist/package/main.{cjs,esm}[.min].{js,mjs}` and `dist/dockview-enterprise.min.js`
- The package is publishable: not `private`, version `7.0.2`, MIT, `main`/`module`/`types`/`exports` resolve to the bundle output, `files: ["dist", "README.md"]` — so the shared `--provenance --access public` publish loop applies cleanly
- Enterprise tests already run in CI (275 passing) via the root `test:cov` glob; no test-config change needed

## Checklist

- [x] `yarn test` passes
- [x] I have added or updated tests where applicable (n/a — CI/publish config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUDm943vwiVCqmAa5BrsEh)_