### PR TITLE
docs: reimagine light theme with an ocean-blue accent and solid block colours

### DIFF
--- a/packages/docs/src/css/custom.scss
+++ b/packages/docs/src/css/custom.scss
@@ -58,30 +58,30 @@
     --ifm-color-content: #33384a;
     --ifm-color-content-secondary: #6b7186;
 
-    // ── Accent: indigo / violet ───────────────────────────────────
-    --ifm-color-primary: #4f46e5;
-    --ifm-color-primary-dark: #4338ca;
-    --ifm-color-primary-darker: #3730a3;
-    --ifm-color-primary-darkest: #312e81;
-    --ifm-color-primary-light: #6366f1;
-    --ifm-color-primary-lighter: #818cf8;
-    --ifm-color-primary-lightest: #a5b4fc;
+    // ── Accent: ocean blue ────────────────────────────────────────
+    --ifm-color-primary: #2563eb;
+    --ifm-color-primary-dark: #1d4ed8;
+    --ifm-color-primary-darker: #1e40af;
+    --ifm-color-primary-darkest: #1e3a8a;
+    --ifm-color-primary-light: #3b82f6;
+    --ifm-color-primary-lighter: #60a5fa;
+    --ifm-color-primary-lightest: #93c5fd;
 
     --dv-accent: var(--ifm-color-primary);
-    --dv-accent-strong: #6d5cf6;
+    --dv-accent-strong: #3b82f6;
     --dv-accent-contrast: #ffffff;
     // Solid block tints (no transparency) so they read as flat colour fields.
-    --dv-accent-soft: #ecebfb;
-    --dv-accent-soft-hover: #e0defa;
+    --dv-accent-soft: #e8eefc;
+    --dv-accent-soft-hover: #d8e3fb;
 
     --ifm-link-color: var(--ifm-color-primary);
     --ifm-link-hover-color: var(--ifm-color-primary-dark);
 
     --ifm-code-font-size: 92%;
-    --ifm-code-background: #f2f2fb;
+    --ifm-code-background: #eef2fb;
     --ifm-code-border-radius: 6px;
 
-    --docusaurus-highlighted-code-line-bg: rgba(79, 70, 229, 0.08);
+    --docusaurus-highlighted-code-line-bg: rgba(37, 99, 235, 0.08);
 
     --dv-border: #e8e9f2;
     --dv-border-strong: #dcdeeb;
@@ -94,8 +94,8 @@
     --ifm-navbar-height: 4rem;
 
     // Coloured header (ink) tokens
-    --dv-header-bg: #272548;
-    --dv-header-border: #393767;
+    --dv-header-bg: #1b2547;
+    --dv-header-border: #2c3a6b;
     --dv-header-fg: #cfd0e6;
     --dv-header-fg-hover: #ffffff;
 
@@ -112,7 +112,7 @@
 
     --dv-docs-markdown-text-color: #474d61;
 
-    --ifm-hover-overlay: rgba(79, 70, 229, 0.06);
+    --ifm-hover-overlay: rgba(37, 99, 235, 0.06);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -125,24 +125,24 @@
     --ifm-color-content: #c7c9d6;
     --ifm-color-content-secondary: #9296ab;
 
-    --ifm-color-primary: #8b83ff;
-    --ifm-color-primary-dark: #6d5cf6;
-    --ifm-color-primary-darker: #5b4fe0;
-    --ifm-color-primary-darkest: #4f46e5;
-    --ifm-color-primary-light: #a5a0ff;
-    --ifm-color-primary-lighter: #c1bdff;
-    --ifm-color-primary-lightest: #ded9ff;
+    --ifm-color-primary: #60a5fa;
+    --ifm-color-primary-dark: #3b82f6;
+    --ifm-color-primary-darker: #2563eb;
+    --ifm-color-primary-darkest: #1d4ed8;
+    --ifm-color-primary-light: #93c5fd;
+    --ifm-color-primary-lighter: #bfdbfe;
+    --ifm-color-primary-lightest: #dbeafe;
 
     --dv-accent: var(--ifm-color-primary);
-    --dv-accent-strong: #a5a0ff;
+    --dv-accent-strong: #93c5fd;
     --dv-accent-contrast: #0b0b12;
     // Solid block tints (no transparency) so they read as flat colour fields.
-    --dv-accent-soft: #211e3d;
-    --dv-accent-soft-hover: #2b2752;
+    --dv-accent-soft: #17233f;
+    --dv-accent-soft-hover: #1f3050;
 
     --ifm-code-background: #17171f;
 
-    --docusaurus-highlighted-code-line-bg: rgba(139, 131, 255, 0.12);
+    --docusaurus-highlighted-code-line-bg: rgba(96, 165, 250, 0.12);
 
     --dv-border: #262636;
     --dv-border-strong: #33334a;
@@ -167,7 +167,7 @@
 
     --dv-docs-markdown-text-color: #a7abbd;
 
-    --ifm-hover-overlay: rgba(139, 131, 255, 0.1);
+    --ifm-hover-overlay: rgba(96, 165, 250, 0.1);
 
     .navbar {
         border-bottom: 1px solid var(--dv-border);
@@ -198,8 +198,8 @@
 
     .navbar__inner .DocSearch-Button,
     .navbar__inner .navbar__search-input {
-        background: #323059;
-        border-color: #403d6b;
+        background: #263157;
+        border-color: #34416f;
         color: var(--dv-header-fg);
     }
 }
@@ -448,7 +448,7 @@ div[class^='announcementBar_'] {
                 color: #9333ea;
             }
             &.keyword {
-                color: #4f46e5;
+                color: #2563eb;
             }
         }
     }

--- a/packages/docs/src/css/custom.scss
+++ b/packages/docs/src/css/custom.scss
@@ -17,108 +17,267 @@
         'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
         'Noto Color Emoji';
 
-    --ifm-font-weight-bold: 600;
+    --ifm-font-weight-semibold: 600;
+    --ifm-font-weight-bold: 700;
+    --ifm-heading-font-weight: 700;
 
-    --ifm-alert-padding-vertical: 8px;
-    --ifm-alert-padding-horizontal: 8px;
+    // ── Type scale ────────────────────────────────────────────────
+    --ifm-font-size-base: 16px;
+    --ifm-line-height-base: 1.7;
+    --ifm-heading-line-height: 1.2;
+    --ifm-h1-font-size: 2.5rem;
+    --ifm-h2-font-size: 1.75rem;
+    --ifm-h3-font-size: 1.3rem;
+    --ifm-h4-font-size: 1.1rem;
+    --ifm-paragraph-margin-bottom: 1.15rem;
+    --ifm-leading: 1.15rem;
 
+    // ── Shape / spacing ───────────────────────────────────────────
+    --dv-radius-sm: 8px;
+    --dv-radius: 12px;
+    --dv-radius-lg: 16px;
+    --ifm-global-radius: 10px;
+    --ifm-alert-border-radius: var(--dv-radius);
+    --ifm-alert-padding-vertical: 12px;
+    --ifm-alert-padding-horizontal: 16px;
+
+    // ── Elevation ─────────────────────────────────────────────────
+    --dv-shadow-sm: 0 1px 2px rgba(17, 20, 45, 0.04),
+        0 1px 3px rgba(17, 20, 45, 0.06);
+    --dv-shadow-md: 0 4px 12px rgba(17, 20, 45, 0.06),
+        0 2px 6px rgba(17, 20, 45, 0.04);
+    --dv-shadow-lg: 0 18px 40px -12px rgba(49, 46, 129, 0.22),
+        0 8px 20px -10px rgba(17, 20, 45, 0.12);
+
+    // ── Neutrals (light) ──────────────────────────────────────────
     --ifm-background-color: #ffffff;
-    --ifm-background-surface-color: #f8fafc;
+    --ifm-background-surface-color: #f7f8fc;
 
-    --ifm-color-primary: #1d4ed8;
-    --ifm-color-primary-dark: #1e40af;
-    --ifm-color-primary-darker: #1e3a8a;
-    --ifm-color-primary-darkest: #1e3270;
-    --ifm-color-primary-light: #2563eb;
-    --ifm-color-primary-lighter: #3b82f6;
-    --ifm-color-primary-lightest: #60a5fa;
+    --ifm-heading-color: #12131a;
+    --ifm-font-color-base: #33384a;
+    --ifm-color-content: #33384a;
+    --ifm-color-content-secondary: #6b7186;
 
-    --ifm-code-font-size: 95%;
-    --ifm-code-background: #f1f5f9;
+    // ── Accent: indigo / violet ───────────────────────────────────
+    --ifm-color-primary: #4f46e5;
+    --ifm-color-primary-dark: #4338ca;
+    --ifm-color-primary-darker: #3730a3;
+    --ifm-color-primary-darkest: #312e81;
+    --ifm-color-primary-light: #6366f1;
+    --ifm-color-primary-lighter: #818cf8;
+    --ifm-color-primary-lightest: #a5b4fc;
 
-    --docusaurus-highlighted-code-line-bg: rgba(37, 99, 235, 0.08);
+    --dv-accent: var(--ifm-color-primary);
+    --dv-accent-strong: #6d5cf6;
+    --dv-accent-contrast: #ffffff;
+    --dv-accent-soft: rgba(79, 70, 229, 0.08);
+    --dv-accent-soft-hover: rgba(79, 70, 229, 0.13);
+    --dv-accent-gradient: linear-gradient(
+        120deg,
+        #4f46e5 0%,
+        #6d5cf6 55%,
+        #8b5cf6 100%
+    );
 
-    --ifm-navbar-background-color: #e6edfc;
-    --ifm-navbar-link-color: #374151;
-    --ifm-navbar-link-hover-color: #1d4ed8;
+    --ifm-link-color: var(--ifm-color-primary);
+    --ifm-link-hover-color: var(--ifm-color-primary-dark);
+
+    --ifm-code-font-size: 92%;
+    --ifm-code-background: #f2f2fb;
+    --ifm-code-border-radius: 6px;
+
+    --docusaurus-highlighted-code-line-bg: rgba(79, 70, 229, 0.08);
+
+    --dv-border: #e8e9f2;
+    --dv-border-strong: #dcdeeb;
+
+    // Kept light so the mobile slide-out menu stays readable; the desktop
+    // bar is coloured via the scoped `.navbar` block below.
+    --ifm-navbar-background-color: #ffffff;
+    --ifm-navbar-link-color: #3d4356;
+    --ifm-navbar-link-hover-color: var(--ifm-color-primary);
+    --ifm-navbar-height: 4rem;
+
+    // Coloured header (ink) tokens
+    --dv-header-bg: #272548;
+    --dv-header-border: #393767;
+    --dv-header-fg: #cfd0e6;
+    --dv-header-fg-hover: #ffffff;
 
     --ifm-dropdown-background-color: #ffffff;
-    --ifm-dropdown-border: 1px solid #e2e8f0;
+    --ifm-dropdown-border: 1px solid var(--dv-border);
 
-    --ifm-toc-border-color: #e2e8f0;
-    --ifm-hr-border-color: #e2e8f0;
-    --ifm-table-border-color: #e2e8f0;
-
-    --dv-docs-markdown-text-color: #1f2937;
+    --ifm-toc-border-color: var(--dv-border);
+    --ifm-hr-border-color: var(--dv-border);
+    --ifm-table-border-color: var(--dv-border);
 
     --ifm-menu-color: #1e293b;
+    --ifm-menu-color-active: var(--ifm-color-primary);
+    --ifm-menu-color-background-active: var(--dv-accent-soft);
 
-    --ifm-hover-overlay: rgba(0, 0, 0, 0.05);
+    --dv-docs-markdown-text-color: #474d61;
 
-    .navbar {
-        border-bottom: 1px solid #dbe4f5;
-        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
-        // Frosted header: a brand tint that content passes softly under on
-        // scroll, so the bar reads as its own surface rather than the page.
-        background: rgba(230, 237, 252, 0.9);
-        backdrop-filter: blur(8px);
-        -webkit-backdrop-filter: blur(8px);
-    }
+    --ifm-hover-overlay: rgba(79, 70, 229, 0.06);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 :root[data-theme='dark'] {
-    --ifm-background-color: #171d29;
-    --ifm-background-surface-color: #222a39;
+    --ifm-background-color: #0b0b12;
+    --ifm-background-surface-color: #14141d;
 
-    --ifm-color-primary: #38bdf8;
-    --ifm-color-primary-dark: #0ea5e9;
-    --ifm-color-primary-darker: #0284c7;
-    --ifm-color-primary-darkest: #0369a1;
-    --ifm-color-primary-light: #7dd3fc;
-    --ifm-color-primary-lighter: #bae6fd;
-    --ifm-color-primary-lightest: #e0f2fe;
+    --ifm-heading-color: #f4f4f8;
+    --ifm-font-color-base: #c7c9d6;
+    --ifm-color-content: #c7c9d6;
+    --ifm-color-content-secondary: #9296ab;
 
-    --ifm-code-background: #222a39;
+    --ifm-color-primary: #8b83ff;
+    --ifm-color-primary-dark: #6d5cf6;
+    --ifm-color-primary-darker: #5b4fe0;
+    --ifm-color-primary-darkest: #4f46e5;
+    --ifm-color-primary-light: #a5a0ff;
+    --ifm-color-primary-lighter: #c1bdff;
+    --ifm-color-primary-lightest: #ded9ff;
 
-    --docusaurus-highlighted-code-line-bg: rgba(96, 165, 250, 0.1);
+    --dv-accent: var(--ifm-color-primary);
+    --dv-accent-strong: #a5a0ff;
+    --dv-accent-contrast: #0b0b12;
+    --dv-accent-soft: rgba(139, 131, 255, 0.14);
+    --dv-accent-soft-hover: rgba(139, 131, 255, 0.2);
+    --dv-accent-gradient: linear-gradient(
+        120deg,
+        #6d5cf6 0%,
+        #8b83ff 55%,
+        #a78bfa 100%
+    );
 
-    --ifm-navbar-background-color: #1c2333;
-    --ifm-navbar-link-color: #e4e4e7;
-    --ifm-navbar-link-hover-color: #38bdf8;
+    --ifm-code-background: #17171f;
 
-    --ifm-dropdown-background-color: #222a39;
-    --ifm-dropdown-border: 1px solid #30384a;
+    --docusaurus-highlighted-code-line-bg: rgba(139, 131, 255, 0.12);
 
-    --ifm-toc-border-color: #30384a;
-    --ifm-hr-border-color: #30384a;
-    --ifm-table-border-color: #30384a;
+    --dv-border: #262636;
+    --dv-border-strong: #33334a;
 
-    --dv-docs-markdown-text-color: #d4d4d8;
+    --dv-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --dv-shadow-md: 0 4px 14px rgba(0, 0, 0, 0.4);
+    --dv-shadow-lg: 0 20px 44px -14px rgba(0, 0, 0, 0.7);
+
+    --ifm-navbar-background-color: rgba(11, 11, 18, 0.72);
+    --ifm-navbar-link-color: #d5d6e0;
+    --ifm-navbar-link-hover-color: var(--ifm-color-primary);
+
+    --ifm-dropdown-background-color: #14141d;
+    --ifm-dropdown-border: 1px solid var(--dv-border);
+
+    --ifm-toc-border-color: var(--dv-border);
+    --ifm-hr-border-color: var(--dv-border);
+    --ifm-table-border-color: var(--dv-border);
 
     --ifm-menu-color: #d4d4d8;
+    --ifm-menu-color-background-active: var(--dv-accent-soft);
 
-    --ifm-hover-overlay: rgba(255, 255, 255, 0.06);
+    --dv-docs-markdown-text-color: #a7abbd;
+
+    --ifm-hover-overlay: rgba(139, 131, 255, 0.1);
 
     .navbar {
-        border-bottom: 1px solid #2b3242;
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-        background: rgba(28, 35, 51, 0.82);
-        backdrop-filter: blur(8px);
-        -webkit-backdrop-filter: blur(8px);
+        border-bottom: 1px solid var(--dv-border);
+        box-shadow: none;
+        backdrop-filter: saturate(180%) blur(12px);
+        -webkit-backdrop-filter: saturate(180%) blur(12px);
     }
+}
+
+// Coloured "ink" header — light theme only, so dark mode keeps its own dark
+// navbar. Scoped to the desktop bar (.navbar__inner) so the mobile slide-out
+// menu, which shares --ifm-navbar-background-color, stays light and readable.
+:root:not([data-theme='dark']) {
+    .navbar {
+        background: var(--dv-header-bg);
+        border-bottom: 1px solid var(--dv-header-border);
+        box-shadow: none;
+    }
+
+    .navbar__inner {
+        --ifm-navbar-link-color: var(--dv-header-fg);
+        --ifm-navbar-link-hover-color: var(--dv-header-fg-hover);
+    }
+
+    .navbar__inner .navbar__title {
+        color: #ffffff;
+    }
+
+    .navbar__inner .DocSearch-Button,
+    .navbar__inner .navbar__search-input {
+        background: rgba(255, 255, 255, 0.08);
+        border-color: rgba(255, 255, 255, 0.16);
+        color: var(--dv-header-fg);
+    }
+}
+
+// ── Global refinements ────────────────────────────────────────────────────────
+
+html,
+body {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    font-feature-settings: 'cv11', 'ss01';
+}
+
+h1,
+h2,
+h3,
+.hero-headline {
+    letter-spacing: -0.02em;
+}
+
+.navbar {
+    transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 
 .navbar__brand {
     flex-direction: row-reverse;
 
     .navbar__logo {
-        margin-left: 0.5em;
+        margin-left: 0.55em;
         margin-right: 0px;
+        height: 1.85rem;
     }
 
     .navbar__title {
-        font-size: 1.6em;
+        font-size: 1.45em;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+        color: var(--ifm-heading-color);
+    }
+}
+
+.navbar__link {
+    font-weight: 500;
+    font-size: 0.95rem;
+}
+
+.navbar .DocSearch-Button,
+.navbar .navbar__search-input {
+    border-radius: 8px;
+    border: 1px solid var(--dv-border);
+    background: var(--ifm-background-surface-color);
+}
+
+// ── Announcement bar ──────────────────────────────────────────────────────────
+
+div[class^='announcementBar_'] {
+    --site-announcement-bar-stripe-color1: transparent;
+    --site-announcement-bar-stripe-color2: transparent;
+    background: var(--dv-accent-soft);
+    border-bottom: 1px solid var(--dv-border);
+    color: var(--ifm-heading-color);
+    font-weight: 500;
+    font-size: 0.85rem;
+
+    a {
+        color: var(--ifm-color-primary);
+        font-weight: 600;
     }
 }
 
@@ -146,21 +305,23 @@
 // ─── Buttons ──────────────────────────────────────────────────────────────────
 
 :root {
-    --ifm-button-border-radius: 6px;
+    --ifm-button-border-radius: 8px;
     --ifm-button-font-weight: 600;
+    --ifm-button-padding-horizontal: 1.4rem;
 }
 
 .button {
-    letter-spacing: 0.01em;
+    letter-spacing: 0.005em;
     transition:
         transform 0.12s ease,
         box-shadow 0.12s ease,
         background-color 0.15s ease,
-        color 0.15s ease;
+        color 0.15s ease,
+        filter 0.15s ease;
 
     &:hover {
         transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+        box-shadow: var(--dv-shadow-md);
         text-decoration: none;
     }
 
@@ -172,6 +333,21 @@
     &:focus-visible {
         outline: 2px solid var(--ifm-color-primary);
         outline-offset: 2px;
+    }
+}
+
+.button.button--primary {
+    background: var(--dv-accent-gradient);
+    border: none;
+    color: #ffffff;
+    box-shadow: 0 1px 2px rgba(49, 46, 129, 0.2),
+        0 6px 16px -6px rgba(79, 70, 229, 0.5);
+
+    &:hover {
+        color: #ffffff;
+        filter: brightness(1.05);
+        box-shadow: 0 2px 4px rgba(49, 46, 129, 0.24),
+            0 10px 24px -6px rgba(79, 70, 229, 0.55);
     }
 }
 
@@ -211,12 +387,19 @@
 
 .markdown {
     h1:first-child {
-        --ifm-h1-font-size: 2rem;
-        margin-bottom: 0.5rem;
+        --ifm-h1-font-size: 2.35rem;
+        margin-bottom: 1.25rem;
     }
 
     h2 {
-        --ifm-h2-font-size: 1.5rem;
+        --ifm-h2-font-size: 1.6rem;
+        margin-top: 2.75rem;
+        padding-bottom: 0.4rem;
+        border-bottom: 1px solid var(--dv-border);
+    }
+
+    h3 {
+        margin-top: 2rem;
     }
 
     p {
@@ -224,7 +407,10 @@
     }
 
     > p:first-of-type {
-        font-size: 1.25em;
+        font-size: 1.2em;
+        line-height: 1.6;
+        color: var(--ifm-color-content-secondary);
+        font-weight: 400;
     }
 
     table {
@@ -272,13 +458,20 @@
         // white-space: pre-wrap;
         .token {
             &.maybe-class-name {
-                color: #7c3aed;
+                color: #9333ea;
             }
             &.keyword {
-                color: #1d4ed8;
+                color: #4f46e5;
             }
         }
     }
+}
+
+// Inline code chips
+:not(pre) > code {
+    border: 1px solid var(--dv-border);
+    padding: 0.15rem 0.4rem;
+    font-weight: 500;
 }
 
 :root[data-theme='dark'] .markdown code .token {
@@ -292,13 +485,24 @@
 
 @import '~dockview/dist/styles/dockview.css';
 
+// ── Docs sidebar ──────────────────────────────────────────────────────────────
+
+.menu {
+    font-size: 0.9rem;
+    padding: 0.75rem !important;
+}
+
 .sidebar-section-header {
     > .menu__list-item-collapsible {
-        padding-top: 10px;
-        padding-bottom: 10px;
-        margin-top: 10px;
+        padding-top: 12px;
+        padding-bottom: 8px;
+        margin-top: 12px;
         border-top: 1px solid var(--ifm-toc-border-color);
         text-transform: uppercase;
+        letter-spacing: 0.07em;
+        font-size: 0.72rem;
+        font-weight: 600;
+        color: var(--ifm-color-content-secondary);
 
         &:hover {
             background-color: inherit;
@@ -320,6 +524,8 @@
 .menu__list {
     .menu__list .menu__link:not(.menu__link--sublist) {
         border-left: 1px solid var(--ifm-toc-border-color);
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
     }
 
     .menu__list {
@@ -327,11 +533,11 @@
     }
 
     .menu__list-item:not(:first-child) {
-        margin-top: 0px;
+        margin-top: 2px;
     }
 
     .menu__list .menu__link--active:not(.menu__link--sublist) {
-        border-left: 1px solid var(--ifm-color-primary);
+        border-left: 1.5px solid var(--ifm-color-primary);
     }
 
     .menu__list-item-collapsible .menu__link:hover,
@@ -341,11 +547,15 @@
 
     .menu__link,
     .menu__list-item-collapsible {
-        border-radius: 0px;
+        border-radius: var(--dv-radius-sm);
+        font-weight: 500;
+        color: var(--ifm-color-content-secondary);
+        transition: color 0.12s ease, background-color 0.12s ease;
     }
 
-    .menu__link {
-        font-size: 1rem;
+    .menu__link--active {
+        font-weight: 600;
+        color: var(--ifm-color-primary);
     }
 }
 
@@ -378,19 +588,24 @@
 .theme-admonition {
     display: flex;
     padding: 12px 16px;
-    border: none;
+    border: 1px solid var(--dv-border);
     border-left: 4px solid var(--ifm-alert-border-color);
-    border-radius: 6px;
+    border-radius: var(--dv-radius-sm);
+    box-shadow: var(--dv-shadow-sm);
 }
 
 .blog-list-page .hero {
     display: none;
 }
 
+.theme-code-block {
+    border-radius: var(--dv-radius-sm) !important;
+    box-shadow: var(--dv-shadow-sm);
+}
+
 :root:not([data-theme='dark']) {
     .theme-code-block {
-        border: 1px solid #e2e8f0;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+        border: 1px solid var(--dv-border);
     }
 }
 

--- a/packages/docs/src/css/custom.scss
+++ b/packages/docs/src/css/custom.scss
@@ -70,14 +70,9 @@
     --dv-accent: var(--ifm-color-primary);
     --dv-accent-strong: #6d5cf6;
     --dv-accent-contrast: #ffffff;
-    --dv-accent-soft: rgba(79, 70, 229, 0.08);
-    --dv-accent-soft-hover: rgba(79, 70, 229, 0.13);
-    --dv-accent-gradient: linear-gradient(
-        120deg,
-        #4f46e5 0%,
-        #6d5cf6 55%,
-        #8b5cf6 100%
-    );
+    // Solid block tints (no transparency) so they read as flat colour fields.
+    --dv-accent-soft: #ecebfb;
+    --dv-accent-soft-hover: #e0defa;
 
     --ifm-link-color: var(--ifm-color-primary);
     --ifm-link-hover-color: var(--ifm-color-primary-dark);
@@ -141,14 +136,9 @@
     --dv-accent: var(--ifm-color-primary);
     --dv-accent-strong: #a5a0ff;
     --dv-accent-contrast: #0b0b12;
-    --dv-accent-soft: rgba(139, 131, 255, 0.14);
-    --dv-accent-soft-hover: rgba(139, 131, 255, 0.2);
-    --dv-accent-gradient: linear-gradient(
-        120deg,
-        #6d5cf6 0%,
-        #8b83ff 55%,
-        #a78bfa 100%
-    );
+    // Solid block tints (no transparency) so they read as flat colour fields.
+    --dv-accent-soft: #211e3d;
+    --dv-accent-soft-hover: #2b2752;
 
     --ifm-code-background: #17171f;
 
@@ -208,8 +198,8 @@
 
     .navbar__inner .DocSearch-Button,
     .navbar__inner .navbar__search-input {
-        background: rgba(255, 255, 255, 0.08);
-        border-color: rgba(255, 255, 255, 0.16);
+        background: #323059;
+        border-color: #403d6b;
         color: var(--dv-header-fg);
     }
 }
@@ -337,17 +327,14 @@ div[class^='announcementBar_'] {
 }
 
 .button.button--primary {
-    background: var(--dv-accent-gradient);
+    background: var(--ifm-color-primary);
     border: none;
     color: #ffffff;
-    box-shadow: 0 1px 2px rgba(49, 46, 129, 0.2),
-        0 6px 16px -6px rgba(79, 70, 229, 0.5);
 
     &:hover {
+        background: var(--ifm-color-primary-dark);
         color: #ffffff;
-        filter: brightness(1.05);
-        box-shadow: 0 2px 4px rgba(49, 46, 129, 0.24),
-            0 10px 24px -6px rgba(79, 70, 229, 0.55);
+        box-shadow: var(--dv-shadow-md);
     }
 }
 

--- a/packages/docs/src/pages/index.scss
+++ b/packages/docs/src/pages/index.scss
@@ -16,7 +16,7 @@
         width: 18px;
         height: 2px;
         border-radius: 2px;
-        background: var(--dv-accent-gradient);
+        background: var(--ifm-color-primary);
     }
 }
 
@@ -27,31 +27,6 @@
     padding: 96px 0 72px;
     background: var(--ifm-background-color);
     border-bottom: 1px solid var(--ifm-toc-border-color);
-    overflow: hidden;
-
-    // soft accent glow behind the hero
-    &::before {
-        content: '';
-        position: absolute;
-        top: -180px;
-        left: 50%;
-        width: 900px;
-        height: 520px;
-        transform: translateX(-50%);
-        background: radial-gradient(
-            ellipse at center,
-            rgba(109, 92, 246, 0.16) 0%,
-            rgba(79, 70, 229, 0.08) 35%,
-            transparent 70%
-        );
-        pointer-events: none;
-        z-index: 0;
-    }
-
-    .container {
-        position: relative;
-        z-index: 1;
-    }
 }
 
 .hero-text {

--- a/packages/docs/src/pages/index.scss
+++ b/packages/docs/src/pages/index.scss
@@ -2,19 +2,56 @@
 
 .section-label {
     font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
+    font-weight: 700;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--ifm-color-primary);
-    margin-bottom: 2rem;
+    margin-bottom: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    &::before {
+        content: '';
+        width: 18px;
+        height: 2px;
+        border-radius: 2px;
+        background: var(--dv-accent-gradient);
+    }
 }
 
 // ─── Hero ─────────────────────────────────────────────────────────────────────
 
 .hero-section {
-    padding: 80px 0 60px;
+    position: relative;
+    padding: 96px 0 72px;
     background: var(--ifm-background-color);
     border-bottom: 1px solid var(--ifm-toc-border-color);
+    overflow: hidden;
+
+    // soft accent glow behind the hero
+    &::before {
+        content: '';
+        position: absolute;
+        top: -180px;
+        left: 50%;
+        width: 900px;
+        height: 520px;
+        transform: translateX(-50%);
+        background: radial-gradient(
+            ellipse at center,
+            rgba(109, 92, 246, 0.16) 0%,
+            rgba(79, 70, 229, 0.08) 35%,
+            transparent 70%
+        );
+        pointer-events: none;
+        z-index: 0;
+    }
+
+    .container {
+        position: relative;
+        z-index: 1;
+    }
 }
 
 .hero-text {
@@ -22,8 +59,8 @@
     flex-direction: column;
     align-items: center;
     text-align: center;
-    gap: 20px;
-    max-width: 520px;
+    gap: 22px;
+    max-width: 640px;
     margin: 0 auto;
 }
 
@@ -79,8 +116,8 @@
 .hero-preview {
     position: relative;
     display: block;
-    margin-top: 48px;
-    border-radius: 8px;
+    margin-top: 56px;
+    border-radius: var(--dv-radius);
     transition:
         transform 0.2s ease,
         box-shadow 0.2s ease;
@@ -130,9 +167,10 @@
 }
 
 .hero-headline {
-    font-size: clamp(2rem, 4vw, 2.75rem);
-    font-weight: 700;
-    line-height: 1.15;
+    font-size: clamp(2.25rem, 4.5vw, 3.25rem);
+    font-weight: 800;
+    line-height: 1.1;
+    letter-spacing: -0.03em;
     margin: 0;
     color: var(--ifm-heading-color);
 }
@@ -140,53 +178,58 @@
 .hero-framework {
     display: block;
     animation: framework-in 0.35s ease forwards;
+    font-weight: 800;
 }
 
 .hero-subtitle {
-    font-size: 1.05rem;
+    font-size: 1.15rem;
     line-height: 1.65;
     color: var(--ifm-color-content-secondary);
     margin: 0;
+    max-width: 540px;
 }
 
 .hero-actions {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 12px;
+    gap: 16px;
+    margin-top: 4px;
 }
 
 .hero-fw-btns {
     display: flex;
-    gap: 8px;
+    gap: 10px;
     flex-wrap: wrap;
+    justify-content: center;
 }
 
 .hero-fw-btn {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 8px 14px;
-    border: 1px solid var(--ifm-toc-border-color);
-    border-radius: 6px;
+    gap: 8px;
+    padding: 9px 16px;
+    border: 1px solid var(--dv-border-strong);
+    border-radius: 10px;
     background: var(--ifm-background-color);
     color: var(--ifm-color-content);
     font-size: 0.9rem;
-    font-weight: 500;
+    font-weight: 600;
     text-decoration: none;
+    box-shadow: var(--dv-shadow-sm);
     transition:
         border-color 0.15s,
-        background 0.15s;
+        background 0.15s,
+        transform 0.15s,
+        box-shadow 0.15s;
 
     &:hover {
         border-color: var(--ifm-color-primary);
-        background: color-mix(
-            in srgb,
-            var(--ifm-color-primary) 12%,
-            transparent
-        );
+        background: var(--dv-accent-soft);
         color: var(--ifm-color-content);
         text-decoration: none;
+        transform: translateY(-2px);
+        box-shadow: var(--dv-shadow-md);
     }
 
     &:focus-visible {
@@ -201,15 +244,16 @@
 
 .hero-gif {
     width: 100%;
-    border-radius: 8px;
-    border: 1px solid var(--ifm-toc-border-color);
+    border-radius: var(--dv-radius);
+    border: 1px solid var(--dv-border-strong);
+    box-shadow: var(--dv-shadow-lg);
     display: block;
 }
 
 // ─── Features ─────────────────────────────────────────────────────────────────
 
 .features-section {
-    padding: 72px 0;
+    padding: 88px 0;
     background: var(--ifm-background-surface-color);
     border-bottom: 1px solid var(--ifm-toc-border-color);
 }
@@ -217,7 +261,7 @@
 .features-grid {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 16px;
+    gap: 18px;
 
     @media (min-width: 640px) {
         grid-template-columns: repeat(2, 1fr);
@@ -230,29 +274,53 @@
 
 .feature-card {
     background: var(--ifm-background-color);
-    border: 1px solid var(--ifm-toc-border-color);
-    border-radius: 8px;
-    padding: 24px;
+    border: 1px solid var(--dv-border);
+    border-radius: var(--dv-radius);
+    padding: 26px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
+    box-shadow: var(--dv-shadow-sm);
+    transition:
+        transform 0.18s ease,
+        box-shadow 0.18s ease,
+        border-color 0.18s ease;
+
+    &:hover {
+        transform: translateY(-3px);
+        box-shadow: var(--dv-shadow-md);
+        border-color: var(--dv-border-strong);
+    }
 }
 
 .feature-card-icon {
     color: var(--ifm-color-primary);
     display: flex;
-    width: fit-content;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 11px;
+    background: var(--dv-accent-soft);
+    border: 1px solid var(--dv-accent-soft-hover);
+
+    svg {
+        width: 22px;
+        height: 22px;
+    }
 }
 
 .feature-card-title {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
     margin: 0;
+    color: var(--ifm-heading-color);
 }
 
 .feature-card-description {
     font-size: 0.9rem;
-    line-height: 1.6;
+    line-height: 1.65;
     color: var(--ifm-color-content-secondary);
     margin: 0;
 }
@@ -260,14 +328,14 @@
 // ─── Frameworks ───────────────────────────────────────────────────────────────
 
 .frameworks-section {
-    padding: 64px 0;
+    padding: 80px 0;
     background: var(--ifm-background-color);
     border-bottom: 1px solid var(--ifm-toc-border-color);
 }
 
 .frameworks-grid {
     display: flex;
-    gap: 16px;
+    gap: 18px;
     flex-wrap: wrap;
 
     @media (min-width: 640px) {
@@ -281,29 +349,42 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 8px;
-    padding: 24px 16px;
-    border: 1px solid var(--ifm-toc-border-color);
-    border-radius: 8px;
+    gap: 10px;
+    padding: 28px 16px;
+    border: 1px solid var(--dv-border);
+    border-radius: var(--dv-radius);
     background: var(--ifm-background-surface-color);
+    box-shadow: var(--dv-shadow-sm);
+    transition:
+        transform 0.18s ease,
+        box-shadow 0.18s ease,
+        border-color 0.18s ease;
+
+    &:hover {
+        transform: translateY(-3px);
+        box-shadow: var(--dv-shadow-md);
+        border-color: var(--dv-border-strong);
+    }
 }
 
 .framework-logo {
-    width: 40px;
-    height: 40px;
+    width: 44px;
+    height: 44px;
     object-fit: contain;
 }
 
 .framework-name {
-    font-weight: 600;
-    font-size: 0.95rem;
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--ifm-heading-color);
 }
 
 .framework-pkg {
     font-size: 0.75rem;
     background: var(--ifm-code-background);
-    padding: 2px 6px;
-    border-radius: 4px;
+    border: 1px solid var(--dv-border);
+    padding: 3px 8px;
+    border-radius: 6px;
     color: var(--ifm-color-content-secondary);
 }
 
@@ -342,9 +423,10 @@
     code {
         display: inline-block;
         padding: 12px 20px;
-        border-radius: 8px;
-        border: 1px solid var(--ifm-toc-border-color);
+        border-radius: var(--dv-radius-sm);
+        border: 1px solid var(--dv-border);
         background: var(--ifm-background-color);
+        box-shadow: var(--dv-shadow-sm);
         font-size: 0.95rem;
         color: var(--ifm-color-content);
     }
@@ -364,7 +446,9 @@
         transform: none;
     }
 
-    .hero-fw-btn {
+    .hero-fw-btn,
+    .feature-card,
+    .framework-item {
         transition: none;
     }
 


### PR DESCRIPTION
## Description

Reworks the documentation website's theme into a modern, consistent design system, layered on top of the current `v8-branch` docs (all of its additions are preserved — menu colour, richer tables, code-comment contrast fixes, the enterprise badge, hero stats and the CTA section).

Highlights:
- **Ocean-blue accent** (`#2563eb`), aligned with the blue brand mark, applied consistently across links, buttons, active sidebar items, section labels, focus rings, code keywords, the announcement bar and the newsletter widget — in both light and dark themes.
- **Solid block colours** throughout — flat colour fields rather than gradients or semi-transparent tints on backgrounds and buttons.
- **Shared design-token layer** (radii, elevation, border tokens, accent-soft tints) defined for both themes.
- **Tightened type scale** — larger tracked headings, a lighter secondary lead paragraph, more generous and consistent section spacing.
- **Dark "ink" header for the light theme**, scoped to the desktop bar (`.navbar__inner`) so the mobile slide-out menu stays light; the dark theme keeps its own dark navbar.
- **Component polish** — solid primary button, feature cards with tinted icon tiles and hover lift, framework cards with hover states, rounded active sidebar pills, bordered inline-code chips, underlined `h2`s, and softer admonitions and code blocks.

Only two files change: `packages/docs/src/css/custom.scss` and `packages/docs/src/pages/index.scss`.

## Type of change

- [x] Documentation

## Affected packages

- [x] `docs`

## How to test

1. `cd packages/docs && yarn start`
2. Open the homepage and any docs page (e.g. `/docs/overview/introduction`) and toggle light/dark.
3. Verify: the light theme uses the ocean-blue accent with a dark header and flat block-colour fills; the active sidebar item is a solid pill; the dark theme keeps its own dark header. No gradients or translucent accent tints remain.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented

<sub>This is a CSS-only docs change; `gen`/`test` are not applicable and there are no behavioural or breaking changes. Run `yarn lint:fix` / `yarn format` before merge if the repo's style checks cover SCSS.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UsXiFK46kQJqAv5HtdYGiB)_