### PR TITLE
feat(enterprise): pin context-menu auto-inject + keyboard pin toggle + multi-row cross-row keyboard nav

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -88,6 +88,11 @@
                 // the pin/unpin flow can be driven from the menu without changing
                 // the item count the base context-menu spec asserts.
                 const pinMenu = params.get('pinmenu') === '1';
+                // `?pinautoinject=1` exercises the module auto-injecting the
+                // built-in Pin/Unpin item even though the app returns none. Off
+                // by default (`contextMenuItem: false`) so the base context-menu
+                // spec keeps seeing exactly its app-supplied items.
+                const pinAutoInject = params.get('pinautoinject') === '1';
                 const dockview = new lib.DockviewComponent(el, {
                     keyboardNavigation: true,
                     overflow,
@@ -98,6 +103,7 @@
                         enabled: true,
                         mode: pinnedMode,
                         compact: params.get('compact') === '1',
+                        contextMenuItem: pinAutoInject,
                     },
                     // Record layout history so the harness can exercise undo/redo
                     // (incl. async popout re-open).

--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -324,4 +324,56 @@ test.describe('multi-row tabs (wrap mode)', () => {
     }) => {
         await reorderAcrossRows(page, 'overflow=wrap&smooth=1');
     });
+
+    // Arrow Up/Down move the roving focus between wrapped rows (core keeps
+    // Left/Right within a row). Real geometry: the target is the tab in the
+    // adjacent row whose horizontal centre is nearest the focused tab's.
+    test('Arrow Up/Down move focus between wrapped rows', async ({ page }) => {
+        await setup(page);
+
+        // Focus a tab on the first row and compute the geometrically-expected
+        // neighbour one row below (nearest horizontal centre).
+        const plan = await page.evaluate(() => {
+            const tabs = Array.from(
+                document.querySelectorAll<HTMLElement>(
+                    '.dv-tabs-container .dv-tab'
+                )
+            );
+            const geo = tabs.map((el) => ({
+                el,
+                top: el.offsetTop,
+                centre: el.offsetLeft + el.offsetWidth / 2,
+                text: el.innerText.trim(),
+            }));
+            const tops = Array.from(new Set(geo.map((g) => g.top))).sort(
+                (a, b) => a - b
+            );
+            const row0 = geo.filter((g) => g.top === tops[0]);
+            const row1 = geo.filter((g) => g.top === tops[1]);
+            const focused = row0[Math.floor(row0.length / 2)];
+            let expected = row1[0];
+            for (const g of row1) {
+                if (
+                    Math.abs(g.centre - focused.centre) <
+                    Math.abs(expected.centre - focused.centre)
+                ) {
+                    expected = g;
+                }
+            }
+            focused.el.focus();
+            return { focusedText: focused.text, expectedText: expected.text };
+        });
+
+        const activeText = () =>
+            page.evaluate(() =>
+                (document.activeElement as HTMLElement).innerText.trim()
+            );
+
+        await page.keyboard.press('ArrowDown');
+        expect(await activeText()).toBe(plan.expectedText);
+
+        // ArrowUp returns to the aligned tab on the row above.
+        await page.keyboard.press('ArrowUp');
+        expect(await activeText()).toBe(plan.focusedText);
+    });
 });

--- a/e2e/tests/pinned-tabs.spec.ts
+++ b/e2e/tests/pinned-tabs.spec.ts
@@ -222,4 +222,59 @@ test.describe('pinned tabs', () => {
             .click();
         await expect(page.locator('.dv-tab--pinned')).toHaveCount(0);
     });
+
+    test('auto-injects the Pin item into the tab menu without app wiring', async ({
+        page,
+    }) => {
+        // `?pinautoinject=1` leaves the app's `getTabContextMenuItems` returning
+        // only its close items — the module injects the Pin item itself.
+        await page.goto('/e2e/fixtures/index.html?pinautoinject=1');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() =>
+            (window as any).__dv.setupPinned(['alpha', 'bravo'], [])
+        );
+        await expect(page.locator('.dv-tab--pinned')).toHaveCount(0);
+
+        await page
+            .locator('.dv-tab', { hasText: 'bravo' })
+            .click({ button: 'right' });
+        await expect(page.locator('.dv-context-menu')).toBeVisible();
+
+        // Pin is prepended ahead of the app's own items.
+        await expect(
+            page.locator('.dv-context-menu-item').first()
+        ).toHaveText('Pin tab');
+
+        await page
+            .locator('.dv-context-menu-item', { hasText: 'Pin tab' })
+            .click();
+        await expect(page.locator('.dv-tab--pinned')).toContainText('bravo');
+    });
+
+    test('toggles the active tab pinned with the keyboard (Ctrl+Shift+Enter)', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() =>
+            (window as any).__dv.setupPinned(['alpha', 'bravo'], [])
+        );
+        // bravo was added last → the active panel.
+        await expect(page.locator('.dv-tab--pinned')).toHaveCount(0);
+
+        // Put focus inside the dock so the binding fires (it acts on the active
+        // panel, whichever tab holds focus).
+        await page.evaluate(() =>
+            document.querySelector<HTMLElement>('.dv-tab')?.focus()
+        );
+        await page.keyboard.press('Control+Shift+Enter');
+        await expect(page.locator('.dv-tab--pinned')).toContainText('bravo');
+
+        // Pressing again unpins.
+        await page.evaluate(() =>
+            document.querySelector<HTMLElement>('.dv-tab')?.focus()
+        );
+        await page.keyboard.press('Control+Shift+Enter');
+        await expect(page.locator('.dv-tab--pinned')).toHaveCount(0);
+    });
 });

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1409,9 +1409,9 @@ export class DockviewComponent
         return this._moduleRegistry.services.contextMenuService;
     }
 
-    private get _pinnedTabsService(): IPinnedTabsService | undefined {
-        // Owned by PinnedTabsModule. Undefined when the module is not
-        // registered.
+    get pinnedTabsService(): IPinnedTabsService | undefined {
+        // Owned by PinnedTabsModule — undefined when the module is not
+        // registered, so callers must `?.`-guard.
         return this._moduleRegistry.services.pinnedTabsService;
     }
 
@@ -1435,7 +1435,7 @@ export class DockviewComponent
         }
 
         const service = assertModule(
-            this._pinnedTabsService,
+            this.pinnedTabsService,
             'PinnedTabs',
             'setPinned'
         );

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -54,6 +54,13 @@ export interface IContextMenuHost {
     readonly options: DockviewComponentOptions;
     readonly api: DockviewApi;
     readonly tabGroupColorPalette: TabGroupColorPalette;
+    /**
+     * The PinnedTabs module service, or `undefined` when that module is not
+     * registered. The tab context menu auto-injects a Pin/Unpin item only when
+     * this is present (and pinning is enabled) — an optional enhancement, never
+     * a hard dependency.
+     */
+    readonly pinnedTabsService: IPinnedTabsService | undefined;
     getPopupServiceForGroup(group: DockviewGroupPanel): PopupService;
 }
 

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -131,6 +131,11 @@ export interface DockviewKeybindings {
     focusPrevGroup: string;
     /** Move focus from panel content to the focused group's tab strip. Default `ctrl+shift+\`. */
     focusTabs: string;
+    /**
+     * Pin / unpin the active panel's tab. Default `ctrl+shift+enter`. Inert
+     * unless the pinned-tabs feature is enabled (`pinnedTabs.enabled`).
+     */
+    togglePin: string;
 }
 
 export interface KeyboardNavigationOptions {

--- a/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
@@ -1282,4 +1282,163 @@ describe('ContextMenuController', () => {
             expect(setPinned).toHaveBeenCalledWith(false);
         });
     });
+
+    describe('auto-injected Pin/Unpin item', () => {
+        const pinPanel = (isPinned = false, setPinned = jest.fn()) =>
+            fromPartial<IDockviewPanel>({
+                api: { isPinned, setPinned, close: jest.fn() },
+            });
+
+        function makePinAccessor(overrides: {
+            pinnedTabs?: any;
+            hasService?: boolean;
+            getTabContextMenuItems?: jest.Mock;
+        }) {
+            const openPopover = jest.fn();
+            const popupService = fromPartial<PopupService>({
+                openPopover,
+                close: jest.fn(),
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                options: {
+                    pinnedTabs: overrides.pinnedTabs,
+                    getTabContextMenuItems: overrides.getTabContextMenuItems,
+                },
+                api: {} as any,
+                popupService,
+                getPopupServiceForGroup: () => popupService,
+                pinnedTabsService:
+                    overrides.hasService === false ? undefined : ({} as any),
+            });
+            return { accessor, openPopover };
+        }
+
+        const labels = (menuEl: HTMLElement): string[] =>
+            Array.from(menuEl.querySelectorAll('.dv-context-menu-item')).map(
+                (el) => el.textContent ?? ''
+            );
+
+        test('prepends Pin/Unpin when enabled, service present, no app callback', () => {
+            const { accessor, openPopover } = makePinAccessor({
+                pinnedTabs: { enabled: true },
+            });
+            const controller = new ContextMenuController(accessor);
+            const setPinned = jest.fn();
+
+            controller.show(
+                pinPanel(false, setPinned),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(labels(menuEl)).toEqual(['Pin tab']);
+
+            fireEvent.click(menuEl.querySelector('.dv-context-menu-item')!);
+            expect(setPinned).toHaveBeenCalledWith(true);
+        });
+
+        test('renders "Unpin tab" for an already-pinned panel', () => {
+            const { accessor, openPopover } = makePinAccessor({
+                pinnedTabs: { enabled: true },
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.show(
+                pinPanel(true),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(labels(menuEl)).toEqual(['Unpin tab']);
+        });
+
+        test('prepends Pin/Unpin ahead of the app-supplied items, preserving them', () => {
+            const { accessor, openPopover } = makePinAccessor({
+                pinnedTabs: { enabled: true },
+                getTabContextMenuItems: jest
+                    .fn()
+                    .mockReturnValue(['close', 'closeOthers']),
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.show(
+                pinPanel(),
+                makeGroup([pinPanel()]),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(labels(menuEl)).toEqual([
+                'Pin tab',
+                'Close',
+                'Close Others',
+            ]);
+        });
+
+        test('does not inject when contextMenuItem is false', () => {
+            const { accessor, openPopover } = makePinAccessor({
+                pinnedTabs: { enabled: true, contextMenuItem: false },
+            });
+            const controller = new ContextMenuController(accessor);
+            const event = new MouseEvent('contextmenu', { cancelable: true });
+            const spy = jest.spyOn(event, 'preventDefault');
+
+            controller.show(pinPanel(), makeGroup(), event);
+
+            // No app items + suppressed pin => no menu at all.
+            expect(openPopover).not.toHaveBeenCalled();
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        test('injects by default when contextMenuItem is unset', () => {
+            const { accessor, openPopover } = makePinAccessor({
+                pinnedTabs: { enabled: true },
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.show(
+                pinPanel(),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(labels(menuEl)).toContain('Pin tab');
+        });
+
+        test('does not inject when the PinnedTabs module is absent', () => {
+            const { accessor, openPopover } = makePinAccessor({
+                pinnedTabs: { enabled: true },
+                hasService: false,
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.show(
+                pinPanel(),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            expect(openPopover).not.toHaveBeenCalled();
+        });
+
+        test('does not inject when pinnedTabs is not enabled', () => {
+            const { accessor, openPopover } = makePinAccessor({
+                pinnedTabs: { enabled: false },
+                getTabContextMenuItems: jest.fn().mockReturnValue(['close']),
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.show(
+                pinPanel(),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(labels(menuEl)).toEqual(['Close']);
+        });
+    });
 });

--- a/packages/dockview-enterprise/src/__tests__/keyboardDocking.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/keyboardDocking.spec.ts
@@ -273,6 +273,92 @@ describe('accessibility: tab switching', () => {
 });
 
 /**
+ * Pin / unpin the active panel by keyboard — Ctrl+Shift+Enter by default,
+ * rebindable via `keymap.togglePin`. Inert unless `pinnedTabs.enabled`.
+ */
+describe('accessibility: toggle pin', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+
+    const make = (
+        keyboardNavigation: boolean | { keymap?: Record<string, string> },
+        pinnedTabs?: { enabled?: boolean }
+    ): void => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            keyboardNavigation,
+            pinnedTabs,
+        });
+        dockview.layout(1000, 1000);
+    };
+
+    const twoTabs = (): void => {
+        dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });
+        dockview.addPanel({ id: 'p2', component: 'default', title: 'P2' });
+    };
+
+    const pressTogglePin = (): void => {
+        fireEvent.keyDown(dockview.element, {
+            key: 'Enter',
+            ctrlKey: true,
+            shiftKey: true,
+        });
+    };
+
+    afterEach(() => {
+        dockview.dispose();
+        container.remove();
+    });
+
+    test('Ctrl+Shift+Enter pins then unpins the active panel', () => {
+        make(true, { enabled: true });
+        twoTabs(); // p2 active
+        expect(dockview.activePanel?.api.isPinned).toBe(false);
+
+        pressTogglePin();
+        expect(dockview.activePanel?.api.isPinned).toBe(true);
+
+        pressTogglePin();
+        expect(dockview.activePanel?.api.isPinned).toBe(false);
+    });
+
+    test('no-op when pinnedTabs is not enabled', () => {
+        make(true); // pinnedTabs undefined
+        twoTabs();
+
+        pressTogglePin();
+        expect(dockview.activePanel?.api.isPinned).toBe(false);
+    });
+
+    test('a rebound keymap.togglePin is honoured (default no longer fires)', () => {
+        make({ keymap: { togglePin: 'alt+p' } }, { enabled: true });
+        twoTabs();
+
+        // default binding overridden — Ctrl+Shift+Enter does nothing now
+        pressTogglePin();
+        expect(dockview.activePanel?.api.isPinned).toBe(false);
+
+        fireEvent.keyDown(dockview.element, { key: 'p', altKey: true });
+        expect(dockview.activePanel?.api.isPinned).toBe(true);
+    });
+
+    test('keeps focus inside the dock after toggling', () => {
+        make(true, { enabled: true });
+        twoTabs();
+        const group = dockview.activeGroup!;
+        // pinning re-orders the strip, which can strand focus on <body>
+        const spy = jest.spyOn(group.model, 'focusContent');
+
+        pressTogglePin();
+
+        expect(dockview.activePanel?.api.isPinned).toBe(true);
+        expect(spy).toHaveBeenCalled();
+    });
+});
+
+/**
  * Jump focus from panel content into the active group's tab strip
  * (Ctrl+Shift+\ by default), from where the tablist's own roving-tabindex
  * arrow navigation takes over.

--- a/packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts
@@ -1,5 +1,7 @@
+import { fireEvent } from '@testing-library/dom';
 import { DockviewComponent } from 'dockview-core';
 import { IContentRenderer } from 'dockview-core';
+import { findVerticalNeighbour } from '../multiRowTabsService';
 
 class TestPanel implements IContentRenderer {
     element = document.createElement('div');
@@ -277,6 +279,215 @@ describe('multi-row tabs (wrap mode)', () => {
         expect(
             b.group.model.tabsListElement.classList.contains(WRAP_CLASS)
         ).toBe(true);
+
+        dockview.dispose();
+    });
+});
+
+/** Mock a tab's layout geometry — jsdom reports 0 for every offset. */
+function setGeometry(
+    el: HTMLElement,
+    top: number,
+    left: number,
+    width: number
+): void {
+    Object.defineProperty(el, 'offsetTop', { value: top, configurable: true });
+    Object.defineProperty(el, 'offsetLeft', {
+        value: left,
+        configurable: true,
+    });
+    Object.defineProperty(el, 'offsetWidth', {
+        value: width,
+        configurable: true,
+    });
+}
+
+/**
+ * The pure row-geometry resolver behind Arrow Up/Down. Bucket tabs into rows by
+ * `offsetTop`, then within the target row pick the tab whose horizontal centre
+ * is nearest.
+ */
+describe('findVerticalNeighbour', () => {
+    const tabAt = (top: number, left: number, width: number): HTMLElement => {
+        const el = document.createElement('div');
+        el.className = 'dv-tab';
+        setGeometry(el, top, left, width);
+        return el;
+    };
+
+    test('steps down to the horizontally-nearest tab in the row below', () => {
+        // row 0: centres 25 / 75 / 125 ; row 1: centres 25 / 75 / 125
+        const t0 = tabAt(0, 0, 50);
+        const t1 = tabAt(0, 50, 50);
+        const t2 = tabAt(0, 100, 50);
+        const t3 = tabAt(30, 0, 50);
+        const t4 = tabAt(30, 50, 50);
+        const t5 = tabAt(30, 100, 50);
+        const tabs = [t0, t1, t2, t3, t4, t5];
+
+        expect(findVerticalNeighbour(tabs, t1, 'down')).toBe(t4);
+    });
+
+    test('steps up to the horizontally-nearest tab in the row above', () => {
+        const t0 = tabAt(0, 0, 50);
+        const t1 = tabAt(0, 50, 50);
+        const t2 = tabAt(30, 0, 50);
+        const t3 = tabAt(30, 50, 50);
+        const tabs = [t0, t1, t2, t3];
+
+        expect(findVerticalNeighbour(tabs, t3, 'up')).toBe(t1);
+    });
+
+    test('picks the nearest centre when rows are misaligned', () => {
+        // top row has two wide tabs; bottom row has three narrow tabs.
+        const top0 = tabAt(0, 0, 90); // centre 45
+        const top1 = tabAt(0, 90, 90); // centre 135
+        const bot0 = tabAt(30, 0, 40); // centre 20
+        const bot1 = tabAt(30, 40, 40); // centre 60
+        const bot2 = tabAt(30, 80, 40); // centre 100
+        const tabs = [top0, top1, bot0, bot1, bot2];
+
+        // top1 centre 135 → nearest bottom centre is bot2 (100)
+        expect(findVerticalNeighbour(tabs, top1, 'down')).toBe(bot2);
+        // top0 centre 45 → nearest bottom centre is bot1 (60)
+        expect(findVerticalNeighbour(tabs, top0, 'down')).toBe(bot1);
+    });
+
+    test('returns undefined at the edges (top row up / bottom row down)', () => {
+        const top = tabAt(0, 0, 50);
+        const bottom = tabAt(30, 0, 50);
+        const tabs = [top, bottom];
+
+        expect(findVerticalNeighbour(tabs, top, 'up')).toBeUndefined();
+        expect(findVerticalNeighbour(tabs, bottom, 'down')).toBeUndefined();
+    });
+});
+
+/**
+ * Cross-row keyboard navigation — Arrow Up/Down move the roving focus between
+ * wrapped rows. Only active while the strip is wrapping a horizontal header;
+ * jsdom has no layout, so tab geometry is mocked (real wrapping is e2e).
+ */
+describe('multi-row tabs: cross-row keyboard navigation', () => {
+    let container: HTMLElement;
+
+    const make = (
+        overflow?: DockviewComponent['options']['overflow'],
+        headerPosition?: 'top' | 'left'
+    ): DockviewComponent => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            overflow,
+            defaultHeaderPosition: headerPosition,
+        });
+        dockview.layout(1000, 1000);
+        return dockview;
+    };
+
+    afterEach(() => {
+        container?.remove();
+    });
+
+    /** Six tabs laid out as two rows of three (centres 25 / 75 / 125). */
+    const sixTabsTwoRows = (dockview: DockviewComponent): HTMLElement[] => {
+        for (const id of ['p1', 'p2', 'p3', 'p4', 'p5', 'p6']) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = dockview.activeGroup!.model.tabsListElement;
+        const tabs = Array.from(list.querySelectorAll<HTMLElement>('.dv-tab'));
+        setGeometry(tabs[0], 0, 0, 50);
+        setGeometry(tabs[1], 0, 50, 50);
+        setGeometry(tabs[2], 0, 100, 50);
+        setGeometry(tabs[3], 30, 0, 50);
+        setGeometry(tabs[4], 30, 50, 50);
+        setGeometry(tabs[5], 30, 100, 50);
+        return tabs;
+    };
+
+    test('ArrowDown moves roving focus to the aligned tab one row below', () => {
+        const dockview = make({ mode: 'wrap' });
+        const tabs = sixTabsTwoRows(dockview);
+
+        tabs[1].focus();
+        fireEvent.keyDown(tabs[1], { key: 'ArrowDown' });
+
+        expect(document.activeElement).toBe(tabs[4]);
+        expect(tabs[4].tabIndex).toBe(0);
+        expect(tabs[1].tabIndex).toBe(-1);
+
+        dockview.dispose();
+    });
+
+    test('ArrowUp moves roving focus to the aligned tab one row above', () => {
+        const dockview = make({ mode: 'wrap' });
+        const tabs = sixTabsTwoRows(dockview);
+
+        tabs[5].focus();
+        fireEvent.keyDown(tabs[5], { key: 'ArrowUp' });
+
+        expect(document.activeElement).toBe(tabs[2]);
+
+        dockview.dispose();
+    });
+
+    test('ArrowUp on the top row is a no-op', () => {
+        const dockview = make({ mode: 'wrap' });
+        const tabs = sixTabsTwoRows(dockview);
+
+        tabs[0].focus();
+        fireEvent.keyDown(tabs[0], { key: 'ArrowUp' });
+
+        expect(document.activeElement).toBe(tabs[0]);
+
+        dockview.dispose();
+    });
+
+    test('is inert when the strip is not wrapping (no cross-row jump)', () => {
+        const dockview = make(); // dropdown overflow — no wrap class, no listener
+        const tabs = sixTabsTwoRows(dockview);
+        expect(
+            dockview.activeGroup!.model.tabsListElement.classList.contains(
+                WRAP_CLASS
+            )
+        ).toBe(false);
+
+        tabs[1].focus();
+        fireEvent.keyDown(tabs[1], { key: 'ArrowDown' });
+
+        // core owns Left/Right for a horizontal strip and ignores Up/Down, so
+        // focus stays put — our cross-row handler never ran.
+        expect(document.activeElement).toBe(tabs[1]);
+
+        dockview.dispose();
+    });
+
+    test('is inert on a vertical header (wrap gate stays closed)', () => {
+        const dockview = make({ mode: 'wrap' }, 'left');
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        const list = dockview.activeGroup!.model.tabsListElement;
+
+        expect(list.classList.contains('dv-tabs-container-vertical')).toBe(
+            true
+        );
+        // wrap (and therefore the cross-row listener) never activates vertically
+        expect(list.classList.contains(WRAP_CLASS)).toBe(false);
+
+        dockview.dispose();
+    });
+
+    test('detaches the listener when wrap is turned off at runtime', () => {
+        const dockview = make({ mode: 'wrap' });
+        const tabs = sixTabsTwoRows(dockview);
+
+        // turn wrap off — the capture listener must be removed
+        dockview.updateOptions({ overflow: { mode: 'dropdown' } });
+
+        tabs[1].focus();
+        fireEvent.keyDown(tabs[1], { key: 'ArrowDown' });
+
+        expect(document.activeElement).toBe(tabs[1]);
 
         dockview.dispose();
     });

--- a/packages/dockview-enterprise/src/contextMenu.ts
+++ b/packages/dockview-enterprise/src/contextMenu.ts
@@ -183,22 +183,55 @@ export class ContextMenuController implements IContextMenuService {
         return buildItem(label, close, () => tabGroup.toggle());
     }
 
+    /**
+     * Whether to auto-inject the built-in Pin/Unpin item at the top of the tab
+     * menu. True only when the PinnedTabs module is registered, pinning is
+     * enabled, and the app has not opted out via `pinnedTabs.contextMenuItem:
+     * false` (the item is on by default). This keeps pinning reachable from the
+     * menu without the app having to return `'pin'` from
+     * `getTabContextMenuItems` itself.
+     */
+    private _shouldInjectPin(): boolean {
+        const pinnedTabs = this.accessor.options.pinnedTabs;
+        return (
+            !!this.accessor.pinnedTabsService &&
+            !!pinnedTabs?.enabled &&
+            pinnedTabs.contextMenuItem !== false
+        );
+    }
+
+    /**
+     * The tab menu items: the app's own items (if any) with the built-in
+     * `'pin'` item prepended when {@link _shouldInjectPin} applies — so the app
+     * keeps full control of its list, and pinning is added without disturbing
+     * it. Reuses the existing `'pin'` token rendering below.
+     */
+    private _resolveTabItems(
+        panel: IDockviewPanel,
+        group: DockviewGroupPanel,
+        event: MouseEvent
+    ): ContextMenuItem[] {
+        const appItems =
+            this.accessor.options.getTabContextMenuItems?.({
+                panel,
+                group,
+                api: this.accessor.api,
+                event,
+            }) ?? [];
+
+        return this._shouldInjectPin() ? ['pin', ...appItems] : appItems;
+    }
+
     show(
         panel: IDockviewPanel,
         group: DockviewGroupPanel,
         event: MouseEvent
     ): void {
-        if (!this.accessor.options.getTabContextMenuItems) {
-            return;
-        }
-
-        const items: ContextMenuItem[] =
-            this.accessor.options.getTabContextMenuItems({
-                panel,
-                group,
-                api: this.accessor.api,
-                event,
-            });
+        const items: ContextMenuItem[] = this._resolveTabItems(
+            panel,
+            group,
+            event
+        );
 
         if (items.length === 0) {
             return;

--- a/packages/dockview-enterprise/src/keyboardNavigationService.ts
+++ b/packages/dockview-enterprise/src/keyboardNavigationService.ts
@@ -16,6 +16,11 @@ const DEFAULT_KEYMAP: DockviewKeybindings = {
     focusNextGroup: 'f6',
     focusPrevGroup: 'shift+f6',
     focusTabs: 'ctrl+shift+\\',
+    // A Ctrl-based combo that steers clear of OS/browser-reserved shortcuts
+    // (unlike, say, `ctrl+shift+p`, which is Firefox's private-window key), and
+    // whose key is unchanged by Shift so it matches reliably across keyboard
+    // layouts. Rebindable via `keymap.togglePin`.
+    togglePin: 'ctrl+shift+enter',
 };
 
 /**
@@ -28,6 +33,8 @@ const DEFAULT_KEYMAP: DockviewKeybindings = {
  *   group in sequence.
  * - **Focus the tab strip** (`Ctrl+Shift+\`) — jump focus from panel content to
  *   the active group's tab strip (the strip's roving-tabindex takes over).
+ * - **Toggle pin** (`Ctrl+Shift+Enter`) — pin / unpin the active panel's tab.
+ *   Inert unless the pinned-tabs feature is enabled.
  * - **Focus restore on close** — when removing a panel/group pulls focus out of
  *   the dock, focus returns to the neighbour the layout just activated instead
  *   of being stranded on `<body>`.
@@ -277,6 +284,9 @@ export class KeyboardNavigationService
         } else if (matchesBinding(e, keymap.focusTabs)) {
             this._consume(e);
             this._focusTabs();
+        } else if (matchesBinding(e, keymap.togglePin)) {
+            this._consume(e);
+            this._togglePin();
         }
     }
 
@@ -286,6 +296,24 @@ export class KeyboardNavigationService
         // Jump from panel content to the active group's tab strip; the
         // tablist's own roving-tabindex handler takes over from there.
         this.host.activeGroup?.model.focusActiveTab();
+    }
+
+    private _togglePin(): void {
+        // Inert unless the pinned-tabs feature is enabled — the binding is dead
+        // weight without it. (`setPinned` is itself gated in core, but guarding
+        // here also skips the needless refocus below when nothing can change.)
+        if (!this.host.options.pinnedTabs?.enabled) {
+            return;
+        }
+        const panel = this.host.activePanel;
+        if (!panel) {
+            return;
+        }
+        panel.api.setPinned(!panel.api.isPinned);
+        // Pinning re-orders the strip (pinned-first), which can strand focus on
+        // <body>; return it to the active content the same way the other
+        // actions do.
+        this._restoreFocus();
     }
 
     private _switchTab(reverse: boolean): void {

--- a/packages/dockview-enterprise/src/multiRowTabsService.ts
+++ b/packages/dockview-enterprise/src/multiRowTabsService.ts
@@ -13,6 +13,52 @@ function isWrapMode(overflow: DockviewOverflowOptions | undefined): boolean {
     return typeof overflow === 'object' && overflow?.mode === 'wrap';
 }
 
+const VERTICAL_TABS_CLASS = 'dv-tabs-container-vertical';
+const TAB_CLASS = 'dv-tab';
+
+/**
+ * The wrapped-row neighbour of `current` one row up or down, or `undefined` when
+ * there is no row in that direction. Tabs are bucketed into rows by `offsetTop`
+ * (the same signal `countRows` uses); within the target row the tab whose
+ * horizontal centre is nearest `current`'s is chosen — so Up/Down lands on the
+ * geometrically-aligned tab rather than a fixed index. Pure geometry (reads
+ * layout only) so it is unit-testable with mocked offsets.
+ */
+export function findVerticalNeighbour(
+    tabs: HTMLElement[],
+    current: HTMLElement,
+    direction: 'up' | 'down'
+): HTMLElement | undefined {
+    const rowTops = Array.from(new Set(tabs.map((t) => t.offsetTop))).sort(
+        (a, b) => a - b
+    );
+    const currentRow = rowTops.indexOf(current.offsetTop);
+    const targetTop =
+        rowTops[direction === 'up' ? currentRow - 1 : currentRow + 1];
+    if (targetTop === undefined) {
+        // Already on the top / bottom row — no wrap-around.
+        return undefined;
+    }
+
+    const centre = (tab: HTMLElement): number =>
+        tab.offsetLeft + tab.offsetWidth / 2;
+    const currentCentre = centre(current);
+
+    let best: HTMLElement | undefined;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (const tab of tabs) {
+        if (tab.offsetTop !== targetTop) {
+            continue;
+        }
+        const distance = Math.abs(centre(tab) - currentCentre);
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            best = tab;
+        }
+    }
+    return best;
+}
+
 /**
  * The row cap from `overflow.maxRows`, normalised to a positive integer, or
  * `undefined` for unbounded wrap (the default, and any non-positive / non-finite
@@ -131,6 +177,7 @@ class WrapController extends CompositeDisposable {
     private _forcedIds: ReadonlySet<string> = new Set();
     private _observer: ResizeObserver | undefined;
     private _pendingMeasure: { win: Window; handle: number } | undefined;
+    private _detachRowNav: (() => void) | undefined;
 
     constructor(
         private readonly group: DockviewGroupPanel,
@@ -175,6 +222,7 @@ class WrapController extends CompositeDisposable {
                     this.scheduleMeasure(list)
                 );
                 this._observer.observe(list);
+                this.attachRowNav(list);
             }
             this.measure();
         } else if (this._wrapped) {
@@ -192,6 +240,70 @@ class WrapController extends CompositeDisposable {
             list.classList.add(CAPPED_CLASS);
             list.style.setProperty(MAX_ROWS_VAR, String(this._maxRows));
         }
+    }
+
+    /**
+     * Add cross-row keyboard nav. Core's tab-strip roving handles Left/Right/
+     * Home/End within a single visual line; when tabs wrap, ArrowUp/ArrowDown
+     * should step between rows too. A capture-phase listener claims only Up/Down
+     * (leaving core's keys untouched) and moves the roving focus to the
+     * nearest-aligned tab in the row above / below. Only wired while the strip is
+     * actually wrapping; the handler re-checks the wrap + horizontal guards so a
+     * stale class can't re-enable it.
+     */
+    private attachRowNav(list: HTMLElement): void {
+        if (this._detachRowNav) {
+            return;
+        }
+        const handler = (event: Event): void =>
+            this.onRowKeyDown(event as KeyboardEvent, list);
+        list.addEventListener('keydown', handler, /* capture */ true);
+        this._detachRowNav = () =>
+            list.removeEventListener('keydown', handler, true);
+    }
+
+    private onRowKeyDown(event: KeyboardEvent, list: HTMLElement): void {
+        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
+            return;
+        }
+        // Inert unless the strip is currently wrapping a horizontal header —
+        // mirror the wrap gate (`apply`) and core's `:not(...-vertical)` guard.
+        if (
+            !list.classList.contains(WRAP_CLASS) ||
+            list.classList.contains(VERTICAL_TABS_CLASS)
+        ) {
+            return;
+        }
+        // Only when a tab element itself holds focus, never a control inside a
+        // custom tab renderer (matches core's `_onKeyDown` target check).
+        const focused = event.target;
+        if (
+            !(focused instanceof HTMLElement) ||
+            !focused.classList.contains(TAB_CLASS)
+        ) {
+            return;
+        }
+        const tabs = Array.from(
+            list.querySelectorAll<HTMLElement>(`.${TAB_CLASS}`)
+        );
+        const target = findVerticalNeighbour(
+            tabs,
+            focused,
+            event.key === 'ArrowUp' ? 'up' : 'down'
+        );
+        if (!target) {
+            return;
+        }
+        // Claim the key so the list doesn't scroll and core's bubble-phase
+        // handler doesn't also see it.
+        event.preventDefault();
+        event.stopPropagation();
+        // Move the roving tabindex the way core's `_focusTab` does: the target
+        // becomes the sole tab-stop, then takes DOM focus.
+        for (const tab of tabs) {
+            tab.tabIndex = tab === target ? 0 : -1;
+        }
+        target.focus();
     }
 
     private scheduleMeasure(list: HTMLElement): void {
@@ -249,6 +361,8 @@ class WrapController extends CompositeDisposable {
         this._pendingMeasure = undefined;
         this._observer?.disconnect();
         this._observer = undefined;
+        this._detachRowNav?.();
+        this._detachRowNav = undefined;
         this._rowCount = 0;
         this._maxRows = undefined;
         this._wrapped = false;


### PR DESCRIPTION
## Description

Three small, self-contained tab-polish features for the enterprise modules. Each sits behind its existing gate, so a component without the relevant module behaves exactly as before.

**Feature 1 — Auto-inject the Pin/Unpin context-menu item.** `ContextMenuController.show` now prepends the built-in `'pin'` item to whatever `getTabContextMenuItems` returns, when the PinnedTabs module is registered **and** `pinnedTabs.enabled` **and** `pinnedTabs.contextMenuItem !== false` (default true). With no app callback a menu containing just Pin/Unpin still shows, so pinning is reachable without any app wiring. Reuses the existing `'pin'` token rendering. The controller detects the module via a new `pinnedTabsService` accessor on `IContextMenuHost` / `DockviewComponent` — ContextMenu stays an optional enhancer (no hard `dependsOn`).

**Feature 2 — Keyboard pin/unpin binding.** Adds a `togglePin` action to `DockviewKeybindings` + `DEFAULT_KEYMAP`, default `Ctrl+Shift+Enter`. The default steers clear of browser-reserved combos (e.g. `Ctrl+Shift+P` is Firefox's private-window shortcut) and uses a Shift-invariant key so it matches reliably across keyboard layouts; it's rebindable via `keymap.togglePin`. Toggles the active panel's pinned state, no-op unless `pinnedTabs.enabled`, and refocuses the active content afterwards (a pinned-first reorder can otherwise strand focus on `<body>`).

**Feature 3 — Multi-row cross-row keyboard navigation.** `WrapController` attaches a capture-phase `keydown` listener — only while wrapping a horizontal header — that handles **only** ArrowUp/ArrowDown (core keeps Left/Right/Home/End). It buckets tabs into rows by `offsetTop` and moves the roving focus to the nearest horizontally-aligned tab in the row above/below. The listener is torn down when wrap turns off. The pure row-geometry resolver (`findVerticalNeighbour`) is unit-tested with mocked offsets.

> Note: changes also touch **`dockview-enterprise`** (no checkbox for it below). No public core export names changed — `__generated__/dockview-core-exports.txt` regenerates with no diff.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

(also `dockview-enterprise`)

## How to test

Covered by unit + e2e tests:

- **Feature 1** — `dockview-enterprise/src/__tests__/contextMenu.spec.ts` (auto-inject describe block) and e2e `pinned-tabs.spec.ts` "auto-injects the Pin item into the tab menu without app wiring" (`?pinautoinject=1`). Verifies Pin/Unpin shows when enabled, is prepended ahead of app items, is suppressed by `contextMenuItem: false`, and is absent when the module isn't registered.
- **Feature 2** — `dockview-enterprise/src/__tests__/keyboardDocking.spec.ts` ("toggle pin" describe) and e2e `pinned-tabs.spec.ts` "toggles the active tab pinned with the keyboard (Ctrl+Shift+Enter)". Verifies toggling, the disabled/no-op case, a rebound `keymap.togglePin`, and focus retention.
- **Feature 3** — `dockview-enterprise/src/__tests__/multiRowTabs.spec.ts` (`findVerticalNeighbour` + cross-row nav describes) and e2e `multi-row-tabs.spec.ts` "Arrow Up/Down move focus between wrapped rows" (real geometry under `?overflow=wrap`). Verifies up/down land on the geometrically-correct tab and that it's inert when not wrapped / on vertical headers / after wrap is turned off.

Full suite green locally: `dockview-core` 1152 unit, `dockview-enterprise` 318 unit, and all 82 e2e.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1UuqPZyS7KbKn3mKDWW5g)_