### PR TITLE
refactor(modules): move TabGroupChipsModule to dockview-core (free tier)

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -286,6 +286,8 @@ SplitviewPanelApi
 Tab
 TabAnimation
 TabDragEvent
+TabGroupChipsModule
+TabGroupChipsService
 TabGroupColorPalette
 TabGroupOptions
 TabPartInitParameters

--- a/packages/dockview-core/src/__tests__/dockview/tabGroupChips.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/tabGroupChips.spec.ts
@@ -1,8 +1,6 @@
-import {
-    DockviewComponent,
-    IContentRenderer,
-    DockviewCompositeDisposable as CompositeDisposable,
-} from 'dockview-core';
+import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { IContentRenderer } from '../../dockview/types';
+import { CompositeDisposable } from '../../lifecycle';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');

--- a/packages/dockview-core/src/dockview/allModules.ts
+++ b/packages/dockview-core/src/dockview/allModules.ts
@@ -7,6 +7,7 @@ import { RootDropTargetModule } from './rootDropTargetService';
 import { HeaderActionsModule } from './headerActionsService';
 import { LiveRegionModule } from './liveRegionService';
 import { AdvancedDnDModule } from './advancedDnDService';
+import { TabGroupChipsModule } from './tabGroupChipsService';
 
 /**
  * Internal list of the built-in modules that ship with the core. Registered
@@ -23,4 +24,5 @@ export const AllModules: DockviewModule<any>[] = [
     HeaderActionsModule,
     LiveRegionModule,
     AdvancedDnDModule,
+    TabGroupChipsModule,
 ];

--- a/packages/dockview-core/src/dockview/tabGroupChipsService.ts
+++ b/packages/dockview-core/src/dockview/tabGroupChipsService.ts
@@ -1,10 +1,7 @@
-import {
-    DockviewCompositeDisposable as CompositeDisposable,
-    DockviewIDisposable as IDisposable,
-} from 'dockview';
-import { DockviewGroupPanel } from 'dockview';
-import { defineModule } from 'dockview';
-import { ITabGroupChipsHost, ITabGroupChipsService } from 'dockview';
+import { CompositeDisposable, IDisposable } from '../lifecycle';
+import { DockviewGroupPanel } from './dockviewGroupPanel';
+import { defineModule } from './modules';
+import { ITabGroupChipsHost, ITabGroupChipsService } from './moduleContracts';
 
 export class TabGroupChipsService implements ITabGroupChipsService {
     private readonly _host: ITabGroupChipsHost;

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -241,6 +241,10 @@ export {
     AdvancedDnDModule,
     AdvancedDnDService,
 } from './dockview/advancedDnDService';
+export {
+    TabGroupChipsModule,
+    TabGroupChipsService,
+} from './dockview/tabGroupChipsService';
 export { FloatingGroupModule } from './dockview/floatingGroupService';
 export { EdgeGroupModule } from './dockview/edgeGroupService';
 export { createCloseButton, createPinButton } from './svg';

--- a/packages/dockview-enterprise/src/index.ts
+++ b/packages/dockview-enterprise/src/index.ts
@@ -1,5 +1,4 @@
 import { DockviewModule, registerModules } from 'dockview';
-import { TabGroupChipsModule } from './tabGroupChipsService';
 import { ContextMenuModule } from './contextMenu';
 import { KeyboardNavigationModule } from './keyboardNavigationService';
 import { LayoutHistoryModule } from './layoutHistoryService';
@@ -17,10 +16,9 @@ import { LicenseModule } from './licenseService';
 // (e.g. markDockviewPackageLoaded) via the re-exported module.
 export * from 'dockview';
 
-export {
-    TabGroupChipsService,
-    TabGroupChipsModule,
-} from './tabGroupChipsService';
+// TabGroupChipsModule / TabGroupChipsService are now FREE and live in
+// dockview-core; they remain re-exported here via `export * from 'dockview'`
+// above so `dockview-enterprise` stays a drop-in superset.
 export { ContextMenuController, ContextMenuModule } from './contextMenu';
 export {
     KeyboardNavigationService,
@@ -66,7 +64,6 @@ export type { LicenseState } from './licenseValidator';
  * for every component in the process.
  */
 export const Modules: DockviewModule<any>[] = [
-    TabGroupChipsModule,
     ContextMenuModule,
     KeyboardNavigationModule,
     LayoutHistoryModule,


### PR DESCRIPTION
## What

Reclassifies `TabGroupChipsModule` from **pro** (`dockview-enterprise`) to **free** (`dockview-core`). The group-tab chip strip is table-stakes multi-group navigation — gating it behind the licence watermark reads as hostile rather than an upsell.

## Changes

- Add `tabGroupChipsService.ts` to `dockview-core` and register it in `allModules.ts`, so it auto-registers (and fires the tab-group lifecycle events) for every component with no enterprise package required.
- Export `TabGroupChipsModule` / `TabGroupChipsService` from `dockview-core`.
- Drop it from `dockview-enterprise`'s `Modules` array and explicit re-export. It stays in the enterprise public surface via `export * from 'dockview'`, so `dockview-enterprise` remains a drop-in superset.
- Move the tab-group events spec into `dockview-core`.

## Notes

- `ContextMenuModule` stays enterprise — the built-in menu builder is the paid value. Free users needing a tab context menu use a custom tab renderer (they own that DOM and can attach their own `contextmenu` listener).
- Behavioural change for `dockview-core`-only consumers: tab-group lifecycle events now fire by default (previously required the modules package). Additive.

## Tests

core 1150 / enterprise 283 green; both packages build clean. Core removability spec now covers the module automatically (it iterates `AllModules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)