### PR TITLE
refactor(core)!: rename api.moveToNext/moveToPrevious → activateNext/activatePrevious

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -223,7 +223,7 @@ The `DockviewApi` (available via the `onReady` event) provides:
 - `removeGroup(group)` — Remove a group
 - `getPanel(id)` — Get panel by ID
 - `getGroup(id)` — Get group by ID
-- `moveToNext()` / `moveToPrevious()` — Navigate between panels
+- `activateNext()` / `activatePrevious()` — Navigate between panels (formerly `moveToNext` / `moveToPrevious`, now deprecated aliases)
 - `addFloatingGroup(panel, options)` — Create a floating group
 - `addEdgeGroup(options)` — Pin a group to a layout edge
 - `createTabGroup(options)` — Create a tab group for visual organization

--- a/packages/dockview-core/src/__tests__/api/component.api.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/component.api.spec.ts
@@ -151,5 +151,39 @@ describe('component.api', () => {
                 expect(f).toHaveBeenCalledTimes(1);
             }
         });
+
+        test('activateNext / activatePrevious delegate to the component', () => {
+            const activateNext = jest.fn();
+            const activatePrevious = jest.fn();
+            const component: Partial<DockviewComponent> = {
+                activateNext,
+                activatePrevious,
+            };
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            cut.activateNext({ includePanel: true });
+            expect(activateNext).toHaveBeenCalledWith({ includePanel: true });
+
+            cut.activatePrevious();
+            expect(activatePrevious).toHaveBeenCalledTimes(1);
+        });
+
+        test('deprecated moveToNext / moveToPrevious alias activateNext / activatePrevious', () => {
+            const activateNext = jest.fn();
+            const activatePrevious = jest.fn();
+            const component: Partial<DockviewComponent> = {
+                activateNext,
+                activatePrevious,
+            };
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            cut.moveToNext({ includePanel: true });
+            expect(activateNext).toHaveBeenCalledWith({ includePanel: true });
+
+            cut.moveToPrevious({ includePanel: false });
+            expect(activatePrevious).toHaveBeenCalledWith({
+                includePanel: false,
+            });
+        });
     });
 });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -958,23 +958,23 @@ describe('dockviewComponent', () => {
         expect(dockview.activeGroup!.model.activePanel).toBe(panel3);
         expect(dockview.activeGroup!.model.indexOf(panel3!)).toBe(1);
 
-        dockview.moveToPrevious({ includePanel: true });
+        dockview.activatePrevious({ includePanel: true });
         expect(dockview.activeGroup).toBe(group2);
         expect(dockview.activeGroup!.model.activePanel).toBe(panel1);
 
-        dockview.moveToNext({ includePanel: true });
+        dockview.activateNext({ includePanel: true });
         expect(dockview.activeGroup).toBe(group2);
         expect(dockview.activeGroup!.model.activePanel).toBe(panel3);
 
-        dockview.moveToPrevious({ includePanel: false });
+        dockview.activatePrevious({ includePanel: false });
         expect(dockview.activeGroup).toBe(group1);
         expect(dockview.activeGroup!.model.activePanel).toBe(panel4);
 
-        dockview.moveToPrevious({ includePanel: true });
+        dockview.activatePrevious({ includePanel: true });
         expect(dockview.activeGroup).toBe(group1);
         expect(dockview.activeGroup!.model.activePanel).toBe(panel2);
 
-        dockview.moveToNext({ includePanel: false });
+        dockview.activateNext({ includePanel: false });
         expect(dockview.activeGroup).toBe(group2);
         expect(dockview.activeGroup!.model.activePanel).toBe(panel3);
     });

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -1122,17 +1122,39 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
     }
 
     /**
-     * Move the focus progmatically to the next panel or group.
+     * Activate the next panel or group, moving focus programmatically. Pass
+     * `{ includePanel: true }` to step through the panels of the active group
+     * before advancing to the next group.
      */
-    moveToNext(options?: MovementOptions): void {
-        this.component.moveToNext(options);
+    activateNext(options?: MovementOptions): void {
+        this.component.activateNext(options);
     }
 
     /**
-     * Move the focus progmatically to the previous panel or group.
+     * Activate the previous panel or group, moving focus programmatically. Pass
+     * `{ includePanel: true }` to step through the panels of the active group
+     * before advancing to the previous group.
+     */
+    activatePrevious(options?: MovementOptions): void {
+        this.component.activatePrevious(options);
+    }
+
+    /**
+     * @deprecated Use {@link DockviewApi.activateNext} instead. Renamed because
+     * this advances the active panel/group (focus), it does not relocate a
+     * panel. Removal planned for a future major release.
+     */
+    moveToNext(options?: MovementOptions): void {
+        this.activateNext(options);
+    }
+
+    /**
+     * @deprecated Use {@link DockviewApi.activatePrevious} instead. Renamed
+     * because this advances the active panel/group (focus), it does not
+     * relocate a panel. Removal planned for a future major release.
      */
     moveToPrevious(options?: MovementOptions): void {
-        this.component.moveToPrevious(options);
+        this.activatePrevious(options);
     }
 
     maximizeGroup(panel: IDockviewPanel): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -425,8 +425,8 @@ export interface IDockviewComponent extends IBaseGrid<DockviewGroupPanel> {
         direction: GroupNavigationDirection
     ): DockviewGroupPanel | undefined;
     // events
-    moveToNext(options?: MovementOptions): void;
-    moveToPrevious(options?: MovementOptions): void;
+    activateNext(options?: MovementOptions): void;
+    activatePrevious(options?: MovementOptions): void;
     setActivePanel(panel: IDockviewPanel): void;
     focus(): void;
     toJSON(): SerializedDockview;
@@ -3006,7 +3006,7 @@ export class DockviewComponent
         this.doSetGroupAndPanelActive(panel.group);
     }
 
-    moveToNext(options: MovementOptions = {}): void {
+    activateNext(options: MovementOptions = {}): void {
         if (!options.group) {
             if (!this.activeGroup) {
                 return;
@@ -3029,7 +3029,7 @@ export class DockviewComponent
         this.doSetGroupAndPanelActive(next);
     }
 
-    moveToPrevious(options: MovementOptions = {}): void {
+    activatePrevious(options: MovementOptions = {}): void {
         if (!options.group) {
             if (!this.activeGroup) {
                 return;

--- a/packages/dockview-core/src/gridview/baseComponentGridview.ts
+++ b/packages/dockview-core/src/gridview/baseComponentGridview.ts
@@ -337,7 +337,7 @@ export abstract class BaseGrid<T extends IGridPanelView>
         this.doRemoveGroup(group);
     }
 
-    public moveToNext(options?: MovementOptions2): void {
+    public activateNext(options?: MovementOptions2): void {
         options ??= {};
         if (!options.group) {
             if (!this.activeGroup) {
@@ -351,7 +351,7 @@ export abstract class BaseGrid<T extends IGridPanelView>
         this.doSetGroupActive(next as T);
     }
 
-    public moveToPrevious(options?: MovementOptions2): void {
+    public activatePrevious(options?: MovementOptions2): void {
         options ??= {};
         if (!options.group) {
             if (!this.activeGroup) {

--- a/packages/docs/docs/advanced/focus-navigation.mdx
+++ b/packages/docs/docs/advanced/focus-navigation.mdx
@@ -12,15 +12,22 @@ enterprise feature covered in [Keyboard Navigation](/docs/advanced/keyboard).
 
 ## Programmatic focus navigation
 
-The two core methods are `moveToNext` and `moveToPrevious`:
+The two core methods are `activateNext` and `activatePrevious`:
 
 ```ts
 // Move focus to the next panel or group
-api.moveToNext({ includePanel: true });
+api.activateNext({ includePanel: true });
 
 // Move focus to the previous panel or group
-api.moveToPrevious({ includePanel: true });
+api.activatePrevious({ includePanel: true });
 ```
+
+:::info Renamed in v8
+These methods were previously called `moveToNext` / `moveToPrevious`. The old
+names still work as deprecated aliases but will be removed in a future major
+release — the new names make it clear they advance the active panel/group
+(focus) rather than relocating a panel.
+:::
 
 Both accept an optional `options` object:
 
@@ -31,15 +38,15 @@ Both accept an optional `options` object:
 
 ```ts
 // Cycle only through groups (not individual panels within them)
-api.moveToNext();
+api.activateNext();
 
 // Cycle through all panels across all groups
-api.moveToNext({ includePanel: true });
+api.activateNext({ includePanel: true });
 ```
 
 ## Spatial navigation
 
-`moveToNext` / `moveToPrevious` cycle through groups in list order. To navigate by _visual_ direction instead, `adjacentGroupInDirection` returns the nearest grid group to the left, right, above, or below a given group (by comparing their centre points). Floating and popout groups are ignored, and it returns `undefined` when there is no group in that direction.
+`activateNext` / `activatePrevious` cycle through groups in list order. To navigate by _visual_ direction instead, `adjacentGroupInDirection` returns the nearest grid group to the left, right, above, or below a given group (by comparing their centre points). Floating and popout groups are ignored, and it returns `undefined` when there is no group in that direction.
 
 ```ts
 const left = api.adjacentGroupInDirection(api.activeGroup, 'left');

--- a/packages/docs/docs/advanced/keyboard.mdx
+++ b/packages/docs/docs/advanced/keyboard.mdx
@@ -13,7 +13,7 @@ between groups, and even docking a panel into a new position, all without a
 mouse. This page covers the built-in keymap and keyboard docking. For the
 accessibility semantics that back it (ARIA roles, screen-reader announcements,
 focus indicators), see [Accessibility](/docs/advanced/accessibility); for the
-free programmatic focus APIs (`moveToNext`, `adjacentGroupInDirection`, …), see
+programmatic focus APIs (`activateNext`, `adjacentGroupInDirection`, …), see
 [Focus Navigation](/docs/advanced/focus-navigation).
 
 ## Enabling the keymap
@@ -82,7 +82,7 @@ to match, case-insensitively — e.g. `'ctrl+]'`, `'shift+f6'`, `'ctrl+tab'`.
 | Move focus to the group in a direction          | `Ctrl+Shift+←/→/↑/↓` | `focusGroup{Left,Right,Up,Down}` |
 
 `F6` / `Shift+F6` cycle the groups in list order. `Ctrl+Shift+Arrows` jump to
-the visually adjacent group instead — the same geometry used by the free
+the visually adjacent group instead — the same geometry used by the
 [`adjacentGroupInDirection`](/docs/advanced/focus-navigation) API, so mouse and
 keyboard agree on what "the group to the left" is. Once focus lands on the tab
 strip (via `Ctrl+Shift+\` or `F6`),
@@ -118,7 +118,7 @@ within a popped-out group and the drop preview, announcements, and resulting
 focus all stay in that window.
 :::
 
-For the free programmatic focus APIs (`moveToNext`, `moveToPrevious`,
+For the programmatic focus APIs (`activateNext`, `activatePrevious`,
 `adjacentGroupInDirection`, …) that let you build your own keyboard handlers
 without the enterprise keymap, see
 [Focus Navigation](/docs/advanced/focus-navigation).

--- a/packages/docs/docs/overview/features.mdx
+++ b/packages/docs/docs/overview/features.mdx
@@ -114,7 +114,7 @@ The guiding rule: capabilities that other free layout managers already offer (fl
 | Panel lifecycle events      | Per-panel `onDidVisibilityChange`, `onDidFocusChange`, `onDidActiveChange`, `onDidDimensionsChange` | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Runtime option updates      | Change behaviour at runtime via `api.updateOptions()`                                               | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Comprehensive events        | Events for every interaction — see [Events](/docs/core/events)                                      | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| Keyboard navigation         | `moveToNext` / `moveToPrevious` to cycle through panels                                             | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| Keyboard navigation         | `activateNext` / `activatePrevious` to cycle through panels                                         | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 
 ### Accessibility
 

--- a/packages/docs/src/generated/api.output.json
+++ b/packages/docs/src/generated/api.output.json
@@ -4539,6 +4539,64 @@
                 }
             },
             {
+                "name": "activateNext",
+                "code": "(options?: MovementOptions2): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activateNext",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options?: MovementOptions2",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions2",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options?: MovementOptions2): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "activatePrevious",
+                "code": "(options?: MovementOptions2): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activatePrevious",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options?: MovementOptions2",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions2",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options?: MovementOptions2): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
                 "name": "addDisposables",
                 "code": "(args: IDisposable[]): void",
                 "kind": "method",
@@ -5030,64 +5088,6 @@
                             "value": "void"
                         },
                         "code": "(panel: BaseGrid.T): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "moveToNext",
-                "code": "(options?: MovementOptions2): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "moveToNext",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "options",
-                                "code": "options?: MovementOptions2",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "MovementOptions2",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(options?: MovementOptions2): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "moveToPrevious",
-                "code": "(options?: MovementOptions2): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "moveToPrevious",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "options",
-                                "code": "options?: MovementOptions2",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "MovementOptions2",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(options?: MovementOptions2): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -5988,7 +5988,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "redo",
-                                "target": 7355
+                                "target": 7367
                             },
                             {
                                 "kind": "text",
@@ -6013,7 +6013,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "redo",
-                            "target": 7355
+                            "target": 7367
                         },
                         {
                             "kind": "text",
@@ -6038,7 +6038,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "undo",
-                                "target": 7381
+                                "target": 7393
                             },
                             {
                                 "kind": "text",
@@ -6048,7 +6048,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "onDidChangeHistory",
-                                "target": 7168
+                                "target": 7174
                             },
                             {
                                 "kind": "text",
@@ -6073,7 +6073,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "undo",
-                            "target": 7381
+                            "target": 7393
                         },
                         {
                             "kind": "text",
@@ -6083,7 +6083,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "onDidChangeHistory",
-                            "target": 7168
+                            "target": 7174
                         },
                         {
                             "kind": "text",
@@ -6424,7 +6424,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "DockviewOrigin",
-                                "target": 12260
+                                "target": 12272
                             },
                             {
                                 "kind": "text",
@@ -6481,7 +6481,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewOrigin",
-                            "target": 12260
+                            "target": 12272
                         },
                         {
                             "kind": "text",
@@ -7279,7 +7279,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "onDidAddPopoutGroup",
-                                "target": 7166
+                                "target": 7172
                             },
                             {
                                 "kind": "text",
@@ -7312,7 +7312,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "onDidAddPopoutGroup",
-                            "target": 7166
+                            "target": 7172
                         },
                         {
                             "kind": "text",
@@ -7815,7 +7815,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "undo",
-                                "target": 7381
+                                "target": 7393
                             },
                             {
                                 "kind": "text",
@@ -7825,7 +7825,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "redo",
-                                "target": 7355
+                                "target": 7367
                             },
                             {
                                 "kind": "text",
@@ -7835,7 +7835,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "fromJSON",
-                                "target": 7296
+                                "target": 7308
                             },
                             {
                                 "kind": "text",
@@ -7867,7 +7867,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "undo",
-                            "target": 7381
+                            "target": 7393
                         },
                         {
                             "kind": "text",
@@ -7877,7 +7877,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "redo",
-                            "target": 7355
+                            "target": 7367
                         },
                         {
                             "kind": "text",
@@ -7887,7 +7887,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "fromJSON",
-                            "target": 7296
+                            "target": 7308
                         },
                         {
                             "kind": "text",
@@ -7950,7 +7950,7 @@
                                 "kind": "inline-tag",
                                 "tag": "@link",
                                 "text": "setSmartGuidesEnabled",
-                                "target": 7376
+                                "target": 7388
                             },
                             {
                                 "kind": "text",
@@ -7983,7 +7983,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "setSmartGuidesEnabled",
-                            "target": 7376
+                            "target": 7388
                         },
                         {
                             "kind": "text",
@@ -8102,6 +8102,128 @@
                         {
                             "kind": "text",
                             "text": "Width of the component."
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "activateNext",
+                "code": "(options?: MovementOptions): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activateNext",
+                        "comment": {
+                            "summary": [
+                                {
+                                    "kind": "text",
+                                    "text": "Activate the next panel or group, moving focus programmatically. Pass\n"
+                                },
+                                {
+                                    "kind": "code",
+                                    "text": "`{ includePanel: true }`"
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": " to step through the panels of the active group\nbefore advancing to the next group."
+                                }
+                            ]
+                        },
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options?: MovementOptions",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options?: MovementOptions): void",
+                        "kind": "callSignature"
+                    }
+                ],
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Activate the next panel or group, moving focus programmatically. Pass\n"
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`{ includePanel: true }`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " to step through the panels of the active group\nbefore advancing to the next group."
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "activatePrevious",
+                "code": "(options?: MovementOptions): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activatePrevious",
+                        "comment": {
+                            "summary": [
+                                {
+                                    "kind": "text",
+                                    "text": "Activate the previous panel or group, moving focus programmatically. Pass\n"
+                                },
+                                {
+                                    "kind": "code",
+                                    "text": "`{ includePanel: true }`"
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": " to step through the panels of the active group\nbefore advancing to the previous group."
+                                }
+                            ]
+                        },
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options?: MovementOptions",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options?: MovementOptions): void",
+                        "kind": "callSignature"
+                    }
+                ],
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Activate the previous panel or group, moving focus programmatically. Pass\n"
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`{ includePanel: true }`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " to step through the panels of the active group\nbefore advancing to the previous group."
                         }
                     ]
                 }
@@ -9645,10 +9767,26 @@
                     {
                         "name": "moveToNext",
                         "comment": {
-                            "summary": [
+                            "summary": [],
+                            "blockTags": [
                                 {
-                                    "kind": "text",
-                                    "text": "Move the focus progmatically to the next panel or group."
+                                    "tag": "@deprecated",
+                                    "content": [
+                                        {
+                                            "kind": "text",
+                                            "text": "Use "
+                                        },
+                                        {
+                                            "kind": "inline-tag",
+                                            "tag": "@link",
+                                            "text": "DockviewApi.activateNext",
+                                            "target": 7242
+                                        },
+                                        {
+                                            "kind": "text",
+                                            "text": " instead. Renamed because\nthis advances the active panel/group (focus), it does not relocate a\npanel. Removal planned for a future major release."
+                                        }
+                                    ]
                                 }
                             ]
                         },
@@ -9674,10 +9812,26 @@
                     }
                 ],
                 "comment": {
-                    "summary": [
+                    "summary": [],
+                    "blockTags": [
                         {
-                            "kind": "text",
-                            "text": "Move the focus progmatically to the next panel or group."
+                            "tag": "@deprecated",
+                            "content": [
+                                {
+                                    "kind": "text",
+                                    "text": "Use "
+                                },
+                                {
+                                    "kind": "inline-tag",
+                                    "tag": "@link",
+                                    "text": "DockviewApi.activateNext",
+                                    "target": 7242
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": " instead. Renamed because\nthis advances the active panel/group (focus), it does not relocate a\npanel. Removal planned for a future major release."
+                                }
+                            ]
                         }
                     ]
                 }
@@ -9690,10 +9844,26 @@
                     {
                         "name": "moveToPrevious",
                         "comment": {
-                            "summary": [
+                            "summary": [],
+                            "blockTags": [
                                 {
-                                    "kind": "text",
-                                    "text": "Move the focus progmatically to the previous panel or group."
+                                    "tag": "@deprecated",
+                                    "content": [
+                                        {
+                                            "kind": "text",
+                                            "text": "Use "
+                                        },
+                                        {
+                                            "kind": "inline-tag",
+                                            "tag": "@link",
+                                            "text": "DockviewApi.activatePrevious",
+                                            "target": 7245
+                                        },
+                                        {
+                                            "kind": "text",
+                                            "text": " instead. Renamed\nbecause this advances the active panel/group (focus), it does not\nrelocate a panel. Removal planned for a future major release."
+                                        }
+                                    ]
                                 }
                             ]
                         },
@@ -9719,10 +9889,26 @@
                     }
                 ],
                 "comment": {
-                    "summary": [
+                    "summary": [],
+                    "blockTags": [
                         {
-                            "kind": "text",
-                            "text": "Move the focus progmatically to the previous panel or group."
+                            "tag": "@deprecated",
+                            "content": [
+                                {
+                                    "kind": "text",
+                                    "text": "Use "
+                                },
+                                {
+                                    "kind": "inline-tag",
+                                    "tag": "@link",
+                                    "text": "DockviewApi.activatePrevious",
+                                    "target": 7245
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": " instead. Renamed\nbecause this advances the active panel/group (focus), it does not\nrelocate a panel. Removal planned for a future major release."
+                                }
+                            ]
                         }
                     ]
                 }
@@ -9875,7 +10061,7 @@
                                     "kind": "inline-tag",
                                     "tag": "@link",
                                     "text": "undo",
-                                    "target": 7381
+                                    "target": 7393
                                 },
                                 {
                                     "kind": "text",
@@ -9903,7 +10089,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "undo",
-                            "target": 7381
+                            "target": 7393
                         },
                         {
                             "kind": "text",
@@ -12187,6 +12373,64 @@
                 }
             },
             {
+                "name": "activateNext",
+                "code": "(options: MovementOptions): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activateNext",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options: MovementOptions",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options: MovementOptions): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "activatePrevious",
+                "code": "(options: MovementOptions): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activatePrevious",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options: MovementOptions",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options: MovementOptions): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
                 "name": "addDisposables",
                 "code": "(args: IDisposable[]): void",
                 "kind": "method",
@@ -13043,7 +13287,7 @@
                                     "kind": "inline-tag",
                                     "tag": "@link",
                                     "text": "DockviewApi",
-                                    "target": 7128
+                                    "target": 7134
                                 },
                                 {
                                     "kind": "text",
@@ -13088,7 +13332,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewApi",
-                            "target": 7128
+                            "target": 7134
                         },
                         {
                             "kind": "text",
@@ -15279,64 +15523,6 @@
                 ]
             },
             {
-                "name": "moveToNext",
-                "code": "(options: MovementOptions): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "moveToNext",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "options",
-                                "code": "options: MovementOptions",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "MovementOptions",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(options: MovementOptions): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "moveToPrevious",
-                "code": "(options: MovementOptions): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "moveToPrevious",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "options",
-                                "code": "options: MovementOptions",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "MovementOptions",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(options: MovementOptions): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
                 "name": "movingLock",
                 "code": "(func: (): T): T",
                 "kind": "method",
@@ -15899,7 +16085,7 @@
             },
             {
                 "name": "removePanel",
-                "code": "(panel: IDockviewPanel, options: { removeEmptyGroup: boolean, skipDispose?: boolean, skipSetActiveGroup?: boolean }): void",
+                "code": "(panel: IDockviewPanel, options?: { removeEmptyGroup?: boolean, skipDispose?: boolean, skipSetActiveGroup?: boolean }): void",
                 "kind": "method",
                 "signature": [
                     {
@@ -15918,12 +16104,12 @@
                             },
                             {
                                 "name": "options",
-                                "code": "options: { removeEmptyGroup: boolean, skipDispose?: boolean, skipSetActiveGroup?: boolean }",
+                                "code": "options?: { removeEmptyGroup?: boolean, skipDispose?: boolean, skipSetActiveGroup?: boolean }",
                                 "type": {
                                     "type": "reflection",
                                     "value": {
                                         "name": "__type",
-                                        "code": "{ removeEmptyGroup: boolean, skipDispose?: boolean, skipSetActiveGroup?: boolean }",
+                                        "code": "{ removeEmptyGroup?: boolean, skipDispose?: boolean, skipSetActiveGroup?: boolean }",
                                         "kind": "typeLiteral",
                                         "properties": [
                                             {
@@ -15934,7 +16120,9 @@
                                                     "type": "intrinsic",
                                                     "value": "boolean"
                                                 },
-                                                "flags": {}
+                                                "flags": {
+                                                    "isOptional": true
+                                                }
                                             },
                                             {
                                                 "name": "skipDispose",
@@ -15970,7 +16158,7 @@
                             "type": "intrinsic",
                             "value": "void"
                         },
-                        "code": "(panel: IDockviewPanel, options: { removeEmptyGroup: boolean, skipDispose?: boolean, skipSetActiveGroup?: boolean }): void",
+                        "code": "(panel: IDockviewPanel, options?: { removeEmptyGroup?: boolean, skipDispose?: boolean, skipSetActiveGroup?: boolean }): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -25908,6 +26096,64 @@
                 }
             },
             {
+                "name": "activateNext",
+                "code": "(options?: MovementOptions2): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activateNext",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options?: MovementOptions2",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions2",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options?: MovementOptions2): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "activatePrevious",
+                "code": "(options?: MovementOptions2): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activatePrevious",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options?: MovementOptions2",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions2",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options?: MovementOptions2): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
                 "name": "addDisposables",
                 "code": "(args: IDisposable[]): void",
                 "kind": "method",
@@ -26587,64 +26833,6 @@
                             "value": "void"
                         },
                         "code": "(panel: GridviewPanel, options: { direction: Direction, reference: string, size?: number }): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "moveToNext",
-                "code": "(options?: MovementOptions2): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "moveToNext",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "options",
-                                "code": "options?: MovementOptions2",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "MovementOptions2",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(options?: MovementOptions2): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "moveToPrevious",
-                "code": "(options?: MovementOptions2): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "moveToPrevious",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "options",
-                                "code": "options?: MovementOptions2",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "MovementOptions2",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(options?: MovementOptions2): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -36781,7 +36969,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "focusOut",
-                            "target": 9870
+                            "target": 9882
                         },
                         {
                             "kind": "text",
@@ -36799,7 +36987,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "elements",
-                            "target": 9866
+                            "target": 9878
                         },
                         {
                             "kind": "text",
@@ -36866,7 +37054,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DismissableLayerOptions.elements",
-                            "target": 9866
+                            "target": 9878
                         },
                         {
                             "kind": "text",
@@ -38047,7 +38235,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewOrigin",
-                            "target": 12260
+                            "target": 12272
                         },
                         {
                             "kind": "text",
@@ -39867,7 +40055,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "AnnouncementEvent",
-                            "target": 9795
+                            "target": 9807
                         },
                         {
                             "kind": "text",
@@ -40371,7 +40559,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DroptargetOverlayModel",
-                            "target": 12266
+                            "target": 12278
                         },
                         {
                             "kind": "text",
@@ -40434,7 +40622,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "Position",
-                            "target": 12308
+                            "target": 12320
                         },
                         {
                             "kind": "text",
@@ -40452,7 +40640,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewApi.updateOptions",
-                            "target": 7383
+                            "target": 7395
                         },
                         {
                             "kind": "text",
@@ -41141,7 +41329,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewMessages",
-                            "target": 10041
+                            "target": 10053
                         },
                         {
                             "kind": "text",
@@ -43915,7 +44103,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewOptions.smartGuides",
-                            "target": 10166
+                            "target": 10178
                         },
                         {
                             "kind": "text",
@@ -43962,7 +44150,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewOptions.floatingGroupDragHandle",
-                            "target": 10141
+                            "target": 10153
                         },
                         {
                             "kind": "text",
@@ -49530,6 +49718,64 @@
                 }
             },
             {
+                "name": "activateNext",
+                "code": "(options?: MovementOptions): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activateNext",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options?: MovementOptions",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options?: MovementOptions): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
+                "name": "activatePrevious",
+                "code": "(options?: MovementOptions): void",
+                "kind": "method",
+                "signature": [
+                    {
+                        "name": "activatePrevious",
+                        "typeParameters": [],
+                        "parameters": [
+                            {
+                                "name": "options",
+                                "code": "options?: MovementOptions",
+                                "type": {
+                                    "type": "reference",
+                                    "value": "MovementOptions",
+                                    "source": "dockview-core"
+                                },
+                                "kind": "parameter"
+                            }
+                        ],
+                        "returnType": {
+                            "type": "intrinsic",
+                            "value": "void"
+                        },
+                        "code": "(options?: MovementOptions): void",
+                        "kind": "callSignature"
+                    }
+                ]
+            },
+            {
                 "name": "addEdgeGroup",
                 "code": "(position: EdgeGroupPosition, options: EdgeGroupOptions): DockviewGroupPanelApi",
                 "kind": "method",
@@ -50442,64 +50688,6 @@
                             "value": "void"
                         },
                         "code": "(options: MoveGroupOrPanelOptions): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "moveToNext",
-                "code": "(options?: MovementOptions): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "moveToNext",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "options",
-                                "code": "options?: MovementOptions",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "MovementOptions",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(options?: MovementOptions): void",
-                        "kind": "callSignature"
-                    }
-                ]
-            },
-            {
-                "name": "moveToPrevious",
-                "code": "(options?: MovementOptions): void",
-                "kind": "method",
-                "signature": [
-                    {
-                        "name": "moveToPrevious",
-                        "typeParameters": [],
-                        "parameters": [
-                            {
-                                "name": "options",
-                                "code": "options?: MovementOptions",
-                                "type": {
-                                    "type": "reference",
-                                    "value": "MovementOptions",
-                                    "source": "dockview-core"
-                                },
-                                "kind": "parameter"
-                            }
-                        ],
-                        "returnType": {
-                            "type": "intrinsic",
-                            "value": "void"
-                        },
-                        "code": "(options?: MovementOptions): void",
                         "kind": "callSignature"
                     }
                 ]
@@ -61491,7 +61679,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "DockviewKeybindings",
-                            "target": 10029
+                            "target": 10041
                         },
                         {
                             "kind": "text",
@@ -63112,7 +63300,7 @@
                             "kind": "inline-tag",
                             "tag": "@link",
                             "text": "PositionResolver",
-                            "target": 11968
+                            "target": 11980
                         },
                         {
                             "kind": "text",
@@ -68478,7 +68666,7 @@
                     "kind": "inline-tag",
                     "tag": "@link",
                     "text": "DockviewApi",
-                    "target": 7128
+                    "target": 7134
                 },
                 {
                     "kind": "text",


### PR DESCRIPTION
## What

Renames the public focus-navigation API on `DockviewApi`:

- **New:** `activateNext(options?)` / `activatePrevious(options?)`
- **Deprecated aliases:** `moveToNext` / `moveToPrevious` still work (delegate to the new methods), with `@deprecated` JSDoc and removal planned for a future major.

## Why

These methods advance the *active* panel/group (move focus) — they do not relocate a panel. The old names misread as panel-moving, which is now actively confusing because keyboard docking offers a real "move panel" action. The new names align with the existing `activeGroup` / `activePanel` vocabulary.

## Scope

- `DockviewApi`, `DockviewComponent` (interface + impl), and `BaseGrid` renamed.
- **Unchanged:** the group-model `moveToNext`/`moveToPrevious` (active-panel cycling *within* a group, powering keyboard tab-switching) — a different concept, left as-is.
- Docs updated: `focus-navigation.mdx` (+ "Renamed in v8" note), `keyboard.mdx`, `features.mdx`, `llms-full.txt`; regenerated `api.output.json`. Also tidied some awkward "free \<noun\>" wording.

## Verification

- Full `dockview-core` suite: **1128/1128 passing** (incl. new delegation + deprecated-alias guard tests).
- Typecheck clean; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)