### PR TITLE
fix(dockview-core): keep floating always-rendered content above its window

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -383,6 +383,31 @@
                             height: 180,
                         });
                     },
+                    // Like setupFloating but the floated panel uses the
+                    // `always` renderer, so its content lives in the overlay
+                    // render container and is positioned/stacked over the
+                    // floating window. Exercises the render-overlay z-index path
+                    // (float via the same `_doAddFloatingGroup` the "Float tab"
+                    // context-menu action uses).
+                    setupFloatingAlways: () => {
+                        dockview.addPanel({
+                            id: 'main',
+                            component: 'default',
+                            title: 'main',
+                        });
+                        const floater = dockview.addPanel({
+                            id: 'floater',
+                            component: 'default',
+                            title: 'floater',
+                            renderer: 'always',
+                        });
+                        dockview.addFloatingGroup(floater, {
+                            x: 150,
+                            y: 100,
+                            width: 240,
+                            height: 180,
+                        });
+                    },
                     peekEdge: (position, on) =>
                         dockview.api.peekEdgeGroup(position, on),
                     // Two floating groups for Smart Guides: a target float on

--- a/e2e/tests/floating-group.spec.ts
+++ b/e2e/tests/floating-group.spec.ts
@@ -41,6 +41,63 @@ test.describe('floating groups', () => {
         expect(box.y).toBeGreaterThan(20);
     });
 
+    test('a floated always-rendered panel paints its content above the floating window', async ({
+        page,
+    }) => {
+        // Regression for the "blank floating window" bug: floating an
+        // `always`-rendered panel (its content lives in the overlay render
+        // container) mounted the overlay but dropped it *behind* the floating
+        // window's opaque background, so the content was invisible until the
+        // window was dragged (which re-applied the stacking via the aria-level
+        // observer). Existing float tests use the default `onlyWhenVisible`
+        // renderer, which mounts content inline and so never exercised this.
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupFloatingAlways());
+
+        // Content renders in the overlay container, not inline in the group.
+        const overlay = page.locator('.dv-render-overlay', {
+            hasText: 'floater',
+        });
+        await expect(overlay).toHaveCount(1);
+
+        // Hit-test the centre of the float: the topmost painted element there
+        // must be the overlay content, not the floating window's own (empty)
+        // content container occluding it. Playwright's `toBeVisible()` ignores
+        // z-index occlusion, so an `elementFromPoint` probe is required to catch
+        // this — it fails when `resize()` clobbers the overlay's floating
+        // z-index back to the grid default.
+        const probe = await page.evaluate(() => {
+            const ov = Array.from(
+                document.querySelectorAll('.dv-render-overlay')
+            ).find((el) => /floater/.test(el.textContent || ''));
+            if (!ov) {
+                return { hit: false, overlayZ: null as string | null };
+            }
+            const r = ov.getBoundingClientRect();
+            const top = document.elementFromPoint(
+                r.left + r.width / 2,
+                r.top + r.height / 2
+            );
+            return {
+                hit: !!top && ov.contains(top),
+                overlayZ: getComputedStyle(ov).zIndex,
+            };
+        });
+        expect(probe.hit).toBe(true);
+
+        // The overlay's resolved stacking must sit above the floating window
+        // itself (the `.dv-resize-container`, z 999) — the `+1` that lifts a
+        // float's content over its own window.
+        const windowZ = await page.evaluate(
+            () =>
+                getComputedStyle(
+                    document.querySelector('.dv-resize-container')!
+                ).zIndex
+        );
+        expect(Number(probe.overlayZ)).toBeGreaterThan(Number(windowZ));
+    });
+
     test('a floating group survives a serialization round-trip', async ({
         page,
     }) => {

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -250,9 +250,18 @@ export class OverlayRenderContainer extends CompositeDisposable {
                     focusContainer.style.pointerEvents = 'none';
                 }
                 // When force-shown for an auto-hide peek, lift the overlay above
-                // the peek's own (opaque) backdrop so the content is visible;
-                // otherwise leave the default stacking.
-                focusContainer.style.zIndex = forceVisible ? '1000' : '';
+                // the peek's own (opaque) backdrop so the content is visible.
+                // For a floating panel the stacking is owned by
+                // `correctLayerPosition()` (tracks the window's aria-level and
+                // lifts the overlay above the floating window); leave it alone
+                // here so we don't clobber it back to the default and drop the
+                // content behind the window. Only reset to the default for a
+                // plain grid-docked overlay.
+                if (forceVisible) {
+                    focusContainer.style.zIndex = '1000';
+                } else if (panel.api.location.type !== 'floating') {
+                    focusContainer.style.zIndex = '';
+                }
 
                 // Clip to the peek's reveal window so an `always` panel emerges
                 // from the strip's inner edge as the container slides, rather


### PR DESCRIPTION
## The bug

Right-clicking a tab whose panel uses `renderer: 'always'` (e.g. **Orders** in the `/demo`) → **Float** opened the floating window, but its content was **blank until the window was dragged**. Popouts were unaffected.

## Root cause

An `always`-rendered panel renders its content in the shared `OverlayRenderContainer`, positioned over its group. When the panel floats, `correctLayerPosition()` lifts the overlay's `z-index` above the floating window (tracking the window's `aria-level`) so the content paints on top.

But `OverlayRenderContainer.resize()` ran, every frame:

```js
focusContainer.style.zIndex = forceVisible ? '1000' : '';
```

The group's first layout inside the float triggers a `resize()` **after** `correctLayerPosition()`, resetting `z-index` back to `''` — dropping the content **behind** the floating window's opaque background. Dragging "fixed" it because `bringToFront()` bumps the `aria-level`, and the `MutationObserver` in `correctLayerPosition()` re-applied the correct stacking.

## The fix

`resize()` now leaves the `z-index` alone for floating panels (that stacking is owned by `correctLayerPosition()`), only resetting it for grid-docked overlays. The auto-hide peek `forceVisible` path is unchanged.

## Why the existing e2e tests missed it

The existing float specs use `setupFloating()` with the **default** `onlyWhenVisible` renderer, which mounts content *inline* — the overlay-stacking path was never exercised.

Added:
- `setupFloatingAlways()` fixture helper (`renderer: 'always'`).
- A regression test that floats an `always` panel and **hit-tests the centre of the float** with `document.elementFromPoint`. Playwright's `toBeVisible()` ignores z-index occlusion, so a plain visibility assertion wouldn't catch this.

Verified the test genuinely catches the regression: reverted the fix → rebuilt → **test fails** (`probe.hit: false`); re-applied → passes. The 22 related specs (floating, auto-hide **peek** which uses the `forceVisible` path, all popout specs) stay green, and the fix was confirmed on the live `/demo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)