### PR TITLE
fix(drop-guide): snap to nearest cell in compass gaps to stop overlay flicker

### DIFF
--- a/packages/dockview-enterprise/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/dropGuide.spec.ts
@@ -115,6 +115,36 @@ describe('drop guide', () => {
         expect(service.resolver!.resolve(args(10, 10))).toBeNull();
     });
 
+    test('fills the gaps between cells so the overlay does not blink out mid-traverse', () => {
+        make(true);
+        const r = service.resolver!;
+        // 200x100: the top cell ends at y=27 and the centre starts at y=31 — a
+        // 4px gap that used to resolve to null (the overlay would disappear). A
+        // pointer in the gap now snaps to whichever cell is nearer, so the
+        // overlay stays on as the cursor crosses between cells.
+        expect(r.resolve(args(100, 28))).toEqual({
+            position: 'top',
+            edge: false,
+        });
+        expect(r.resolve(args(100, 30))).toEqual({
+            position: 'center',
+            edge: false,
+        });
+        // the horizontal gap between left (ends x=77) and centre (starts x=81)
+        expect(r.resolve(args(78, 50))).toEqual({
+            position: 'left',
+            edge: false,
+        });
+        // a corner (off both axes) is still a genuine dead zone
+        expect(r.resolve(args(10, 10))).toBeNull();
+    });
+
+    test('does not snap a pointer more than a gap beyond the outermost cell', () => {
+        make({ edges: false });
+        // the right cell ends at x=161; a pointer well past it stays null
+        expect(service.resolver!.resolve(args(180, 50))).toBeNull();
+    });
+
     test("honours the target's accepted zones", () => {
         make(true);
         // left cell is not offered when the target only accepts center

--- a/packages/dockview-enterprise/src/dropGuideService.ts
+++ b/packages/dockview-enterprise/src/dropGuideService.ts
@@ -137,6 +137,8 @@ class CompassResolver implements PositionResolver {
             zones,
             this.edgesEnabled()
         );
+
+        // Exact hit — the fast path.
         for (const cell of cells) {
             if (
                 args.x >= cell.left &&
@@ -147,7 +149,47 @@ class CompassResolver implements PositionResolver {
                 return { position: cell.position, edge: cell.edge };
             }
         }
-        return null;
+
+        // Gap-fill. The cells form a plus/cross — a vertical column (all share
+        // the central cell's x) and a horizontal row (all share its y) —
+        // separated by a GAP-wide space. Exact hit-testing returns null in those
+        // gaps, so the drop overlay blinks out as the cursor crosses from one
+        // cell to its neighbour. Snap a pointer sitting in an on-axis gap to its
+        // nearest collinear cell (within one GAP) so the overlay stays put. A
+        // pointer off both axes (a corner) is a genuine dead zone → null.
+        const half = CELL / 2;
+        const cx = args.width / 2 - half; // the central cell's left
+        const cy = args.height / 2 - half; // the central cell's top
+        const inColumn = args.x >= cx && args.x <= cx + CELL;
+        const inRow = args.y >= cy && args.y <= cy + CELL;
+
+        let best: CompassCell | undefined;
+        let bestDist = Infinity;
+        for (const cell of cells) {
+            let dist: number;
+            if (inColumn && cell.left === cx) {
+                // a vertical neighbour — gap distance along y
+                dist = Math.max(
+                    cell.top - args.y,
+                    args.y - (cell.top + cell.size),
+                    0
+                );
+            } else if (inRow && cell.top === cy) {
+                // a horizontal neighbour — gap distance along x
+                dist = Math.max(
+                    cell.left - args.x,
+                    args.x - (cell.left + cell.size),
+                    0
+                );
+            } else {
+                continue;
+            }
+            if (dist <= GAP && dist < bestDist) {
+                bestDist = dist;
+                best = cell;
+            }
+        }
+        return best ? { position: best.position, edge: best.edge } : null;
     }
 }
 


### PR DESCRIPTION
## Problem

The drop-guide compass paints a plus/cross of fixed-size cells with a small gap between collinear cells. The drop overlay is driven by what `CompassResolver.resolve()` returns, and exact hit-testing returned `null` in those inter-cell gaps. So as the cursor crossed from one cell to its neighbour (e.g. centre → an arm), the resolver returned `null` for a frame and the translucent overlay **blinked out**, producing a janky flicker.

## Fix

After the exact-hit fast path, `resolve()` now **snaps a pointer sitting in an on-axis gap to its nearest collinear cell** (within one gap width). The cells form a vertical column and a horizontal row; a pointer in the column's x-band or the row's y-band snaps to the nearest cell along that axis. A pointer off both axes (a genuine corner dead zone) still returns `null`, so intentional dead zones are preserved.

Because `_clearFeedbackIfOffCells` calls the same resolver, the aimed-cell highlight stops clearing in the gaps too — overlay and highlight stay in lockstep automatically. This matches how VS/Qt dock guides behave: no dead band between adjacent aim targets.

## Tests

- Added coverage: a pointer in the gap between two cells now snaps to the nearer cell (previously `null`); a corner still resolves to `null`; a pointer more than a gap beyond the outermost cell still resolves to `null`.
- Full suite green (277/277), typecheck + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)