### PR TITLE
docs(v8): update What's new + migration for edge docking and method rename

### DIFF
--- a/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
+++ b/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
@@ -1,13 +1,14 @@
 ---
 title: Migrating to v8
 sidebar_position: 1
-description: How to upgrade from Dockview v7 to v8 — an additive release with a single behavioural change to reported panel dimensions.
+description: How to upgrade from Dockview v7 to v8 — an additive release with one behavioural change to reported panel dimensions and one deprecating method rename.
 ---
 
 **v8 is additive.** Every new feature ships as an opt-in `DockviewOptions` field
 that is off by default, so most projects upgrade with no code changes. There are
-no package renames, no removed options, and no renamed public exports. The one
-thing to check is a behavioural change to the dimensions reported to panels.
+no package renames and no removed options. Two things are worth checking: a
+behavioural change to the dimensions reported to panels, and a method rename that
+keeps the old names as deprecated aliases (so nothing breaks today).
 
 ## Behavioural change — reported panel dimensions
 
@@ -34,6 +35,31 @@ themselves from the reported dimensions, such as **canvas**, **virtualised**, or
 is no longer double-counted); adjust any code that compensated for the header.
 :::
 
+## Renamed methods — `moveToNext` / `moveToPrevious` {#renamed-methods}
+
+`api.moveToNext` and `api.moveToPrevious` are renamed to
+[`api.activateNext` / `api.activatePrevious`](/docs/advanced/focus-navigation).
+They advance the **active** panel/group (they move focus); they never relocate a
+panel, and the old names misread as panel-moving — especially now that keyboard
+docking offers a genuine "move panel" action.
+
+```diff
+- api.moveToNext({ includePanel: true });
++ api.activateNext({ includePanel: true });
+
+- api.moveToPrevious({ includePanel: true });
++ api.activatePrevious({ includePanel: true });
+```
+
+:::info Nothing breaks today
+The old names remain as **deprecated aliases** that delegate to the new ones, so
+existing code keeps working. Removal is planned for a future major release —
+rename at your convenience.
+:::
+
+The group-model `moveToNext` / `moveToPrevious` (active-panel cycling _within_ a
+single group) are a different concept and are unchanged.
+
 ## No other breaking changes
 
 For clarity, none of the following changed in v8:
@@ -44,7 +70,9 @@ For clarity, none of the following changed in v8:
   applies if you are coming from v6.
 - **No removed or renamed options.** Every v7 `DockviewOptions` field keeps its
   name and meaning.
-- **No removed or renamed public exports.** The v8 surface only _adds_ exports.
+- **No removed public exports.** The v8 surface only _adds_ exports. The single
+  method rename above ([`moveToNext` / `moveToPrevious`](#renamed-methods))
+  keeps the old names as deprecated aliases, so nothing is removed yet.
 
 ## New opt-in options
 
@@ -60,6 +88,12 @@ They are off by default; set the ones you want:
 | `smartGuides`          | [Smart guides — floating-group snapping](/docs/core/dnd/smartGuides)   |
 | `layoutHistory`        | [Layout history (undo/redo)](/docs/core/state/history)                 |
 | `autoHideEdgeGroups`   | [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups)          |
+| `dockToEdgeGroups`     | [Dock to edge groups — drag-revealed edges](/docs/core/groups/autoEdgeGroups) |
+| `edgeGroupPeek`        | Peek animation tuning for [auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) |
+
+`autoHideEdgeGroups` and `dockToEdgeGroups` accept an `EdgeGroupSet` — pass
+`true` to enable all four edges, or an object such as `{ left: true, right: true }`
+to opt edges in individually.
 
 The tab context menu also gains a `'pin'` built-in item for toggling a panel's
 pinned state; it is a no-op when pinning is not enabled.

--- a/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
@@ -18,8 +18,8 @@ This page covers the headline additions. For the upgrade notes and the single
 v8 introduces `dockview-enterprise`, a separately-licensed package for the
 features marked **Enterprise** in [Features](/docs/overview/features) — pinned
 tabs, multi-row tabs, the drop guide compass, smart guides, layout history,
-auto-hide edge groups, and keyboard docking. The free, open-source `dockview`
-packages are unchanged.
+auto-hide edge groups, dock-to-edge groups, and keyboard docking. The free,
+open-source `dockview` packages are unchanged.
 :::
 
 ## Highlights
@@ -73,8 +73,23 @@ windows. See [Layout history](/docs/core/state/history).
 Groups docked against an edge of the layout can now collapse to a strip and peek
 back into view on demand, VS Code tool-window style. Enable it with the new
 [`autoHideEdgeGroups`](/docs/core/groups/autoHideEdgeGroups) option; clicking a collapsed
-tab peeks the group, and you can pin it back to a docked group or dismiss it. See
+tab peeks the group, and you can pin it back to a docked group or dismiss it.
+Auto-hide is resolved **per edge** (and can be toggled per group via
+`addEdgeGroup({ autoHide })` / `api.setAutoHide`), so a static and an auto-hiding
+edge group can co-exist; peek animation is tuned globally through the new
+`edgeGroupPeek` option. See
 [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups).
+
+### Dock to edge groups
+
+The new [`dockToEdgeGroups`](/docs/core/groups/autoEdgeGroups) option makes an edge
+behave like a VS Code sidebar: an edge with no content takes up **zero space**, a
+drop zone for it appears only **while dragging**, and dropping a panel on the far
+edge **docks an edge group** there. A newly revealed edge is created collapsed,
+and when its last panel leaves it tears down to zero footprint again. It composes
+with the drop guide compass (outer ring docks to the grid edge; the true outer band
+docks an edge group) and with auto-hide, and can be driven programmatically via
+`api.revealEdgeGroupWithData`. See [Dock to edge groups](/docs/core/groups/autoEdgeGroups).
 
 ### Keyboard docking across popout windows & refreshed a11y
 
@@ -88,10 +103,16 @@ and [Accessibility](/docs/advanced/accessibility).
 ## Breaking changes
 
 v8 is additive — every new feature above is opt-in and off by default. There is
-a single behavioural change to be aware of, covered in full in
-[Migrating to v8](/docs/releases/migrating/migrating-to-v8):
+one behavioural change and one method rename to be aware of, both covered in full
+in [Migrating to v8](/docs/releases/migrating/migrating-to-v8):
 
 - **Reported panel dimensions** — `onDidDimensionsChange` (and the height passed
   to renderers) now report the **content area** (the group box minus the header)
   instead of the header-inclusive group box. CSS-fill renderers are unaffected;
   only consumers that read the numeric dimensions need to check this.
+- **`api.moveToNext` / `api.moveToPrevious` renamed** to
+  [`activateNext` / `activatePrevious`](/docs/advanced/focus-navigation) — the
+  new names make clear they advance the active panel/group (focus) rather than
+  relocating a panel. The old names still work as **deprecated aliases**, so no
+  code breaks today; update at your convenience before they are removed in a
+  future major.


### PR DESCRIPTION
## Description

Brings the v8 **What's new** and **Migration** guides in line with changes that landed on `v8-branch` after the guides were first written (at `68b868bca`). No product code changes — documentation only.

- **Dock to edge groups** (`dockToEdgeGroups`) — drag-revealed, zero-footprint edge groups (#1409, #1412). Added a "What's new" highlight and listed the option, plus the new `edgeGroupPeek` peek-animation tuning, in the migration "New opt-in options" table.
- **Auto-hide edge groups** — now resolved **per edge / per group** (`EdgeGroupSet`), so a static and an auto-hiding edge group can co-exist. Refreshed that section and noted the `true | { left: true, right: true }` shape.
- **`api.moveToNext` / `api.moveToPrevious` → `activateNext` / `activatePrevious`** (#1404) — documented in the What's new breaking-changes list and in a dedicated migration section. Framed accurately as a soft rename: the old names remain as `@deprecated` aliases, so nothing breaks today.
- Refreshed the `dockview-enterprise` feature list to include dock-to-edge groups.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

- Review the rendered copy of `docs/releases/whats-new/whats-new-v8.mdx` and `docs/releases/migrating/migrating-to-v8.mdx`.
- All internal links added/touched resolve to existing doc files (`autoEdgeGroups`, `autoHideEdgeGroups`, `advanced/focus-navigation`, `core/state/history`, `overview/features`). The renamed-methods migration anchor uses an explicit `{#renamed-methods}` id to avoid em-dash slug ambiguity.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [x] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQnAEBkQeei6wa81zwbHDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQnAEBkQeei6wa81zwbHDR)_