### PR TITLE
docs: humanize wording and remove AI-style em dashes

### DIFF
--- a/packages/docs/AGENTS.md
+++ b/packages/docs/AGENTS.md
@@ -2,6 +2,25 @@
 
 Documentation website built with Docusaurus v3.
 
+## Writing Style
+
+Documentation prose should read as though a person wrote it, not a language
+model. When writing or editing docs:
+
+- Do not use em dashes (`—`). Rewrite the sentence with a comma, colon,
+  semicolon, parentheses, or a full stop, whichever fits. This is the single
+  most common tell; avoid it everywhere, including frontmatter `description`
+  fields, tables, and code comments.
+- Drop filler and marketing words. Avoid "comprehensive", "a wide variety of",
+  "out of the box", "seamlessly", "powerful", "robust", "unlocks", "leverage",
+  "delve into", "first-class", "it's worth noting", "keep in mind". State the
+  concrete thing instead.
+- Prefer short, direct sentences. Cut words that carry no meaning; don't hedge
+  or pad.
+- Keep British spelling (behaviour, colour, localise) to match the existing
+  docs.
+- An en dash in a numeric range (`v5.0–5.2`) is correct and fine to keep.
+
 ## Build Commands
 
 - `build` - Build templates then build Docusaurus site

--- a/packages/docs/docs/advanced/accessibility.mdx
+++ b/packages/docs/docs/advanced/accessibility.mdx
@@ -1,15 +1,15 @@
 ---
 title: Accessibility
-description: The ARIA semantics, keyboard support and screen-reader announcements Dockview ships out of the box.
+description: The ARIA semantics, keyboard support and screen-reader announcements Dockview provides by default.
 sidebar_position: 1
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-Dockview ships a baseline of accessibility in core — WAI-ARIA roles and labels,
+Dockview ships a baseline of accessibility in core: WAI-ARIA roles and labels,
 roving-tabindex navigation within the tab strip, screen-reader announcements of
-layout changes, and keyboard-only focus indicators — included out of the box in
-the `dockview` package and the framework packages. No configuration is required
+layout changes, and keyboard-only focus indicators. These come with the
+`dockview` package and the framework packages. No configuration is required
 for the semantics below; the options on this page tune the announcements and the
 opt-in keymap.
 
@@ -28,7 +28,7 @@ technology can describe the layout:
 - Close buttons expose an accessible name that includes the panel title (e.g.
   "Close Orders").
 
-These roles are reactive — activating a tab, floating a group or calling
+These roles are reactive: activating a tab, floating a group or calling
 `setTitle` updates the relevant attributes.
 
 ## Keyboard navigation
@@ -38,8 +38,8 @@ stop, and the arrow keys move between tabs once the strip has focus. `Home` /
 `End` jump to the first / last tab, and `Enter` / `Space` activate the focused
 tab. This within-strip navigation is always on.
 
-Broader keyboard operability — switching tabs, cycling groups with `F6`, jumping
-focus to the tab strip, and keyboard-driven docking — is enabled with the
+Broader keyboard operability (switching tabs, cycling groups with `F6`, jumping
+focus to the tab strip, and keyboard-driven docking) is enabled with the
 `keyboardNavigation` option and is documented in full on the
 [Keyboard](/docs/advanced/keyboard) page, including the rebindable keymap.
 
@@ -59,8 +59,8 @@ focused by keyboard.
 
 ## Screen-reader announcements
 
-Dockview narrates layout changes — panels opening/closing, groups floating,
-docking, popping out, maximising/restoring — through visually-hidden ARIA live
+Dockview narrates layout changes (panels opening/closing, groups floating,
+docking, popping out, maximising/restoring) through visually-hidden ARIA live
 regions (a polite region for routine status and an assertive one for
 cancellations). This is on by default.
 
@@ -126,7 +126,7 @@ const options = {
 
 For full translations, provide a `messages` catalog. Each entry is a function
 that builds the string from the relevant context (e.g. the panel title); supply
-any subset — unset entries keep the English defaults:
+any subset; unset entries keep the English defaults:
 
 ```ts
 const options = {
@@ -154,5 +154,5 @@ const options = {
 
 ## See also
 
-- [Focus navigation](/docs/advanced/focus-navigation) — `DockviewApi` methods for moving focus between panels and groups
-- [Keyboard](/docs/advanced/keyboard) — the opt-in keymap, `F6` group cycling and keyboard-driven docking
+- [Focus navigation](/docs/advanced/focus-navigation): `DockviewApi` methods for moving focus between panels and groups
+- [Keyboard](/docs/advanced/keyboard): the opt-in keymap, `F6` group cycling and keyboard-driven docking

--- a/packages/docs/docs/advanced/focus-navigation.mdx
+++ b/packages/docs/docs/advanced/focus-navigation.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 `DockviewApi` exposes a small set of framework-agnostic methods for moving
 focus between panels and groups programmatically. They work in every framework
-binding — useful for wiring up your own keyboard shortcut handlers. The rebindable keymap and keyboard docking are a separate,
+binding, useful for wiring up your own keyboard shortcut handlers. The rebindable keymap and keyboard docking are a separate,
 enterprise feature covered in [Keyboard Navigation](/docs/advanced/keyboard).
 
 ## Programmatic focus navigation
@@ -24,7 +24,7 @@ api.activatePrevious({ includePanel: true });
 :::info Renamed in v8
 These methods were previously called `moveToNext` / `moveToPrevious`. The old
 names still work as deprecated aliases but will be removed in a future major
-release — the new names make it clear they advance the active panel/group
+release; the new names make it clear they advance the active panel/group
 (focus) rather than relocating a panel.
 :::
 
@@ -65,5 +65,5 @@ const layout = api.groups.map((group) => ({
 
 ## See also
 
-- [Keyboard](/docs/advanced/keyboard) — the rebindable keymap and keyboard-driven docking built on top of these primitives
-- [Accessibility](/docs/advanced/accessibility) — the ARIA semantics and within-strip keyboard navigation Dockview ships by default
+- [Keyboard](/docs/advanced/keyboard): the rebindable keymap and keyboard-driven docking built on top of these primitives
+- [Accessibility](/docs/advanced/accessibility): the ARIA semantics and within-strip keyboard navigation Dockview ships by default

--- a/packages/docs/docs/advanced/keyboard.mdx
+++ b/packages/docs/docs/advanced/keyboard.mdx
@@ -9,7 +9,7 @@ sidebar_custom_props:
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-Dockview can be driven entirely from the keyboard — switching tabs, moving focus
+Dockview can be driven entirely from the keyboard: switching tabs, moving focus
 between groups, and even docking a panel into a new position, all without a
 mouse. This page covers the built-in keymap and keyboard docking. For the
 accessibility semantics that back it (ARIA roles, screen-reader announcements,
@@ -54,7 +54,7 @@ const options = {
 };
 ```
 
-The keymap is rebindable — pass an object with a `keymap` to override individual
+The keymap is rebindable: pass an object with a `keymap` to override individual
 keys. Unset keys keep their defaults:
 
 ```ts
@@ -71,7 +71,7 @@ const options = {
 Each binding is a `+`-separated string, modifiers first. Recognised modifiers
 are `ctrl`, `shift`, `alt`, and `meta` (alias `cmd`); the final part is the
 [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
-to match, case-insensitively — e.g. `'ctrl+]'`, `'shift+f6'`, `'ctrl+tab'`.
+to match, case-insensitively, for example `'ctrl+]'`, `'shift+f6'`, `'ctrl+tab'`.
 
 ## Moving between tabs and groups
 
@@ -85,11 +85,11 @@ to match, case-insensitively — e.g. `'ctrl+]'`, `'shift+f6'`, `'ctrl+tab'`.
 | Move focus to the group in a direction          | `Ctrl+Shift+←/→/↑/↓` | `focusGroup{Left,Right,Up,Down}` |
 
 `F6` / `Shift+F6` cycle the groups in list order. `Ctrl+Shift+Arrows` jump to
-the visually adjacent group instead — the same geometry used by the
+the visually adjacent group instead, the same geometry used by the
 [`adjacentGroupInDirection`](/docs/advanced/focus-navigation) API, so mouse and
 keyboard agree on what "the group to the left" is. Once focus lands on the tab
 strip (via `Ctrl+Shift+\` or `F6`),
-the strip's own arrow-key navigation takes over — see
+the strip's own arrow-key navigation takes over. See
 [Accessibility](/docs/advanced/accessibility#keyboard-navigation).
 
 ## Keyboard docking
@@ -98,9 +98,9 @@ Press `Ctrl+M` to dock the active panel somewhere new without dragging. A live
 drop preview follows the current selection, and each step is announced to screen
 readers:
 
-1. **Pick a target group** — arrow keys cycle through the groups (including the
+1. **Pick a target group**: arrow keys cycle through the groups (including the
    panel's own, so you can split a tab out of its group); `Enter` selects one.
-2. **Pick an edge** — arrow keys choose a split edge (left / right / top /
+2. **Pick an edge**: arrow keys choose a split edge (left / right / top /
    bottom), or the centre to tab into the group; `Enter` commits the move.
 
 `Esc` steps back a phase, or cancels the move entirely from the first phase.

--- a/packages/docs/docs/api/dockview/groupApi.mdx
+++ b/packages/docs/docs/api/dockview/groupApi.mdx
@@ -1,12 +1,12 @@
 ---
 title: Group API
 sidebar_position: 3
-description: Reference for the Dockview Group API — methods and events for controlling individual groups.
+description: Reference for the Dockview Group API: methods and events for controlling individual groups.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The group API controls a single group of panels — its active panel, location, and header.
+The group API controls a single group of panels: its active panel, location, and header.
 
 :::info
 Use the group API sparingly. As you move panels, groups change and if you don't track this correctly you may encounter unexpected
@@ -17,5 +17,5 @@ behaviours. You should be able to achieve most things directly through the panel
 
 ## See also
 
-- [Add a group](/docs/core/groups/add) — how groups are created and populated.
-- [Add a panel](/docs/core/panels/add) — the panels a group contains.
+- [Add a group](/docs/core/groups/add): how groups are created and populated.
+- [Add a panel](/docs/core/panels/add): the panels a group contains.

--- a/packages/docs/docs/api/dockview/options.mdx
+++ b/packages/docs/docs/api/dockview/options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Options
 sidebar_position: 0
-description: Configuration options for the Dockview component — props and initialization settings.
+description: Configuration options for the Dockview component: props and initialization settings.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
@@ -26,5 +26,5 @@ The options available when creating a Dockview component.
 
 ## See also
 
-- [Dockview overview](/docs/core/overview) — where these options fit in the bigger picture.
-- [Panel rendering](/docs/core/panels/rendering) — the rendering behaviour several options control.
+- [Dockview overview](/docs/core/overview): where these options fit in the bigger picture.
+- [Panel rendering](/docs/core/panels/rendering): the rendering behaviour several options control.

--- a/packages/docs/docs/api/dockview/overview.mdx
+++ b/packages/docs/docs/api/dockview/overview.mdx
@@ -1,16 +1,16 @@
 ---
 title: API
 sidebar_position: 1
-description: Full reference for the Dockview API — the primary interface for creating and managing panels and groups.
+description: Full reference for the Dockview API: the primary interface for creating and managing panels and groups.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The `DockviewApi` is the primary interface for controlling a Dockview instance — adding panels and groups, saving and restoring layouts, and subscribing to events.
+The `DockviewApi` is the primary interface for controlling a Dockview instance: adding panels and groups, saving and restoring layouts, and subscribing to events.
 
 <DocRef declaration="DockviewApi" />
 
 ## See also
 
-- [Dockview overview](/docs/core/overview) — the concepts and setup behind Dockview.
-- [Add a panel](/docs/core/panels/add) — how to populate the layout with content.
+- [Dockview overview](/docs/core/overview): the concepts and setup behind Dockview.
+- [Add a panel](/docs/core/panels/add): how to populate the layout with content.

--- a/packages/docs/docs/api/dockview/panelApi.mdx
+++ b/packages/docs/docs/api/dockview/panelApi.mdx
@@ -1,16 +1,16 @@
 ---
 title: Panel API
 sidebar_position: 2
-description: Reference for the Dockview Panel API — methods and events available within individual panels.
+description: Reference for the Dockview Panel API: methods and events available within individual panels.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The panel API controls a single Dockview panel — sizing, visibility, focus, and parameter updates.
+The panel API controls a single Dockview panel: sizing, visibility, focus, and parameter updates.
 
 <DocRef declaration="DockviewPanelApi" />
 
 ## See also
 
-- [Add a panel](/docs/core/panels/add) — how panels are created and referenced.
-- [Panel rendering](/docs/core/panels/rendering) — how a panel's content is rendered.
+- [Add a panel](/docs/core/panels/add): how panels are created and referenced.
+- [Panel rendering](/docs/core/panels/rendering): how a panel's content is rendered.

--- a/packages/docs/docs/api/gridview/api.mdx
+++ b/packages/docs/docs/api/gridview/api.mdx
@@ -1,15 +1,15 @@
 ---
 title: API
 sidebar_position: 1
-description: Full reference for the Gridview API — methods and events for controlling the grid layout.
+description: Full reference for the Gridview API: methods and events for controlling the grid layout.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The `GridviewApi` is the primary interface for controlling a Gridview instance — adding and moving panels, saving and restoring layouts, and subscribing to events.
+The `GridviewApi` is the primary interface for controlling a Gridview instance: adding and moving panels, saving and restoring layouts, and subscribing to events.
 
 <DocRef declaration="GridviewApi" />
 
 ## See also
 
-- [Gridview overview](/docs/other/gridview/overview) — concepts and a live example of the grid.
+- [Gridview overview](/docs/other/gridview/overview): concepts and a live example of the grid.

--- a/packages/docs/docs/api/gridview/options.mdx
+++ b/packages/docs/docs/api/gridview/options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Options
 sidebar_position: 0
-description: Configuration options for the Gridview component — props and initialization settings.
+description: Configuration options for the Gridview component: props and initialization settings.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
@@ -26,4 +26,4 @@ The options available when creating a Gridview component.
 
 ## See also
 
-- [Gridview overview](/docs/other/gridview/overview) — concepts and a live example of the grid.
+- [Gridview overview](/docs/other/gridview/overview): concepts and a live example of the grid.

--- a/packages/docs/docs/api/gridview/panelApi.mdx
+++ b/packages/docs/docs/api/gridview/panelApi.mdx
@@ -1,15 +1,15 @@
 ---
 title: Panel API
 sidebar_position: 2
-description: Reference for the Gridview Panel API — methods and events available within individual grid panels.
+description: Reference for the Gridview Panel API: methods and events available within individual grid panels.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The panel API controls a single Gridview panel — sizing, visibility, focus, and parameter updates.
+The panel API controls a single Gridview panel: sizing, visibility, focus, and parameter updates.
 
 <DocRef declaration="GridviewPanelApi" />
 
 ## See also
 
-- [Gridview overview](/docs/other/gridview/overview) — concepts and a live example of the grid.
+- [Gridview overview](/docs/other/gridview/overview): concepts and a live example of the grid.

--- a/packages/docs/docs/api/paneview/api.mdx
+++ b/packages/docs/docs/api/paneview/api.mdx
@@ -1,15 +1,15 @@
 ---
 title: API
 sidebar_position: 1
-description: Full reference for the Paneview API — methods and events for controlling the pane layout.
+description: Full reference for the Paneview API: methods and events for controlling the pane layout.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The `PaneviewApi` is the primary interface for controlling a Paneview instance — adding and moving panes, saving and restoring layouts, and subscribing to events.
+The `PaneviewApi` is the primary interface for controlling a Paneview instance: adding and moving panes, saving and restoring layouts, and subscribing to events.
 
 <DocRef declaration="PaneviewApi" />
 
 ## See also
 
-- [Paneview overview](/docs/other/paneview/overview) — concepts and a live example of the pane view.
+- [Paneview overview](/docs/other/paneview/overview): concepts and a live example of the pane view.

--- a/packages/docs/docs/api/paneview/options.mdx
+++ b/packages/docs/docs/api/paneview/options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Options
 sidebar_position: 0
-description: Configuration options for the Paneview component — props and initialization settings.
+description: Configuration options for the Paneview component: props and initialization settings.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
@@ -26,4 +26,4 @@ The options available when creating a Paneview component.
 
 ## See also
 
-- [Paneview overview](/docs/other/paneview/overview) — concepts and a live example of the pane view.
+- [Paneview overview](/docs/other/paneview/overview): concepts and a live example of the pane view.

--- a/packages/docs/docs/api/paneview/panelApi.mdx
+++ b/packages/docs/docs/api/paneview/panelApi.mdx
@@ -1,15 +1,15 @@
 ---
 title: Panel API
 sidebar_position: 2
-description: Reference for the Paneview Panel API — methods and events available within individual pane panels.
+description: Reference for the Paneview Panel API: methods and events available within individual pane panels.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The panel API controls a single Paneview pane — sizing, visibility, focus, and parameter updates.
+The panel API controls a single Paneview pane: sizing, visibility, focus, and parameter updates.
 
 <DocRef declaration="PaneviewPanelApi" />
 
 ## See also
 
-- [Paneview overview](/docs/other/paneview/overview) — concepts and a live example of the pane view.
+- [Paneview overview](/docs/other/paneview/overview): concepts and a live example of the pane view.

--- a/packages/docs/docs/api/splitview/api.mdx
+++ b/packages/docs/docs/api/splitview/api.mdx
@@ -1,15 +1,15 @@
 ---
 title: API
 sidebar_position: 1
-description: Full reference for the Splitview API — methods and events for controlling the split layout.
+description: Full reference for the Splitview API: methods and events for controlling the split layout.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The `SplitviewApi` is the primary interface for controlling a Splitview instance — adding and moving views, saving and restoring layouts, and subscribing to events.
+The `SplitviewApi` is the primary interface for controlling a Splitview instance: adding and moving views, saving and restoring layouts, and subscribing to events.
 
 <DocRef declaration="SplitviewApi" />
 
 ## See also
 
-- [Splitview overview](/docs/other/splitview/overview) — concepts and a live example of the split view.
+- [Splitview overview](/docs/other/splitview/overview): concepts and a live example of the split view.

--- a/packages/docs/docs/api/splitview/options.mdx
+++ b/packages/docs/docs/api/splitview/options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Options
 sidebar_position: 0
-description: Configuration options for the Splitview component — props and initialization settings.
+description: Configuration options for the Splitview component: props and initialization settings.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
@@ -26,4 +26,4 @@ The options available when creating a Splitview component.
 
 ## See also
 
-- [Splitview overview](/docs/other/splitview/overview) — concepts and a live example of the split view.
+- [Splitview overview](/docs/other/splitview/overview): concepts and a live example of the split view.

--- a/packages/docs/docs/api/splitview/panelApi.mdx
+++ b/packages/docs/docs/api/splitview/panelApi.mdx
@@ -1,15 +1,15 @@
 ---
 title: Panel API
 sidebar_position: 2
-description: Reference for the Splitview Panel API — methods and events available within individual split panels.
+description: Reference for the Splitview Panel API: methods and events available within individual split panels.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-The panel API controls a single Splitview panel — sizing, visibility, focus, and parameter updates.
+The panel API controls a single Splitview panel: sizing, visibility, focus, and parameter updates.
 
 <DocRef declaration="SplitviewPanelApi" />
 
 ## See also
 
-- [Splitview overview](/docs/other/splitview/overview) — concepts and a live example of the split view.
+- [Splitview overview](/docs/other/splitview/overview): concepts and a live example of the split view.

--- a/packages/docs/docs/core/dnd/disable.mdx
+++ b/packages/docs/docs/core/dnd/disable.mdx
@@ -30,12 +30,12 @@ You may want to combine this with `locked={true}` to provide a locked grid with 
 
 ## Building a tabview
 
-Selectively restricting the default drag and drop behaviours turns a dock into a plain _tabview_ — a single group of tabs with no rearranging. The example below shows the effect:
+Selectively restricting the default drag and drop behaviours turns a dock into a plain _tabview_: a single group of tabs with no rearranging. The example below shows the effect:
 
 <CodeRunner id="dockview/tabview" />
 
 ## See also
 
-- [Drag and drop strategy](/docs/core/dnd/strategy) — `disableDnd` overrides whichever backend is selected.
-- [Drag and drop](/docs/core/dnd/dragAndDrop) — the drag and drop behaviour you are switching off.
-- [Tabs](/docs/core/panels/tabs) — customising how tabs are rendered.
+- [Drag and drop strategy](/docs/core/dnd/strategy): `disableDnd` overrides whichever backend is selected.
+- [Drag and drop](/docs/core/dnd/dragAndDrop): the drag and drop behaviour you are switching off.
+- [Tabs](/docs/core/panels/tabs): customising how tabs are rendered.

--- a/packages/docs/docs/core/dnd/dragAndDrop.mdx
+++ b/packages/docs/docs/core/dnd/dragAndDrop.mdx
@@ -75,7 +75,7 @@ const api = createDockview(parentElement, {
 
 For interaction with the drag events directly the component exposes some methods to help determine whether external drag events should be interacted with or not.
 
-The `onDidDrop` handler and `onUnhandledDragOver` registration use the same API across all frameworks — only the component wiring differs.
+The `onDidDrop` handler and `onUnhandledDragOver` registration use the same API across all frameworks; only the component wiring differs.
 
 ```ts
 /**
@@ -142,7 +142,7 @@ parentElement.addEventListener('drop', (e) => onDidDrop(e));
 
 ## Customising the group drag ghost
 
-When the user drags a whole group of panels by its empty header area, Dockview shows a small floating ghost that follows the cursor. By default it renders the text `Multiple Panels (N)` — to localise the label or replace the visual entirely, supply a `createGroupDragGhostComponent` factory. It receives the `DockviewGroupPanel` being dragged and must return an `IGroupDragGhostRenderer`.
+When the user drags a whole group of panels by its empty header area, Dockview shows a small floating ghost that follows the cursor. By default it renders the text `Multiple Panels (N)`. To localise the label or replace the visual entirely, supply a `createGroupDragGhostComponent` factory. It receives the `DockviewGroupPanel` being dragged and must return an `IGroupDragGhostRenderer`.
 
 <FrameworkSpecific framework="React">
   <DocRef declaration="IDockviewReactProps" methods={['groupDragGhostComponent']} />
@@ -170,7 +170,7 @@ interface IGroupDragGhostRenderer {
 }
 ````
 
-The ghost is captured by the browser at drag start and removed shortly after, so the component is short-lived — render synchronously enough to be painted before the browser snapshots the element.
+The ghost is captured by the browser at drag start and removed shortly after, so the component is short-lived; render synchronously enough to be painted before the browser snapshots the element.
 
 <FrameworkSpecific framework="React">
 ```tsx
@@ -233,8 +233,8 @@ createGroupDragGhostComponent: (group) => new MyGroupDragGhost(),
 
 ## See also
 
-- [External drag and drop events](/docs/core/dnd/external) — intercept drops that originate outside Dockview.
-- [Drag and drop strategy](/docs/core/dnd/strategy) — choose the HTML5 or pointer backend and tune touch gestures.
-- [Third-party libraries](/docs/core/dnd/thirdParty) — using other drag and drop libraries inside a panel.
-- [Disable drag and drop](/docs/core/dnd/disable) — turn dragging off for a fixed layout.
+- [External drag and drop events](/docs/core/dnd/external): intercept drops that originate outside Dockview.
+- [Drag and drop strategy](/docs/core/dnd/strategy): choose the HTML5 or pointer backend and tune touch gestures.
+- [Third-party libraries](/docs/core/dnd/thirdParty): using other drag and drop libraries inside a panel.
+- [Disable drag and drop](/docs/core/dnd/disable): turn dragging off for a fixed layout.
 ```

--- a/packages/docs/docs/core/dnd/dropGuide.mdx
+++ b/packages/docs/docs/core/dnd/dropGuide.mdx
@@ -45,9 +45,9 @@ const api = createDockview(element, {
 
 While dragging over an accepting group the compass shows:
 
-- **Inner cells** (`top` / `bottom` / `left` / `right` / `center`) — split this group on that edge, or `center` to
+- **Inner cells** (`top` / `bottom` / `left` / `right` / `center`): split this group on that edge, or `center` to
   tab into the group. These have the same result as today's cursor quadrants.
-- **Outer cells** (`top` / `bottom` / `left` / `right`) — dock against the **whole layout** edge, even though the
+- **Outer cells** (`top` / `bottom` / `left` / `right`): dock against the **whole layout** edge, even though the
   cursor is over a group.
 
 A cell is only shown when a drop there is actually possible, so the compass reflects exactly the legal drops for the
@@ -69,12 +69,12 @@ const api = createDockview(element, {
 });
 ```
 
-- `zones` — restrict which **inner** cells appear. For example `['center']` allows reorder / merge only.
+- `zones`: restrict which **inner** cells appear. For example `['center']` allows reorder / merge only.
   Defaults to all zones the target accepts.
-- `edges` — include the **outer** whole-layout-edge cells. Defaults to `true`; set `false` for group-only docking.
+- `edges`: include the **outer** whole-layout-edge cells. Defaults to `true`; set `false` for group-only docking.
 
 ## See also
 
-- [Smart Guides](/docs/core/dnd/smartGuides) — alignment snapping for floating groups.
-- [Drop overlay](/docs/core/dnd/overlay) — customise the overlay that previews the resolved drop zone.
-- [Drop Position Resolver](/docs/core/dnd/dropPosition) — a lower-level seam to override where a pointer maps to a drop position.
+- [Smart Guides](/docs/core/dnd/smartGuides): alignment snapping for floating groups.
+- [Drop overlay](/docs/core/dnd/overlay): customise the overlay that previews the resolved drop zone.
+- [Drop Position Resolver](/docs/core/dnd/dropPosition): a lower-level seam to override where a pointer maps to a drop position.

--- a/packages/docs/docs/core/dnd/dropPosition.mdx
+++ b/packages/docs/docs/core/dnd/dropPosition.mdx
@@ -39,7 +39,7 @@ unaffected). When unset, the built-in cursor-quadrant behaviour is used, unchang
     />
 </FrameworkSpecific>
 
-A `PositionResolver` maps the pointer location within a target to a drop `Position` — or `null` for no drop. Both drag
+A `PositionResolver` maps the pointer location within a target to a drop `Position`, or `null` for no drop. Both drag
 backends consult the same resolver. It is read live, so it can be swapped at runtime via `api.updateOptions`.
 
 ```ts
@@ -93,12 +93,12 @@ const api = createDockview(element, {
 
 :::info
 The visual aim-at-a-cell overlay is covered in [Drop Guide](/docs/core/dnd/dropGuide). That compass (`dndGuide`)
-installs its own resolver, so enable one or the other — `dndGuide` when you want the built-in aim-at-a-cell affordance,
+installs its own resolver, so enable one or the other: `dndGuide` when you want the built-in aim-at-a-cell affordance,
 `dropPositionResolver` when you want full control over the resolved position.
 :::
 
 ## See also
 
-- [Drop overlay](/docs/core/dnd/overlay) — shape the overlay that previews the resolved drop zone.
-- [Drop guide](/docs/core/dnd/dropGuide) — the aim-at-a-cell compass built on top of this resolver.
-- [Smart guides](/docs/core/dnd/smartGuides) — alignment snapping for floating groups.
+- [Drop overlay](/docs/core/dnd/overlay): shape the overlay that previews the resolved drop zone.
+- [Drop guide](/docs/core/dnd/dropGuide): the aim-at-a-cell compass built on top of this resolver.
+- [Smart guides](/docs/core/dnd/smartGuides): alignment snapping for floating groups.

--- a/packages/docs/docs/core/dnd/external.mdx
+++ b/packages/docs/docs/core/dnd/external.mdx
@@ -28,17 +28,17 @@ Narrow before reading `DragEvent`-only fields like `dataTransfer`:
 ```ts
 api.onWillDragPanel((event) => {
     if (!(event.nativeEvent instanceof DragEvent)) {
-        return; // touch / pen drag — no DataTransfer
+        return; // touch / pen drag, no DataTransfer
     }
     event.nativeEvent.dataTransfer?.setData('text/plain', '...');
 });
 ```
 
-Touch and pen drags cannot bridge to external HTML5 drop zones, so skipping them here is the intended behaviour — the drag still works inside Dockview.
+Touch and pen drags cannot bridge to external HTML5 drop zones, so skipping them here is the intended behaviour; the drag still works inside Dockview.
 
 ## See also
 
-- [Drag and drop](/docs/core/dnd/dragAndDrop) — the drag events and hooks these utilities build on.
-- [Third-party libraries](/docs/core/dnd/thirdParty) — using other drag and drop libraries inside a panel.
-- [Drag and drop strategy](/docs/core/dnd/strategy) — why `nativeEvent` can be a `PointerEvent`, and the touch / pen backend.
-- [Disable drag and drop](/docs/core/dnd/disable) — turn drag and drop off entirely.
+- [Drag and drop](/docs/core/dnd/dragAndDrop): the drag events and hooks these utilities build on.
+- [Third-party libraries](/docs/core/dnd/thirdParty): using other drag and drop libraries inside a panel.
+- [Drag and drop strategy](/docs/core/dnd/strategy): why `nativeEvent` can be a `PointerEvent`, and the touch / pen backend.
+- [Disable drag and drop](/docs/core/dnd/disable): turn drag and drop off entirely.

--- a/packages/docs/docs/core/dnd/overlay.mdx
+++ b/packages/docs/docs/core/dnd/overlay.mdx
@@ -6,7 +6,7 @@ description: Shape the drag-and-drop overlay per target with the dropOverlayMode
 
 When you drag a panel or group over Dockview, a highlighted overlay previews
 where it will land. The `dropOverlayModel` option lets you shape that overlay
-**per drop target** — its size, the activation threshold, and the small-element
+**per drop target**: its size, the activation threshold, and the small-element
 boundaries.
 
 :::info
@@ -46,13 +46,13 @@ The returned model accepts:
 
 ## The outer edge overlay
 
-`dropOverlayModel` does **not** dispatch the `'edge'` target — the overlay shown
+`dropOverlayModel` does **not** dispatch the `'edge'` target, the overlay shown
 when dragging to the outer edges of the whole layout. That is configured
 separately via the `dndEdges` option. If you were using `rootOverlayModel`
 purely to size the outer edge overlay, use `dndEdges` instead.
 
 ## See also
 
-- [Drop position resolver](/docs/core/dnd/dropPosition) — override where a pointer location maps to a drop position.
-- [Drop guide](/docs/core/dnd/dropGuide) — the VS Code-style aim-at-a-cell compass overlay.
-- [Smart guides](/docs/core/dnd/smartGuides) — alignment snapping and guides for floating groups.
+- [Drop position resolver](/docs/core/dnd/dropPosition): override where a pointer location maps to a drop position.
+- [Drop guide](/docs/core/dnd/dropGuide): the VS Code-style aim-at-a-cell compass overlay.
+- [Smart guides](/docs/core/dnd/smartGuides): alignment snapping and guides for floating groups.

--- a/packages/docs/docs/core/dnd/overview.mdx
+++ b/packages/docs/docs/core/dnd/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Overview'
 sidebar_position: 0
-description: Overview of built-in drag and drop capabilities in Dockview — tab reordering, group merging, and edge drop positions.
+description: Overview of built-in drag and drop capabilities in Dockview: tab reordering, group merging, and edge drop positions.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-Dockview supports a wide variety of built-in Drag and Drop possibilities.
+Dockview supports a range of built-in drag and drop behaviours.
 
 #### Position a tab between two other tabs
 
@@ -60,13 +60,13 @@ Dockview supports a wide variety of built-in Drag and Drop possibilities.
 
 ## Touch and pen input
 
-Mouse drags use the browser's HTML5 drag-and-drop. Touch and pen drags are driven by a pointer-events backend with a long-press-to-drag gesture, so taps and native scroll still work on mobile. The backend is selected automatically and can be overridden — see [Dnd Strategy](./strategy) for the `dndStrategy` option and the full gesture table.
+Mouse drags use the browser's HTML5 drag-and-drop. Touch and pen drags are driven by a pointer-events backend with a long-press-to-drag gesture, so taps and native scroll still work on mobile. The backend is selected automatically and can be overridden. See [Dnd Strategy](./strategy) for the `dndStrategy` option and the full gesture table.
 
 ## Advanced drag-and-drop hooks
 
-Dockview exposes advanced drag-and-drop hooks — `onWillDragPanel`, `onWillDragGroup`, `onWillDrop` and `onWillShowOverlay` — for attaching metadata to drags, cancelling a drag, or customising the drop overlay. See [Dnd](./dragAndDrop) and [External Dnd Events](./external) for details.
+Dockview exposes advanced drag-and-drop hooks (`onWillDragPanel`, `onWillDragGroup`, `onWillDrop` and `onWillShowOverlay`) for attaching metadata to drags, cancelling a drag, or customising the drop overlay. See [Dnd](./dragAndDrop) and [External Dnd Events](./external) for details.
 
 ## Going further
 
-- [Drop Guide](./dropGuide) — show a VS Code-style aim-at-a-cell compass while dragging, or override where a drop lands with a pluggable position resolver.
-- [Smart Guides](./smartGuides) — alignment snapping and guide overlays for floating groups.
+- [Drop Guide](./dropGuide): show a VS Code-style aim-at-a-cell compass while dragging, or override where a drop lands with a pluggable position resolver.
+- [Smart Guides](./smartGuides): alignment snapping and guide overlays for floating groups.

--- a/packages/docs/docs/core/dnd/smartGuides.mdx
+++ b/packages/docs/docs/core/dnd/smartGuides.mdx
@@ -54,7 +54,7 @@ const api = createDockview(element, {
 ### How snapping works
 
 - **Alignment.** As a floating group is dragged, its leading edge, center, and trailing edge on each axis are compared against the alignment lines contributed by the other floating groups and the container. When a probe lands within `snapDistance` of a line, the group snaps so the two align exactly, and a guide line is drawn.
-- **Independent X and Y.** The horizontal and vertical axes are resolved independently — a group can snap horizontally to one neighbour and vertically to another at the same time, drawing a guide for each alignment.
+- **Independent X and Y.** The horizontal and vertical axes are resolved independently; a group can snap horizontally to one neighbour and vertically to another at the same time, drawing a guide for each alignment.
 - **Hysteresis.** To avoid the group "sticking then jumping" at the snap boundary, a snap engages at `snapDistance` but only releases once the pointer moves past `snapDistance + releaseDistance`. This asymmetric threshold keeps snapping stable and stops oscillation.
 - **Guides.** Set `showGuides: false` to keep the magnetic snapping behaviour but hide the alignment lines.
 
@@ -64,9 +64,9 @@ Choose which sources a dragged floating group aligns against with `snapTargets`:
 
 <DocRef declaration="SmartGuidesSnapTargets" />
 
-- `floats` (default `true`) — align to the other floating groups' edges and centers.
-- `container` (default `true`) — align to the container's edges and center. Set `containerInset` to also emit guide lines a fixed number of pixels inside the container edges (e.g. a content margin).
-- `splitters` (default `false`) — align to the underlying grid's splitter (sash) positions, so a floating group can line up with the docked layout behind it.
+- `floats` (default `true`): align to the other floating groups' edges and centers.
+- `container` (default `true`): align to the container's edges and center. Set `containerInset` to also emit guide lines a fixed number of pixels inside the container edges (e.g. a content margin).
+- `splitters` (default `false`): align to the underlying grid's splitter (sash) positions, so a floating group can line up with the docked layout behind it.
 
 ```ts
 const api = createDockview(element, {
@@ -92,7 +92,7 @@ A drop preview is shown during the drag, and the dock/merge is committed on drop
 
 ### Disabling snapping mid-drag
 
-Hold the configured modifier key while dragging to temporarily suspend snapping and hide the guides — the floating group then follows the pointer freely (Figma / Keynote parity). Snapping re-engages as soon as the modifier is released.
+Hold the configured modifier key while dragging to temporarily suspend snapping and hide the guides; the floating group then follows the pointer freely (Figma / Keynote parity). Snapping re-engages as soon as the modifier is released.
 
 The modifier defaults to `Alt` and is configured via `disableSnapModifier` (`'alt' | 'ctrl' | 'meta' | 'shift'`, or `false` to remove the gate entirely).
 
@@ -139,8 +139,8 @@ Two events fire when a drag commits on drop:
     methods={['onDidSnapFloat', 'onDidSnapTogether']}
 />
 
-- `onDidSnapFloat` — fires when a dragged floating group commits an **alignment** snap on drop, reporting which axes (`'x'` / `'y'`) were snapped.
-- `onDidSnapTogether` — fires when a dragged floating group **docks or merges** into another on drop, reporting the `target` group and the `position` (`'left' | 'right' | 'top' | 'bottom' | 'center'`).
+- `onDidSnapFloat`: fires when a dragged floating group commits an **alignment** snap on drop, reporting which axes (`'x'` / `'y'`) were snapped.
+- `onDidSnapTogether`: fires when a dragged floating group **docks or merges** into another on drop, reporting the `target` group and the `position` (`'left' | 'right' | 'top' | 'bottom' | 'center'`).
 
 ```ts
 api.onDidSnapFloat((event) => {
@@ -160,6 +160,6 @@ api.onDidSnapTogether((event) => {
 
 ## See also
 
-- [Drop guide](/docs/core/dnd/dropGuide) — aim-at-a-cell compass for docking into groups.
-- [Drop overlay](/docs/core/dnd/overlay) — shape the drop-preview overlay.
-- [Floating groups](/docs/core/groups/floatingGroups) — the floating groups Smart Guides align and snap.
+- [Drop guide](/docs/core/dnd/dropGuide): aim-at-a-cell compass for docking into groups.
+- [Drop overlay](/docs/core/dnd/overlay): shape the drop-preview overlay.
+- [Floating groups](/docs/core/groups/floatingGroups): the floating groups Smart Guides align and snap.

--- a/packages/docs/docs/core/dnd/strategy.mdx
+++ b/packages/docs/docs/core/dnd/strategy.mdx
@@ -12,7 +12,7 @@ import { DocRef } from '@site/src/components/ui/reference/docRef';
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `'auto'` (default) | HTML5 drives mouse drags; pointer events drive touch and pen drags.                                                                                                                                                                                |
 | `'pointer'`        | Pointer events drive every input type. Useful where HTML5 drag-and-drop is unreliable (some Linux browsers, certain Safari versions, embedded webviews). Cross-window HTML5 drag and the native browser drag image are not available in this mode. |
-| `'html5'`          | HTML5 drag-and-drop only — touch and pen drags are disabled.                                                                                                                                                                                       |
+| `'html5'`          | HTML5 drag-and-drop only; touch and pen drags are disabled.                                                                                                                                                                                       |
 
 `disableDnd: true` overrides every strategy. The strategy can also be changed at runtime via `api.updateOptions({ dndStrategy: ... })`; the change propagates to every existing drag source.
 
@@ -46,6 +46,6 @@ Under `'auto'` and `'pointer'`, touch drags use a long-press-then-drag gesture s
 
 ## See also
 
-- [Drag and drop](/docs/core/dnd/dragAndDrop) — the drag events and hooks the backend drives.
-- [External drag and drop events](/docs/core/dnd/external) — narrowing `nativeEvent` across the two backends.
-- [Disable drag and drop](/docs/core/dnd/disable) — `disableDnd` overrides every strategy.
+- [Drag and drop](/docs/core/dnd/dragAndDrop): the drag events and hooks the backend drives.
+- [External drag and drop events](/docs/core/dnd/external): narrowing `nativeEvent` across the two backends.
+- [Disable drag and drop](/docs/core/dnd/disable): `disableDnd` overrides every strategy.

--- a/packages/docs/docs/core/dnd/thirdParty.mdx
+++ b/packages/docs/docs/core/dnd/thirdParty.mdx
@@ -15,5 +15,5 @@ raise an issue.
 
 ## See also
 
-- [Drag and drop](/docs/core/dnd/dragAndDrop) — Dockview's own drag and drop and the events it exposes.
-- [External drag and drop events](/docs/core/dnd/external) — intercept drops entering the layout from outside.
+- [Drag and drop](/docs/core/dnd/dragAndDrop): Dockview's own drag and drop and the events it exposes.
+- [External drag and drop events](/docs/core/dnd/external): intercept drops entering the layout from outside.

--- a/packages/docs/docs/core/events.mdx
+++ b/packages/docs/docs/core/events.mdx
@@ -1,12 +1,12 @@
 ---
 title: Events
 sidebar_position: 7
-description: Reference for Dockview events — subscribe to layout changes, panel lifecycle, focus changes, and more.
+description: Reference for Dockview events: subscribe to layout changes, panel lifecycle, focus changes, and more.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-`DockviewApi` exposes a comprehensive set of events so your application can react to layout changes. All events follow the same subscription pattern and return a disposable that you should call when you no longer need the listener.
+`DockviewApi` exposes events so your application can react to layout changes. All events follow the same subscription pattern and return a disposable that you should call when you no longer need the listener.
 
 ```ts
 const disposable = api.onDidAddPanel((panel) => {
@@ -77,7 +77,7 @@ api.onDidMaximizedGroupChange((event: DockviewMaximizedGroupChangeEvent) => {});
 
 ### Mutation boundary
 
-`onWillMutateLayout` and `onDidMutateLayout` bracket each top-level structural change to the layout. Unlike `onDidLayoutChange` — which is coalesced and only fires _after_ a change — these provide an explicit before/after pair, so you can capture a snapshot of the layout _before_ the mutation runs. This makes them the right hook for autosave, dirty-tracking and undo/redo.
+`onWillMutateLayout` and `onDidMutateLayout` bracket each top-level structural change to the layout. Unlike `onDidLayoutChange` (which is coalesced and only fires _after_ a change), these provide an explicit before/after pair, so you can capture a snapshot of the layout _before_ the mutation runs. This makes them the right hook for autosave, dirty-tracking and undo/redo.
 
 ```ts
 // Fires immediately before a structural mutation
@@ -94,7 +94,7 @@ api.onDidMutateLayout((event: DockviewLayoutMutationEvent) => {});
 
 A compound operation brackets as a **single** transaction: dragging a panel to a new group, or restoring a whole layout via `fromJSON`, fires exactly one before/after pair rather than one per internal step.
 
-`event.origin` distinguishes _who_ caused the change — `'user'` for direct interaction (drag-and-drop, tab UI), `'api'` for a programmatic `DockviewApi` call made by your own code — so consumers such as an undo stack can choose to ignore the app's own programmatic mutations.
+`event.origin` distinguishes _who_ caused the change: `'user'` for direct interaction (drag-and-drop, tab UI), `'api'` for a programmatic `DockviewApi` call made by your own code. Consumers such as an undo stack can use this to ignore the app's own programmatic mutations.
 
 ## Drag and drop
 
@@ -141,7 +141,7 @@ api.onDidAddPopoutGroup((event: PopoutGroup) => {
     event.window.focus();
 });
 
-// Fires when a popout group is removed — the user closed its window or it was
+// Fires when a popout group is removed: the user closed its window or it was
 // docked back programmatically. Not fired during component disposal.
 api.onDidRemovePopoutGroup((event: PopoutGroup) => {
     // event.id, event.group

--- a/packages/docs/docs/core/groups/add.mdx
+++ b/packages/docs/docs/core/groups/add.mdx
@@ -91,6 +91,6 @@ api.fromJSON(layout, { reuseExistingPanels: true });
 
 ## See also
 
-- [Core concepts](/docs/core/overview) — how panels and groups fit together
-- [Move group](/docs/core/groups/move) — reposition a group once it exists
-- [Group controls](/docs/core/groups/controls) — add custom actions to a group header
+- [Core concepts](/docs/core/overview): how panels and groups fit together
+- [Move group](/docs/core/groups/move): reposition a group once it exists
+- [Group controls](/docs/core/groups/controls): add custom actions to a group header

--- a/packages/docs/docs/core/groups/autoEdgeGroups.mdx
+++ b/packages/docs/docs/core/groups/autoEdgeGroups.mdx
@@ -48,7 +48,7 @@ const api = createDockview(element, {
 ```
 </FrameworkSpecific>
 
-To enable dock-to-edge on only some edges, name them individually — `true`/`false` (or an omitted edge) toggles each of `top`, `bottom`, `left`, `right`:
+To enable dock-to-edge on only some edges, name them individually; `true`/`false` (or an omitted edge) toggles each of `top`, `bottom`, `left`, `right`:
 
 ```ts
 const api = createDockview(element, {
@@ -58,7 +58,7 @@ const api = createDockview(element, {
 });
 ```
 
-Dock-to-edge is **off by default** — leaving `dockToEdgeGroups` unset (or `false`) keeps the standard behaviour, where an edge must be created explicitly with `addEdgeGroup` and an emptied edge collapses to a strip rather than disappearing.
+Dock-to-edge is **off by default**; leaving `dockToEdgeGroups` unset (or `false`) keeps the standard behaviour, where an edge must be created explicitly with `addEdgeGroup` and an emptied edge collapses to a strip rather than disappearing.
 
 <CodeRunner id="dockview/auto-edge-groups" height={500} />
 
@@ -67,13 +67,13 @@ Dock-to-edge is **off by default** — leaving `dockToEdgeGroups` unset (or `fal
 While dragging a panel toward the layout edge there are two drop zones:
 
 - The **outer band**, hugging the true edge (marked by a coloured indicator line), docks the panel as a dedicated **edge group**.
-- Just **inside** it, the panel splits the primary grid as usual — the standard `dndEdges` behaviour.
+- Just **inside** it, the panel splits the primary grid as usual, the standard `dndEdges` behaviour.
 
 A newly revealed edge group is created **collapsed**: the drop adds a tab to its strip rather than popping the group open. Dropping onto an edge that already exists simply adds the panel to its tabs and leaves the group's collapsed/expanded state untouched. Combine with [auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) so a revealed edge peeks open on click.
 
 ## Zero footprint when empty
 
-An edge group created by a drag reveal is flagged to **tear down to zero footprint** once its last panel leaves — the edge occupies no space and shows no strip until something is dragged back to it. This is the difference from a normal edge group, which collapses to a persistent strip when emptied.
+An edge group created by a drag reveal is flagged to **tear down to zero footprint** once its last panel leaves: the edge occupies no space and shows no strip until something is dragged back to it. This is the difference from a normal edge group, which collapses to a persistent strip when emptied.
 
 Revealed edges still serialize and restore like any other edge group; a transient empty edge (mid-teardown) is never persisted.
 
@@ -81,14 +81,14 @@ Revealed edges still serialize and restore like any other edge group; a transien
 
 If the [drop guide](/docs/core/dnd/dropGuide) compass is also enabled, the two compose rather than conflict. A drop can target **either**:
 
-- the **grid layout edge** — the compass's outer ring, or
-- an **edge group** — the true outer edge band (drag-reveal).
+- the **grid layout edge**, the compass's outer ring, or
+- an **edge group**, the true outer edge band (drag-reveal).
 
 The distinction is by pointer depth: the compass's outer ring sits well inside the edge band, and the edge-group indicator takes over at the very edge.
 
 ## Revealing programmatically
 
-Reveal (create-or-fill) an edge group and move a dragged item into it — the primitive the drag affordance is built on:
+Reveal (create-or-fill) an edge group and move a dragged item into it, the primitive the drag affordance is built on:
 
 <DocRef declaration="DockviewApi" methods={['revealEdgeGroupWithData']} />
 
@@ -105,6 +105,6 @@ Dock-to-edge groups require both the edge-group and drag-and-drop overlay functi
 
 ## See also
 
-- [Edge groups](/docs/core/groups/edgeGroups) — creating, sizing, collapsing, and serializing edge groups
-- [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) — peek a collapsed edge group open on click
-- [Drag and drop](/docs/core/dnd/overview) — the `dndEdges` layout-edge drop zones
+- [Edge groups](/docs/core/groups/edgeGroups): creating, sizing, collapsing, and serializing edge groups
+- [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups): peek a collapsed edge group open on click
+- [Drag and drop](/docs/core/dnd/overview): the `dndEdges` layout-edge drop zones

--- a/packages/docs/docs/core/groups/autoHideEdgeGroups.mdx
+++ b/packages/docs/docs/core/groups/autoHideEdgeGroups.mdx
@@ -17,7 +17,7 @@ For the basics of creating, sizing, collapsing, and serializing edge groups, see
 
 The `autoHideEdgeGroups` option sets the per-edge default, but auto-hide is also resolved **per group**: pass `autoHide` to `addEdgeGroup`, or call `api.setAutoHide` at runtime, to opt a single edge group in or out. This lets a static always-docked edge group and an auto-hiding one co-exist in the same layout.
 
-Enable it with the `autoHideEdgeGroups` option — pass `true` for all four edges, or an object to enable specific edges:
+Enable it with the `autoHideEdgeGroups` option: pass `true` for all four edges, or an object to enable specific edges:
 
 <FrameworkSpecific framework="React">
     ```tsx
@@ -50,7 +50,7 @@ const api = createDockview(element, {
 ```
 </FrameworkSpecific>
 
-To enable auto-hide on only some edges, name them individually — `true`/`false` (or an omitted edge) toggles each of `top`, `bottom`, `left`, `right`:
+To enable auto-hide on only some edges, name them individually; `true`/`false` (or an omitted edge) toggles each of `top`, `bottom`, `left`, `right`:
 
 ```ts
 const api = createDockview(element, {
@@ -60,15 +60,15 @@ const api = createDockview(element, {
 });
 ```
 
-Auto-hide is **off by default** — leaving `autoHideEdgeGroups` unset (or `false`) keeps the plain collapse/expand behaviour, with no peek overlay.
+Auto-hide is **off by default**; leaving `autoHideEdgeGroups` unset (or `false`) keeps the plain collapse/expand behaviour, with no peek overlay.
 
 <CodeRunner id="dockview/auto-hide-edge-groups" height={400} />
 
 ## The click-to-peek model
 
-Auto-hide is entirely **click-driven** — there is no hover interaction. Once an edge group is auto-hidden (collapsed) it renders a strip of its tabs along the edge, and:
+Auto-hide is entirely **click-driven**; there is no hover interaction. Once an edge group is auto-hidden (collapsed) it renders a strip of its tabs along the edge, and:
 
-- **Click a tab** → that tab's panel **peeks** out as an overlay anchored to the strip's inner edge. The group stays logically collapsed, so **the grid is not reflowed** — the panel simply floats over your content. The overlay carries a **title bar** (the active panel's title on the left; a **pin** and a **close** button on the right).
+- **Click a tab** → that tab's panel **peeks** out as an overlay anchored to the strip's inner edge. The group stays logically collapsed, so **the grid is not reflowed**; the panel simply floats over your content. The overlay carries a **title bar** (the active panel's title on the left; a **pin** and a **close** button on the right).
 - **Click the same tab again**, **click anywhere outside** the strip and peek, or press **Escape** → the peek hides. Clicking empty space inside the strip does nothing.
 - **Click a different tab** while peeking → the peek switches to that panel and retitles.
 - **Pin** → the group **docks** (expands) permanently. A docked group renders as a tool window: the title bar sits on top and the tab strip moves to the bottom. Pinning again auto-hides it back to the strip.
@@ -92,7 +92,7 @@ const api = createDockview(element, {
 });
 ```
 
-- `animate` — slide the peek overlay in. Default `true`; ignored when the OS requests reduced motion.
+- `animate`: slide the peek overlay in. Default `true`; ignored when the OS requests reduced motion.
 
 ## API
 
@@ -144,5 +144,5 @@ The peek overlay shares the same stacking context as floating and popout groups,
 
 ## See also
 
-- [Edge groups](/docs/core/groups/edgeGroups) — creating, sizing, collapsing, and serializing edge groups
-- [Group controls](/docs/core/groups/controls) — render controls specific to edge groups via the `location` prop
+- [Edge groups](/docs/core/groups/edgeGroups): creating, sizing, collapsing, and serializing edge groups
+- [Group controls](/docs/core/groups/controls): render controls specific to edge groups via the `location` prop

--- a/packages/docs/docs/core/groups/constraints.mdx
+++ b/packages/docs/docs/core/groups/constraints.mdx
@@ -20,5 +20,5 @@ Constraints come with several caveats. They are not serialized with layouts and 
 
 ## See also
 
-- [Resizing](/docs/core/panels/resizing) — set a panel or group's exact height and width programmatically
-- [Sizing and layout](/docs/core/sizing) — control initial and proportional sizing
+- [Resizing](/docs/core/panels/resizing): set a panel or group's exact height and width programmatically
+- [Sizing and layout](/docs/core/sizing): control initial and proportional sizing

--- a/packages/docs/docs/core/groups/controls.mdx
+++ b/packages/docs/docs/core/groups/controls.mdx
@@ -5,7 +5,7 @@ description: How to add custom actions and controls to the Dockview group header
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-Header action components let you render your own controls — buttons, menus, or status indicators — into the left, right, and prefix regions of a group's header bar. Use them to add per-group actions such as split, close, or a context menu.
+Header action components let you render your own controls (buttons, menus, or status indicators) into the left, right, and prefix regions of a group's header bar. Use them to add per-group actions such as split, close, or a context menu.
 
 <CodeRunner id="dockview/group-actions" />
 
@@ -181,5 +181,5 @@ panel.group.header.hidden = true;
 
 ## See also
 
-- [Managing groups](/docs/core/groups/add) — create, remove, and clear groups
-- [Edge groups](/docs/core/groups/edgeGroups) — use the `location` prop to show controls specific to edge groups
+- [Managing groups](/docs/core/groups/add): create, remove, and clear groups
+- [Edge groups](/docs/core/groups/edgeGroups): use the `location` prop to show controls specific to edge groups

--- a/packages/docs/docs/core/groups/edgeGroups.mdx
+++ b/packages/docs/docs/core/groups/edgeGroups.mdx
@@ -1,13 +1,13 @@
 ---
 title: Edge groups
-description: How to create and manage edge groups in Dockview — groups that are pinned to the edges of the layout, like a VS Code sidebar or panel.
+description: How to create and manage edge groups in Dockview: groups that are pinned to the edges of the layout, like a VS Code sidebar or panel.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
 import { CodeRunner } from '@site/src/components/ui/codeRunner';
 
-Edge groups are `DockviewGroupPanel` instances pinned to one of the four edges of the layout (`'left'`, `'right'`, `'top'`, `'bottom'`). They support tabs, drag-and-drop, overflow, and the full group panel API — and their state is included in `toJSON` / `fromJSON`.
+Edge groups are `DockviewGroupPanel` instances pinned to one of the four edges of the layout (`'left'`, `'right'`, `'top'`, `'bottom'`). They support tabs, drag-and-drop, overflow, and the full group panel API, and their state is included in `toJSON` / `fromJSON`.
 
 <CodeRunner id="dockview/edge-groups" height={500} />
 
@@ -135,11 +135,11 @@ Themes that set a custom `edgeGroupCollapsedSize`:
 When an edge group loses all of its panels it is automatically collapsed. Adding a new panel to it will expand it again.
 :::
 
-Collapsed edge groups can auto-hide and peek back on demand — see [Auto-hide Edge Groups](/docs/core/groups/autoHideEdgeGroups).
+Collapsed edge groups can auto-hide and peek back on demand. See [Auto-hide Edge Groups](/docs/core/groups/autoHideEdgeGroups).
 
 ## Dock to edge groups
 
-With the `dockToEdgeGroups` option an edge takes up **zero space** when empty and is revealed by dragging a panel to it, like a VS Code sidebar — see [Dock to edge groups](/docs/core/groups/autoEdgeGroups).
+With the `dockToEdgeGroups` option an edge takes up **zero space** when empty and is revealed by dragging a panel to it, like a VS Code sidebar. See [Dock to edge groups](/docs/core/groups/autoEdgeGroups).
 
 ## Auto-hide co-existence
 
@@ -254,5 +254,5 @@ api.fromJSON(state); // auto-creates and restores edge groups
 
 ## See also
 
-- [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) — turn a collapsed edge group into a pinnable tool window
-- [Group controls](/docs/core/groups/controls) — render controls specific to edge groups via the `location` prop
+- [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups): turn a collapsed edge group into a pinnable tool window
+- [Group controls](/docs/core/groups/controls): render controls specific to edge groups via the `location` prop

--- a/packages/docs/docs/core/groups/floatingGroups.mdx
+++ b/packages/docs/docs/core/groups/floatingGroups.mdx
@@ -1,12 +1,12 @@
 ---
 title: Floating groups
-description: How to create and manage floating groups in Dockview — groups that float freely over the layout.
+description: How to create and manage floating groups in Dockview: groups that float freely over the layout.
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-Floating groups sit above the grid in a free-floating, draggable container instead of being docked into it — useful for tool palettes, inspectors, or any panel you want to keep visible over the rest of the layout.
+Floating groups sit above the grid in a free-floating, draggable container instead of being docked into it, useful for tool palettes, inspectors, or any panel you want to keep visible over the rest of the layout.
 
 :::info
 Floating groups **cannot** be maximized. Calling maximize function on groups in these states will have no effect.
@@ -60,7 +60,7 @@ You can control the bounding box of floating groups through the optional `floati
 `floatingGroupDragHandle` selects which element moves a floating group when dragged:
 
 - `'titlebar'` (default): a dedicated, blank drag-handle bar is rendered above the group's tab bar. Dragging it moves the floating window; shift+drag (mouse) or long-press (touch) redocks the group back into the grid. Style it with the `--dv-floating-titlebar-*` theme variables.
-- `'tabbar'`: the legacy behaviour — the empty space in the tab bar (the "void container") doubles as the move handle, with no dedicated bar rendered.
+- `'tabbar'`: the legacy behaviour, where the empty space in the tab bar (the "void container") doubles as the move handle, with no dedicated bar rendered.
 
 ```ts
 const api = createDockview(element, {
@@ -70,7 +70,7 @@ const api = createDockview(element, {
 
 ### Customising drag behaviour
 
-`transformFloatingGroupDrag` lets you adjust a floating group's position while it is being dragged — for snapping to a grid, aligning to other floating groups, or constraining a group to a region. It runs on every pointer-move frame with the proposed top-left (before Dockview's container clamp) and returns an adjusted top-left, or nothing to leave it unchanged. It affects moving only — resizing is unaffected.
+`transformFloatingGroupDrag` lets you adjust a floating group's position while it is being dragged, for snapping to a grid, aligning to other floating groups, or constraining a group to a region. It runs on every pointer-move frame with the proposed top-left (before Dockview's container clamp) and returns an adjusted top-left, or nothing to leave it unchanged. It affects moving only; resizing is unaffected.
 
 ```ts
 const api = createDockview(element, {
@@ -142,5 +142,5 @@ You can check whether a group is floating via the `group.api.location` property.
 
 ## See also
 
-- [Popout windows](/docs/core/groups/popoutGroups) — move a group into a separate browser window
-- [Maximized groups](/docs/core/groups/maximizedGroups) — expand a group to fill the viewport
+- [Popout windows](/docs/core/groups/popoutGroups): move a group into a separate browser window
+- [Maximized groups](/docs/core/groups/maximizedGroups): expand a group to fill the viewport

--- a/packages/docs/docs/core/groups/maximizedGroups.mdx
+++ b/packages/docs/docs/core/groups/maximizedGroups.mdx
@@ -5,7 +5,7 @@ description: How to maximize a group to fill the Dockview viewport and restore i
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-Maximizing a group temporarily expands it to fill the entire Dockview viewport, hiding the other groups until you restore it — handy for focusing on a single panel without changing the underlying layout.
+Maximizing a group temporarily expands it to fill the entire Dockview viewport, hiding the other groups until you restore it, handy for focusing on a single panel without changing the underlying layout.
 
 <CodeRunner id="dockview/maximize-group" />
 
@@ -64,5 +64,5 @@ The methods exist on the panel `api` object for convenience.
 
 ## See also
 
-- [Floating groups](/docs/core/groups/floatingGroups) — float a group above the grid
-- [Popout windows](/docs/core/groups/popoutGroups) — move a group into a separate browser window
+- [Floating groups](/docs/core/groups/floatingGroups): float a group above the grid
+- [Popout windows](/docs/core/groups/popoutGroups): move a group into a separate browser window

--- a/packages/docs/docs/core/groups/move.mdx
+++ b/packages/docs/docs/core/groups/move.mdx
@@ -6,7 +6,7 @@ description: How to move a group to a different position in the Dockview layout 
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-Moving a group repositions it within the layout — docking it against another group or panel, or against an absolute edge — through the [Group API](/docs/api/dockview/groupApi)'s `moveTo` method.
+Moving a group repositions it within the layout (docking it against another group or panel, or against an absolute edge) through the [Group API](/docs/api/dockview/groupApi)'s `moveTo` method.
 
 ## Methods
 
@@ -22,6 +22,6 @@ panel.group.api.moveTo({ group, position, index });
 
 ## See also
 
-- [Managing groups](/docs/core/groups/add) — create, remove, and clear groups
-- [Group controls](/docs/core/groups/controls) — add custom actions to a group header
-- [Locking](/docs/core/locked) — block drop interactions on a group or the whole layout
+- [Managing groups](/docs/core/groups/add): create, remove, and clear groups
+- [Group controls](/docs/core/groups/controls): add custom actions to a group header
+- [Locking](/docs/core/locked): block drop interactions on a group or the whole layout

--- a/packages/docs/docs/core/groups/popoutGroups.mdx
+++ b/packages/docs/docs/core/groups/popoutGroups.mdx
@@ -5,7 +5,7 @@ description: How to pop out a Dockview group into a separate browser window and 
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-Popout groups open a group in a separate native browser window while it stays part of the same Dockview layout — useful for spreading panels across multiple monitors. The group can be docked back into the grid at any time.
+Popout groups open a group in a separate native browser window while it stays part of the same Dockview layout, useful for spreading panels across multiple monitors. The group can be docked back into the grid at any time.
 
 :::info
 Popout groups **cannot** be maximized. Calling maximize function on groups in these states will have no effect.
@@ -20,7 +20,7 @@ as needed.
 
 The popout lifecycle is observable: `onDidAddPopoutGroup` /
 `onDidRemovePopoutGroup` fire as windows open and close (or dock back), and
-`api.getPopouts()` enumerates the open popout windows — see
+`api.getPopouts()` enumerates the open popout windows. See
 [Events](/docs/core/events#popout-window).
 
 Popout windows require your website to have a blank `.html` page that can be used, by default this is set to `/popout.html` but
@@ -42,7 +42,7 @@ api.addPopoutGroup(
 
 :::warning Security: same-origin only
 
-`popoutUrl` must point to a same-origin `http(s)` location. Dockview rejects `javascript:`, `data:`, `blob:`, and cross-origin URLs to prevent a malicious value — for example, from a layout JSON loaded from an untrusted source — from executing script in a context the browser still associates with your application via `window.opener`. The guard runs automatically when the popout is opened, including on layouts restored via `fromJSON()`.
+`popoutUrl` must point to a same-origin `http(s)` location. Dockview rejects `javascript:`, `data:`, `blob:`, and cross-origin URLs to prevent a malicious value (for example, from a layout JSON loaded from an untrusted source) from executing script in a context the browser still associates with your application via `window.opener`. The guard runs automatically when the popout is opened, including on layouts restored via `fromJSON()`.
 :::
 
 From within a panel you may say
@@ -72,11 +72,11 @@ choose a new location.
 
 ## Overlays inside popout windows
 
-Floating overlays — including drag-target indicators, the tab context menu, and tab group chip popovers (color picker, rename) — render inside the DOM of the window that hosts them. When a group lives in a popout window, those overlays render in the popout window's document, not the parent. This means:
+Floating overlays, including drag-target indicators, the tab context menu, and tab group chip popovers (color picker, rename), render inside the DOM of the window that hosts them. When a group lives in a popout window, those overlays render in the popout window's document, not the parent. This means:
 
 - Custom chip components and context menu components are mounted in the popout window's DOM tree.
 - CSS that you load into the main page is automatically copied into popout windows; if you ship custom styles outside the standard import pipeline (for example, lazily injected stylesheets), make sure they are also available in the popout window.
-- Event handlers and portals inside custom components should not assume the document is the main window — use the element's `ownerDocument` when you need a reference.
+- Event handlers and portals inside custom components should not assume the document is the main window; use the element's `ownerDocument` when you need a reference.
 
 ## Popout window events
 
@@ -101,6 +101,6 @@ api.onDidOpenPopoutWindowFail(() => {
 
 ## See also
 
-- [Floating groups](/docs/core/groups/floatingGroups) — float a group above the grid without a separate window
-- [Events](/docs/core/events#popout-window) — observe the popout window lifecycle
-- [Security](/docs/core/security) — same-origin requirements and CSP for popout windows
+- [Floating groups](/docs/core/groups/floatingGroups): float a group above the grid without a separate window
+- [Events](/docs/core/events#popout-window): observe the popout window lifecycle
+- [Security](/docs/core/security): same-origin requirements and CSP for popout windows

--- a/packages/docs/docs/core/locked.mdx
+++ b/packages/docs/docs/core/locked.mdx
@@ -34,6 +34,6 @@ Use `true` to keep the drop zones at the top, right, bottom and left of the grou
 
 ## See also
 
-- [Disable drag and drop](/docs/core/dnd/disable) — turn off drag and drop per panel, group, or the whole layout
-- [Managing groups](/docs/core/groups/add) — create, remove, and clear groups
-- [Move group](/docs/core/groups/move) — reposition a group within the layout
+- [Disable drag and drop](/docs/core/dnd/disable): turn off drag and drop per panel, group, or the whole layout
+- [Managing groups](/docs/core/groups/add): create, remove, and clear groups
+- [Move group](/docs/core/groups/move): reposition a group within the layout

--- a/packages/docs/docs/core/nested.mdx
+++ b/packages/docs/docs/core/nested.mdx
@@ -13,5 +13,5 @@ If you wish to interact with the drop event from one Dockview instance in anothe
 
 ## See also
 
-- [Core concepts](/docs/core/overview) — how panels, groups, and the API fit together
-- [Events](/docs/core/events) — `onUnhandledDragOver` and `onDidDrop` for bridging drops between instances
+- [Core concepts](/docs/core/overview): how panels, groups, and the API fit together
+- [Events](/docs/core/events): `onUnhandledDragOver` and `onDidDrop` for bridging drops between instances

--- a/packages/docs/docs/core/overview.mdx
+++ b/packages/docs/docs/core/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Core concepts
 sidebar_position: 0
-description: Core concepts of Dockview — panels, groups, the API pattern, and how they fit together.
+description: Core concepts of Dockview: panels, groups, the API pattern, and how they fit together.
 ---
 
 Dockview organises content into **panels** and **groups** arranged in a resizable grid. Understanding these primitives and the API pattern is all you need to get started.

--- a/packages/docs/docs/core/panels/add.mdx
+++ b/packages/docs/docs/core/panels/add.mdx
@@ -230,7 +230,7 @@ api.addPanel({
 
 ## See also
 
-- [Registering panels](/docs/core/panels/register) — register the components that `addPanel` instantiates by name.
-- [Move panel](/docs/core/panels/move) — reposition a panel after it has been added.
-- [Remove panel](/docs/core/panels/remove) — remove a panel from the layout.
-- [Panel API](/docs/api/dockview/panelApi) — control an individual panel once it exists.
+- [Registering panels](/docs/core/panels/register): register the components that `addPanel` instantiates by name.
+- [Move panel](/docs/core/panels/move): reposition a panel after it has been added.
+- [Remove panel](/docs/core/panels/remove): remove a panel from the layout.
+- [Panel API](/docs/api/dockview/panelApi): control an individual panel once it exists.

--- a/packages/docs/docs/core/panels/headerPosition.mdx
+++ b/packages/docs/docs/core/panels/headerPosition.mdx
@@ -81,6 +81,6 @@ const onReady = (event: DockviewReadyEvent) => {
 
 ## See also
 
-- [Tabs](/docs/core/panels/tabs) — customise how the tabs in the header are rendered.
-- [Tab overflow](/docs/core/panels/tabOverflow) — how surplus tabs are handled when the header runs out of room.
-- [Multi-row tabs](/docs/core/panels/multiRowTabs) — wrapping tabs, which applies to horizontal headers only.
+- [Tabs](/docs/core/panels/tabs): customise how the tabs in the header are rendered.
+- [Tab overflow](/docs/core/panels/tabOverflow): how surplus tabs are handled when the header runs out of room.
+- [Multi-row tabs](/docs/core/panels/multiRowTabs): wrapping tabs, which applies to horizontal headers only.

--- a/packages/docs/docs/core/panels/move.mdx
+++ b/packages/docs/docs/core/panels/move.mdx
@@ -29,6 +29,6 @@ group.api.moveTo({ group, position });
 
 ## See also
 
-- [Move group](/docs/core/groups/move) — move a whole group rather than a single panel.
-- [Adding panels](/docs/core/panels/add) — position a panel at creation time with the same `direction` semantics.
-- [Panel API](/docs/api/dockview/panelApi) — the panel API surface that exposes `moveTo`.
+- [Move group](/docs/core/groups/move): move a whole group rather than a single panel.
+- [Adding panels](/docs/core/panels/add): position a panel at creation time with the same `direction` semantics.
+- [Panel API](/docs/api/dockview/panelApi): the panel API surface that exposes `moveTo`.

--- a/packages/docs/docs/core/panels/multiRowTabs.mdx
+++ b/packages/docs/docs/core/panels/multiRowTabs.mdx
@@ -20,7 +20,7 @@ is covered in [Tab Overflow](/docs/core/panels/tabOverflow).
 ## Multi-row (wrapping) tabs
 
 Set `overflow.mode: 'wrap'` and, instead of clipping the surplus tabs into the
-dropdown, the tab strip wraps onto additional rows and the header grows to fit — a
+dropdown, the tab strip wraps onto additional rows and the header grows to fit, a
 JetBrains-style layout where every tab stays visible at once. As tabs are added or
 removed, the header grows and shrinks by whole rows, and the panel content area
 resizes to match.
@@ -79,7 +79,7 @@ api.updateOptions({ overflow: { mode: 'wrap' } });
 `overflow.mode: 'wrap'` is provided by the multi-row tabs module, which is included
 in the default `dockview` bundle. If you assemble your own set of modules and omit
 it, `mode: 'wrap'` is ignored and the standard single-row strip with the dropdown is
-used instead — no error, no regression.
+used instead; no error, no regression.
 :::
 
 ### `maxRows`
@@ -114,13 +114,13 @@ switcher.
 
 :::warning
 These fields are reserved for a not-yet-shipped advanced overflow module and currently
-have **no effect**. They are documented here only as forward-looking API surface —
+have **no effect**. They are documented here only as forward-looking API surface;
 setting them today does nothing. Rely on `mode` and (once implemented) `maxRows`.
 :::
 
 ## See also
 
-- [Tab overflow](/docs/core/panels/tabOverflow) — the default single-row dropdown this mode replaces.
-- [Pinned tabs](/docs/core/panels/pinnedTabs) — another way to keep important tabs visible.
-- [Tab header position](/docs/core/panels/headerPosition) — wrapping applies to horizontal headers only.
+- [Tab overflow](/docs/core/panels/tabOverflow): the default single-row dropdown this mode replaces.
+- [Pinned tabs](/docs/core/panels/pinnedTabs): another way to keep important tabs visible.
+- [Tab header position](/docs/core/panels/headerPosition): wrapping applies to horizontal headers only.
 ```

--- a/packages/docs/docs/core/panels/pinnedTabs.mdx
+++ b/packages/docs/docs/core/panels/pinnedTabs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pinned tabs
-description: Pin tabs so they render first, never overflow, and resist reordering — modelled on VS Code and Chrome.
+description: Pin tabs so they render first, never overflow, and resist reordering, modelled on VS Code and Chrome.
 sidebar_position: 10
 enterprise: true
 sidebar_custom_props:
@@ -11,9 +11,9 @@ import { DocRef } from '@site/src/components/ui/reference/docRef';
 
 Pinned tabs let you mark the tabs that matter so they stay put. Modelled on VS Code and Chrome, a pinned tab:
 
-- **renders first** — pinned tabs always sort ahead of unpinned tabs in their group;
-- **never overflows** — pinned tabs are excluded from the overflow dropdown, so they stay visible even as the strip fills up;
-- **resists reordering** — you cannot drag an unpinned tab to the left of a pinned one (the pin boundary is enforced).
+- **renders first**: pinned tabs always sort ahead of unpinned tabs in their group;
+- **never overflows**: pinned tabs are excluded from the overflow dropdown, so they stay visible even as the strip fills up;
+- **resists reordering**: you cannot drag an unpinned tab to the left of a pinned one (the pin boundary is enforced).
 
 The pinned order is stable: pinning appends a tab to the end of the pinned block, and unpinning returns it to the front of the unpinned block.
 
@@ -49,11 +49,11 @@ const api = createDockview(element, {
 
 <DocRef declaration="PinnedTabsOptions" />
 
-- **`enabled`** — the master switch. Leave it unset (or `false`) to keep pinning dormant; the tab strip then behaves identically to the default.
-- **`mode`** — `'inline'` (the default) keeps pinned tabs first within the existing tab strip. `'separate-row'` renders them on their own VS-Code-style row above the main strip; the row collapses when no tab in the group is pinned.
-- **`compact`** — render pinned tabs icon-only (title and close button hidden), like VS Code and Chrome. Defaults to `false` because Dockview's default tab has no favicon, so pinned tabs stay labelled (with a pin glyph) unless you opt in. Best paired with a custom tab renderer that shows an icon.
-- **`togglePinOnCrossBoundaryDrag`** — when `true`, dragging a tab across the pin boundary toggles its pinned state (VS-Code behaviour). Defaults to `false`: dragging across the boundary is clamped back, matching Chrome, where pinning is an explicit action.
-- **`contextMenuItem`** — add a built-in "Pin"/"Unpin" item to the tab context menu. Defaults to `true`; requires the context menu to be available.
+- **`enabled`**: the master switch. Leave it unset (or `false`) to keep pinning dormant; the tab strip then behaves identically to the default.
+- **`mode`**: `'inline'` (the default) keeps pinned tabs first within the existing tab strip. `'separate-row'` renders them on their own VS-Code-style row above the main strip; the row collapses when no tab in the group is pinned.
+- **`compact`**: render pinned tabs icon-only (title and close button hidden), like VS Code and Chrome. Defaults to `false` because Dockview's default tab has no favicon, so pinned tabs stay labelled (with a pin glyph) unless you opt in. Best paired with a custom tab renderer that shows an icon.
+- **`togglePinOnCrossBoundaryDrag`**: when `true`, dragging a tab across the pin boundary toggles its pinned state (VS-Code behaviour). Defaults to `false`: dragging across the boundary is clamped back, matching Chrome, where pinning is an explicit action.
+- **`contextMenuItem`**: add a built-in "Pin"/"Unpin" item to the tab context menu. Defaults to `true`; requires the context menu to be available.
 
 :::info
 `mode: 'separate-row'` renders pinned tabs in a dedicated row. In `'inline'` mode pinned and unpinned tabs share the single strip, with pinned tabs sorted to the front.
@@ -127,11 +127,11 @@ api.fromJSON(state); // pinned tabs are restored, in their pinned order
 ```
 
 :::info
-Layouts saved before pinning was enabled — or restored into a component with `pinnedTabs` disabled — load as a normal, unpinned strip. The `pinned` key is simply ignored when pinning is off.
+Layouts saved before pinning was enabled (or restored into a component with `pinnedTabs` disabled) load as a normal, unpinned strip. The `pinned` key is simply ignored when pinning is off.
 :::
 
 ## See also
 
-- [Tabs](/docs/core/panels/tabs) — custom tab renderers and the tab context menu that hosts the `'pin'` item.
-- [Tab overflow](/docs/core/panels/tabOverflow) — the overflow dropdown that pinned tabs are excluded from.
-- [Multi-row tabs](/docs/core/panels/multiRowTabs) — an alternative way to keep every tab visible as the strip fills up.
+- [Tabs](/docs/core/panels/tabs): custom tab renderers and the tab context menu that hosts the `'pin'` item.
+- [Tab overflow](/docs/core/panels/tabOverflow): the overflow dropdown that pinned tabs are excluded from.
+- [Multi-row tabs](/docs/core/panels/multiRowTabs): an alternative way to keep every tab visible as the strip fills up.

--- a/packages/docs/docs/core/panels/register.mdx
+++ b/packages/docs/docs/core/panels/register.mdx
@@ -85,7 +85,7 @@ const api = createDockview(parentElement, {
 <FrameworkSpecific framework='Vue'>
 
 Pass your panel components directly to `<DockviewVue>` via the `components`
-prop. This is the recommended pattern and works with `<script setup>` — no
+prop. This is the recommended pattern and works with `<script setup>`; no
 global `app.component(...)` registration is required.
 
 ```vue
@@ -108,7 +108,7 @@ function onReady(event: DockviewReadyEvent) {
 </template>
 ```
 
-Legacy Options-API style is still supported — components registered on any
+Legacy Options-API style is still supported; components registered on any
 ancestor via `components: { ... }` (or globally via `app.component(...)`) are
 resolved by name as before.
 
@@ -123,7 +123,7 @@ updated in place when you call `panel.api.updateParameters(...)`. `api`,
 ```tsx
 @Component({
     selector: 'panel-component-1',
-    template: `<div>Panel Content 1 — {{ params?.myCustomKey }}</div>`,
+    template: `<div>Panel Content 1: {{ params?.myCustomKey }}</div>`,
 })
 export class PanelComponent1 {
     @Input() params: { myCustomKey?: string };

--- a/packages/docs/docs/core/panels/remove.mdx
+++ b/packages/docs/docs/core/panels/remove.mdx
@@ -32,6 +32,6 @@ api.removePanel(panel);
 
 ## See also
 
-- [Adding panels](/docs/core/panels/add) — the counterpart for creating panels.
-- [Move panel](/docs/core/panels/move) — relocate a panel instead of destroying it.
-- [Panel API](/docs/api/dockview/panelApi) — the full set of per-panel methods, including `close`.
+- [Adding panels](/docs/core/panels/add): the counterpart for creating panels.
+- [Move panel](/docs/core/panels/move): relocate a panel instead of destroying it.
+- [Panel API](/docs/api/dockview/panelApi): the full set of per-panel methods, including `close`.

--- a/packages/docs/docs/core/panels/rendering.mdx
+++ b/packages/docs/docs/core/panels/rendering.mdx
@@ -1,7 +1,7 @@
 ---
 title: Rendering panels
 sidebar_position: 5
-description: How Dockview renders panels — lazy rendering, deferred mounting, and visibility behaviour.
+description: How Dockview renders panels: lazy rendering, deferred mounting, and visibility behaviour.
 ---
 
 import { CodeRunner } from '@site/src/components/ui/codeRunner';
@@ -9,7 +9,7 @@ import { CodeRunner } from '@site/src/components/ui/codeRunner';
 Rendering type is an important consideration when creating your application and whether your panels should be destroyed when hidden.
 
 :::tip
-Hosting an **iframe** in a panel needs `renderer: 'always'` — see [iframes](#iframes) below.
+Hosting an **iframe** in a panel needs `renderer: 'always'`. See [iframes](#iframes) below.
 :::
 
 When a panel is selected all other panels in that group are not visible. The API does expose methods to determine whether your panel is visible or not
@@ -71,7 +71,7 @@ api.addPanel({
 
 When a panel uses `always` render mode, the panel component instance is kept alive even when the panel is not visible. This means reactive state, subscriptions, and lifecycle hooks continue to run in the background.
 
-Hidden panels are hidden via `visibility: hidden` rather than being removed from layout, so browser-driven work — CSS animations, `requestAnimationFrame` loops, autoplay `<video>` elements, and embedded `<iframe>` documents — also continues while the panel is hidden. If you need to pause that work, listen to `onDidVisibilityChange` and stop it explicitly; you can also conditionally render inner content only when the panel is visible.
+Hidden panels are hidden via `visibility: hidden` rather than being removed from layout, so browser-driven work (CSS animations, `requestAnimationFrame` loops, autoplay `<video>` elements, and embedded `<iframe>` documents) also continues while the panel is hidden. If you need to pause that work, listen to `onDidVisibilityChange` and stop it explicitly; you can also conditionally render inner content only when the panel is visible.
 
 <FrameworkSpecific framework='React'>
 ```tsx title="Only rendering the React Component when the panel is visible, otherwise rendering a null React Component"
@@ -136,7 +136,7 @@ disposable.dispose();
 
 <template>
     <template v-if="visible">
-        <!-- expensive panel content — only mounted when panel is visible -->
+        <!-- expensive panel content, only mounted when panel is visible -->
     </template>
 </template>
 ```
@@ -150,7 +150,7 @@ import type { DockviewPanelApi } from 'dockview-angular';
 @Component({
 selector: 'my-panel',
 template: `         <ng-container *ngIf="visible">
-            <!-- expensive panel content — only rendered when panel is visible -->
+            <!-- expensive panel content, only rendered when panel is visible -->
         </ng-container>
     `,
 })
@@ -192,9 +192,9 @@ class MyPanel implements IContentRenderer {
     init(parameters: GroupviewPanelState): void {
         parameters.api.onDidVisibilityChange((event) => {
             if (event.isVisible) {
-                // panel is now visible — start expensive work
+                // panel is now visible, start expensive work
             } else {
-                // panel is hidden — pause expensive work
+                // panel is hidden, pause expensive work
             }
         });
     }
@@ -213,8 +213,8 @@ Toggling the checkbox in the live example shows the panel component being destro
 
 When you implement a custom `IContentRenderer` (typically only relevant for JavaScript consumers), you can opt into two optional lifecycle hooks that fire when a panel transitions between hidden and visible. These hooks complement `api.onDidVisibilityChange` and run regardless of which `renderer` mode is in use:
 
-- `onShow()` — fires when the panel becomes visible (active in its group, or when its group is unhidden).
-- `onHide()` — fires when the panel becomes hidden (another tab in the group is selected, or the group is hidden).
+- `onShow()`: fires when the panel becomes visible (active in its group, or when its group is unhidden).
+- `onHide()`: fires when the panel becomes hidden (another tab in the group is selected, or the group is hidden).
 
 ```ts
 import { IContentRenderer, GroupPanelPartInitParameters } from 'dockview';
@@ -244,11 +244,11 @@ class MyPanel implements IContentRenderer {
 }
 ```
 
-Both hooks are optional. The framework wrappers (React, Vue, Angular) handle visibility internally — these hooks are primarily intended for JavaScript `IContentRenderer` implementations and for framework adapters that need to detach/reattach DOM (for example, the Angular adapter uses them to detach and reattach `TemplateRef` views).
+Both hooks are optional. The framework wrappers (React, Vue, Angular) handle visibility internally; these hooks are primarily intended for JavaScript `IContentRenderer` implementations and for framework adapters that need to detach/reattach DOM (for example, the Angular adapter uses them to detach and reattach `TemplateRef` views).
 
 ## iframes
 
-iframes need special attention because of how browsers render them: **re-parenting an iframe within the DOM reloads its contents.** Since docking moves a panel's element between groups, an iframe-hosting panel rendered the default way would reload every time it is moved. This is a documented browser behaviour — see the discussions [here](https://bugzilla.mozilla.org/show_bug.cgi?id=254144) and [here](https://github.com/whatwg/html/issues/5484).
+iframes need special attention because of how browsers render them: **re-parenting an iframe within the DOM reloads its contents.** Since docking moves a panel's element between groups, an iframe-hosting panel rendered the default way would reload every time it is moved. This is a documented browser behaviour. See the discussions [here](https://bugzilla.mozilla.org/show_bug.cgi?id=254144) and [here](https://github.com/whatwg/html/issues/5484).
 
 To keep an iframe alive, render its panel with `renderer: 'always'` so the element is never removed from the DOM (or set Dockview's `defaultRenderer` to `'always'`):
 
@@ -264,5 +264,5 @@ api.addPanel({
 
 ## See also
 
-- [Adding panels](/docs/core/panels/add) — set a panel's `renderer` mode when it is created.
-- [Update panel](/docs/core/panels/update) — how parameter changes drive a panel to re-render.
+- [Adding panels](/docs/core/panels/add): set a panel's `renderer` mode when it is created.
+- [Update panel](/docs/core/panels/update): how parameter changes drive a panel to re-render.

--- a/packages/docs/docs/core/panels/resizing.mdx
+++ b/packages/docs/docs/core/panels/resizing.mdx
@@ -4,14 +4,14 @@ sidebar_position: 6
 description: How to programmatically resize a panel or group in Dockview.
 ---
 
-Each Dockview instance contains groups and each group contains panels. Panels are sized indirectly through the group that contains them, so resizing a panel really means resizing the group it lives in. You can drive either from code — set a height and width, or observe dimension changes — and both approaches achieve the same result.
+Each Dockview instance contains groups and each group contains panels. Panels are sized indirectly through the group that contains them, so resizing a panel really means resizing the group it lives in. You can drive either from code (set a height and width, or observe dimension changes), and both approaches achieve the same result.
 
 import { CodeRunner } from '@site/src/components/ui/codeRunner';
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
 ## Resizing a panel
 
-Logically a user may want to resize a panel, but this translates to resizing the group which contains that panel. The panel API mirrors the group's resize methods, so you can set a panel's height and width — or observe dimension changes — without reaching for the group directly.
+Logically a user may want to resize a panel, but this translates to resizing the group which contains that panel. The panel API mirrors the group's resize methods, so you can set a panel's height and width (or observe dimension changes) without reaching for the group directly.
 
 <DocRef
     declaration="DockviewPanelApi"
@@ -51,7 +51,7 @@ You can see an example invoking both approaches below.
 
 ## See also
 
-- [Adding panels](/docs/core/panels/add) — set `initialWidth`/`initialHeight` and minimum/maximum size constraints when creating a panel.
-- [Constraints](/docs/core/groups/constraints) — set minimum and maximum group sizes.
-- [Sizing and layout](/docs/core/sizing) — control initial and proportional sizing.
-- [Panel API](/docs/api/dockview/panelApi) — the panel API surface that exposes `setSize`, `height`, `width` and `onDidDimensionsChange`.
+- [Adding panels](/docs/core/panels/add): set `initialWidth`/`initialHeight` and minimum/maximum size constraints when creating a panel.
+- [Constraints](/docs/core/groups/constraints): set minimum and maximum group sizes.
+- [Sizing and layout](/docs/core/sizing): control initial and proportional sizing.
+- [Panel API](/docs/api/dockview/panelApi): the panel API surface that exposes `setSize`, `height`, `width` and `onDidDimensionsChange`.

--- a/packages/docs/docs/core/panels/tabGroups.mdx
+++ b/packages/docs/docs/core/panels/tabGroups.mdx
@@ -101,7 +101,7 @@ tabGroup.indexOfPanel('panel-1');
 
 ## Colour palette
 
-`tabGroup.color` is any CSS color string — either an id from the active palette
+`tabGroup.color` is any CSS color string: either an id from the active palette
 or a raw CSS literal (`'#abc123'`, `'rgb(...)'`). Resolution to a concrete value
 is handled by Dockview's color palette.
 
@@ -125,7 +125,7 @@ purely via CSS overrides. The full set is exported as `DEFAULT_TAB_GROUP_COLORS`
 ### Custom palette
 
 Replace the default palette with `tabGroupColors`. The list fully replaces the
-defaults — there is no merge. Each entry needs an `id` (stored on `tabGroup.color`
+defaults; there is no merge. Each entry needs an `id` (stored on `tabGroup.color`
 and serialized) and a `value` (any CSS color expression). An optional `label`
 appears as a tooltip in the context-menu picker.
 
@@ -175,7 +175,7 @@ chip renderers that want to read from it (e.g. to render their own picker).
 Set `tabGroupAccent: 'off'` to opt out of the built-in color concept entirely.
 Dockview stops writing the `--dv-tab-group-color` custom property, hides
 the color picker, and applies `dv-tab-group-chip--accent-off` to chips. The
-`tabGroup.color` field is still preserved as data — pair this with a
+`tabGroup.color` field is still preserved as data, so pair this with a
 `createTabGroupChipComponent` to own the chip visual end-to-end.
 
 <FrameworkSpecific framework="React">
@@ -221,7 +221,7 @@ const api = createDockview(parentElement, {
 
 ## Component params
 
-Use `componentParams` to attach free-form data to a tab group — typically
+Use `componentParams` to attach free-form data to a tab group, typically
 consumed by a custom chip renderer. The value is a `Record<string, unknown>`
 that round-trips through `toJSON` / `fromJSON`, so it must be JSON-serializable.
 
@@ -232,7 +232,7 @@ const tabGroup = api.createTabGroup({
     componentParams: { icon: '📊', priority: 1 },
 });
 
-// Update at runtime — fires onDidChange so a custom chip can re-render
+// Update at runtime, fires onDidChange so a custom chip can re-render
 tabGroup.setComponentParams({ icon: '⭐️', priority: 1 });
 ```
 
@@ -262,7 +262,7 @@ tabGroup.onDidDestroy(() => {});
 
 ## Chip context menu
 
-Right-clicking a tab group chip can show a context menu. This is opt-in — no menu is shown unless
+Right-clicking a tab group chip can show a context menu. This is opt-in; no menu is shown unless
 `getTabGroupChipContextMenuItems` is provided. Return an empty array to suppress the menu for specific chips.
 
 <FrameworkSpecific framework="React">

--- a/packages/docs/docs/core/panels/tabOverflow.mdx
+++ b/packages/docs/docs/core/panels/tabOverflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tab overflow
-description: How Dockview handles more tabs than fit in a header — the default overflow dropdown.
+description: How Dockview handles more tabs than fit in a header: the default overflow dropdown.
 sidebar_position: 8
 ---
 
@@ -12,10 +12,10 @@ behind an overflow **dropdown**.
 
 ## Default overflow (dropdown)
 
-Out of the box, tabs that no longer fit are clipped and collapsed behind a chevron
+By default, tabs that no longer fit are clipped and collapsed behind a chevron
 button in the header's right actions. Clicking the chevron opens a dropdown listing
 the hidden tabs; a count badge shows how many are hidden. This is the default and
-requires no configuration — it is equivalent to `overflow.mode: 'dropdown'`.
+requires no configuration; it is equivalent to `overflow.mode: 'dropdown'`.
 
 You can turn overflow handling off entirely with `disableTabsOverflowList`, in which
 case the strip simply scrolls.

--- a/packages/docs/docs/core/panels/tabs.mdx
+++ b/packages/docs/docs/core/panels/tabs.mdx
@@ -7,7 +7,7 @@ description: How to customize tab appearance and behaviour in Dockview, includin
 import { CodeRunner } from '@site/src/components/ui/codeRunner';
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-Each panel is represented by a tab in its group's header. Dockview ships a default tab renderer, and this page covers replacing or extending it — custom tab components, accessing panel parameters, context menus, full-width and reorder behaviour, and tab groups.
+Each panel is represented by a tab in its group's header. Dockview ships a default tab renderer, and this page covers replacing or extending it: custom tab components, accessing panel parameters, context menus, full-width and reorder behaviour, and tab groups.
 
 ## Register a tab component
 
@@ -396,7 +396,7 @@ The example below shows a custom tab renderer that displays the panel title alon
 
 ## Tab context menu
 
-Right-clicking a tab can show a context menu. This is opt-in — no menu is shown unless
+Right-clicking a tab can show a context menu. This is opt-in; no menu is shown unless
 `getTabContextMenuItems` is provided. Return an empty array to suppress the menu for specific panels.
 
 <FrameworkSpecific framework="React">
@@ -595,7 +595,7 @@ Controls how tabs animate when reordered via drag and drop.
 
 | Mode        | Behaviour                                                                       |
 | ----------- | ------------------------------------------------------------------------------- |
-| `'default'` | Tabs swap positions instantly on drop — the original behaviour.                 |
+| `'default'` | Tabs swap positions instantly on drop; the original behaviour.                 |
 | `'smooth'`  | Tabs slide smoothly to open a gap for the dragged tab, similar to browser tabs. |
 
 <CodeRunner id="dockview/tabview" />
@@ -678,7 +678,7 @@ Tab height can be controlled through CSS.
 
 ## See also
 
-- [Tab overflow & multi-row tabs](/docs/core/panels/tabOverflow) — how Dockview handles more tabs than fit across the header, and the wrapping multi-row layout.
-- [Pinned tabs](/docs/core/panels/pinnedTabs) — pin tabs so they render first and never overflow.
-- [Tab groups](/docs/core/panels/tabGroups) — organise tabs into coloured, collapsible chips.
+- [Tab overflow & multi-row tabs](/docs/core/panels/tabOverflow): how Dockview handles more tabs than fit across the header, and the wrapping multi-row layout.
+- [Pinned tabs](/docs/core/panels/pinnedTabs): pin tabs so they render first and never overflow.
+- [Tab groups](/docs/core/panels/tabGroups): organise tabs into coloured, collapsible chips.
 

--- a/packages/docs/docs/core/panels/update.mdx
+++ b/packages/docs/docs/core/panels/update.mdx
@@ -6,7 +6,7 @@ description: How to pass updated parameters to an existing panel in Dockview.
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-A panel's `params` can be changed after it has been created, and the panel and its tab re-render with the new values. Use this for small amounts of static view data — not application or dynamic panel state.
+A panel's `params` can be changed after it has been created, and the panel and its tab re-render with the new values. Use this for small amounts of static view data, not application or dynamic panel state.
 
 :::warning
 **Use this feature sparingly**: Anything you assign to the `params` options of a panel will be saved when calling `api.toJSON()`.
@@ -45,6 +45,6 @@ panel.api.updateParameters({
 
 ## See also
 
-- [Adding panels](/docs/core/panels/add) — set the initial `params` when the panel is first created.
-- [Rendering panels](/docs/core/panels/rendering) — how a panel re-renders in response to parameter changes.
-- [Panel API](/docs/api/dockview/panelApi) — the panel API surface that exposes `updateParameters`.
+- [Adding panels](/docs/core/panels/add): set the initial `params` when the panel is first created.
+- [Rendering panels](/docs/core/panels/rendering): how a panel re-renders in response to parameter changes.
+- [Panel API](/docs/api/dockview/panelApi): the panel API surface that exposes `updateParameters`.

--- a/packages/docs/docs/core/security.mdx
+++ b/packages/docs/docs/core/security.mdx
@@ -12,7 +12,7 @@ For the main document Dockview only writes to `element.style` properties (e.g. p
 
 The **one** place Dockview needs dynamic styling is when opening a **popout window**: Dockview reads the parent window's stylesheets and recreates them in the popout's `<head>`, preserving the original cascade order. Stylesheets that were loaded via an `href` (i.e. external CSS files) are recreated as `<link rel="stylesheet">` elements; only stylesheet objects without an `href` (inline `<style>` or CSSOM-created sheets) are recreated as inline `<style>` elements. This is the path that interacts with `style-src`.
 
-Because external sheets are re-attached as `<link>` elements, the popout loads them asynchronously and may render unstyled for a frame before the network (or HTTP cache) resolves the request. For same-origin sheets this is generally invisible — the browser serves them from cache — but expect a brief flash if your CSS is hosted on a slow origin.
+Because external sheets are re-attached as `<link>` elements, the popout loads them asynchronously and may render unstyled for a frame before the network (or HTTP cache) resolves the request. For same-origin sheets this is generally invisible (the browser serves them from cache), but expect a brief flash if your CSS is hosted on a slow origin.
 
 ## Content Security Policy
 
@@ -31,12 +31,12 @@ Note that:
 
 - You do **not** need `'unsafe-inline'` in `style-src`.
 - `RANDOM_NONCE` must be regenerated per response. It should be the same nonce that your server-rendered HTML applies to its own `<script>` / `<style>` tags.
-- The nonce only authorises the inline `<style>` elements Dockview injects. Any external CSS files Dockview re-attaches as `<link rel="stylesheet">` in the popout are still subject to your `style-src` **source expressions** — make sure those URLs are covered by `'self'` or an explicit origin in the directive.
+- The nonce only authorises the inline `<style>` elements Dockview injects. Any external CSS files Dockview re-attaches as `<link rel="stylesheet">` in the popout are still subject to your `style-src` **source expressions**, so make sure those URLs are covered by `'self'` or an explicit origin in the directive.
 - If your popout is same-origin (the default for `window.open(url)` where `url` is on your origin), the popout document inherits your CSP and nonce, so the same nonce works for both windows.
 
 ### Passing the nonce to Dockview
 
-Dockview forwards a `nonce` option to every `<style>` element it creates. The nonce must be valid for the document the `<style>` lands in, which — for popout windows — is **not** the opener document. Because `popout.html` is a separate HTTP response with its own freshly-generated nonce, the parent page's nonce is never valid in the popout's CSP context.
+Dockview forwards a `nonce` option to every `<style>` element it creates. The nonce must be valid for the document the `<style>` lands in, which (for popout windows) is **not** the opener document. Because `popout.html` is a separate HTTP response with its own freshly-generated nonce, the parent page's nonce is never valid in the popout's CSP context.
 
 For this reason `nonce` accepts either a **string** (when the same nonce is known to cover both documents, e.g. during local development with a static policy) or a **function** that is called with the target `Document` so you can read the nonce directly off the popout page.
 
@@ -89,4 +89,4 @@ Dockview is also compatible with [Trusted Types](https://developer.mozilla.org/e
 
 ## See also
 
-- [Popout windows](/docs/core/groups/popoutGroups) — the main feature affected by CSP and same-origin rules
+- [Popout windows](/docs/core/groups/popoutGroups): the main feature affected by CSP and same-origin rules

--- a/packages/docs/docs/core/sizing.mdx
+++ b/packages/docs/docs/core/sizing.mdx
@@ -97,7 +97,7 @@ You can read the current dimensions at any time via `api.width` and `api.height`
 
 ## Hiding borders
 
-By default, Dockview renders thin borders between groups in the grid. The `hideBorders` option removes them — see [Hiding borders](/docs/core/theming#hiding-borders) on the theming page for the full example.
+By default, Dockview renders thin borders between groups in the grid. The `hideBorders` option removes them. See [Hiding borders](/docs/core/theming#hiding-borders) on the theming page for the full example.
 
 ## Updating options at runtime
 
@@ -113,5 +113,5 @@ api.updateOptions({
 
 ## See also
 
-- [Resizing](/docs/core/panels/resizing) — set a panel or group's exact height and width programmatically
-- [Constraints](/docs/core/groups/constraints) — set minimum and maximum group sizes
+- [Resizing](/docs/core/panels/resizing): set a panel or group's exact height and width programmatically
+- [Constraints](/docs/core/groups/constraints): set minimum and maximum group sizes

--- a/packages/docs/docs/core/state/history.mdx
+++ b/packages/docs/docs/core/state/history.mdx
@@ -1,6 +1,6 @@
 ---
 title: Layout history
-description: Undo and redo layout mutations — close, move, float, popout, maximize and resize — with a bounded history stack.
+description: Undo and redo layout mutations (close, move, float, popout, maximize and resize) with a bounded history stack.
 sidebar_position: 3
 enterprise: true
 sidebar_custom_props:
@@ -90,17 +90,17 @@ layoutHistory: { enabled: true },
 ## What gets recorded
 
 Each undoable step is a full snapshot of the layout captured before and after
-the mutation, so an undo restores the whole layout — including a closed panel's
+the mutation, so an undo restores the whole layout, including a closed panel's
 `params` and `title`.
 
 The following **structural mutations** each record one undo step:
 
--   `add` / `remove` — adding and closing panels or groups
--   `move` — dragging or moving a panel or group to a new location
--   `float` — floating a group
--   `popout` — opening a group in a popout window
--   `maximize` — maximizing / restoring a group
--   `tab-group` — tab-group changes (such as recolouring)
+-   `add` / `remove`: adding and closing panels or groups
+-   `move`: dragging or moving a panel or group to a new location
+-   `float`: floating a group
+-   `popout`: opening a group in a popout window
+-   `maximize`: maximizing / restoring a group
+-   `tab-group`: tab-group changes (such as recolouring)
 
 **Resize** (dragging a sash) has no discrete mutation boundary, so it is caught
 separately and a continuous drag is coalesced into a single entry. It is
@@ -110,7 +110,7 @@ debounce window with `coalesceMs` (default `400`ms).
 :::info
 A panel's state is only restorable on undo if it is serialized into the panel's
 `params`. State held imperatively outside `params` (for example a chart's zoom
-kept in a closure) is not captured by the snapshot — this is the same constraint
+kept in a closure) is not captured by the snapshot; this is the same constraint
 that [`fromJSON`](/docs/core/state/load) already imposes.
 :::
 
@@ -122,7 +122,7 @@ retained; pushing past the limit drops the oldest entry.
 ### User vs programmatic mutations
 
 By default only **user gestures** (drag-dock, tab close button, sash resize)
-enter the stack — a programmatic `DockviewApi` call such as `api.addPanel(...)`
+enter the stack. A programmatic `DockviewApi` call such as `api.addPanel(...)`
 is treated as the app's own state management and is not something the end user
 expects `Ctrl+Z` to revert. Set `undoableProgrammaticMutations: true` to record
 those too.
@@ -136,7 +136,7 @@ a full restore.
 
 ## Driving undo / redo
 
-Dockview binds no keyboard shortcuts itself — wiring `Ctrl+Z` / `Ctrl+Shift+Z`
+Dockview binds no keyboard shortcuts itself; wiring `Ctrl+Z` / `Ctrl+Shift+Z`
 (or toolbar buttons) to `api.undo()` / `api.redo()` is the host app's call. Use
 `canUndo` / `canRedo` to drive the disabled state of your controls, and listen
 to `onDidChangeHistory` to keep them in sync as the stacks change.
@@ -284,7 +284,7 @@ redoButton.addEventListener('click', () => api.redo());
 ## Cross-window support
 
 Undo and redo restore the whole layout, including floating groups and popout
-windows — a mutation made _inside_ a popout window is still a mutation of the
+windows. A mutation made _inside_ a popout window is still a mutation of the
 same dock and records a single step on the shared stack.
 
 Floating groups restore synchronously, but popout **windows** re-open
@@ -299,5 +299,5 @@ button click); otherwise the popout falls back to an inline group.
 
 ## See also
 
-- [Saving state](/docs/core/state/save) — persist a layout snapshot with `toJSON`.
-- [Loading state](/docs/core/state/load) — restore a serialized layout with `fromJSON`.
+- [Saving state](/docs/core/state/save): persist a layout snapshot with `toJSON`.
+- [Loading state](/docs/core/state/load): restore a serialized layout with `fromJSON`.

--- a/packages/docs/docs/core/state/load.mdx
+++ b/packages/docs/docs/core/state/load.mdx
@@ -148,5 +148,5 @@ if (!success) {
 
 ## See also
 
-- [Saving state](/docs/core/state/save) — serialize the current layout with `toJSON`.
-- [Layout history](/docs/core/state/history) — undo and redo layout changes without reloading from JSON.
+- [Saving state](/docs/core/state/save): serialize the current layout with `toJSON`.
+- [Layout history](/docs/core/state/history): undo and redo layout changes without reloading from JSON.

--- a/packages/docs/docs/core/state/save.mdx
+++ b/packages/docs/docs/core/state/save.mdx
@@ -120,5 +120,5 @@ const disposable = api.onDidLayoutChange(() => {
 
 ## See also
 
-- [Loading state](/docs/core/state/load) — restore a serialized layout with `fromJSON`.
-- [Layout history](/docs/core/state/history) — undo and redo layout changes without a full save and restore.
+- [Loading state](/docs/core/state/load): restore a serialized layout with `fromJSON`.
+- [Layout history](/docs/core/state/history): undo and redo layout changes without a full save and restore.

--- a/packages/docs/docs/core/theming.mdx
+++ b/packages/docs/docs/core/theming.mdx
@@ -113,8 +113,8 @@ The `DockviewTheme` object accepts a number of optional properties beyond `name`
 
 Controls how tabs animate when they are reordered or moved across groups.
 
-- `'none'` (default) — no animation, tabs snap to their new position.
-- `'smooth'` — animated FLIP transition between positions, including for vertical tab strips and cross-group moves.
+- `'none'` (default): no animation, tabs snap to their new position.
+- `'smooth'`: animated FLIP transition between positions, including for vertical tab strips and cross-group moves.
 
 ```ts
 import { themeAbyss } from 'dockview-react';
@@ -126,8 +126,8 @@ const theme = { ...themeAbyss, tabAnimation: 'smooth' as const };
 
 Controls how the indicator under a tab group's tabs is rendered.
 
-- `'wrap'` (default) — a continuous coloured bar wraps the group's tabs.
-- `'none'` — no indicator is drawn.
+- `'wrap'` (default): a continuous coloured bar wraps the group's tabs.
+- `'none'`: no indicator is drawn.
 
 ### `dndOverlayBorder`
 
@@ -137,8 +137,8 @@ Controls whether drop-target overlays (the highlight that appears when dragging 
 
 Controls how the drop position indicator within a tab strip is drawn while dragging a tab.
 
-- `'line'` — a thin coloured line marks the insertion point.
-- `'fill'` — the target slot is filled with the active accent colour.
+- `'line'`: a thin coloured line marks the insertion point.
+- `'fill'`: the target slot is filled with the active accent colour.
 
 ### `edgeGroupCollapsedSize`
 
@@ -146,7 +146,7 @@ Per-theme override for the pixel size of an [edge group](/docs/core/groups/edgeG
 
 ### `colorScheme`
 
-Hint passed to the browser via the `color-scheme` CSS property — `'light'` or `'dark'`. Native form controls and scrollbars adapt accordingly.
+Hint passed to the browser via the `color-scheme` CSS property, either `'light'` or `'dark'`. Native form controls and scrollbars adapt accordingly.
 
 ## Interactive theme builder
 

--- a/packages/docs/docs/index.mdx
+++ b/packages/docs/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dockview documentation
-description: Dockview documentation — guides, API reference, and live examples for the zero-dependency docking layout manager.
+description: Dockview documentation: guides, API reference, and live examples for the zero-dependency docking layout manager.
 hide_table_of_contents: true
 ---
 
@@ -8,12 +8,12 @@ Dockview is a zero-dependency docking layout manager for building IDE-like inter
 
 ## Get started
 
-- [Introduction](/docs/overview/introduction) — what Dockview is and its core concepts
-- [Installation](/docs/overview/installation) — add Dockview to your framework
-- [Quickstart](/docs/overview/quickstart) — build your first layout
+- [Introduction](/docs/overview/introduction): what Dockview is and its core concepts
+- [Installation](/docs/overview/installation): add Dockview to your framework
+- [Quickstart](/docs/overview/quickstart): build your first layout
 
 ## Explore
 
-- [Core features](/docs/core/overview) — panels, groups, drag and drop, theming, and state
-- [API reference](/docs/api/dockview/overview) — the full `DockviewApi` surface
+- [Core features](/docs/core/overview): panels, groups, drag and drop, theming, and state
+- [API reference](/docs/api/dockview/overview): the full `DockviewApi` surface
 - [Live demo](/demo) and [examples](/examples)

--- a/packages/docs/docs/other/gridview/overview.mdx
+++ b/packages/docs/docs/other/gridview/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 sidebar_position: 0
-description: Overview of the Gridview component — a resizable grid layout without tabs or drag and drop.
+description: Overview of the Gridview component: a resizable grid layout without tabs or drag and drop.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
@@ -29,6 +29,6 @@ which is exposed as a separate component to be used independently.
 
 ## See also
 
-- [Gridview API](/docs/api/gridview/api) — methods and events for controlling the grid.
-- [Gridview options](/docs/api/gridview/options) — configuration when creating the component.
-- [Gridview panel API](/docs/api/gridview/panelApi) — control an individual panel.
+- [Gridview API](/docs/api/gridview/api): methods and events for controlling the grid.
+- [Gridview options](/docs/api/gridview/options): configuration when creating the component.
+- [Gridview panel API](/docs/api/gridview/panelApi): control an individual panel.

--- a/packages/docs/docs/other/paneview/overview.mdx
+++ b/packages/docs/docs/other/paneview/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 sidebar_position: 0
-description: Overview of the Paneview component — a vertical stack of collapsible, resizable panes.
+description: Overview of the Paneview component: a vertical stack of collapsible, resizable panes.
 ---
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
@@ -28,6 +28,6 @@ A _splitview_ control where each panel contains a header and collapsible content
 
 ## See also
 
-- [Paneview API](/docs/api/paneview/api) — methods and events for controlling the pane view.
-- [Paneview options](/docs/api/paneview/options) — configuration when creating the component.
-- [Paneview panel API](/docs/api/paneview/panelApi) — control an individual pane.
+- [Paneview API](/docs/api/paneview/api): methods and events for controlling the pane view.
+- [Paneview options](/docs/api/paneview/options): configuration when creating the component.
+- [Paneview panel API](/docs/api/paneview/panelApi): control an individual pane.

--- a/packages/docs/docs/other/splitview/overview.mdx
+++ b/packages/docs/docs/other/splitview/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 sidebar_position: 0
-description: Overview of the Splitview component — the primitive resizable split container underlying Dockview.
+description: Overview of the Splitview component: the primitive resizable split container underlying Dockview.
 ---
 
 The implementation of Dockview is a collection of nested _splitview_ controls
@@ -29,6 +29,6 @@ import { DocRef } from '@site/src/components/ui/reference/docRef';
 
 ## See also
 
-- [Splitview API](/docs/api/splitview/api) — methods and events for controlling the split view.
-- [Splitview options](/docs/api/splitview/options) — configuration when creating the component.
-- [Splitview panel API](/docs/api/splitview/panelApi) — control an individual panel.
+- [Splitview API](/docs/api/splitview/api): methods and events for controlling the split view.
+- [Splitview options](/docs/api/splitview/options): configuration when creating the component.
+- [Splitview panel API](/docs/api/splitview/panelApi): control an individual panel.

--- a/packages/docs/docs/overview/editions.mdx
+++ b/packages/docs/docs/overview/editions.mdx
@@ -1,19 +1,19 @@
 ---
 title: Editions
 sidebar_position: 0.6
-description: Dockview comes in two editions — the free open-source library and Dockview Enterprise. Learn which is right for you and what Enterprise adds.
+description: Dockview comes in two editions: the free open-source library and Dockview Enterprise. Learn which is right for you and what Enterprise adds.
 ---
 
 Dockview comes in two editions that share the same core and the same API:
 
-- **Dockview** — the free, open-source library, published under the MIT licence. Everything you need to build a complete, fully working docking layout manager.
-- **Dockview Enterprise** — a drop-in superset (the `dockview-enterprise` package) that adds more advanced features on top of the free core, under a commercial licence.
+- **Dockview**: the free, open-source library, published under the MIT licence. Everything you need to build a complete, fully working docking layout manager.
+- **Dockview Enterprise**: a drop-in superset (the `dockview-enterprise` package) that adds more advanced features on top of the free core, under a commercial licence.
 
 Enterprise is the same library with more modules turned on, so it includes every free feature.
 
 ## Which edition is right for you?
 
-### Dockview — free
+### Dockview: free
 
 The free edition suits you if you are:
 
@@ -21,7 +21,7 @@ The free edition suits you if you are:
 - Working on a personal, open-source or commercial project and want a dependency-free, MIT-licensed layout manager.
 - Happy with the core docking experience and don't need the more advanced features below.
 
-All framework packages — `dockview-react`, `dockview-vue` and `dockview-angular` — are free and work with both the free and Enterprise editions.
+All framework packages (`dockview-react`, `dockview-vue` and `dockview-angular`) are free and work with both the free and Enterprise editions.
 
 ### Dockview Enterprise
 
@@ -37,12 +37,12 @@ See the <a href="/enterprise">pricing page</a> for details and to buy.
 
 All of the following are provided by the `dockview-enterprise` package:
 
-- **Advanced docking** — the [drop guide compass](/docs/core/dnd/dropGuide) for aim-at-a-cell docking, and [smart guides](/docs/core/dnd/smartGuides) with magnetic alignment for floating groups.
-- **Advanced tabs** — [multi-row tabs](/docs/core/panels/multiRowTabs) that wrap instead of overflowing, and [pinned tabs](/docs/core/panels/pinnedTabs).
-- **Tool windows and edges** — [auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) that collapse to a strip and peek on demand, and [dock-to-edge groups](/docs/core/groups/autoEdgeGroups).
-- **Keyboard and navigation** — [keyboard navigation](/docs/advanced/keyboard) with F6 and spatial movement, and [focus navigation](/docs/advanced/focus-navigation) across groups and popout windows.
-- **Layout lifecycle** — [layout history](/docs/core/state/history) with undo and redo.
-- **Context menus** — built-in right-click menus for tabs and tab group chips.
+- **Advanced docking**: the [drop guide compass](/docs/core/dnd/dropGuide) for aim-at-a-cell docking, and [smart guides](/docs/core/dnd/smartGuides) with magnetic alignment for floating groups.
+- **Advanced tabs**: [multi-row tabs](/docs/core/panels/multiRowTabs) that wrap instead of overflowing, and [pinned tabs](/docs/core/panels/pinnedTabs).
+- **Tool windows and edges**: [auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) that collapse to a strip and peek on demand, and [dock-to-edge groups](/docs/core/groups/autoEdgeGroups).
+- **Keyboard and navigation**: [keyboard navigation](/docs/advanced/keyboard) with F6 and spatial movement, and [focus navigation](/docs/advanced/focus-navigation) across groups and popout windows.
+- **Layout lifecycle**: [layout history](/docs/core/state/history) with undo and redo.
+- **Context menus**: built-in right-click menus for tabs and tab group chips.
 
 For the exact, feature-by-feature breakdown, see the [full feature comparison](/docs/overview/features).
 

--- a/packages/docs/docs/overview/features.mdx
+++ b/packages/docs/docs/overview/features.mdx
@@ -1,7 +1,7 @@
 ---
 title: Features
 sidebar_position: 0.5
-description: A complete list of Dockview features — docking, drag and drop, floating groups, popout windows, theming, serialization and more.
+description: A complete list of Dockview features: docking, drag and drop, floating groups, popout windows, theming, serialization and more.
 ---
 
 A complete list of features Dockview provides.
@@ -31,8 +31,8 @@ The guiding rule: capabilities that other free layout managers already offer (fl
 | Header action slots   | Render custom controls in the header's left, right or prefix area                                               | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Tab overflow menu     | Automatic overflow dropdown when tabs don't fit                                                                 | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Animated tab dragging | Smooth animated reorder while dragging tabs                                                                     | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| Multi-row tabs        | Wrap tabs onto multiple rows instead of an overflow menu — see [Multi-row tabs](/docs/core/panels/multiRowTabs) |                                          | <span className="feature-check">✓</span> |
-| Pinned tabs           | Keep tabs first in the strip, out of the overflow menu — see [Pinned tabs](/docs/core/panels/pinnedTabs)        |                                          | <span className="feature-check">✓</span> |
+| Multi-row tabs        | Wrap tabs onto multiple rows instead of an overflow menu. See [Multi-row tabs](/docs/core/panels/multiRowTabs) |                                          | <span className="feature-check">✓</span> |
+| Pinned tabs           | Keep tabs first in the strip, out of the overflow menu. See [Pinned tabs](/docs/core/panels/pinnedTabs)        |                                          | <span className="feature-check">✓</span> |
 | Tab group chips       | Colour-coded chips that group related tabs together                                                             |                                          | <span className="feature-check">✓</span> |
 | Custom chip renderer  | Replace the default chip with your own component                                                                |                                          | <span className="feature-check">✓</span> |
 | Tab context menus     | Custom right-click menus on tabs                                                                                | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
@@ -44,15 +44,15 @@ The guiding rule: capabilities that other free layout managers already offer (fl
 | ------------------------- | ----------------------------------------------------------------------------------------------------------- | :--------------------------------------: | :--------------------------------------: |
 | Tab drag and drop         | Reorder tabs and move them between groups                                                                   | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Group drag and drop       | Drag entire groups to restructure the layout                                                                | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| External drag and drop    | Accept drops from outside the layout — see [drag and drop docs](/docs/core/dnd/overview)                    | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| External drag and drop    | Accept drops from outside the layout. See [drag and drop docs](/docs/core/dnd/overview)                    | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Touch and pen support     | Switchable pointer-event backend for non-mouse input                                                        | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Per-feature opt-out       | Disable drag and drop, floating, overflow and more individually                                             | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Edge drop zones           | Dock against the outer layout by dropping on the viewport edges via `dndEdges`                              | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| DnD backend strategy      | Choose the drag backend — `auto` (HTML5 + pointer), `pointer` or `html5` — via `dndStrategy`                | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| DnD backend strategy      | Choose the drag backend via `dndStrategy`: `auto` (HTML5 + pointer), `pointer` or `html5`                   | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Custom drop overlay       | Configure the shape and behaviour of drop targets                                                           |                                          | <span className="feature-check">✓</span> |
 | Custom group drag preview | Replace the default ghost shown while dragging a group                                                      |                                          | <span className="feature-check">✓</span> |
-| Drop guide compass        | Aim-at-a-cell docking overlay that previews the landing region — see [Drop guide](/docs/core/dnd/dropGuide) |                                          | <span className="feature-check">✓</span> |
-| Smart guides              | Alignment guides and magnetic snapping for floating groups — see [Smart guides](/docs/core/dnd/smartGuides) |                                          | <span className="feature-check">✓</span> |
+| Drop guide compass        | Aim-at-a-cell docking overlay that previews the landing region. See [Drop guide](/docs/core/dnd/dropGuide) |                                          | <span className="feature-check">✓</span> |
+| Smart guides              | Alignment guides and magnetic snapping for floating groups. See [Smart guides](/docs/core/dnd/smartGuides) |                                          | <span className="feature-check">✓</span> |
 
 ### Groups and windows
 
@@ -65,8 +65,8 @@ The guiding rule: capabilities that other free layout managers already offer (fl
 | Popout windows             | Move a group into a native browser window with style and lifecycle sync                                                                                                       | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Custom popout URL          | Render popout windows into your own host page via `popoutUrl`                                                                                                                 | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Edge groups                | Pin fixed groups to top, bottom, left or right (shell layout)                                                                                                                 | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| Auto-hide edge groups      | Collapse edge groups to a strip and peek them on demand — see [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups)                                                   |                                          | <span className="feature-check">✓</span> |
-| Dock to edge groups        | Drag a panel to the layout edge to dock it as an edge group that is invisible when empty via `dockToEdgeGroups` — see [Dock to edge groups](/docs/core/groups/autoEdgeGroups) |                                          | <span className="feature-check">✓</span> |
+| Auto-hide edge groups      | Collapse edge groups to a strip and peek them on demand. See [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups)                                                   |                                          | <span className="feature-check">✓</span> |
+| Dock to edge groups        | Drag a panel to the layout edge to dock it as an edge group that is invisible when empty via `dockToEdgeGroups`. See [Dock to edge groups](/docs/core/groups/autoEdgeGroups) |                                          | <span className="feature-check">✓</span> |
 | Locked groups and panels   | Lock [groups and panels](/docs/core/locked) against drag and close                                                                                                            | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 
 ### Sizing
@@ -82,25 +82,25 @@ The guiding rule: capabilities that other free layout managers already offer (fl
 
 | Feature            | Description                                                                                |                   Free                   |                Enterprise                |
 | ------------------ | ------------------------------------------------------------------------------------------ | :--------------------------------------: | :--------------------------------------: |
-| Render modes       | `onlyWhenVisible` (default, lazy) and `always` — set per panel or as the default           | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| Render modes       | `onlyWhenVisible` (default, lazy) and `always`, set per panel or as the default            | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Custom scrollbars  | [Native or custom](/docs/core/scrollbars) scrollbar implementation                         | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| Strict CSP support | Works in strict Content-Security-Policy environments — see [Security](/docs/core/security) | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| Strict CSP support | Works in strict Content-Security-Policy environments. See [Security](/docs/core/security) | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 
 ### State and persistence
 
 | Feature                  | Description                                                                                                                        |                   Free                   |                Enterprise                |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------: | :--------------------------------------: |
-| Save and restore layouts | `api.toJSON()` / `api.fromJSON()` round-trip the full layout — see [Save](/docs/core/state/save) and [Load](/docs/core/state/load) | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| Save and restore layouts | `api.toJSON()` / `api.fromJSON()` round-trip the full layout. See [Save](/docs/core/state/save) and [Load](/docs/core/state/load) | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Full state capture       | Floating, popout and edge groups all serialize                                                                                     | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Custom panel state       | Persist and restore arbitrary per-panel state                                                                                      | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Empty state behaviour    | `emptyGroup`, watermark or custom component when no panels are open                                                                | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| Layout history           | Undo and redo layout changes — see [Layout history](/docs/core/state/history)                                                      |                                          | <span className="feature-check">✓</span> |
+| Layout history           | Undo and redo layout changes. See [Layout history](/docs/core/state/history)                                                      |                                          | <span className="feature-check">✓</span> |
 
 ### Theming
 
 | Feature                  | Description                                                                          |                   Free                   |                Enterprise                |
 | ------------------------ | ------------------------------------------------------------------------------------ | :--------------------------------------: | :--------------------------------------: |
-| Built-in themes          | light, dark, abyss, dracula, replit, vs and more — see [Theming](/docs/core/theming) | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| Built-in themes          | light, dark, abyss, dracula, replit, vs and more. See [Theming](/docs/core/theming) | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | CSS variable theming     | Override colours, spacing and chrome via CSS variables                               | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Tab group colour palette | Configurable chip colours and accent mode                                            | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 
@@ -109,23 +109,23 @@ The guiding rule: capabilities that other free layout managers already offer (fl
 | Feature                     | Description                                                                                         |                   Free                   |                Enterprise                |
 | --------------------------- | --------------------------------------------------------------------------------------------------- | :--------------------------------------: | :--------------------------------------: |
 | Programmatic layout control | Add, move and remove panels and groups from code                                                    | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| Directional placement       | Place panels relative to others — left / right / above / below / within                             | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| Directional placement       | Place panels relative to others: left / right / above / below / within                              | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Panel and group APIs        | `setTitle`, `setSize`, `moveTo`, `setRenderer`, `close`, `maximize` on each panel and group         | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Active panel tracking       | `api.activePanel`, `api.activeGroup` and corresponding change events                                | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Panel lifecycle events      | Per-panel `onDidVisibilityChange`, `onDidFocusChange`, `onDidActiveChange`, `onDidDimensionsChange` | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Runtime option updates      | Change behaviour at runtime via `api.updateOptions()`                                               | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Custom UI messages          | Override built-in interface text via `messages`                                                     | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| Comprehensive events        | Events for every interaction — see [Events](/docs/core/events)                                      | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| Comprehensive events        | Events for every interaction. See [Events](/docs/core/events)                                      | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Keyboard navigation         | `activateNext` / `activatePrevious` to cycle through panels                                         | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 
 ### Accessibility
 
 | Feature                     | Description                                                                                                         |                   Free                   |                Enterprise                |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------- | :--------------------------------------: | :--------------------------------------: |
-| ARIA roles and labels       | Semantic roles, labels and roving tabindex across the tab strip — see [Accessibility](/docs/advanced/accessibility) | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| ARIA roles and labels       | Semantic roles, labels and roving tabindex across the tab strip. See [Accessibility](/docs/advanced/accessibility) | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Screen-reader announcements | Live-region announcements for layout changes, routed to the focused window                                          | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | Focus indicators            | `:focus-visible` focus rings that appear for keyboard users only                                                    | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| Keyboard docking            | Move and dock groups by keyboard, including across popout windows — see [Keyboard](/docs/advanced/keyboard)         |                                          | <span className="feature-check">✓</span> |
+| Keyboard docking            | Move and dock groups by keyboard, including across popout windows. See [Keyboard](/docs/advanced/keyboard)         |                                          | <span className="feature-check">✓</span> |
 
 ### Framework support
 
@@ -138,7 +138,7 @@ The guiding rule: capabilities that other free layout managers already offer (fl
 
 ## See also
 
-- [Introduction](/docs/overview/introduction) — what Dockview is and how the pieces fit together
-- [Quickstart](/docs/overview/quickstart) — get a layout on screen in a few lines
-- [Theming](/docs/core/theming) — built-in themes and CSS-variable customisation
-- [Events](/docs/core/events) — the full event surface behind these features
+- [Introduction](/docs/overview/introduction): what Dockview is and how the pieces fit together
+- [Quickstart](/docs/overview/quickstart): get a layout on screen in a few lines
+- [Theming](/docs/core/theming): built-in themes and CSS-variable customisation
+- [Events](/docs/core/events): the full event surface behind these features

--- a/packages/docs/docs/overview/introduction.mdx
+++ b/packages/docs/docs/overview/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 sidebar_position: 0
-description: An introduction to Dockview — a zero-dependency layout manager for building IDE-like interfaces with tabs, groups, drag and drop, and floating panels.
+description: An introduction to Dockview: a zero-dependency layout manager for building IDE-like interfaces with tabs, groups, drag and drop, and floating panels.
 ---
 
 Dockview is a zero-dependency layout manager for building IDE-like interfaces in the browser. It provides tabs, groups, drag and drop, floating panels, popout windows, and serialization with no external runtime dependencies.

--- a/packages/docs/docs/releases/migrating/migrating-to-v7.mdx
+++ b/packages/docs/docs/releases/migrating/migrating-to-v7.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrating to v7
 sidebar_position: 2
-description: How to upgrade from Dockview v6 to v7 — the package realignment and the breaking API changes.
+description: How to upgrade from Dockview v6 to v7: the package realignment and the breaking API changes.
 ---
 
 v7 realigns the package names so that **`dockview` is the framework-agnostic
@@ -11,20 +11,20 @@ consumer.
 
 | Package            | v6                       | v7                                                          |
 | ------------------ | ------------------------ | ----------------------------------------------------------- |
-| `dockview-core`    | JavaScript core (public) | JavaScript core — **internal implementation detail**        |
-| `dockview`         | **React bindings**       | JavaScript (re-export of `dockview-core`) — **recommended** |
+| `dockview-core`    | JavaScript core (public) | JavaScript core (**internal implementation detail**)        |
+| `dockview`         | **React bindings**       | JavaScript (re-export of `dockview-core`), **recommended** |
 | `dockview-react`   | Re-export of `dockview`  | **React bindings**                                          |
 | `dockview-vue`     | Vue bindings             | Vue bindings (now consume `dockview`)                       |
 | `dockview-angular` | Angular bindings         | Angular bindings (now consume `dockview`)                   |
 
-## React users — action required
+## React users: action required
 
 The React bindings **moved from `dockview` to `dockview-react`**. In v7 the
 `dockview` package is the JavaScript library (a re-export of
 `dockview-core`), so it no longer exports the React components.
 
 :::warning Symptoms if you don't migrate
-The React names are simply gone — core names like `DockviewComponent` still
+The React names are simply gone; core names like `DockviewComponent` still
 resolve from `dockview`, but the React components do not:
 
 - **TypeScript:** `error TS2305: Module '"dockview"' has no exported member 'DockviewReact'`
@@ -50,16 +50,16 @@ Install and import from `dockview-react`:
 ```
 
 A one-shot codemod for a source tree (uses `perl` for cross-platform in-place
-editing — works on macOS and Linux):
+editing; works on macOS and Linux):
 
 ```sh
 grep -rl "from 'dockview'" src | xargs perl -pi -e "s/from 'dockview'/from 'dockview-react'/g"
 ```
 
-## JavaScript users — recommended
+## JavaScript users: recommended
 
 `dockview-core` is now considered an internal implementation detail. Install the
-`dockview` package instead — it re-exports the entire core API.
+`dockview` package instead; it re-exports the entire core API.
 
 ```diff
 - npm install dockview-core
@@ -92,10 +92,10 @@ built-in features are no longer part of bare `dockview-core`:
   navigation / focus management / screen-reader announcements)
 
 These now live in the `dockview` package, which enables them automatically.
-**`dockview-core` is an internal package — use `dockview`** (or a framework
-package — `dockview-react` / `-vue` / `-angular`, which all consume `dockview`).
-Nothing throws if you stay on bare `dockview-core` — the affected features
-simply do nothing — and a one-time `console.warn` steers you to `dockview`.
+**`dockview-core` is an internal package; use `dockview`** (or a framework
+package: `dockview-react` / `-vue` / `-angular`, which all consume `dockview`).
+Nothing throws if you stay on bare `dockview-core` (the affected features
+simply do nothing) and a one-time `console.warn` steers you to `dockview`.
 
 ## Removed and changed APIs
 
@@ -117,7 +117,7 @@ model applied to the root drop target. Drop-overlay shaping is now driven by
 ```
 
 `dropOverlayModel` shapes the overlay **per drop target**; return `undefined` to
-keep the default for that target. It does **not** dispatch the `'edge'` target —
+keep the default for that target. It does **not** dispatch the `'edge'` target;
 if you used `rootOverlayModel` purely to size the outer edge overlay, use
 `dndEdges` instead.
 
@@ -153,19 +153,19 @@ The handler argument is now an object, so `panel.id` / `panel.api` read as
 
 The group-level `group.api.onDidActivePanelChange` is scoped to a single group;
 it keeps emitting the panel and additionally carries `origin` (its payload type
-is `DockviewGroupActivePanelChangeEvent`). This is additive — handlers reading
+is `DockviewGroupActivePanelChangeEvent`). This is additive; handlers reading
 `event.panel` keep working.
 
 ### Renamed types and events
 
-These are pure renames — the shape is unchanged, only the identifier moved.
+These are pure renames; the shape is unchanged, only the identifier moved.
 
 | v6                                      | v7                                      | Notes                                                                       |
 | --------------------------------------- | --------------------------------------- | --------------------------------------------------------------------------- |
-| `onUnhandledDragOverEvent`              | `onUnhandledDragOver`                   | Event on the Dockview / Paneview API — dropped the redundant `Event` suffix |
+| `onUnhandledDragOverEvent`              | `onUnhandledDragOver`                   | Event on the Dockview / Paneview API; dropped the redundant `Event` suffix |
 | `PaneviewDropEvent`                     | `PaneviewDidDropEvent`                  | Now matches `DockviewDidDropEvent`                                          |
 | `DockviewMaximizedGroupChanged`         | `DockviewMaximizedGroupChangeEvent`     | Now matches every other `…ChangeEvent` payload type                         |
-| `DockviewGroupPanelFloatingChangeEvent` | `DockviewGroupPanelLocationChangeEvent` | Payload of `onDidLocationChange` — name now reflects the event              |
+| `DockviewGroupPanelFloatingChangeEvent` | `DockviewGroupPanelLocationChangeEvent` | Payload of `onDidLocationChange`; name now reflects the event              |
 | `AddComponentOptions`                   | `AddGridviewComponentOptions`           | Now matches `AddSplitviewComponentOptions` / `AddPaneviewComponentOptions`  |
 | `Contraints`                            | `Constraints`                           | Typo fix (this type also feeds `AddPanelOptions`)                           |
 
@@ -185,7 +185,7 @@ These are pure renames — the shape is unchanged, only the identifier moved.
 
 ## Vue / Angular users
 
-No source changes required — keep installing `dockview-vue` / `dockview-angular`
+No source changes required; keep installing `dockview-vue` / `dockview-angular`
 and importing from them. Internally these now depend on `dockview` rather than
 `dockview-core`; this is transparent to consumers.
 

--- a/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
+++ b/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrating to v8
 sidebar_position: 1
-description: How to upgrade from Dockview v7 to v8 — an additive release with one behavioural change to reported panel dimensions and one deprecating method rename.
+description: How to upgrade from Dockview v7 to v8: an additive release with one behavioural change to reported panel dimensions and one deprecating method rename.
 ---
 
 **v8 is additive.** Every new feature ships as an opt-in `DockviewOptions` field
@@ -10,12 +10,12 @@ no package renames and no removed options. Two things are worth checking: a
 behavioural change to the dimensions reported to panels, and a method rename that
 keeps the old names as deprecated aliases (so nothing breaks today).
 
-## Behavioural change — reported panel dimensions
+## Behavioural change: reported panel dimensions
 
 In v7, the size forwarded to a panel (and reported through
 `api.onDidDimensionsChange`) was the **full group box, including the tab
 header**. That over-reported the available content height by the header size. In
-v8, panels receive the **content area** — the group box minus the header along
+v8, panels receive the **content area**: the group box minus the header along
 its axis (the header height for a top/bottom header, its width for a
 left/right header; a hidden header measures zero, so nothing is subtracted).
 
@@ -29,18 +29,18 @@ left/right header; a hidden header measures zero, so nothing is subtracted).
 
 :::info CSS-fill renderers are unaffected
 The default rendering path fills its container with CSS, so it never reads these
-numbers — the change is invisible. It only matters for renderers that size
+numbers, the change is invisible. It only matters for renderers that size
 themselves from the reported dimensions, such as **canvas**, **virtualised**, or
 **embedded** content. If that's you, the numbers are now more correct (the header
 is no longer double-counted); adjust any code that compensated for the header.
 :::
 
-## Renamed methods — `moveToNext` / `moveToPrevious` {#renamed-methods}
+## Renamed methods: `moveToNext` / `moveToPrevious` {#renamed-methods}
 
 `api.moveToNext` and `api.moveToPrevious` are renamed to
 [`api.activateNext` / `api.activatePrevious`](/docs/advanced/focus-navigation).
 They advance the **active** panel/group (they move focus); they never relocate a
-panel, and the old names misread as panel-moving — especially now that keyboard
+panel, and the old names misread as panel-moving, especially now that keyboard
 docking offers a genuine "move panel" action.
 
 ```diff
@@ -53,7 +53,7 @@ docking offers a genuine "move panel" action.
 
 :::info Nothing breaks today
 The old names remain as **deprecated aliases** that delegate to the new ones, so
-existing code keeps working. Removal is planned for a future major release —
+existing code keeps working. Removal is planned for a future major release;
 rename at your convenience.
 :::
 
@@ -85,13 +85,13 @@ They are off by default; set the ones you want:
 | `overflow`             | [Multi-row / wrapping tabs & overflow](/docs/core/panels/multiRowTabs) |
 | `dndGuide`             | [Drop guide compass](/docs/core/dnd/dropGuide)                         |
 | `dropPositionResolver` | [Custom drop-position resolution](/docs/core/dnd/dropGuide)            |
-| `smartGuides`          | [Smart guides — floating-group snapping](/docs/core/dnd/smartGuides)   |
+| `smartGuides`          | [Smart guides, floating-group snapping](/docs/core/dnd/smartGuides)   |
 | `layoutHistory`        | [Layout history (undo/redo)](/docs/core/state/history)                 |
 | `autoHideEdgeGroups`   | [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups)          |
-| `dockToEdgeGroups`     | [Dock to edge groups — drag-revealed edges](/docs/core/groups/autoEdgeGroups) |
+| `dockToEdgeGroups`     | [Dock to edge groups, drag-revealed edges](/docs/core/groups/autoEdgeGroups) |
 | `edgeGroupPeek`        | Peek animation tuning for [auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups) |
 
-`autoHideEdgeGroups` and `dockToEdgeGroups` accept an `EdgeGroupSet` — pass
+`autoHideEdgeGroups` and `dockToEdgeGroups` accept an `EdgeGroupSet`: pass
 `true` to enable all four edges, or an object such as `{ left: true, right: true }`
 to opt edges in individually.
 

--- a/packages/docs/docs/releases/whats-new/whats-new-v6.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v6.mdx
@@ -1,7 +1,7 @@
 ---
 title: What's new in v6
 sidebar_position: 3
-description: Highlights and breaking changes in Dockview 6.0 — Tab Groups, Edge Groups, theme system overhaul, and more.
+description: Highlights and breaking changes in Dockview 6.0: Tab Groups, Edge Groups, theme system overhaul, and more.
 ---
 
 Dockview 6.0 is the largest release since 4.0. It introduces two new structural features
@@ -39,7 +39,7 @@ See [Tab groups](/docs/core/panels/tabs#tab-groups) for the full reference.
 ### Edge groups
 
 Edge groups are persistent, single-purpose panels anchored to one edge of the
-Dockview shell — useful for activity bars, status panels, or output panes that
+Dockview shell, useful for activity bars, status panels, or output panes that
 shouldn't participate in normal layout drag-and-drop. They support collapse /
 expand with size memory and survive `toJSON` / `fromJSON`.
 ([#1122](https://github.com/mathuo/dockview/pull/1122),
@@ -91,7 +91,7 @@ chips, with `'colorPicker'` and `'rename'` shortcuts on top of the standard
 
 `IContentRenderer` gained optional `onShow()` / `onHide()` hooks that fire as
 panels are attached to / detached from the DOM under
-`renderer: 'onlyWhenVisible'`. This unlocks correct behaviour for renderers
+`renderer: 'onlyWhenVisible'`. This matters for renderers
 that need to detach from a host framework's lifecycle (notably Angular
 `TemplateRef` views). ([#1158](https://github.com/mathuo/dockview/pull/1158))
 
@@ -116,10 +116,10 @@ control without touching SCSS:
 
 | Property                 | Purpose                                                     |
 | ------------------------ | ----------------------------------------------------------- |
-| `colorScheme`            | `'light' \| 'dark'` — lets panel content adapt              |
-| `tabAnimation`           | `'smooth' \| 'default'` — moved here from `DockviewOptions` |
-| `tabGroupIndicator`      | `'wrap' \| 'none'` — Chrome-style underline vs. flat bar    |
-| `dndTabIndicator`        | `'line' \| 'fill'` — drop-target style                      |
+| `colorScheme`            | `'light' | 'dark'`, lets panel content adapt              |
+| `tabAnimation`           | `'smooth' | 'default'`, moved here from `DockviewOptions` |
+| `tabGroupIndicator`      | `'wrap' | 'none'`, Chrome-style underline vs. flat bar    |
+| `dndTabIndicator`        | `'line' | 'fill'`, drop-target style                      |
 | `dndOverlayBorder`       | CSS expression for `--dv-drag-over-border`                  |
 | `edgeGroupCollapsedSize` | px override for collapsed edge group size                   |
 
@@ -143,7 +143,7 @@ Seven new themes ship in v6:
 
 ### `tabAnimation` moved to the theme object
 
-`tabAnimation` is no longer a top-level `DockviewOptions` property — it now
+`tabAnimation` is no longer a top-level `DockviewOptions` property; it now
 lives on the `DockviewTheme` object alongside `gap`, `dndPanelOverlay`, etc.
 ([#1181](https://github.com/mathuo/dockview/pull/1181))
 
@@ -160,7 +160,7 @@ const options: DockviewOptions = {
 };
 ```
 
-The `DEFAULT_TAB_ANIMATION` constant has also been removed — read
+The `DEFAULT_TAB_ANIMATION` constant has also been removed; read
 `theme.tabAnimation` directly if you need the active value.
 
 ### `dockview.css` is no longer auto-injected

--- a/packages/docs/docs/releases/whats-new/whats-new-v7.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v7.mdx
@@ -1,7 +1,7 @@
 ---
 title: What's new in v7
 sidebar_position: 2
-description: Highlights and breaking changes in Dockview 7.0 — package realignment, the accessibility pack, and more.
+description: Highlights and breaking changes in Dockview 7.0: package realignment, the accessibility pack, and more.
 ---
 
 Dockview 7.0 realigns the package names so the ecosystem is consistent
@@ -19,14 +19,14 @@ This page covers the headline additions. For the upgrade steps and the
 `dockview` is now the **framework-agnostic** JavaScript package (a re-export of
 `dockview-core`), and the **React bindings moved to `dockview-react`**. Every
 framework package (`dockview-react` / `-vue` / `-angular`) consumes `dockview`.
-React users must switch their imports — see
-[Migrating to v7](/docs/releases/migrating/migrating-to-v7#react-users--action-required).
+React users must switch their imports. See
+[Migrating to v7](/docs/releases/migrating/migrating-to-v7#react-users-action-required).
 
 ### Keyboard navigation & announcements
 
 A new [`keyboardNavigation`](/docs/advanced/accessibility#keyboard-navigation)
-option enables a rebindable keymap for moving around the layout — tab switching,
-F6 group cycling, and jumping to the tab strip — alongside focus management
+option enables a rebindable keymap for moving around the layout (tab switching,
+F6 group cycling, and jumping to the tab strip) alongside focus management
 (focus restore on close, floating-group focus containment). Layout changes can
 also be narrated to screen readers via a built-in live region, with hooks
 ([`announcements`](/docs/advanced/accessibility#screen-reader-announcements),
@@ -69,15 +69,15 @@ gesture or an API call via `event.origin`. This is a
 v7's breaking changes are covered in full, with codemods, in
 [Migrating to v7](/docs/releases/migrating/migrating-to-v7):
 
-- **Package realignment** — React bindings moved from `dockview` to
+- **Package realignment**: React bindings moved from `dockview` to
   `dockview-react`; `dockview` is now JavaScript core.
-- **`rootOverlayModel` removed** — use [`dropOverlayModel`](/docs/core/dnd/overlay)
+- **`rootOverlayModel` removed**: use [`dropOverlayModel`](/docs/core/dnd/overlay)
   / `dndEdges` instead.
-- **`onDidActivePanelChange` payload** — now emits `{ panel, origin }` instead of
+- **`onDidActivePanelChange` payload**: now emits `{ panel, origin }` instead of
   the panel directly.
-- **`dockview-core` no longer bundles every feature** — use `dockview` (or a
+- **`dockview-core` no longer bundles every feature**: use `dockview` (or a
   framework package).
-- **API naming cleanups** — a few public types/events were renamed for
+- **API naming cleanups**: a few public types/events were renamed for
   consistency (e.g. `onUnhandledDragOverEvent` → `onUnhandledDragOver`,
   `PaneviewDropEvent` → `PaneviewDidDropEvent`) and some dead/deprecated members
   were removed. See [Migrating to v7](/docs/releases/migrating/migrating-to-v7) for the

--- a/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
@@ -1,7 +1,7 @@
 ---
 title: What's new in v8
 sidebar_position: 1
-description: Highlights and breaking changes in Dockview 8.0 — pinned tabs, multi-row tabs, smarter drag-and-drop, layout history, and more.
+description: Highlights and breaking changes in Dockview 8.0: pinned tabs, multi-row tabs, smarter drag-and-drop, layout history, and more.
 ---
 
 Dockview 8.0 is an additive release focused on the tab header and drag-and-drop:
@@ -16,7 +16,7 @@ This page covers the headline additions. For the upgrade notes and the single
 
 :::info The `dockview-enterprise` package
 v8 introduces `dockview-enterprise`, a separately-licensed package for the
-features marked **Enterprise** in [Features](/docs/overview/features) — pinned
+features marked **Enterprise** in [Features](/docs/overview/features): pinned
 tabs, multi-row tabs, the drop guide compass, smart guides, layout history,
 auto-hide edge groups, dock-to-edge groups, and keyboard docking. The free,
 open-source `dockview` packages are unchanged.
@@ -64,8 +64,8 @@ snap together into a docked or merged group. See
 ### Layout history (undo/redo)
 
 The new [`layoutHistory`](/docs/core/state/history) option records structural
-layout mutations and lets you undo and redo them — move, float, popout,
-maximize, add, and remove — coalescing resize gestures and spanning popout
+layout mutations and lets you undo and redo them (move, float, popout,
+maximize, add, and remove) coalescing resize gestures and spanning popout
 windows. See [Layout history](/docs/core/state/history).
 
 ### Auto-hide edge groups
@@ -95,23 +95,23 @@ docks an edge group) and with auto-hide, and can be driven programmatically via
 
 Keyboard docking now works across popout windows, so you can move a group into or
 out of a popout entirely from the keyboard, with a dedicated "float" terminal
-action. It builds on refreshed accessibility work — per-window live regions with
+action. It builds on refreshed accessibility work: per-window live regions with
 focus-aware routing, `:focus-visible` focus indicators, and honest, localised
 accessible names on tab controls. See [Keyboard navigation](/docs/advanced/keyboard)
 and [Accessibility](/docs/advanced/accessibility).
 
 ## Breaking changes
 
-v8 is additive — every new feature above is opt-in and off by default. There is
+v8 is additive; every new feature above is opt-in and off by default. There is
 one behavioural change and one method rename to be aware of, both covered in full
 in [Migrating to v8](/docs/releases/migrating/migrating-to-v8):
 
-- **Reported panel dimensions** — `onDidDimensionsChange` (and the height passed
+- **Reported panel dimensions**: `onDidDimensionsChange` (and the height passed
   to renderers) now report the **content area** (the group box minus the header)
   instead of the header-inclusive group box. CSS-fill renderers are unaffected;
   only consumers that read the numeric dimensions need to check this.
 - **`api.moveToNext` / `api.moveToPrevious` renamed** to
-  [`activateNext` / `activatePrevious`](/docs/advanced/focus-navigation) — the
+  [`activateNext` / `activatePrevious`](/docs/advanced/focus-navigation): the
   new names make clear they advance the active panel/group (focus) rather than
   relocating a panel. The old names still work as **deprecated aliases**, so no
   code breaks today; update at your convenience before they are removed in a


### PR DESCRIPTION
## Description

Reworks prose across the documentation site so it reads as human-written rather than AI-generated. Rebased onto `v8-branch` and targets `v8-branch`.

The most visible tell was the em dash: there were ~400 across the v8 doc pages. Every one is removed, replaced with whatever the sentence actually calls for (comma, colon, semicolon, parentheses, or full stop) rather than a mechanical swap. Also dropped a few stock phrasings ("a comprehensive set of events", "a wide variety of", "out of the box", "This unlocks correct behaviour").

Deliberately left alone: British spelling (behaviour, colour, localise), the en dash in numeric ranges like `v5.0–5.2`, and pre-existing typos in older hand-written sections, since none of those read as AI.

Also adds a **Writing Style** section to `packages/docs/AGENTS.md` so future doc edits avoid the same tells.

Knock-on changes: removing em dashes from a few headings changed their slugs, so `## React users — action required` became `## React users: action required` and the cross-reference anchor in `whats-new-v7.mdx` was updated to match. The `## Renamed methods` heading keeps its explicit `{#renamed-methods}` anchor, so its inbound link is unaffected.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

Prose-only changes; no runtime behaviour is affected. To review:

- Read the diff for wording and punctuation.
- Confirm the internal link from **What's new in v7** to **Migrating to v7 → React users: action required** still resolves (its heading slug changed alongside the em-dash removal).

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes (docs package is deliberately excluded from Prettier)
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01698iGKTFkcMr51WC1grrvT