### PR TITLE
docs: Editions page and free-trial signup

### DIFF
--- a/packages/docs/docs/overview/editions.mdx
+++ b/packages/docs/docs/overview/editions.mdx
@@ -1,0 +1,60 @@
+---
+title: Editions
+sidebar_position: 0.6
+description: Dockview comes in two editions — the free open-source library and Dockview Enterprise. Learn which is right for you and what Enterprise adds.
+---
+
+Dockview comes in two editions that share the same core and the same API:
+
+- **Dockview** — the free, open-source library, published under the MIT licence. Everything you need to build a complete, fully working docking layout manager.
+- **Dockview Enterprise** — a drop-in superset (the `dockview-enterprise` package) that adds more advanced features on top of the free core, under a commercial licence.
+
+Enterprise is the same library with more modules turned on, so it includes every free feature.
+
+## Which edition is right for you?
+
+### Dockview — free
+
+The free edition suits you if you are:
+
+- Building a dashboard, editor or tool that needs solid docking, tabs, splitters and floating or popout panels.
+- Working on a personal, open-source or commercial project and want a dependency-free, MIT-licensed layout manager.
+- Happy with the core docking experience and don't need the more advanced features below.
+
+All framework packages — `dockview-react`, `dockview-vue` and `dockview-angular` — are free and work with both the free and Enterprise editions.
+
+### Dockview Enterprise
+
+Enterprise is aimed at you if you are:
+
+- Building an application where the layout itself is a core part of the product and you want the more advanced features below.
+- A team that wants the advanced docking, keyboard operability and layout-lifecycle features listed below, plus email support.
+- Adopting a business-critical dependency and want a commercial licence behind it.
+
+See the <a href="/enterprise">pricing page</a> for details and to buy.
+
+## What Enterprise adds
+
+All of the following are provided by the `dockview-enterprise` package:
+
+- **Advanced docking** — the [drop guide compass](/docs/core/dnd/dropGuide) for aim-at-a-cell docking, and [smart guides](/docs/core/dnd/smartGuides) with magnetic alignment for floating groups.
+- **Advanced tabs** — [multi-row tabs](/docs/core/panels/multiRowTabs) that wrap instead of overflowing, and [pinned tabs](/docs/core/panels/pinnedTabs).
+- **Tool windows and edges** — [auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) that collapse to a strip and peek on demand, and [dock-to-edge groups](/docs/core/groups/autoEdgeGroups).
+- **Keyboard and navigation** — [keyboard navigation](/docs/advanced/keyboard) with F6 and spatial movement, and [focus navigation](/docs/advanced/focus-navigation) across groups and popout windows.
+- **Layout lifecycle** — [layout history](/docs/core/state/history) with undo and redo.
+- **Context menus** — built-in right-click menus for tabs and tab group chips.
+
+For the exact, feature-by-feature breakdown, see the [full feature comparison](/docs/overview/features).
+
+## Get started
+
+Dockview Enterprise requires a licence. Start a free trial to evaluate every Enterprise feature for 30 days, or purchase a licence when you're ready.
+
+<div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+    <a className="button button--primary" href="/trial">
+        Start a free trial →
+    </a>
+    <a className="button button--secondary" href="/enterprise">
+        Purchase a licence
+    </a>
+</div>

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -23,6 +23,7 @@ const sidebars = {
             items: [
                 'overview/introduction',
                 'overview/features',
+                'overview/editions',
                 'overview/quickstart',
                 'overview/installation',
                 {

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -454,6 +454,12 @@ function CallToAction() {
                     >
                         Live demo
                     </Link>
+                    <Link
+                        to="/trial"
+                        className="button button--secondary button--lg"
+                    >
+                        Start free trial
+                    </Link>
                 </div>
             </div>
         </section>

--- a/packages/docs/src/pages/trial.tsx
+++ b/packages/docs/src/pages/trial.tsx
@@ -1,0 +1,381 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+
+// Public Turnstile site key (safe to expose — it's rendered into the page). The
+// matching secret lives only in the licensing worker (TURNSTILE_SECRET_KEY).
+const TURNSTILE_SITE_KEY = '0x4AAAAAADx1eYe1Ro1u3YUq';
+
+// Cloudflare's visible "always passes" TEST site key. Used on localhost so
+// local dev doesn't depend on the real widget's domain allowlist or network —
+// pair it with the matching TEST secret in the worker's .dev.vars.
+const TURNSTILE_TEST_SITE_KEY = '1x00000000000000000000AA';
+
+function turnstileSiteKey(): string {
+    if (
+        typeof window !== 'undefined' &&
+        window.location.hostname === 'localhost'
+    ) {
+        return TURNSTILE_TEST_SITE_KEY;
+    }
+    return TURNSTILE_SITE_KEY;
+}
+
+const TURNSTILE_SCRIPT =
+    'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+
+// The trial API lives on the licensing worker under /enterprise. Same origin
+// as the docs site in production; in local dev the worker runs on :4000.
+function trialApiUrl(): string {
+    if (
+        typeof window !== 'undefined' &&
+        window.location.hostname === 'localhost'
+    ) {
+        return 'http://localhost:4000/enterprise/api/trial';
+    }
+    return '/enterprise/api/trial';
+}
+
+declare global {
+    interface Window {
+        turnstile?: {
+            render: (
+                el: HTMLElement,
+                opts: {
+                    sitekey: string;
+                    callback: (token: string) => void;
+                    'expired-callback'?: () => void;
+                    'error-callback'?: () => void;
+                }
+            ) => string;
+            reset: (id?: string) => void;
+        };
+    }
+}
+
+interface FormState {
+    firstName: string;
+    lastName: string;
+    email: string;
+    company: string;
+}
+
+type Status = 'idle' | 'submitting' | 'done' | 'error';
+
+function Field(props: {
+    label: string;
+    value: string;
+    onChange: (v: string) => void;
+    type?: string;
+    placeholder?: string;
+    required?: boolean;
+    error?: string;
+}) {
+    return (
+        <label style={{ display: 'block' }}>
+            <span
+                style={{
+                    display: 'block',
+                    fontSize: '0.85rem',
+                    fontWeight: 600,
+                    marginBottom: 6,
+                    color: 'var(--ifm-heading-color)',
+                }}
+            >
+                {props.label}
+                {!props.required && (
+                    <span
+                        style={{
+                            color: 'var(--ifm-color-content-secondary)',
+                            fontWeight: 400,
+                        }}
+                    >
+                        {' '}
+                        (optional)
+                    </span>
+                )}
+            </span>
+            <input
+                type={props.type ?? 'text'}
+                value={props.value}
+                placeholder={props.placeholder}
+                onChange={(e) => props.onChange(e.target.value)}
+                style={{
+                    width: '100%',
+                    padding: '10px 12px',
+                    borderRadius: 8,
+                    border: `1px solid ${
+                        props.error
+                            ? 'var(--ifm-color-danger)'
+                            : 'var(--ifm-color-emphasis-300)'
+                    }`,
+                    background: 'var(--ifm-background-color)',
+                    color: 'var(--ifm-font-color-base)',
+                    fontSize: '0.95rem',
+                }}
+            />
+            {props.error && (
+                <span
+                    style={{
+                        display: 'block',
+                        color: 'var(--ifm-color-danger)',
+                        fontSize: '0.8rem',
+                        marginTop: 4,
+                    }}
+                >
+                    {props.error}
+                </span>
+            )}
+        </label>
+    );
+}
+
+function TrialForm() {
+    const [form, setForm] = React.useState<FormState>({
+        firstName: '',
+        lastName: '',
+        email: '',
+        company: '',
+    });
+    const [errors, setErrors] = React.useState<Partial<FormState>>({});
+    const [status, setStatus] = React.useState<Status>('idle');
+    const [message, setMessage] = React.useState('');
+    const [token, setToken] = React.useState('');
+    const widgetRef = React.useRef<HTMLDivElement>(null);
+    const renderedRef = React.useRef(false);
+
+    // Load the Turnstile script once and render the widget explicitly.
+    React.useEffect(() => {
+        function render() {
+            if (renderedRef.current || !widgetRef.current || !window.turnstile)
+                return;
+            renderedRef.current = true;
+            window.turnstile.render(widgetRef.current, {
+                sitekey: turnstileSiteKey(),
+                callback: setToken,
+                'expired-callback': () => setToken(''),
+                'error-callback': () => setToken(''),
+            });
+        }
+
+        if (window.turnstile) {
+            render();
+            return;
+        }
+        const existing = document.querySelector<HTMLScriptElement>(
+            `script[src="${TURNSTILE_SCRIPT}"]`
+        );
+        const script = existing ?? document.createElement('script');
+        script.src = TURNSTILE_SCRIPT;
+        script.async = true;
+        script.defer = true;
+        script.addEventListener('load', render);
+        if (!existing) document.head.appendChild(script);
+        return () => script.removeEventListener('load', render);
+    }, []);
+
+    function update(key: keyof FormState, value: string) {
+        setForm((f) => ({ ...f, [key]: value }));
+        setErrors((e) => ({ ...e, [key]: undefined }));
+    }
+
+    function validate(): boolean {
+        const next: Partial<FormState> = {};
+        if (!form.firstName.trim()) next.firstName = 'First name is required.';
+        if (!form.lastName.trim()) next.lastName = 'Last name is required.';
+        if (!form.email.trim()) next.email = 'Email is required.';
+        else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim()))
+            next.email = 'Please enter a valid email address.';
+        setErrors(next);
+        return Object.keys(next).length === 0;
+    }
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        if (!validate()) return;
+        if (!token) {
+            setStatus('error');
+            setMessage('Please complete the bot check and try again.');
+            return;
+        }
+
+        setStatus('submitting');
+        setMessage('');
+        try {
+            const res = await fetch(trialApiUrl(), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    firstName: form.firstName.trim(),
+                    lastName: form.lastName.trim(),
+                    email: form.email.trim().toLowerCase(),
+                    company: form.company.trim() || undefined,
+                    turnstileToken: token,
+                }),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(
+                    data.error ?? 'Something went wrong. Please try again.'
+                );
+            }
+            setStatus('done');
+        } catch (err) {
+            setStatus('error');
+            setMessage(
+                err instanceof Error
+                    ? err.message
+                    : 'Something went wrong. Please try again.'
+            );
+            window.turnstile?.reset();
+            setToken('');
+        }
+    }
+
+    if (status === 'done') {
+        return (
+            <div
+                style={{
+                    border: '1px solid var(--ifm-color-emphasis-200)',
+                    borderRadius: 12,
+                    padding: '32px 28px',
+                    textAlign: 'center',
+                    background: 'var(--ifm-card-background-color)',
+                }}
+            >
+                <h2 style={{ marginTop: 0 }}>Check your inbox</h2>
+                <p
+                    style={{
+                        color: 'var(--ifm-color-content-secondary)',
+                        marginBottom: 0,
+                    }}
+                >
+                    We&rsquo;ve sent a confirmation link to{' '}
+                    <strong>{form.email.trim().toLowerCase()}</strong>. Click it
+                    to activate your 30-day trial and receive your licence key.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <form
+            onSubmit={handleSubmit}
+            style={{
+                border: '1px solid var(--ifm-color-emphasis-200)',
+                borderRadius: 12,
+                padding: '28px',
+                background: 'var(--ifm-card-background-color)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 18,
+            }}
+        >
+            <div
+                style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gap: 18,
+                }}
+            >
+                <Field
+                    label="First name"
+                    value={form.firstName}
+                    onChange={(v) => update('firstName', v)}
+                    placeholder="Jane"
+                    required
+                    error={errors.firstName}
+                />
+                <Field
+                    label="Last name"
+                    value={form.lastName}
+                    onChange={(v) => update('lastName', v)}
+                    placeholder="Smith"
+                    required
+                    error={errors.lastName}
+                />
+            </div>
+            <Field
+                label="Email address"
+                type="email"
+                value={form.email}
+                onChange={(v) => update('email', v)}
+                placeholder="jane@acme.com"
+                required
+                error={errors.email}
+            />
+            <Field
+                label="Company"
+                value={form.company}
+                onChange={(v) => update('company', v)}
+                placeholder="Acme Corp"
+            />
+
+            <div ref={widgetRef} />
+
+            {status === 'error' && message && (
+                <div
+                    style={{
+                        color: 'var(--ifm-color-danger)',
+                        fontSize: '0.9rem',
+                    }}
+                >
+                    {message}
+                </div>
+            )}
+
+            <button
+                type="submit"
+                className="button button--primary button--lg"
+                disabled={status === 'submitting'}
+                style={{ width: '100%' }}
+            >
+                {status === 'submitting' ? 'Sending…' : 'Request free trial'}
+            </button>
+
+            <p
+                style={{
+                    fontSize: '0.8rem',
+                    color: 'var(--ifm-color-content-secondary)',
+                    margin: 0,
+                    textAlign: 'center',
+                }}
+            >
+                We&rsquo;ll email you a confirmation link. One trial per email
+                address.
+            </p>
+        </form>
+    );
+}
+
+export default function Trial(): JSX.Element {
+    return (
+        <Layout
+            title="Free trial"
+            description="Start a free 30-day trial of Dockview's enterprise features."
+        >
+            <main>
+                <div
+                    style={{
+                        maxWidth: 560,
+                        margin: '64px auto',
+                        padding: '0 24px',
+                        minHeight: '60vh',
+                    }}
+                >
+                    <h1 style={{ marginBottom: 8 }}>Start a free trial</h1>
+                    <p
+                        style={{
+                            color: 'var(--ifm-color-content-secondary)',
+                            marginBottom: 32,
+                        }}
+                    >
+                        Evaluate Dockview&rsquo;s enterprise features for 30
+                        days — no payment required. Enter your details and
+                        we&rsquo;ll email you a licence key.
+                    </p>
+                    <TrialForm />
+                </div>
+            </main>
+        </Layout>
+    );
+}


### PR DESCRIPTION
Adds a docs **Editions** page and a **/trial** signup page, plus a home-page CTA.

## What's here
- **`docs/overview/editions.mdx`** — explains the free vs Enterprise editions, who each is for, what Enterprise adds (links to each feature doc), and CTAs to the trial + pricing pages. Added to the Overview sidebar.
- **`src/pages/trial.tsx`** — `/trial` signup form (first/last name, email, optional company) with a Cloudflare Turnstile bot check, posting to the licensing worker's `/enterprise/api/trial`. Uses Turnstile test keys on localhost and the real site key in production.
- **`src/pages/index.tsx`** — "Start free trial" button in the home-page CTA.

## Notes
- The trial issuance backend (double opt-in, key minting, email) lives in the separate `dockview-licencing` repo (already committed there).
- No client library changes — a trial key is just a short-dated licence key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)