### PR TITLE
feat(enterprise): overflow.maxRows cap + dropdown spillover for multi-row tabs

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -205,6 +205,8 @@ MeasuredValue
 MovePanelEvent
 MovementOptions
 MovementOptions2
+OVERFLOW_MAX_TAB_ROWS_VARIABLE
+OVERFLOW_WRAP_TABS_CAPPED_CLASS
 OVERFLOW_WRAP_TABS_CLASS
 Orientation
 OverflowThumbnailRenderer

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -52,9 +52,17 @@
                 const params = new URLSearchParams(location.search);
                 // Opt-in multi-row (wrapping) tabs via `?overflow=wrap` so the
                 // wrap behaviour is exercised without affecting other specs.
+                // `?maxRows=N` caps the header at N rows (surplus spills to the
+                // dropdown).
+                const maxRowsParam = params.get('maxRows');
                 const overflow =
                     params.get('overflow') === 'wrap'
-                        ? { mode: 'wrap' }
+                        ? {
+                              mode: 'wrap',
+                              ...(maxRowsParam
+                                  ? { maxRows: Number(maxRowsParam) }
+                                  : {}),
+                          }
                         : undefined;
                 // `?smooth=1` turns on the smooth tab reorder animation (needed
                 // to exercise the 2-D cross-row wrap reorder path).
@@ -195,6 +203,10 @@
                             });
                         }
                     },
+                    // Change the overflow options at runtime (e.g. raise
+                    // `maxRows`) so the multi-row cap reflow can be exercised.
+                    setOverflow: (overflow) =>
+                        dockview.updateOptions({ overflow }),
                     closePanel: (id) => panels[id] && panels[id].api.close(),
                     // Add a panel, optionally splitting a new group off in a
                     // direction (records an 'add' mutation for layout history).

--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -156,6 +156,68 @@ test.describe('multi-row tabs (wrap mode)', () => {
         ).toBeVisible();
     });
 
+    test('the overflow dropdown lists the surplus tabs (a suffix of the strip)', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html?overflow=wrap&maxRows=2');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupWrapTabs(20));
+
+        // Open the chevron dropdown.
+        const handle = page.locator('.dv-tabs-overflow-dropdown-default');
+        await expect(handle).toBeVisible();
+        await handle.click();
+
+        const overflow = page.locator('.dv-tabs-overflow-container');
+        await expect(overflow).toBeVisible();
+
+        const listed = await overflow
+            .locator('.dv-tab')
+            .allInnerTexts()
+            .then((texts) => texts.map((t) => t.trim()));
+
+        // The surplus is a suffix: the last tab spilled, the first did not.
+        expect(listed).toContain('wrap-tab-long-title-19');
+        expect(listed).not.toContain('wrap-tab-long-title-0');
+
+        // Picking a spilled tab activates it and closes the dropdown.
+        await overflow
+            .locator('.dv-tab', { hasText: 'wrap-tab-long-title-19' })
+            .click();
+        await expect(page.locator('.dv-active-tab')).toHaveText(
+            'wrap-tab-long-title-19'
+        );
+        await expect(overflow).toHaveCount(0);
+    });
+
+    test('closing the surplus tabs reflows the cap away (dropdown disappears)', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html?overflow=wrap&maxRows=2');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupWrapTabs(20));
+
+        // Surplus present → dropdown shown.
+        await expect(
+            page.locator('.dv-tabs-overflow-dropdown-root').first()
+        ).toBeVisible();
+
+        // Close most panels so the remainder fits within the 2-row cap.
+        await page.evaluate(() => {
+            for (let i = 4; i < 20; i++) {
+                (window as any).__dv.closePanel('wrap-tab-' + i);
+            }
+        });
+
+        // No surplus left → the dropdown is gone, but wrap is still active.
+        await expect(
+            page.locator('.dv-tabs-overflow-dropdown-root')
+        ).toHaveCount(0);
+        await expect(page.locator('.dv-tabs-container').first()).toHaveClass(
+            /dv-tabs-container--wrap-capped/
+        );
+    });
+
     test('raising maxRows re-admits the surplus rows and grows the header', async ({
         page,
     }) => {

--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -112,6 +112,83 @@ test.describe('multi-row tabs (wrap mode)', () => {
         );
     });
 
+    // `overflow.maxRows` caps the header height; the surplus rows spill into the
+    // chevron dropdown. Real-browser only (row count is a layout fact).
+    test('maxRows caps the header and spills the surplus into the dropdown', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html?overflow=wrap&maxRows=2');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupWrapTabs(20));
+
+        const tabsList = page.locator('.dv-tabs-container').first();
+        await expect(tabsList).toHaveClass(/dv-tabs-container--wrap-capped/);
+
+        const m = await page.evaluate(() => {
+            const list = document.querySelector(
+                '.dv-tabs-container'
+            ) as HTMLElement;
+            const header = document.querySelector(
+                '.dv-tabs-and-actions-container'
+            ) as HTMLElement;
+            const rowH = parseFloat(
+                getComputedStyle(header).getPropertyValue(
+                    '--dv-tabs-and-actions-container-height'
+                )
+            );
+            return {
+                rowH,
+                headerH: header.offsetHeight,
+                clientH: list.clientHeight,
+                scrollH: list.scrollHeight,
+            };
+        });
+
+        // The header grew past a single row but is capped at two.
+        expect(m.headerH).toBeGreaterThan(m.rowH);
+        expect(m.headerH).toBeLessThanOrEqual(m.rowH * 2 + 1);
+        // The strip clips the surplus rows (natural content is taller than the
+        // capped client box).
+        expect(m.scrollH).toBeGreaterThan(m.clientH);
+        // The surplus tabs appear in the overflow dropdown chevron.
+        await expect(
+            page.locator('.dv-tabs-overflow-dropdown-root').first()
+        ).toBeVisible();
+    });
+
+    test('raising maxRows re-admits the surplus rows and grows the header', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html?overflow=wrap&maxRows=2');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupWrapTabs(20));
+
+        const cappedHeader = (await page
+            .locator('.dv-tabs-and-actions-container')
+            .first()
+            .boundingBox())!;
+
+        // Raise the cap high enough to fit every row.
+        await page.evaluate(() =>
+            (window as any).__dv.setOverflow({ mode: 'wrap', maxRows: 20 })
+        );
+
+        // The header grew (more rows now fit) and the dropdown emptied.
+        await expect
+            .poll(async () => {
+                const box = await page
+                    .locator('.dv-tabs-and-actions-container')
+                    .first()
+                    .boundingBox();
+                return box!.height;
+            })
+            .toBeGreaterThan(cappedHeader.height);
+
+        await expect(
+            page.locator('.dv-tabs-overflow-dropdown-root')
+        ).toHaveCount(0);
+    });
+
     test('no wrap class without the opt-in', async ({ page }) => {
         await page.goto('/e2e/fixtures/index.html');
         await page.waitForFunction(() => (window as any).__ready === true);

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsForcedOverflow.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsForcedOverflow.spec.ts
@@ -1,0 +1,143 @@
+import { Tabs } from '../../../../dockview/components/titlebar/tabs';
+import { fromPartial } from '@total-typescript/shoehorn';
+import { DockviewGroupPanel } from '../../../../dockview/dockviewGroupPanel';
+import { DockviewComponent } from '../../../../dockview/dockviewComponent';
+import { IDockviewPanel } from '../../../../dockview/dockviewPanel';
+import { ITabRenderer } from '../../../../dockview/types';
+import { IDockviewPanelModel } from '../../../../dockview/dockviewPanelModel';
+
+function createMockPanel(id: string): IDockviewPanel {
+    const tabRenderer: ITabRenderer = {
+        element: document.createElement('div'),
+        init: jest.fn(),
+        update: jest.fn(),
+        dispose: jest.fn(),
+    };
+    return fromPartial<IDockviewPanel>({
+        id,
+        view: fromPartial<IDockviewPanelModel>({ tab: tabRenderer }),
+    });
+}
+
+function createTabs(): Tabs {
+    const accessor = fromPartial<DockviewComponent>({
+        id: 'test-accessor-id',
+        options: {},
+        onDidOptionsChange: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+    });
+    const group = fromPartial<DockviewGroupPanel>({
+        id: 'test-group-id',
+        locked: false,
+        model: fromPartial({
+            canDisplayOverlay: jest.fn().mockReturnValue(true),
+            getTabGroupForPanel: jest.fn().mockReturnValue(null),
+            getTabGroups: jest.fn().mockReturnValue([]),
+        }),
+    });
+    return new Tabs(group, accessor, { showTabsOverflowControl: true });
+}
+
+/**
+ * The forced-overflow seam the `MultiRowTabsModule` consumes: it pushes the
+ * surplus rows (beyond `overflow.maxRows`) into the dropdown even though nothing
+ * clips horizontally in wrap mode. jsdom has zero geometry, so
+ * `isChildEntirelyVisibleWithinParent` reports every tab as fully visible — the
+ * default overflow set is empty here, isolating the forcing predicate.
+ */
+describe('tabs — forced overflow seam', () => {
+    const fire = (
+        tabs: Tabs,
+        reset: boolean
+    ): { tabs: string[]; reset: boolean } => {
+        const events: { tabs: string[]; reset: boolean }[] = [];
+        const sub = tabs.onOverflowTabsChange((e) => events.push(e));
+        (tabs as any).toggleDropdown({ reset });
+        sub.dispose();
+        return events[events.length - 1];
+    };
+
+    test('nothing is in the overflow set when nothing clips and nothing is forced', () => {
+        const tabs = createTabs();
+        tabs.openPanel(createMockPanel('a'));
+        tabs.openPanel(createMockPanel('b'));
+
+        expect(fire(tabs, false).tabs).toEqual([]);
+        tabs.element.remove();
+    });
+
+    test('a forced panel enters the overflow set even though nothing clips', () => {
+        const tabs = createTabs();
+        tabs.openPanel(createMockPanel('a'));
+        tabs.openPanel(createMockPanel('b'));
+        tabs.openPanel(createMockPanel('c'));
+
+        tabs.setForcedOverflow((id) => id === 'b' || id === 'c');
+
+        expect(fire(tabs, false).tabs).toEqual(['b', 'c']);
+        tabs.element.remove();
+    });
+
+    test('setForcedOverflow recomputes immediately while observing', () => {
+        const tabs = createTabs();
+        tabs.openPanel(createMockPanel('a'));
+        tabs.openPanel(createMockPanel('b'));
+
+        const events: { tabs: string[] }[] = [];
+        tabs.onOverflowTabsChange((e) => events.push(e));
+
+        tabs.setForcedOverflow((id) => id === 'a');
+
+        // The setter itself fired a recompute (no manual toggleDropdown).
+        expect(events[events.length - 1].tabs).toEqual(['a']);
+        tabs.element.remove();
+    });
+
+    test('forced tabs survive a reset (wrap mode never reports horizontal clip)', () => {
+        const tabs = createTabs();
+        tabs.openPanel(createMockPanel('a'));
+        tabs.openPanel(createMockPanel('b'));
+
+        tabs.setForcedOverflow((id) => id === 'b');
+
+        // The `OverflowObserver` reports no overflow in wrap mode and asks for a
+        // reset — the forced set must still be surfaced (as a non-reset fire).
+        const event = fire(tabs, true);
+        expect(event.tabs).toEqual(['b']);
+        expect(event.reset).toBe(false);
+        tabs.element.remove();
+    });
+
+    test('a plain reset with nothing forced still clears the dropdown', () => {
+        const tabs = createTabs();
+        tabs.openPanel(createMockPanel('a'));
+
+        const event = fire(tabs, true);
+        expect(event.tabs).toEqual([]);
+        expect(event.reset).toBe(true);
+        tabs.element.remove();
+    });
+
+    test('exclusion wins over forcing (a pinned surplus tab is not forced out)', () => {
+        const tabs = createTabs();
+        tabs.openPanel(createMockPanel('a'));
+        tabs.openPanel(createMockPanel('b'));
+
+        tabs.setOverflowExclude((id) => id === 'b');
+        tabs.setForcedOverflow((id) => id === 'b');
+
+        expect(fire(tabs, false).tabs).toEqual([]);
+        tabs.element.remove();
+    });
+
+    test('clearing the forced predicate restores the empty overflow set', () => {
+        const tabs = createTabs();
+        tabs.openPanel(createMockPanel('a'));
+        tabs.openPanel(createMockPanel('b'));
+
+        tabs.setForcedOverflow((id) => id === 'a');
+        tabs.setForcedOverflow(() => false);
+
+        expect(fire(tabs, false).tabs).toEqual([]);
+        tabs.element.remove();
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/multiRowTabsSeam.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/multiRowTabsSeam.spec.ts
@@ -98,4 +98,40 @@ describe('multi-row tabs seam', () => {
 
         cut.dispose();
     });
+
+    test('tab elements carry their panel id (surplus-set lookup)', () => {
+        const cut = createComponent();
+        const panel = cut.addPanel({ id: 'panel1', component: 'component' });
+
+        const tab =
+            panel.group.model.tabsListElement.querySelector<HTMLElement>(
+                '.dv-tab'
+            )!;
+        expect(tab.getAttribute('data-tab-panel-id')).toBe('panel1');
+
+        cut.dispose();
+    });
+
+    test('host setForcedOverflow routes a panel into the dropdown even when nothing clips', () => {
+        const cut = createComponent();
+        const a = cut.addPanel({ id: 'a', component: 'component' });
+        cut.addPanel({ id: 'b', component: 'component' });
+
+        const dropdown = (): Element | null =>
+            a.group.element.querySelector('.dv-tabs-overflow-dropdown-root');
+
+        // jsdom has no layout, so nothing clips → no dropdown by default.
+        expect(dropdown()).toBeNull();
+
+        // Force 'b' into overflow (the wrap surplus set) — the dropdown appears
+        // although 'b' is not horizontally clipped.
+        cut.setForcedOverflow(a.group, (id) => id === 'b');
+        expect(dropdown()).not.toBeNull();
+
+        // Clearing the forcing removes it again.
+        cut.setForcedOverflow(a.group, () => false);
+        expect(dropdown()).toBeNull();
+
+        cut.dispose();
+    });
 });

--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -86,6 +86,12 @@ export class Tab extends CompositeDisposable {
         this._element.id = nextTabId();
         this._element.setAttribute('role', 'tab');
         this._element.setAttribute('aria-selected', 'false');
+        // Panel identity on the tab element so the multi-row wrap controller can
+        // map a wrapped tab (read for its `offsetTop` row) back to its panel id
+        // when computing the surplus set that spills to the overflow dropdown.
+        // Tab-specific attribute name so it doesn't collide with generic
+        // `[data-panel-id]` lookups elsewhere (e.g. the overlay render container).
+        this._element.setAttribute('data-tab-panel-id', this.panel.id);
         const contentContainerId = this.group?.model?.contentContainerId;
         if (contentContainerId) {
             this._element.setAttribute('aria-controls', contentContainerId);

--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -91,7 +91,8 @@ export class Tab extends CompositeDisposable {
         // when computing the surplus set that spills to the overflow dropdown.
         // Tab-specific attribute name so it doesn't collide with generic
         // `[data-panel-id]` lookups elsewhere (e.g. the overlay render container).
-        this._element.setAttribute('data-tab-panel-id', this.panel.id);
+        // `dataset.tabPanelId` maps to the `data-tab-panel-id` attribute.
+        this._element.dataset.tabPanelId = this.panel.id;
         const contentContainerId = this.group?.model?.contentContainerId;
         if (contentContainerId) {
             this._element.setAttribute('aria-controls', contentContainerId);

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -30,6 +30,20 @@
             height: var(--dv-tabs-and-actions-container-height);
         }
 
+        // `overflow.maxRows` cap. The MultiRowTabsModule adds
+        // `.dv-tabs-container--wrap-capped` and sets `--dv-max-tab-rows` to the
+        // cap: clip the strip to that many rows so the header stops growing,
+        // while the surplus rows (still laid out below, hence measurable by the
+        // controller) are routed into the overflow dropdown. Uncapped wrap keeps
+        // `overflow: visible` above and grows unbounded.
+        &.dv-tabs-container--wrap-capped {
+            max-height: calc(
+                var(--dv-tabs-and-actions-container-height) *
+                    var(--dv-max-tab-rows)
+            );
+            overflow: hidden;
+        }
+
         // Discrete drop indicator for 2-D cross-row reorder (the 1-D gap
         // animation is suppressed in wrap). A bar on the leading/trailing edge
         // of the tab the drop would land before/after.

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -55,6 +55,16 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
      * resize.
      */
     private _overflowExclude: (panelId: string) => boolean = () => false;
+    /**
+     * Predicate that forces a panel's tab INTO the overflow dropdown regardless
+     * of horizontal fit — the complement of {@link _overflowExclude}. Wired by
+     * the MultiRowTabs module: in wrap mode tabs never clip horizontally (they
+     * wrap), so the `OverflowObserver` detects nothing; this routes the surplus
+     * rows beyond `overflow.maxRows` into the dropdown. Defaults to a no-op so
+     * behaviour is unchanged when the module is absent. Must stay a pure lookup
+     * (no DOM reads) — it runs inside the overflow filter.
+     */
+    private _forcedOverflow: (panelId: string) => boolean = () => false;
     private _direction: DockviewHeaderDirection = 'horizontal';
     private _voidContainerListeners: IDisposable | null = null;
 
@@ -125,6 +135,17 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
      */
     setOverflowExclude(fn: (panelId: string) => boolean): void {
         this._overflowExclude = fn;
+        this.refreshOverflow();
+    }
+
+    /**
+     * Register a predicate that forces matching panels into the overflow
+     * dropdown regardless of horizontal fit (the MultiRowTabs surplus set —
+     * rows beyond `overflow.maxRows`). Re-evaluates the dropdown immediately.
+     * Passing `() => false` restores default behaviour.
+     */
+    setForcedOverflow(fn: (panelId: string) => boolean): void {
+        this._forcedOverflow = fn;
         this.refreshOverflow();
     }
 
@@ -1039,7 +1060,16 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
     }
 
     private toggleDropdown(options: { reset: boolean }): void {
-        if (options.reset) {
+        // Surplus tabs forced past the wrap row cap must land in the dropdown
+        // even on a reset: in wrap mode nothing clips horizontally, so the
+        // `OverflowObserver` reports no overflow and asks for a reset every time.
+        const hasForced = this._tabs.some(
+            (tab) =>
+                !this._overflowExclude(tab.value.panel.id) &&
+                this._forcedOverflow(tab.value.panel.id)
+        );
+
+        if (options.reset && !hasForced) {
             this._onOverflowTabsChange.fire({
                 tabs: [],
                 tabGroups: [],
@@ -1052,10 +1082,12 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
             .filter(
                 (tab) =>
                     !this._overflowExclude(tab.value.panel.id) &&
-                    !isChildEntirelyVisibleWithinParent(
-                        tab.value.element,
-                        this._tabsList
-                    )
+                    (this._forcedOverflow(tab.value.panel.id) ||
+                        (!options.reset &&
+                            !isChildEntirelyVisibleWithinParent(
+                                tab.value.element,
+                                this._tabsList
+                            )))
             )
             .map((x) => x.value.panel.id);
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -75,6 +75,7 @@ export interface ITabsContainer extends IDisposable {
     updateTabGroups(): void;
     refreshTabGroupAccent(): void;
     setOverflowExclude(fn: (panelId: string) => boolean): void;
+    setForcedOverflow(fn: (panelId: string) => boolean): void;
     refreshOverflow(): void;
     setDropIndexResolver(fn: (panelId: string, index: number) => number): void;
     resolveDropIndex(panelId: string, index: number): number;
@@ -422,6 +423,10 @@ export class TabsContainer
 
     setOverflowExclude(fn: (panelId: string) => boolean): void {
         this.tabs.setOverflowExclude(fn);
+    }
+
+    setForcedOverflow(fn: (panelId: string) => boolean): void {
+        this.tabs.setForcedOverflow(fn);
     }
 
     refreshOverflow(): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1055,6 +1055,15 @@ export class DockviewComponent
         group.relayout();
     }
 
+    /** IMultiRowTabsHost — force the wrap controller's surplus set (rows beyond
+     *  `overflow.maxRows`) into the group's overflow dropdown. */
+    setForcedOverflow(
+        group: DockviewGroupPanel,
+        fn: (panelId: string) => boolean
+    ): void {
+        group.model.header.setForcedOverflow(fn);
+    }
+
     /** IDropGuideHost — the layout root (`.dv-dockview`, a positioned element),
      *  the surface the outer-cell landing preview is drawn over. */
     getLayoutElement(): HTMLElement {

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -172,6 +172,10 @@ export interface IHeader {
     /** Register a predicate that keeps matching panels out of the overflow
      *  dropdown (used by the PinnedTabs module). No-op default. */
     setOverflowExclude(fn: (panelId: string) => boolean): void;
+    /** Register a predicate that forces matching panels into the overflow
+     *  dropdown regardless of horizontal fit (used by the MultiRowTabs module
+     *  for the surplus rows beyond `overflow.maxRows`). No-op default. */
+    setForcedOverflow(fn: (panelId: string) => boolean): void;
     /** Re-evaluate the overflow dropdown now (e.g. after the exclusion set
      *  changed). */
     refreshOverflow(): void;

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -550,6 +550,18 @@ export interface IMultiRowTabsHost {
      * the free `DockviewGroupPanel.relayout()`.
      */
     relayoutGroup(group: DockviewGroupPanel): void;
+    /**
+     * Force a set of the group's panels into the overflow dropdown regardless of
+     * horizontal fit — the wrap controller's surplus set (the tabs on rows
+     * beyond `overflow.maxRows`). In wrap mode nothing clips horizontally, so the
+     * free `OverflowObserver` never surfaces these; this seam routes them to the
+     * dropdown and re-evaluates it immediately. Passing `() => false` clears the
+     * forcing.
+     */
+    setForcedOverflow(
+        group: DockviewGroupPanel,
+        fn: (panelId: string) => boolean
+    ): void;
 }
 
 export interface IMultiRowTabsService extends IDisposable {

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -274,6 +274,22 @@ export type OverflowThumbnailRenderer = (
 export const OVERFLOW_WRAP_TABS_CLASS = 'dv-tabs-container--wrap';
 
 /**
+ * The CSS class the `MultiRowTabsModule` adds alongside
+ * {@link OVERFLOW_WRAP_TABS_CLASS} once `overflow.maxRows` is set. It clips the
+ * wrapped strip to `--dv-max-tab-rows` rows (the surplus rows spill to the
+ * dropdown) so the header stops growing at the cap. Shared here so core (SCSS)
+ * and the module agree on the one string.
+ */
+export const OVERFLOW_WRAP_TABS_CAPPED_CLASS = 'dv-tabs-container--wrap-capped';
+
+/**
+ * The custom property the `MultiRowTabsModule` sets on a capped wrapped strip to
+ * carry the `overflow.maxRows` value into the SCSS `max-height` calc. Shared for
+ * the same reason as the class names above.
+ */
+export const OVERFLOW_MAX_TAB_ROWS_VARIABLE = '--dv-max-tab-rows';
+
+/**
  * Tab-header overflow behaviour. One shared block across the overflow axis:
  * `mode` chooses dropdown vs wrap; the remaining fields enrich the dropdown.
  * Each capability names the module it needs — without that module the field is
@@ -286,11 +302,10 @@ export interface DockviewOverflowOptions {
      */
     mode?: 'dropdown' | 'wrap';
     /**
-     * Wrap mode only: cap the number of header rows; the surplus tabs spill to
-     * the dropdown.
-     *
-     * NOT YET IMPLEMENTED — reserved for a follow-up. Wrap is currently
-     * unbounded regardless of this value; setting it has no effect today.
+     * Wrap mode only: cap the number of header rows. The strip grows to at most
+     * `maxRows` rows; tabs that would land on a row beyond the cap spill into the
+     * overflow dropdown instead. Requires the `MultiRowTabsModule`. Default:
+     * unbounded (wrap grows to fit every tab).
      */
     maxRows?: number;
     /**

--- a/packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts
@@ -18,6 +18,23 @@ class TestPanel implements IContentRenderer {
 }
 
 const WRAP_CLASS = 'dv-tabs-container--wrap';
+const CAPPED_CLASS = 'dv-tabs-container--wrap-capped';
+const MAX_ROWS_VAR = '--dv-max-tab-rows';
+
+/**
+ * jsdom has no layout, so every tab reports `offsetTop` 0. Stamp synthetic row
+ * offsets onto the tab elements (in DOM = insertion order) so the controller's
+ * `offsetTop`-bucketed row count / surplus computation can be exercised without
+ * real geometry. `tops[i]` is the row offset for the i-th tab.
+ */
+function stampRows(list: HTMLElement, tops: number[]): void {
+    list.querySelectorAll<HTMLElement>('.dv-tab').forEach((el, i) => {
+        Object.defineProperty(el, 'offsetTop', {
+            configurable: true,
+            value: tops[i] ?? 0,
+        });
+    });
+}
 
 /**
  * Multi-row (wrapping) tabs — Phase 2 (wrap render mode). The module toggles the
@@ -133,6 +150,116 @@ describe('multi-row tabs (wrap mode)', () => {
         // ...and back off
         dockview.updateOptions({ overflow: { mode: 'dropdown' } });
         expect(list.classList.contains(WRAP_CLASS)).toBe(false);
+
+        dockview.dispose();
+    });
+
+    test('maxRows adds the capped class and the --dv-max-tab-rows var', () => {
+        const dockview = make({ mode: 'wrap', maxRows: 3 });
+        const panel = dockview.addPanel({ id: 'a', component: 'default' });
+        const list = panel.group.model.tabsListElement;
+
+        expect(list.classList.contains(CAPPED_CLASS)).toBe(true);
+        expect(list.style.getPropertyValue(MAX_ROWS_VAR)).toBe('3');
+
+        dockview.dispose();
+    });
+
+    test('unbounded wrap (no maxRows) has no cap class or var', () => {
+        const dockview = make({ mode: 'wrap' });
+        const panel = dockview.addPanel({ id: 'a', component: 'default' });
+        const list = panel.group.model.tabsListElement;
+
+        expect(list.classList.contains(WRAP_CLASS)).toBe(true);
+        expect(list.classList.contains(CAPPED_CLASS)).toBe(false);
+        expect(list.style.getPropertyValue(MAX_ROWS_VAR)).toBe('');
+
+        dockview.dispose();
+    });
+
+    test('a non-positive maxRows is treated as unbounded', () => {
+        const dockview = make({ mode: 'wrap', maxRows: 0 });
+        const panel = dockview.addPanel({ id: 'a', component: 'default' });
+        const list = panel.group.model.tabsListElement;
+
+        expect(list.classList.contains(CAPPED_CLASS)).toBe(false);
+
+        dockview.dispose();
+    });
+
+    test('the surplus set (rows beyond maxRows) is routed to the forced-overflow seam', () => {
+        const dockview = make({ mode: 'wrap', maxRows: 2 });
+        const ids = ['p0', 'p1', 'p2', 'p3', 'p4', 'p5'];
+        const first = dockview.addPanel({ id: ids[0], component: 'default' });
+        for (const id of ids.slice(1)) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+
+        // 3 rows of two tabs each; maxRows=2 → the third row (p4, p5) is surplus.
+        stampRows(list, [0, 0, 44, 44, 88, 88]);
+
+        const spy = jest.spyOn(dockview, 'setForcedOverflow');
+        // Re-apply (fires onDidOptionsChange) to trigger a measure with the
+        // stamped geometry in place.
+        dockview.updateOptions({ overflow: { mode: 'wrap', maxRows: 2 } });
+
+        expect(spy).toHaveBeenCalled();
+        const forced = spy.mock.calls.at(-1)![1];
+        expect(forced('p4')).toBe(true);
+        expect(forced('p5')).toBe(true);
+        expect(forced('p0')).toBe(false);
+        expect(forced('p2')).toBe(false);
+
+        dockview.dispose();
+    });
+
+    test('within the cap nothing is forced into the dropdown', () => {
+        const dockview = make({ mode: 'wrap', maxRows: 3 });
+        const first = dockview.addPanel({ id: 'p0', component: 'default' });
+        for (const id of ['p1', 'p2', 'p3']) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+
+        // Two rows only — within the 3-row cap, so no surplus.
+        stampRows(list, [0, 0, 44, 44]);
+
+        const spy = jest.spyOn(dockview, 'setForcedOverflow');
+        dockview.updateOptions({ overflow: { mode: 'wrap', maxRows: 3 } });
+
+        // Either not called (set unchanged from empty) or called with an
+        // all-false predicate — never forcing a real panel out.
+        for (const call of spy.mock.calls) {
+            const forced = call[1];
+            expect(['p0', 'p1', 'p2', 'p3'].some((id) => forced(id))).toBe(
+                false
+            );
+        }
+
+        dockview.dispose();
+    });
+
+    test('raising maxRows re-admits previously-surplus rows', () => {
+        const dockview = make({ mode: 'wrap', maxRows: 2 });
+        const first = dockview.addPanel({ id: 'p0', component: 'default' });
+        for (const id of ['p1', 'p2', 'p3', 'p4', 'p5']) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+        stampRows(list, [0, 0, 44, 44, 88, 88]);
+
+        // Cap at 2 → p4/p5 surplus.
+        dockview.updateOptions({ overflow: { mode: 'wrap', maxRows: 2 } });
+
+        const spy = jest.spyOn(dockview, 'setForcedOverflow');
+        // Raise to 3 → the 3-row layout now fits; nothing is surplus.
+        dockview.updateOptions({ overflow: { mode: 'wrap', maxRows: 3 } });
+        expect(list.style.getPropertyValue(MAX_ROWS_VAR)).toBe('3');
+
+        const forced = spy.mock.calls.at(-1)![1];
+        expect(forced('p4')).toBe(false);
+        expect(forced('p5')).toBe(false);
 
         dockview.dispose();
     });

--- a/packages/dockview-enterprise/src/multiRowTabsService.ts
+++ b/packages/dockview-enterprise/src/multiRowTabsService.ts
@@ -79,8 +79,9 @@ function measureRows(
     const surplus: string[] = [];
     for (const tab of tabs) {
         if (tab.offsetTop >= capTop) {
-            const id = tab.getAttribute('data-tab-panel-id');
-            if (id !== null) {
+            // `dataset.tabPanelId` maps to the `data-tab-panel-id` attribute.
+            const id = tab.dataset.tabPanelId;
+            if (id !== undefined) {
                 surplus.push(id);
             }
         }

--- a/packages/dockview-enterprise/src/multiRowTabsService.ts
+++ b/packages/dockview-enterprise/src/multiRowTabsService.ts
@@ -3,6 +3,8 @@ import {
     DockviewGroupPanel,
     DockviewOverflowOptions,
     OVERFLOW_WRAP_TABS_CLASS as WRAP_CLASS,
+    OVERFLOW_WRAP_TABS_CAPPED_CLASS as CAPPED_CLASS,
+    OVERFLOW_MAX_TAB_ROWS_VARIABLE as MAX_ROWS_VAR,
     defineModule,
 } from 'dockview';
 import { IMultiRowTabsHost, IMultiRowTabsService } from 'dockview';
@@ -12,29 +14,107 @@ function isWrapMode(overflow: DockviewOverflowOptions | undefined): boolean {
 }
 
 /**
- * The number of wrapped rows in a tab list — the count of distinct tab
- * `offsetTop` values. Zero for an empty strip. (jsdom reports `offsetTop` 0 for
- * every tab, so this is 1 there regardless of width — real wrapping is e2e.)
+ * The row cap from `overflow.maxRows`, normalised to a positive integer, or
+ * `undefined` for unbounded wrap (the default, and any non-positive / non-finite
+ * value). Only meaningful in wrap mode.
  */
-function countRows(list: HTMLElement): number {
+function resolveMaxRows(
+    overflow: DockviewOverflowOptions | undefined
+): number | undefined {
+    const maxRows = overflow?.maxRows;
+    if (
+        typeof maxRows !== 'number' ||
+        !Number.isFinite(maxRows) ||
+        maxRows < 1
+    ) {
+        return undefined;
+    }
+    return Math.floor(maxRows);
+}
+
+interface RowMeasurement {
+    /**
+     * The number of wrapped rows the tabs occupy in their natural (uncapped)
+     * layout — the count of distinct tab `offsetTop` values. Zero for an empty
+     * strip. Capped tabs stay in flow (clipped, not removed), so this is always
+     * the natural count. (jsdom reports `offsetTop` 0 for every tab, so this is
+     * 1 there regardless of width — real wrapping is e2e.)
+     */
+    rows: number;
+    /**
+     * Panel ids of the tabs that wrapped onto a row at/after the `maxRows` cap —
+     * the surplus set routed to the overflow dropdown. Empty when uncapped or
+     * when the natural layout already fits within the cap.
+     */
+    surplus: string[];
+}
+
+/**
+ * Bucket a tab list's tabs by `offsetTop` (each distinct value is one wrapped
+ * row) to derive the natural row count and, given a cap, the surplus set of
+ * panel ids on rows beyond it.
+ */
+function measureRows(
+    list: HTMLElement,
+    maxRows: number | undefined
+): RowMeasurement {
     const tabs = Array.from(list.querySelectorAll<HTMLElement>('.dv-tab'));
     if (tabs.length === 0) {
-        return 0;
+        return { rows: 0, surplus: [] };
     }
-    const tops = new Set<number>();
+
+    // Distinct row offsets, ascending — one entry per wrapped row.
+    const tops = Array.from(new Set(tabs.map((tab) => tab.offsetTop))).sort(
+        (a, b) => a - b
+    );
+    const rows = tops.length;
+
+    if (maxRows === undefined || rows <= maxRows) {
+        return { rows, surplus: [] };
+    }
+
+    // The first surplus row is the one at index `maxRows`; every tab at or below
+    // it (offsetTop >= that row's top) spills to the dropdown.
+    const capTop = tops[maxRows];
+    const surplus: string[] = [];
     for (const tab of tabs) {
-        tops.add(tab.offsetTop);
+        if (tab.offsetTop >= capTop) {
+            const id = tab.getAttribute('data-tab-panel-id');
+            if (id !== null) {
+                surplus.push(id);
+            }
+        }
     }
-    return tops.size;
+    return { rows, surplus };
+}
+
+function sameSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+    if (a.size !== b.size) {
+        return false;
+    }
+    for (const value of a) {
+        if (!b.has(value)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 /**
  * Drives wrap layout for one group. The wrap itself is CSS (the inert
- * `.dv-tabs-container--wrap` rules in core); this controller only toggles that
- * class on the group's tab list and, when the wrapped row count changes, asks
- * the host to relayout so the now-taller header shrinks the content area (the
- * free header-aware content-sizing seam does the subtraction). v1 wraps only
- * horizontal headers — a hidden or vertical header is a no-op.
+ * `.dv-tabs-container--wrap` rules in core); this controller toggles that class
+ * on the group's tab list and, when the wrapped row count changes, asks the host
+ * to relayout so the now-taller header shrinks the content area (the free
+ * header-aware content-sizing seam does the subtraction).
+ *
+ * With `overflow.maxRows` set it also caps growth: it adds the capped class +
+ * `--dv-max-tab-rows` var (so CSS clips the strip to the cap), measures the
+ * natural row count from per-tab `offsetTop` buckets, and hands the surplus set
+ * (tabs on rows beyond the cap) to the free forced-overflow seam so those tabs
+ * spill into the dropdown. Detection is a row-count test, not the free path's
+ * horizontal-clip test — nothing clips horizontally when tabs wrap.
+ *
+ * v1 wraps only horizontal headers — a hidden or vertical header is a no-op.
  *
  * Wrap is (re)evaluated on construction and on `overflow` option changes. A
  * runtime header-direction flip (`setHeaderPosition` horizontal↔vertical) is
@@ -44,7 +124,10 @@ function countRows(list: HTMLElement): number {
  */
 class WrapController extends CompositeDisposable {
     private _wrapped = false;
+    /** The effective (capped) row count last propagated via relayout. */
     private _rowCount = 0;
+    private _maxRows: number | undefined;
+    private _forcedIds: ReadonlySet<string> = new Set();
     private _observer: ResizeObserver | undefined;
     private _pendingMeasure: { win: Window; handle: number } | undefined;
 
@@ -72,24 +155,41 @@ class WrapController extends CompositeDisposable {
             !!list &&
             !list.classList.contains('dv-tabs-container-vertical');
 
-        if (wrap === this._wrapped) {
-            return;
-        }
-        this._wrapped = wrap;
-
         if (wrap && list) {
+            const first = !this._wrapped;
+            this._wrapped = true;
             list.classList.add(WRAP_CLASS);
-            // Mutating layout synchronously inside the ResizeObserver callback
-            // trips the browser's "ResizeObserver loop" warning, so the RO
-            // schedules the measure on the next frame. The initial measure runs
-            // synchronously (it's not inside an RO callback).
-            this._observer = new ResizeObserver(() =>
-                this.scheduleMeasure(list)
-            );
-            this._observer.observe(list);
+
+            // Sync the row cap (may change without a wrap on/off transition, e.g.
+            // a runtime `overflow.maxRows` update).
+            this._maxRows = resolveMaxRows(this.host.options.overflow);
+            this.applyCap(list);
+
+            if (first) {
+                // Mutating layout synchronously inside the ResizeObserver
+                // callback trips the browser's "ResizeObserver loop" warning, so
+                // the RO schedules the measure on the next frame. The initial
+                // measure runs synchronously (it's not inside an RO callback).
+                this._observer = new ResizeObserver(() =>
+                    this.scheduleMeasure(list)
+                );
+                this._observer.observe(list);
+            }
             this.measure();
-        } else {
+        } else if (this._wrapped) {
             this.teardown();
+        }
+    }
+
+    /** Toggle the capped class + `--dv-max-tab-rows` var so CSS clips the strip
+     *  to the cap (or removes the clip when unbounded). */
+    private applyCap(list: HTMLElement): void {
+        if (this._maxRows === undefined) {
+            list.classList.remove(CAPPED_CLASS);
+            list.style.removeProperty(MAX_ROWS_VAR);
+        } else {
+            list.classList.add(CAPPED_CLASS);
+            list.style.setProperty(MAX_ROWS_VAR, String(this._maxRows));
         }
     }
 
@@ -119,9 +219,24 @@ class WrapController extends CompositeDisposable {
         if (!list) {
             return;
         }
-        const rows = countRows(list);
-        if (rows !== this._rowCount) {
-            this._rowCount = rows;
+
+        const { rows, surplus } = measureRows(list, this._maxRows);
+
+        // Only the visible (capped) rows drive header height, so relayout keys
+        // off the effective count, not the natural one.
+        const effectiveRows =
+            this._maxRows === undefined ? rows : Math.min(rows, this._maxRows);
+
+        // Route the surplus set to the dropdown (idempotent: skip when unchanged
+        // so we don't rebuild the dropdown, which would loop via the observer).
+        const forced = new Set(surplus);
+        if (!sameSet(forced, this._forcedIds)) {
+            this._forcedIds = forced;
+            this.host.setForcedOverflow(this.group, (id) => forced.has(id));
+        }
+
+        if (effectiveRows !== this._rowCount) {
+            this._rowCount = effectiveRows;
             this.host.relayoutGroup(this.group);
         }
     }
@@ -134,7 +249,17 @@ class WrapController extends CompositeDisposable {
         this._observer?.disconnect();
         this._observer = undefined;
         this._rowCount = 0;
-        this.host.getTabsListElement(this.group)?.classList.remove(WRAP_CLASS);
+        this._maxRows = undefined;
+        this._wrapped = false;
+        if (this._forcedIds.size > 0) {
+            this._forcedIds = new Set();
+            this.host.setForcedOverflow(this.group, () => false);
+        }
+        const list = this.host.getTabsListElement(this.group);
+        if (list) {
+            list.classList.remove(WRAP_CLASS, CAPPED_CLASS);
+            list.style.removeProperty(MAX_ROWS_VAR);
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Implements the previously-inert `overflow.maxRows` option for the `MultiRowTabsModule`. In wrap mode (`overflow: { mode: 'wrap' }`) the header now grows to **at most `maxRows` rows**; tabs that would wrap onto a row beyond the cap spill into the existing chevron overflow dropdown — so wrap and dropdown **compose** rather than conflict. Default (`maxRows` undefined) is unchanged, unbounded wrap.

### New core seam
The free dropdown detects overflow by **horizontal clipping** (`OverflowObserver` / `isChildEntirelyVisibleWithinParent`). In wrap mode nothing ever clips horizontally — tabs wrap — so that detection reports nothing. The cap therefore needed a complementary seam:

- **`setForcedOverflow(fn)`** — a predicate that *forces* matching panels **into** the overflow dropdown regardless of horizontal fit (the inverse of the pinned-tabs `setOverflowExclude`). Plumbed the same way pinned tabs was: `Tabs` → `TabsContainer` (proxy) → `IHeader` → `DockviewGroupPanelModel` → `IMultiRowTabsHost.setForcedOverflow(group, fn)` on the host contract. `Tabs.toggleDropdown` now unions the forced set and still surfaces it on a *reset* (in wrap mode the observer reports no overflow and asks to reset every fire).
- **`data-tab-panel-id`** on each tab element so the controller can map a wrapped tab (read for its row) back to its panel id. (Tab-specific name to avoid colliding with generic `[data-panel-id]` lookups.)
- **SCSS** `.dv-tabs-container--wrap-capped` + `--dv-max-tab-rows` clip the strip to the cap via `max-height` + `overflow: hidden`. Surplus rows stay in natural flow (still measurable) but are visually clipped, so the header truly stops at the cap.

### Surplus detection
`WrapController` buckets tabs by `offsetTop` (one distinct value per wrapped row). When `rows > maxRows`, the tabs on rows at/after the cap are the surplus set, handed to `setForcedOverflow`. Because capping is done with `max-height` (not by removing tabs from flow), the natural row count stays measurable and the reflow converges; the surplus-set update is idempotent (skipped when unchanged) so it doesn't loop the ResizeObserver. Raising `maxRows` or removing tabs re-admits rows and reflows.

## Type of change

- [x] New feature

## Affected packages

- [x] `dockview-core` (new forced-overflow seam, `data-tab-panel-id`, SCSS, option docs)
- [x] `dockview` (vanilla JS) — re-exports the new core constants

Also affects **`dockview-enterprise`** (the `MultiRowTabsModule` cap logic), which is not a checkbox above.

## How to test

- **Core unit:** `packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsForcedOverflow.spec.ts` (forced predicate, reset survival, exclude-wins-over-force) and `multiRowTabsSeam.spec.ts` (host seam routes a panel into the dropdown even when nothing clips; `data-tab-panel-id`).
- **Enterprise unit:** `packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts` — cap class/var applied, surplus-set computation via mocked `offsetTop`, raising the cap re-admits rows. (jsdom has no layout, so `offsetTop` is stamped.)
- **e2e:** `e2e/tests/multi-row-tabs.spec.ts` gains a `?maxRows=` fixture param — asserts the header caps at N rows with the surplus in the dropdown, and that raising `maxRows` at runtime grows the header and empties the dropdown.

All suites pass locally: core (1161), dockview-enterprise (303), e2e (81).

## Checklist

- [x] `yarn format` passes (ran on the changed files; `packages/docs` untouched)
- [x] `npm run gen` has been run — `__generated__/dockview-core-exports.txt` updated for the 2 new public constants
- [x] `yarn test` passes (core + enterprise + e2e)
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented — n/a (additive; default behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmtpCbzhE7dXL2HBJLybrV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmtpCbzhE7dXL2HBJLybrV)_