### PR TITLE
fix: resolve new-code reliability issues failing the quality gate

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3321,15 +3321,19 @@ export class DockviewComponent
 
     removePanel(
         panel: IDockviewPanel,
-        options: {
-            removeEmptyGroup: boolean;
+        options?: {
+            removeEmptyGroup?: boolean;
             skipDispose?: boolean;
             skipSetActiveGroup?: boolean;
-        } = {
-            removeEmptyGroup: true,
         }
     ): void {
-        this.mutation('remove', () => this._doRemovePanel(panel, options));
+        this.mutation('remove', () =>
+            this._doRemovePanel(panel, {
+                removeEmptyGroup: options?.removeEmptyGroup ?? true,
+                skipDispose: options?.skipDispose,
+                skipSetActiveGroup: options?.skipSetActiveGroup,
+            })
+        );
     }
 
     private _doRemovePanel(
@@ -3338,8 +3342,6 @@ export class DockviewComponent
             removeEmptyGroup: boolean;
             skipDispose?: boolean;
             skipSetActiveGroup?: boolean;
-        } = {
-            removeEmptyGroup: true,
         }
     ): void {
         const group = panel.group;

--- a/packages/dockview-core/src/theme/_space-mixin.scss
+++ b/packages/dockview-core/src/theme/_space-mixin.scss
@@ -27,7 +27,7 @@
     // dimensions don't overflow the content box and trigger scrollbars.
     // .dv-dockview already has no padding, so this is a defensive zero that
     // guarantees the inner element never picks up the spaced inset.
-    & .dv-dockview {
+    .dv-dockview {
         padding: 0;
     }
 


### PR DESCRIPTION
## Description

Follow-up to #1395. Two **MEDIUM reliability** issues on new code were holding `new_reliability_rating` at **C** on `master` (the quality gate's only failing condition; maintainability was already A). This clears both so the rating returns to **A**.

- **`css:S8776`** — `_space-mixin.scss:30` *"Missing scoping root"*: the explicit `&` had no style-rule parent to resolve against inside `@mixin dockview-design-space-mixin`, and it was the only selector in the mixin using `&`. Dropped it — a bare nested `.dv-dockview` compiles to the **identical** descendant selector and matches the sibling selectors. Verified by compiling `theme.scss` before/after: the generated CSS is **byte-identical**.
- **`typescript:S7737`** — `dockviewComponent.ts` `removePanel` / `_doRemovePanel` *"Do not use an object literal as default for parameter"*: replaced the `= { removeEmptyGroup: true }` parameter default with an optional `options` and an explicit `removeEmptyGroup ?? true` applied in the body. `_doRemovePanel` (single caller) now takes required options. Behaviour is unchanged, and `removePanel`'s public signature stays compatible (options was always an internal extra).

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

No behavioural change is intended:

- The SCSS change is verified to produce byte-identical compiled CSS (compiled `theme.scss` pre/post and diffed).
- `dockview-core` typechecks clean and all 1073 tests pass (covers `removePanel`).

## Checklist

- [x] `yarn lint:fix` passes (no errors; only pre-existing warnings)
- [x] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date (n/a — no generated sources affected)
- [x] `yarn test` passes
- [ ] I have added or updated tests where applicable (n/a — behaviour-preserving)
- [ ] Breaking changes are documented (n/a — no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiZ9eADKvMUzPp7JLa6cXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiZ9eADKvMUzPp7JLa6cXy)_