### PR TITLE
test(e2e): expand cross-window / real-browser coverage + fix popout-restore content bug

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -353,6 +353,10 @@
                         a.api.maximize();
                         return a.group.id;
                     },
+                    // Lock/unlock a panel's group (boolean or
+                    // 'no-drop-target') for locked-group DnD tests.
+                    setGroupLocked: (id, value) =>
+                        panels[id] && (panels[id].group.api.locked = value),
                     // A docked `main` panel plus a `floater` pulled out into a
                     // floating group at a fixed box — for floating-group
                     // lifecycle + serialization tests.

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -326,6 +326,27 @@
                         return { groupId, tabGroupId: tabGroup.id };
                     },
                     floatingCount: () => dockview.floatingGroups.length,
+                    // A docked `main` panel plus a `floater` pulled out into a
+                    // floating group at a fixed box — for floating-group
+                    // lifecycle + serialization tests.
+                    setupFloating: () => {
+                        dockview.addPanel({
+                            id: 'main',
+                            component: 'default',
+                            title: 'main',
+                        });
+                        const floater = dockview.addPanel({
+                            id: 'floater',
+                            component: 'default',
+                            title: 'floater',
+                        });
+                        dockview.addFloatingGroup(floater, {
+                            x: 150,
+                            y: 100,
+                            width: 240,
+                            height: 180,
+                        });
+                    },
                     peekEdge: (position, on) =>
                         dockview.api.peekEdgeGroup(position, on),
                     // Two floating groups for Smart Guides: a target float on

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -326,6 +326,33 @@
                         return { groupId, tabGroupId: tabGroup.id };
                     },
                     floatingCount: () => dockview.floatingGroups.length,
+                    // Reload-safe maximize queries: read the live component, not
+                    // the `panels` map (which is empty after a restore into a
+                    // freshly-loaded fixture).
+                    hasMaximizedGroup: () => dockview.hasMaximizedGroup(),
+                    maximizedGroupId: () => {
+                        const g = dockview.groups.find((g) =>
+                            g.api.isMaximized()
+                        );
+                        return g ? g.id : null;
+                    },
+                    // Two groups side by side; returns their ids. Like
+                    // setupTwoGroups but named for the maximize round-trip.
+                    setupTwoGroupsMaximizeFirst: () => {
+                        const a = dockview.addPanel({
+                            id: 'a',
+                            component: 'default',
+                            title: 'a',
+                        });
+                        dockview.addPanel({
+                            id: 'b',
+                            component: 'default',
+                            title: 'b',
+                            position: { direction: 'right' },
+                        });
+                        a.api.maximize();
+                        return a.group.id;
+                    },
                     // A docked `main` panel plus a `floater` pulled out into a
                     // floating group at a fixed box — for floating-group
                     // lifecycle + serialization tests.

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -357,6 +357,11 @@
                     // 'no-drop-target') for locked-group DnD tests.
                     setGroupLocked: (id, value) =>
                         panels[id] && (panels[id].group.api.locked = value),
+                    // Apply size constraints to a panel's group (e.g.
+                    // { maximumWidth } / { minimumWidth }) for sash-resize tests.
+                    setGroupConstraints: (id, constraints) =>
+                        panels[id] &&
+                        panels[id].group.api.setConstraints(constraints),
                     // A docked `main` panel plus a `floater` pulled out into a
                     // floating group at a fixed box — for floating-group
                     // lifecycle + serialization tests.

--- a/e2e/tests/dnd-docking.spec.ts
+++ b/e2e/tests/dnd-docking.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Pointer drag-and-drop docking (dndStrategy: 'pointer'). Real-browser only:
+ * the pointer backend attaches move/up listeners and computes drop zones from
+ * live element geometry, which jsdom's no-layout DOM can't produce.
+ *
+ * The compass (content-centre / outer-cell) drops are covered by
+ * `drop-guide.spec.ts`; these cover the tab-strip seams it doesn't: reordering
+ * within a strip, and merging by dropping onto another group's header.
+ */
+test.describe('pointer dnd docking', () => {
+    const tabTitles = (page: Page) =>
+        page.evaluate(() => (window as any).__dv.tabTitles());
+
+    const dragTab = async (
+        page: Page,
+        fromTab: string,
+        to: { x: number; y: number }
+    ) => {
+        const t = (await page
+            .locator('.dv-tab', { hasText: fromTab })
+            .boundingBox())!;
+        await page.mouse.move(t.x + t.width / 2, t.y + t.height / 2);
+        await page.mouse.down();
+        // small nudge to enter drag mode, then travel to the target
+        await page.mouse.move(t.x + t.width / 2 + 6, t.y + t.height / 2, {
+            steps: 3,
+        });
+        await page.mouse.move(to.x, to.y, { steps: 14 });
+    };
+
+    test('a tab reorders within its own strip', async ({ page }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => {
+            for (const id of ['a', 'b', 'c']) (window as any).__dv.addPanel(id);
+        });
+        expect(await tabTitles(page)).toEqual(['a', 'b', 'c']);
+
+        // Drag 'a' to the right past 'c' → it lands at the end of the strip.
+        const c = (await page
+            .locator('.dv-tab', { hasText: 'c' })
+            .boundingBox())!;
+        await dragTab(page, 'a', {
+            x: c.x + c.width - 4,
+            y: c.y + c.height / 2,
+        });
+        await page.mouse.up();
+
+        // Same three tabs, same group, 'a' now last — no compass, no new group.
+        await expect.poll(() => tabTitles(page)).toEqual(['b', 'c', 'a']);
+        expect(
+            await page.evaluate(() => (window as any).__dv.groupCount())
+        ).toBe(1);
+    });
+
+    test('dropping a tab on another group’s header merges the groups', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupTwoGroups()); // one | two
+        expect(
+            await page.evaluate(() => (window as any).__dv.groupCount())
+        ).toBe(2);
+
+        // Drop 'one' onto the second group's tab strip (not the content
+        // compass) → the two groups merge into one.
+        const strip = (await page
+            .locator('.dv-tabs-container')
+            .nth(1)
+            .boundingBox())!;
+        await dragTab(page, 'one', {
+            x: strip.x + strip.width - 6,
+            y: strip.y + strip.height / 2,
+        });
+        await page.mouse.up();
+
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
+            .toBe(1);
+        // Both panels now share the surviving group's strip.
+        await expect(page.locator('.dv-tab')).toHaveText(['two', 'one']);
+    });
+});

--- a/e2e/tests/floating-group.spec.ts
+++ b/e2e/tests/floating-group.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Floating group lifecycle — real-browser behaviour: a floating group renders
+ * as a positioned overlay (`.dv-resize-container`) stacked above the docked
+ * grid, and its geometry + content survive a serialization round-trip. The
+ * overlay positioning depends on a real measured layout, which jsdom can't
+ * produce.
+ */
+test.describe('floating groups', () => {
+    const setup = async (page: Page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupFloating());
+    };
+
+    test('a floating group renders as a positioned overlay with its content', async ({
+        page,
+    }) => {
+        await setup(page);
+
+        // Exactly one floating group, rendered as a single resize-container.
+        expect(
+            await page.evaluate(() => (window as any).__dv.floatingCount())
+        ).toBe(1);
+        const overlay = page.locator('.dv-resize-container');
+        await expect(overlay).toHaveCount(1);
+
+        // Its panel content is mounted and the docked `main` panel still shows.
+        await expect(overlay.locator('.dv-test-panel')).toContainText(
+            'floater'
+        );
+        await expect(
+            page.locator('.dv-test-panel', { hasText: 'main' })
+        ).toBeVisible();
+
+        // The overlay is offset from the container origin (a genuine float at
+        // ~150,100), not pinned to the top-left like a docked group.
+        const box = (await overlay.boundingBox())!;
+        expect(box.x).toBeGreaterThan(20);
+        expect(box.y).toBeGreaterThan(20);
+    });
+
+    test('a floating group survives a serialization round-trip', async ({
+        page,
+    }) => {
+        await setup(page);
+        const before = (await page
+            .locator('.dv-resize-container')
+            .boundingBox())!;
+
+        // Snapshot carries the floating group…
+        const json = await page.evaluate(() =>
+            JSON.stringify((window as any).__dv.snapshot())
+        );
+        expect(json).toContain('floatingGroups');
+
+        // …and a fresh component restoring it rebuilds the float with its
+        // content and geometry (unlike a popout, a float restores its content).
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(
+            (state) => (window as any).__dv.restore(JSON.parse(state)),
+            json
+        );
+
+        expect(
+            await page.evaluate(() => (window as any).__dv.floatingCount())
+        ).toBe(1);
+        const overlay = page.locator('.dv-resize-container');
+        await expect(overlay).toHaveCount(1);
+        await expect(overlay.locator('.dv-test-panel')).toContainText(
+            'floater'
+        );
+
+        // Geometry is preserved across the round-trip.
+        const after = (await overlay.boundingBox())!;
+        expect(Math.abs(after.x - before.x)).toBeLessThanOrEqual(2);
+        expect(Math.abs(after.y - before.y)).toBeLessThanOrEqual(2);
+        expect(Math.abs(after.width - before.width)).toBeLessThanOrEqual(2);
+        expect(Math.abs(after.height - before.height)).toBeLessThanOrEqual(2);
+    });
+});

--- a/e2e/tests/group-resize.spec.ts
+++ b/e2e/tests/group-resize.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Group resizing via the main-window sash, and the size constraints that bound
+ * it. Real-browser only: dragging the sash and the constraint clamp both act on
+ * measured pixel geometry, which jsdom's no-layout DOM can't produce.
+ * (popout-pointer-drag covers a sash *inside a popout*; this covers the main
+ * window and the `setConstraints` clamp — historically fragile, see #717/#869.)
+ */
+test.describe('group resize (main-window sash)', () => {
+    const setup = async (page: Page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupTwoGroups()); // one | two
+    };
+
+    const firstGroupWidth = async (page: Page) =>
+        (await page.locator('.dv-groupview').first().boundingBox())!.width;
+
+    const dragSash = async (page: Page, dx: number) => {
+        const sash = (await page.locator('.dv-sash').first().boundingBox())!;
+        const cx = sash.x + sash.width / 2;
+        const cy = sash.y + sash.height / 2;
+        await page.mouse.move(cx, cy);
+        await page.mouse.down();
+        await page.mouse.move(cx + dx, cy, { steps: 10 });
+        await page.mouse.up();
+    };
+
+    test('dragging the sash resizes the adjacent groups', async ({ page }) => {
+        await setup(page);
+        const before = await firstGroupWidth(page);
+
+        await dragSash(page, 120);
+
+        // The first group grew by ~120px (the boundary moved with the sash).
+        const after = await firstGroupWidth(page);
+        expect(after).toBeGreaterThan(before + 100);
+        expect(Math.abs(after - (before + 120))).toBeLessThan(8);
+    });
+
+    test('a maximumWidth constraint clamps the sash resize', async ({
+        page,
+    }) => {
+        await setup(page);
+        // Cap the first group at 700px, then try to drag well past it.
+        await page.evaluate(() =>
+            (window as any).__dv.setGroupConstraints('one', {
+                maximumWidth: 700,
+            })
+        );
+
+        await dragSash(page, 200); // 640 + 200 = 840 requested
+
+        // The group is clamped at its maximum, not grown to the drag distance.
+        const after = await firstGroupWidth(page);
+        expect(Math.abs(after - 700)).toBeLessThan(4);
+    });
+});

--- a/e2e/tests/locked-group.spec.ts
+++ b/e2e/tests/locked-group.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Locked groups — a group with `locked` set rejects panel drops. Real-browser
+ * only: the drop is decided from live pointer geometry over the target group,
+ * and the rejection is observable as the compass never appearing and the layout
+ * not changing.
+ */
+test.describe('locked group', () => {
+    const setup = async (page: Page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupTwoGroups()); // one | two
+    };
+
+    const dragOntoSecondGroup = async (page: Page) => {
+        const oneTab = (await page
+            .locator('.dv-tab', { hasText: 'one' })
+            .boundingBox())!;
+        const target = (await page
+            .locator('.dv-groupview')
+            .nth(1)
+            .boundingBox())!;
+        await page.mouse.move(
+            oneTab.x + oneTab.width / 2,
+            oneTab.y + oneTab.height / 2
+        );
+        await page.mouse.down();
+        await page.mouse.move(
+            oneTab.x + oneTab.width / 2 + 6,
+            oneTab.y + oneTab.height / 2,
+            { steps: 3 }
+        );
+        await page.mouse.move(
+            target.x + target.width / 2,
+            target.y + target.height / 2,
+            { steps: 12 }
+        );
+    };
+
+    const groupCount = (page: Page) =>
+        page.evaluate(() => (window as any).__dv.groupCount());
+
+    test('a locked group rejects a tab dropped onto it', async ({ page }) => {
+        await setup(page);
+        await page.evaluate(() =>
+            (window as any).__dv.setGroupLocked('two', true)
+        );
+        expect(await groupCount(page)).toBe(2);
+
+        await dragOntoSecondGroup(page);
+        // No compass appears over the locked group…
+        await expect(page.locator('.dv-drop-guide')).toHaveCount(0);
+        await page.mouse.up();
+
+        // …and the layout is unchanged (no merge).
+        await expect.poll(() => groupCount(page)).toBe(2);
+        await expect(
+            page.locator('.dv-groupview').nth(1).locator('.dv-tab')
+        ).toHaveText(['two']);
+    });
+
+    test('unlocking the group restores drops (control)', async ({ page }) => {
+        await setup(page);
+        // Lock then unlock — the same drag should now be accepted.
+        await page.evaluate(() =>
+            (window as any).__dv.setGroupLocked('two', true)
+        );
+        await page.evaluate(() =>
+            (window as any).__dv.setGroupLocked('two', false)
+        );
+
+        await dragOntoSecondGroup(page);
+        await expect(page.locator('.dv-drop-guide')).toBeVisible();
+        await page.mouse.up();
+
+        // The two groups merged into one.
+        await expect.poll(() => groupCount(page)).toBe(1);
+        await expect(page.locator('.dv-tab')).toHaveText(['two', 'one']);
+    });
+});

--- a/e2e/tests/popout-lifecycle.spec.ts
+++ b/e2e/tests/popout-lifecycle.spec.ts
@@ -76,6 +76,41 @@ test.describe('cross-window popout lifecycle', () => {
         await expect(page.locator('.dv-test-panel')).toHaveCount(0);
     });
 
+    test('closing a popout with a nested split re-docks both groups', async ({
+        page,
+        context,
+    }) => {
+        const win = await twoPanelPopout(page, context);
+        // Split a second group into the popout, so it hosts two groups.
+        await page.evaluate(() =>
+            (window as any).__dv.splitIntoPopout('delta')
+        );
+        await win.locator('.dv-sash').first().waitFor();
+        await expect(win.locator('.dv-groupview')).toHaveCount(2);
+
+        // Close the popout window → both of its groups return to the opener.
+        await win.close({ runBeforeUnload: true });
+
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__dv.popoutCount()))
+            .toBe(0);
+        // Two groups re-docked, all three tabs present, active content rendered.
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
+            .toBe(2);
+        await expect(page.locator('.dv-tab')).toHaveText([
+            'delta',
+            'alpha',
+            'beta',
+        ]);
+        await expect(
+            page.locator('.dv-test-panel', { hasText: 'delta' })
+        ).toBeVisible();
+        await expect(
+            page.locator('.dv-test-panel', { hasText: 'beta' })
+        ).toBeVisible();
+    });
+
     // Capture a snapshot that contains a live popout, then simulate an app
     // reload (fresh component with no panels) and restore that snapshot — the
     // canonical "persist layout, reload the app, restore it" flow.

--- a/e2e/tests/popout-lifecycle.spec.ts
+++ b/e2e/tests/popout-lifecycle.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, Page, BrowserContext } from '@playwright/test';
+
+/**
+ * Cross-window popout lifecycle — behaviours that only a real second window
+ * exercises (jsdom's mock popout shares the opener's document, so a "popout"
+ * there never truly leaves the main window):
+ *
+ *   - closing a popout re-docks its group's panels back into the opener;
+ *   - a panel moved into a popout renders inside the popout, not the opener;
+ *   - a live popout survives a serialization round-trip (toJSON → fromJSON
+ *     re-opens the window and restores its content).
+ *
+ * The popout smoke test (`popout.spec.ts`) only proves a window opens; these
+ * cover what happens to the layout afterwards.
+ */
+test.describe('cross-window popout lifecycle', () => {
+    const twoPanelPopout = async (page: Page, context: BrowserContext) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => {
+            (window as any).__dv.addPanel('alpha');
+            (window as any).__dv.addPanel('beta'); // beta active, same group
+        });
+        const [win] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__dv.popoutActiveGroup()),
+        ]);
+        await (win as Page).waitForLoadState();
+        return win as Page;
+    };
+
+    test('closing a popout re-docks its group into the opener', async ({
+        page,
+        context,
+    }) => {
+        const win = await twoPanelPopout(page, context);
+
+        // While popped out, the content lives in the popout, not the opener.
+        await expect(win.locator('.dv-test-panel')).toContainText('beta');
+        await expect(page.locator('.dv-test-panel')).toHaveCount(0);
+
+        // Close the popout *window* itself (not via the group API, which would
+        // remove the group). dockview re-docks on the window's `beforeunload`,
+        // so the close must run it (Playwright skips it by default).
+        await win.close({ runBeforeUnload: true });
+
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__dv.popoutCount()))
+            .toBe(0);
+
+        // Both tabs are back in the opener's single group, beta still rendered.
+        await expect(page.locator('.dv-tab')).toHaveCount(2);
+        await expect(page.locator('.dv-test-panel')).toContainText('beta');
+        expect(
+            await page.evaluate(() => (window as any).__dv.groupCount())
+        ).toBe(1);
+    });
+
+    test('a panel moved into a popout renders inside the popout window', async ({
+        page,
+        context,
+    }) => {
+        const win = await twoPanelPopout(page, context);
+
+        // Split a fresh panel into the popout's own gridview.
+        await page.evaluate(() =>
+            (window as any).__dv.splitIntoPopout('delta')
+        );
+
+        // Its content mounts in the popout, and the popout now holds two groups
+        // (two tab strips) side by side — while the opener stays empty.
+        await expect(
+            win.locator('.dv-test-panel', { hasText: 'delta' })
+        ).toBeVisible();
+        await expect(win.locator('.dv-tabs-container')).toHaveCount(2);
+        await expect(page.locator('.dv-test-panel')).toHaveCount(0);
+    });
+
+    // Capture a snapshot that contains a live popout, then simulate an app
+    // reload (fresh component with no panels) and restore that snapshot — the
+    // canonical "persist layout, reload the app, restore it" flow.
+    const snapshotThenReloadAndRestore = async (
+        page: Page,
+        context: BrowserContext
+    ): Promise<Page> => {
+        const win = await twoPanelPopout(page, context);
+        // The serialized layout must carry the popout group.
+        const json = await page.evaluate(() =>
+            JSON.stringify((window as any).__dv.snapshot())
+        );
+        expect(json).toContain('"popoutGroups"');
+        await win.close({ runBeforeUnload: true });
+
+        // Fresh component (as after a page reload), then restore. The popout
+        // re-opens asynchronously — awaited via popoutRestorationPromise.
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        const [restored] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(async (state) => {
+                (window as any).__dv.restore(JSON.parse(state));
+                await (window as any).__dv.awaitPopoutRestore();
+            }, json),
+        ]);
+        await (restored as Page).waitForLoadState();
+        return restored as Page;
+    };
+
+    test('restoring a serialized layout re-opens the popout with its tab strip', async ({
+        page,
+        context,
+    }) => {
+        const restored = await snapshotThenReloadAndRestore(page, context);
+
+        // The popout window is back, with the group's tab strip and both tabs.
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__dv.popoutCount()))
+            .toBe(1);
+        await expect(restored.locator('.dv-tabs-container')).toHaveCount(1);
+        await expect(restored.locator('.dv-tab')).toHaveText(['alpha', 'beta']);
+    });
+
+    // KNOWN BUG: restoring a layout that contains a popout group rebuilds the
+    // popout window and its tab strip, but never creates the panel *content*
+    // components inside it — the popout's content area stays empty. A non-popout
+    // fromJSON restore renders content correctly, so this is specific to the
+    // popout-restoration path. Flip to `test(...)` once the content renders.
+    test.fixme('restored popout renders its active panel content', async ({
+        page,
+        context,
+    }) => {
+        const restored = await snapshotThenReloadAndRestore(page, context);
+        await expect(restored.locator('.dv-test-panel')).toContainText('beta');
+    });
+});

--- a/e2e/tests/popout-lifecycle.spec.ts
+++ b/e2e/tests/popout-lifecycle.spec.ts
@@ -120,16 +120,14 @@ test.describe('cross-window popout lifecycle', () => {
         await expect(restored.locator('.dv-tab')).toHaveText(['alpha', 'beta']);
     });
 
-    // KNOWN BUG: restoring a layout that contains a popout group rebuilds the
-    // popout window and its tab strip, but never creates the panel *content*
-    // components inside it — the popout's content area stays empty. A non-popout
-    // fromJSON restore renders content correctly, so this is specific to the
-    // popout-restoration path. Flip to `test(...)` once the content renders.
-    test.fixme('restored popout renders its active panel content', async ({
+    test('restored popout renders its active panel content', async ({
         page,
         context,
     }) => {
         const restored = await snapshotThenReloadAndRestore(page, context);
+        // The active panel's content must be mounted inside the popout — a
+        // render-container swap on the (already-populated) restored group used
+        // to leave the onlyWhenVisible content detached, so nothing rendered.
         await expect(restored.locator('.dv-test-panel')).toContainText('beta');
     });
 });

--- a/e2e/tests/serialization-roundtrip.spec.ts
+++ b/e2e/tests/serialization-roundtrip.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Serialization round-trips for v8 features — snapshot a live layout, reload
+ * into a fresh component, and restore. Real-browser only: the restored view
+ * has to actually render (maximized hiding, edge-group shell, chip mount) for
+ * these assertions to mean anything, which jsdom's no-layout DOM can't produce.
+ *
+ * (The popout and floating-group round-trips live in their own specs.)
+ */
+test.describe('serialization round-trips', () => {
+    const ready = async (page: Page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+    };
+
+    const reloadAndRestore = async (page: Page, json: string) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(
+            (state) => (window as any).__dv.restore(JSON.parse(state)),
+            json
+        );
+    };
+
+    const snapshot = (page: Page) =>
+        page.evaluate(() => JSON.stringify((window as any).__dv.snapshot()));
+
+    test('a maximized group round-trips', async ({ page }) => {
+        await ready(page);
+        const maxId = await page.evaluate(() =>
+            (window as any).__dv.setupTwoGroupsMaximizeFirst()
+        );
+        // Live: one group is maximized.
+        expect(
+            await page.evaluate(() => (window as any).__dv.hasMaximizedGroup())
+        ).toBe(true);
+        expect(
+            await page.evaluate(() => (window as any).__dv.maximizedGroupId())
+        ).toBe(maxId);
+
+        const json = await snapshot(page);
+        expect(json).toContain('maximizedNode');
+
+        await reloadAndRestore(page, json);
+
+        // The same group is maximized again after the round-trip.
+        await expect
+            .poll(() =>
+                page.evaluate(() => (window as any).__dv.hasMaximizedGroup())
+            )
+            .toBe(true);
+        expect(
+            await page.evaluate(() => (window as any).__dv.maximizedGroupId())
+        ).toBe(maxId);
+    });
+
+    test('an edge group round-trips with its panel content', async ({
+        page,
+    }) => {
+        await ready(page);
+        await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
+        expect(
+            await page.evaluate(() =>
+                (window as any).__dv.edgeGroupExists('left')
+            )
+        ).toBe(true);
+
+        const json = await snapshot(page);
+        expect(json).toContain('edgeGroups');
+
+        await reloadAndRestore(page, json);
+
+        // The edge group is rebuilt at its position, still holding its panel,
+        // and the panel content renders.
+        await expect
+            .poll(() =>
+                page.evaluate(() =>
+                    (window as any).__dv.edgeGroupExists('left')
+                )
+            )
+            .toBe(true);
+        expect(
+            await page.evaluate(() =>
+                (window as any).__dv.edgeGroupPanelIds('left')
+            )
+        ).toEqual(['sidebar']);
+        // The edge group restores auto-hidden (collapsed), so its panel is
+        // present in the DOM but not visible — the content component is still
+        // rebuilt, and the docked `main` panel renders.
+        await expect(
+            page.locator('.dv-test-panel', { hasText: 'sidebar' })
+        ).toBeAttached();
+        await expect(
+            page.locator('.dv-test-panel', { hasText: 'main' })
+        ).toBeVisible();
+    });
+
+    test('a tab group chip round-trips with its label', async ({ page }) => {
+        await ready(page);
+        await page.evaluate(() => (window as any).__dv.setupTabGroupChip());
+        await expect(page.locator('.dv-tab-group-chip')).toHaveText(
+            'Monitoring'
+        );
+
+        const json = await snapshot(page);
+        expect(json).toContain('tabGroups');
+
+        await reloadAndRestore(page, json);
+
+        // The chip is rebuilt with its label.
+        await expect(page.locator('.dv-tab-group-chip')).toHaveText(
+            'Monitoring'
+        );
+    });
+});

--- a/e2e/tests/tab-overflow-dropdown.spec.ts
+++ b/e2e/tests/tab-overflow-dropdown.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Tab overflow dropdown — when a strip is too narrow for its tabs, the extras
+ * collapse behind a dropdown handle; opening it and picking a hidden tab
+ * activates that panel. Real-browser only: whether the strip overflows (and
+ * which tabs are pushed into the dropdown) is decided from measured widths,
+ * which jsdom can't produce.
+ *
+ * (pinned-tabs.spec.ts covers that a pinned tab is *excluded* from the
+ * dropdown; this covers the open-and-select flow itself.)
+ */
+test.describe('tab overflow dropdown', () => {
+    const setup = async (page: Page) => {
+        await page.setViewportSize({ width: 300, height: 500 });
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => {
+            for (let i = 0; i < 12; i++)
+                (window as any).__dv.addPanel('panel-long-title-' + i);
+        });
+    };
+
+    test('selecting a hidden tab from the dropdown activates it', async ({
+        page,
+    }) => {
+        await setup(page);
+
+        // The strip overflows: the dropdown handle appears.
+        const handle = page.locator('.dv-tabs-overflow-dropdown-default');
+        await expect(handle).toBeVisible();
+        await handle.click();
+
+        // The dropdown lists the overflowed tabs.
+        const overflow = page.locator('.dv-tabs-overflow-container');
+        await expect(overflow).toBeVisible();
+        await expect(overflow.locator('.dv-tab')).not.toHaveCount(0);
+
+        // Pick the first hidden tab → it becomes the active tab…
+        const hiddenTab = overflow.locator('.dv-tab').first();
+        const title = (await hiddenTab.textContent())!.trim();
+        await hiddenTab.click();
+
+        await expect(page.locator('.dv-active-tab')).toHaveText(title);
+        // …and the dropdown closes.
+        await expect(overflow).toHaveCount(0);
+    });
+});

--- a/e2e/tests/watermark.spec.ts
+++ b/e2e/tests/watermark.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Watermark — the placeholder shown when the grid has no groups. Real-browser
+ * only: it mounts/unmounts in the live DOM as groups come and go, and must not
+ * linger over a restored (non-empty) layout. jsdom's no-layout DOM makes the
+ * mount/unmount observable but the restore-persistence regression (#515) is
+ * best guarded end-to-end.
+ */
+test.describe('watermark', () => {
+    const ready = async (page: Page) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+    };
+
+    const watermark = (page: Page) => page.locator('.dv-watermark-container');
+
+    test('shows on an empty grid, hides once a panel is added', async ({
+        page,
+    }) => {
+        await ready(page);
+        await expect(watermark(page)).toHaveCount(1);
+
+        await page.evaluate(() => (window as any).__dv.addPanel('alpha'));
+        await expect(watermark(page)).toHaveCount(0);
+    });
+
+    test('returns when the last panel is removed', async ({ page }) => {
+        await ready(page);
+        await page.evaluate(() => (window as any).__dv.addPanel('alpha'));
+        await expect(watermark(page)).toHaveCount(0);
+
+        await page.evaluate(() => (window as any).__dv.closePanel('alpha'));
+        await expect(watermark(page)).toHaveCount(1);
+    });
+
+    test('does not persist over a restored non-empty layout', async ({
+        page,
+    }) => {
+        await ready(page);
+        await page.evaluate(() => {
+            (window as any).__dv.addPanel('a');
+            (window as any).__dv.addPanel('b');
+        });
+        const json = await page.evaluate(() =>
+            JSON.stringify((window as any).__dv.snapshot())
+        );
+
+        // Fresh component shows the watermark (empty)…
+        await ready(page);
+        await expect(watermark(page)).toHaveCount(1);
+
+        // …restoring a non-empty layout must clear it (the watermark mounted
+        // during the empty state must not linger over the restored groups).
+        await page.evaluate(
+            (state) => (window as any).__dv.restore(JSON.parse(state)),
+            json
+        );
+        await expect(watermark(page)).toHaveCount(0);
+        await expect(page.locator('.dv-test-panel')).toContainText('b');
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
@@ -848,6 +848,56 @@ describe('dockviewGroupPanelModel', () => {
         expect(contentContainer.item(0)).toBe(panel3.view.content.element);
     });
 
+    test('swapping renderContainer keeps the active panel content mounted', () => {
+        // Regression: swapping the render container on an already-populated
+        // group (e.g. restoring a popout group from JSON, where the popout
+        // window gets its own OverlayRenderContainer) used to leave the active
+        // onlyWhenVisible panel's content detached — so nothing rendered.
+        const dockviewComponent = new DockviewComponent(
+            document.createElement('div'),
+            {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'component':
+                            return new TestContentPart(options.id);
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            }
+        );
+
+        const groupviewContainer = document.createElement('div');
+        const cut = new DockviewGroupPanelModel(
+            groupviewContainer,
+            dockviewComponent,
+            'id',
+            {},
+            null as any
+        );
+        const contentContainer = groupviewContainer
+            .getElementsByClassName('dv-content-container')
+            .item(0)!.childNodes;
+
+        const panel1 = new TestPanel('id_1', panelApi);
+        const panel2 = new TestPanel('id_2', panelApi);
+        cut.openPanel(panel1);
+        cut.openPanel(panel2); // panel2 active, its content mounted
+
+        expect(contentContainer).toHaveLength(1);
+        expect(contentContainer.item(0)).toBe(panel2.view.content.element);
+
+        // Swap to a fresh render container (as the popout-restore path does).
+        cut.renderContainer = new OverlayRenderContainer(
+            document.createElement('div'),
+            dockviewComponent
+        );
+
+        // The active panel's content is still mounted, not left detached.
+        expect(contentContainer).toHaveLength(1);
+        expect(contentContainer.item(0)).toBe(panel2.view.content.element);
+    });
+
     test('that should not show drop target is external event', () => {
         const accessor = fromPartial<DockviewComponent>({
             id: 'testcomponentid',

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1233,6 +1233,17 @@ export class DockviewGroupPanelModel
         this.panels.forEach((panel) => {
             this.rerender(panel);
         });
+
+        // rerender() re-attaches each panel with asActive:false; for the default
+        // onlyWhenVisible renderer that loop leaves the active panel's content
+        // detached. Re-show it so swapping the render container on an
+        // already-populated group (e.g. restoring a popout group from JSON)
+        // keeps the active content mounted.
+        if (this._activePanel) {
+            this.contentContainer.renderPanel(this._activePanel, {
+                asActive: true,
+            });
+        }
     }
 
     get renderContainer(): OverlayRenderContainer {


### PR DESCRIPTION
## Description

Expands the Playwright e2e suite (real-browser behaviour the jsdom unit tests can't reach) and fixes a bug that this new coverage surfaced.

The suite grows from **58 → 78 tests**. New specs:

- **`popout-lifecycle.spec.ts`** — closing a popout re-docks its group into the opener; a panel moved into a popout renders inside it; closing a popout with a nested split re-docks both groups; a serialized layout re-opens the popout and restores its content.
- **`floating-group.spec.ts`** — a floating group renders as a positioned overlay with content and survives a serialization round-trip (geometry + content).
- **`serialization-roundtrip.spec.ts`** — maximize (`maximizedNode`), edge groups, and tab-group chips each snapshot → reload → restore.
- **`dnd-docking.spec.ts`** — tab-strip seams the compass specs don't cover: intra-strip reorder, and merge-by-dropping-on-another-group's-header.
- **`watermark.spec.ts`** — shows on empty, hides on add, returns on remove-all, and does not persist over a restored non-empty layout.
- **`locked-group.spec.ts`** — a locked group rejects a dropped tab (no compass, no merge); unlocking restores drops.
- **`tab-overflow-dropdown.spec.ts`** — a narrow strip overflows; selecting a hidden tab from the dropdown activates it.
- **`group-resize.spec.ts`** — main-window sash resize, and a `maximumWidth` constraint clamps it.

**Bug fixed** (`dockview-core`): restoring a layout containing a **popout group** rebuilt the window and tab strip but left the content area empty. The popout installs its own `OverlayRenderContainer`, so restore sets `renderContainer` on an already-populated group; the setter re-rendered each panel with `asActive: false`, which for the default `onlyWhenVisible` renderer left the active panel's content detached. The live-popout path avoided this (empty group first, then `openPanel`); floating restore avoided it (no container swap). Fix: re-show the active panel after the rerender loop so a container swap on a populated group keeps its content mounted.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [x] Build / CI / tooling <!-- test-only additions -->

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

(Plus the repo-root `e2e/` Playwright suite and its fixture.)

## How to test

```bash
yarn nx run-many -t build:bundle -p dockview-core dockview-enterprise
yarn test:e2e
```

- All 78 e2e tests pass headless.
- The popout-restore fix is covered both ways: a `dockview-core` unit test (`swapping renderContainer keeps the active panel content mounted` in `dockviewGroupPanelModel.spec.ts`, which fails without the fix) and the `restored popout renders its active panel content` e2e test.

## Checklist

- [x] `yarn lint:fix` passes (only pre-existing warnings in `dockviewGroupPanelModel.ts`)
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes (`dockview-core`: 1152 unit tests; e2e: 78)
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGmVYAWX8ff6TZ6rhGw2ym)_