### PR TITLE
test(e2e): add dockview-vue keep-alive + cross-window popout coverage

### DIFF
--- a/e2e/fixtures/vue.html
+++ b/e2e/fixtures/vue.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>dockview-vue e2e fixture</title>
+        <style>
+            html,
+            body,
+            #app {
+                margin: 0;
+                height: 100%;
+                width: 100%;
+            }
+            /* DockviewVue is a multi-root (fragment) component, so a `style`/
+               `class` attribute can't fall through to its host `<div ref="el">`.
+               `<DockviewVue>` is the only element child the root renders, so size
+               it here — otherwise `api.layout(clientWidth, clientHeight)` sees 0
+               and nothing renders. */
+            #app > div {
+                height: 100%;
+                width: 100%;
+            }
+            .vue-panel {
+                height: 100%;
+                box-sizing: border-box;
+                padding: 8px;
+            }
+        </style>
+
+        <!-- Built stylesheet so layout-sensitive behaviour (content sizing,
+             popout window geometry) matches real usage — as index.html does. -->
+        <link
+            rel="stylesheet"
+            href="/packages/dockview-core/dist/styles/dockview.css"
+        />
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <!-- Globals loaded in dependency order. The dockview-vue UMD externalizes
+             its deps and references the `Vue` and `dockview` globals (see the
+             `globals` map in packages/dockview-vue/vite.config.ts — it never
+             references a standalone `dockview-core` global because the self-
+             contained `dockview` bundle already provides the core). So:
+               1. vue.global.js  -> window.Vue          (FULL build: the template
+                                                          compiler is included, so
+                                                          inline `template:` strings
+                                                          work with no SFC step)
+               2. dockview.js     -> window.dockview      (bundles dockview-core in)
+               3. dockview-vue.umd.js -> window['dockview-vue'] (exposes DockviewVue)
+             Load order matters: the UMD throws on a missing global otherwise. -->
+        <script src="/node_modules/vue/dist/vue.global.js"></script>
+        <script src="/packages/dockview/dist/dockview.js"></script>
+        <script src="/packages/dockview-vue/dist/dockview-vue.umd.js"></script>
+
+        <script>
+            (function () {
+                const {
+                    createApp,
+                    ref,
+                    onMounted,
+                    onUnmounted,
+                    onActivated,
+                    onDeactivated,
+                    watchEffect,
+                } = window.Vue;
+                const { DockviewVue } = window['dockview-vue'];
+
+                // Shared, per-panel lifecycle-counter + persisted-state registry
+                // keyed by panel id. The panel components write into it; the
+                // `window.__vue` handle reads it back for assertions. It lives in
+                // the MAIN window's JS realm, so it stays readable even while a
+                // panel's DOM is teleported into a popout window.
+                const lifecycle = {};
+                function record(pid) {
+                    return (lifecycle[pid] ||= {
+                        mounted: 0,
+                        unmounted: 0,
+                        activated: 0,
+                        deactivated: 0,
+                        count: 0,
+                        text: '',
+                    });
+                }
+
+                // Inner panel content. Wrapped by `<keep-alive>` in PanelWrapper
+                // below so switching the active panel DEACTIVATES/REACTIVATES this
+                // component (state cached) instead of unmounting/remounting it.
+                // Holds a mutable, in-panel piece of state (`count` + a text
+                // `<input>`) whose survival across a switch/popout proves caching.
+                const InnerPanel = {
+                    name: 'InnerPanel',
+                    props: ['pid'],
+                    setup(props) {
+                        const rec = record(props.pid);
+                        const count = ref(rec.count);
+                        const text = ref(rec.text);
+                        // Imperative setters so a test can seed state without
+                        // depending on the panel currently being in the DOM.
+                        rec.setCount = (v) => {
+                            count.value = v;
+                        };
+                        rec.setText = (v) => {
+                            text.value = v;
+                        };
+                        onMounted(() => {
+                            rec.mounted++;
+                        });
+                        onUnmounted(() => {
+                            rec.unmounted++;
+                        });
+                        onActivated(() => {
+                            rec.activated++;
+                        });
+                        onDeactivated(() => {
+                            rec.deactivated++;
+                        });
+                        // Mirror live state into the shared record so the handle
+                        // can read it regardless of which window holds the DOM.
+                        watchEffect(() => {
+                            rec.count = count.value;
+                            rec.text = text.value;
+                        });
+                        return { pid: props.pid, count, text };
+                    },
+                    template: `
+                        <div class="vue-panel" :data-pid="pid">
+                            <span class="pid">{{ pid }}</span>
+                            <span class="count">{{ count }}</span>
+                            <input class="field" v-model="text" />
+                            <button class="inc" @click="count++">inc</button>
+                        </div>`,
+                };
+
+                // The component registered with dockview. It is teleported into
+                // dockview's DOM by <DockviewPortals>, which keeps it a true
+                // descendant of <DockviewVue> in the Vue component tree — the
+                // ancestry (PR #1380 / issue #1369) that lets `<keep-alive>` reach
+                // the panel. It drives that keep-alive off the panel's visibility:
+                // the default `onlyWhenVisible` render mode hides inactive panels,
+                // so an inactive panel is CACHED here, not destroyed.
+                const PanelWrapper = {
+                    name: 'PanelWrapper',
+                    components: { InnerPanel },
+                    props: ['params'],
+                    setup(props) {
+                        const api = props.params.api;
+                        const visible = ref(api.isVisible);
+                        const disposable = api.onDidVisibilityChange((e) => {
+                            visible.value = e.isVisible;
+                        });
+                        onUnmounted(() => disposable.dispose());
+                        return { visible, pid: api.id };
+                    },
+                    template: `
+                        <keep-alive>
+                            <InnerPanel v-if="visible" :key="pid" :pid="pid" />
+                        </keep-alive>`,
+                };
+
+                let dvApi = null;
+                const panels = {};
+
+                const Root = {
+                    name: 'Root',
+                    components: { DockviewVue },
+                    setup() {
+                        return {
+                            components: { panel: PanelWrapper },
+                            onReady: (event) => {
+                                dvApi = event.api;
+                                // Signal readiness only once the api exists
+                                // (the `ready` event fires async, after mount).
+                                window.__ready = true;
+                            },
+                        };
+                    },
+                    // `onlyWhenVisible` is the default render mode — the natural
+                    // keep-alive scenario (one active panel rendered at a time).
+                    template: `
+                        <DockviewVue
+                            :components="components"
+                            :popout-url="'/e2e/fixtures/popout.html'"
+                            @ready="onReady"
+                        />`,
+                };
+
+                createApp(Root).mount('#app');
+
+                // Test-facing handle (kept separate from the vanilla `__dv` so the
+                // shared index.html fixture other specs depend on is untouched).
+                window.__vue = {
+                    addPanel: (id, opts) => {
+                        panels[id] = dvApi.addPanel({
+                            id,
+                            component: 'panel',
+                            title: id,
+                            inactive: !!(opts && opts.inactive),
+                        });
+                    },
+                    setActive: (id) => panels[id] && panels[id].api.setActive(),
+                    activePanelId: () =>
+                        dvApi.activeGroup?.activePanel?.id ?? null,
+                    // Seed in-panel state imperatively (works even while the
+                    // panel is deactivated/hidden).
+                    setState: (id, count, text) => {
+                        const r = lifecycle[id];
+                        if (!r) return;
+                        if (count != null && r.setCount) r.setCount(count);
+                        if (text != null && r.setText) r.setText(text);
+                    },
+                    // Per-panel keep-alive lifecycle counters.
+                    counters: (id) => {
+                        const r = record(id);
+                        return {
+                            mounted: r.mounted,
+                            unmounted: r.unmounted,
+                            activated: r.activated,
+                            deactivated: r.deactivated,
+                        };
+                    },
+                    // Persisted in-panel state (readable from the main window
+                    // even while the DOM is in a popout).
+                    state: (id) => {
+                        const r = record(id);
+                        return { count: r.count, text: r.text };
+                    },
+                    popoutActiveGroup: () =>
+                        dvApi.addPopoutGroup(dvApi.activeGroup),
+                    closePopout: () => dvApi.getPopouts()[0].group.api.close(),
+                    popoutCount: () => dvApi.getPopouts().length,
+                    groupCount: () => dvApi.groups.length,
+                };
+            })();
+        </script>
+    </body>
+</html>

--- a/e2e/fixtures/vue.html
+++ b/e2e/fixtures/vue.html
@@ -63,6 +63,8 @@
                     onActivated,
                     onDeactivated,
                     watchEffect,
+                    provide,
+                    inject,
                 } = window.Vue;
                 const { DockviewVue } = window['dockview-vue'];
 
@@ -80,8 +82,14 @@
                         deactivated: 0,
                         count: 0,
                         text: '',
+                        injected: null,
                     });
                 }
+
+                // Token a panel resolves through `inject` — provided by Root,
+                // above the DockviewVue host. Reaching it from a teleported panel
+                // proves live component-tree ancestry (the other half of #1369).
+                const SHARED_TOKEN = 'shared-token';
 
                 // Inner panel content. Wrapped by `<keep-alive>` in PanelWrapper
                 // below so switching the active panel DEACTIVATES/REACTIVATES this
@@ -95,6 +103,10 @@
                         const rec = record(props.pid);
                         const count = ref(rec.count);
                         const text = ref(rec.text);
+                        // Resolved through the Vue component tree, across the
+                        // <Teleport> boundary, from Root's `provide`.
+                        const injected = inject(SHARED_TOKEN, 'not-injected');
+                        rec.injected = injected;
                         // Imperative setters so a test can seed state without
                         // depending on the panel currently being in the DOM.
                         rec.setCount = (v) => {
@@ -121,12 +133,13 @@
                             rec.count = count.value;
                             rec.text = text.value;
                         });
-                        return { pid: props.pid, count, text };
+                        return { pid: props.pid, count, text, injected };
                     },
                     template: `
                         <div class="vue-panel" :data-pid="pid">
                             <span class="pid">{{ pid }}</span>
                             <span class="count">{{ count }}</span>
+                            <span class="injected">{{ injected }}</span>
                             <input class="field" v-model="text" />
                             <button class="inc" @click="count++">inc</button>
                         </div>`,
@@ -165,6 +178,9 @@
                     name: 'Root',
                     components: { DockviewVue },
                     setup() {
+                        // Provide a value above the host so a teleported panel
+                        // can `inject` it (proves live tree ancestry).
+                        provide(SHARED_TOKEN, 'from-root');
                         return {
                             components: { panel: PanelWrapper },
                             onReady: (event) => {
@@ -225,8 +241,24 @@
                         const r = record(id);
                         return { count: r.count, text: r.text };
                     },
+                    // Value a panel resolved via `inject`.
+                    injected: (id) => record(id).injected,
                     popoutActiveGroup: () =>
                         dvApi.addPopoutGroup(dvApi.activeGroup),
+                    // Add a fresh panel and move it to the right of the current
+                    // popout group, so the popout window hosts a second group.
+                    splitIntoPopout: (id) => {
+                        const popoutGroup = dvApi.getPopouts()[0].group;
+                        panels[id] = dvApi.addPanel({
+                            id,
+                            component: 'panel',
+                            title: id,
+                        });
+                        panels[id].api.moveTo({
+                            group: popoutGroup,
+                            position: 'right',
+                        });
+                    },
                     closePopout: () => dvApi.getPopouts()[0].group.api.close(),
                     popoutCount: () => dvApi.getPopouts().length,
                     groupCount: () => dvApi.groups.length,

--- a/e2e/tests/vue-keep-alive.spec.ts
+++ b/e2e/tests/vue-keep-alive.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, Page, BrowserContext } from '@playwright/test';
+
+/**
+ * dockview-vue + Vue `<keep-alive>`, in a real browser.
+ *
+ * Since PR #1380 (fixing #1369) dockview-vue mounts panels via `<Teleport>`, so
+ * a panel stays a real descendant of `<DockviewVue>` in the Vue component tree.
+ * That ancestry is what lets `<keep-alive>` reach panels: switching the active
+ * panel DEACTIVATES/REACTIVATES the cached component (`onDeactivated`/
+ * `onActivated`) instead of unmounting/remounting it, so in-panel state
+ * survives. jsdom unit tests (packages/dockview-vue/src/__tests__/keepalive)
+ * cover the single-window case; these cover it in a real browser AND across the
+ * cross-window popout round-trip, which jsdom cannot model.
+ *
+ * The fixture (e2e/fixtures/vue.html) wraps each panel's content in
+ * `<keep-alive>` driven by the panel's visibility, and exposes `window.__vue`.
+ */
+test.describe('dockview-vue <keep-alive>', () => {
+    const open = async (page: Page) => {
+        await page.goto('/e2e/fixtures/vue.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+    };
+
+    test('switching the active panel deactivates/reactivates (not unmount/remount) and keeps state', async ({
+        page,
+    }) => {
+        await open(page);
+
+        // Two panels in one group; `one` stays active, `two` is added inactive.
+        await page.evaluate(() => {
+            (window as any).__vue.addPanel('one');
+            (window as any).__vue.addPanel('two', { inactive: true });
+        });
+
+        // Panel mount is async under Teleport (Vue flush) — await the locator.
+        const field = page.locator('[data-pid="one"] .field');
+        await expect(field).toBeVisible();
+
+        // Seed in-panel state on the visible panel by typing into its input.
+        await field.fill('kept-alive-value');
+        await expect(field).toHaveValue('kept-alive-value');
+
+        const before = await page.evaluate(() =>
+            (window as any).__vue.counters('one')
+        );
+        // Sanity: it mounted exactly once and hasn't been destroyed.
+        expect(before.mounted).toBe(1);
+        expect(before.unmounted).toBe(0);
+
+        // Switch away to `two`, then back to `one`.
+        await page.evaluate(() => (window as any).__vue.setActive('two'));
+        await expect(page.locator('[data-pid="two"] .field')).toBeVisible();
+        // While cached, panel one's content is removed from the DOM.
+        await expect(field).toHaveCount(0);
+
+        await page.evaluate(() => (window as any).__vue.setActive('one'));
+        await expect(field).toBeVisible();
+
+        const after = await page.evaluate(() =>
+            (window as any).__vue.counters('one')
+        );
+
+        // keep-alive lifecycle fired — NOT a fresh mount/unmount cycle.
+        expect(after.deactivated).toBeGreaterThanOrEqual(1);
+        expect(after.activated).toBeGreaterThan(before.activated);
+        expect(after.mounted).toBe(1); // never re-mounted
+        expect(after.unmounted).toBe(0); // never destroyed
+
+        // The in-panel state survived the round-trip (proves caching, not
+        // remount — a remount would have reset the input to empty).
+        await expect(field).toHaveValue('kept-alive-value');
+    });
+
+    test('popout round-trip keeps a kept-alive panel and its state, without remounting', async ({
+        page,
+        context,
+    }) => {
+        await open(page);
+
+        await page.evaluate(() => {
+            (window as any).__vue.addPanel('alpha');
+            (window as any).__vue.addPanel('beta', { inactive: true });
+        });
+
+        const alpha = page.locator('[data-pid="alpha"] .field');
+        await expect(alpha).toBeVisible();
+        await alpha.fill('survives-popout');
+
+        const before = await page.evaluate(() =>
+            (window as any).__vue.counters('alpha')
+        );
+        expect(before.mounted).toBe(1);
+        expect(before.unmounted).toBe(0);
+
+        // Pop the active group out into its own window and capture that window.
+        const [win] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__vue.popoutActiveGroup()),
+        ]);
+        await (win as Page).waitForLoadState();
+
+        // The panel now renders inside the popout, with its state intact, and no
+        // longer in the opener.
+        const popoutAlpha = win.locator('[data-pid="alpha"] .field');
+        await expect(popoutAlpha).toBeVisible();
+        await expect(popoutAlpha).toHaveValue('survives-popout');
+        await expect(page.locator('[data-pid="alpha"]')).toHaveCount(0);
+        // Same component instance moved by Teleport — not destroyed+recreated.
+        expect(
+            await page.evaluate(() => (window as any).__vue.counters('alpha'))
+        ).toMatchObject({ mounted: 1, unmounted: 0 });
+
+        // Evacuate back to the main window. Closing the popout WINDOW runs core's
+        // `disposePopoutWindow`, which moves the panels back to the main document
+        // (moveGroupWithoutDestroying) before tearing the window down — the
+        // panel-preserving path (cf. popout-lifecycle.spec). dockview re-docks on
+        // `beforeunload`, so the close must run it.
+        await win.close({ runBeforeUnload: true });
+
+        await expect
+            .poll(() =>
+                page.evaluate(() => (window as any).__vue.popoutCount())
+            )
+            .toBe(0);
+
+        // Back in the opener: present again, state STILL intact, and never
+        // destroyed — the persistent teleport target wasn't stranded.
+        await expect(alpha).toBeVisible();
+        await expect(alpha).toHaveValue('survives-popout');
+        expect(
+            await page.evaluate(() => (window as any).__vue.counters('alpha'))
+        ).toMatchObject({ mounted: 1, unmounted: 0 });
+        expect(
+            await page.evaluate(() => (window as any).__vue.groupCount())
+        ).toBe(1);
+    });
+});

--- a/e2e/tests/vue-keep-alive.spec.ts
+++ b/e2e/tests/vue-keep-alive.spec.ts
@@ -134,4 +134,103 @@ test.describe('dockview-vue <keep-alive>', () => {
             await page.evaluate(() => (window as any).__vue.groupCount())
         ).toBe(1);
     });
+
+    test('provide/inject reaches a teleported panel and survives a popout round-trip', async ({
+        page,
+        context,
+    }) => {
+        await open(page);
+
+        // Root `provide`s a value above the DockviewVue host; a teleported panel
+        // must resolve it through the (live) component tree.
+        await page.evaluate(() => (window as any).__vue.addPanel('one'));
+
+        const injected = page.locator('[data-pid="one"] .injected');
+        await expect(injected).toHaveText('from-root');
+        expect(
+            await page.evaluate(() => (window as any).__vue.injected('one'))
+        ).toBe('from-root');
+
+        // The injected value must still resolve after the panel is teleported
+        // into a popout window (the tree ancestry is what popout mustn't sever).
+        const [win] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__vue.popoutActiveGroup()),
+        ]);
+        await (win as Page).waitForLoadState();
+        await expect(win.locator('[data-pid="one"] .injected')).toHaveText(
+            'from-root'
+        );
+
+        // ...and after it is evacuated back to the main window.
+        await win.close({ runBeforeUnload: true });
+        await expect
+            .poll(() =>
+                page.evaluate(() => (window as any).__vue.popoutCount())
+            )
+            .toBe(0);
+        await expect(injected).toHaveText('from-root');
+    });
+
+    test('closing a multi-group popout evacuates every group with state intact and no remounts', async ({
+        page,
+        context,
+    }) => {
+        await open(page);
+
+        // A single group popped out, then a second group split into the popout's
+        // own gridview — so the popout window hosts two groups.
+        await page.evaluate(() => (window as any).__vue.addPanel('alpha'));
+        await expect(page.locator('[data-pid="alpha"] .field')).toBeVisible();
+        await page.locator('[data-pid="alpha"] .field').fill('alpha-state');
+
+        const [win] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__vue.popoutActiveGroup()),
+        ]);
+        await (win as Page).waitForLoadState();
+
+        await page.evaluate(() =>
+            (window as any).__vue.splitIntoPopout('gamma')
+        );
+
+        // Both panels live in the popout; seed the second one there.
+        const gammaInPopout = win.locator('[data-pid="gamma"] .field');
+        await expect(gammaInPopout).toBeVisible();
+        await gammaInPopout.fill('gamma-state');
+        await expect(win.locator('.dv-tabs-container')).toHaveCount(2);
+        await expect(page.locator('[data-pid="alpha"]')).toHaveCount(0);
+
+        const beforeGamma = await page.evaluate(() =>
+            (window as any).__vue.counters('gamma')
+        );
+        expect(beforeGamma).toMatchObject({ mounted: 1, unmounted: 0 });
+
+        // Close the popout window → BOTH groups evacuate back to the opener.
+        await win.close({ runBeforeUnload: true });
+
+        await expect
+            .poll(() =>
+                page.evaluate(() => (window as any).__vue.popoutCount())
+            )
+            .toBe(0);
+        await expect
+            .poll(() => page.evaluate(() => (window as any).__vue.groupCount()))
+            .toBe(2);
+
+        // Both panels are back, with their state, and neither was destroyed —
+        // no popout member was stranded on teardown.
+        await expect(page.locator('[data-pid="alpha"] .field')).toHaveValue(
+            'alpha-state'
+        );
+        await expect(page.locator('[data-pid="gamma"] .field')).toHaveValue(
+            'gamma-state'
+        );
+        expect(
+            await page.evaluate(() => (window as any).__vue.counters('alpha'))
+        ).toMatchObject({ mounted: 1, unmounted: 0 });
+        expect(
+            await page.evaluate(() => (window as any).__vue.counters('gamma'))
+        ).toMatchObject({ mounted: 1, unmounted: 0 });
+    });
 });


### PR DESCRIPTION
## Description

Adds the first framework (Vue) coverage to the cross-window e2e (Playwright) harness, proving the `<Teleport>`-based panel mounting (PR #1380, fixing #1369) makes Vue `<keep-alive>`, `provide`/`inject`, and the popout round-trip work with `dockview-vue` — behaviour the jsdom unit tests cannot reach because they can't model a second `document`.

New files only; no package source changed.

- **`e2e/fixtures/vue.html`** — a new fixture mirroring `index.html` but loading the Vue full build + `dockview` + `dockview-vue` UMD bundles (in dependency order), driving a real `<DockviewVue>` under the default `onlyWhenVisible` render mode. Panels are wrapped in `<keep-alive>` off the panel's visibility, `Root` `provide`s a token, and the fixture exposes a `window.__vue` handle (kept separate from the vanilla `__dv` so existing specs are untouched).
- **`e2e/tests/vue-keep-alive.spec.ts`** — four tests:
  1. Switching the active panel fires `onDeactivated`/`onActivated` (not unmount/remount) and in-panel state survives.
  2. A kept-alive panel popped out to its own window, then evacuated back, keeps its state and is never remounted.
  3. `provide`/`inject` reaches a teleported panel and keeps resolving across a popout round-trip.
  4. Closing a multi-group popout evacuates **every** group back to the opener with state intact and no remounts (no member stranded on teardown).

## Type of change

- [x] Build / CI / tooling (test coverage only)

## Affected packages

- [x] `dockview-vue` (under test; exercised via the e2e harness — no package source changed)

## How to test

```bash
yarn nx run-many -t build:bundle -p dockview-core dockview dockview-enterprise
yarn nx build dockview-vue          # produces dist/dockview-vue.umd.js
yarn playwright install chromium    # first time only
yarn test:e2e
```

All 83 e2e tests pass locally (4 new Vue tests + the existing suite). The new tests were verified non-vacuous: removing the `<keep-alive>` wrapper makes test 1 fail (panel remounts, state resets).

## Checklist

- [x] `yarn format` passes (new files formatted with the repo Prettier config)
- [x] `yarn test:e2e` passes
- [x] I have added or updated tests where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzAXqpFsGLNLuwc3VJuURL)_