### PR TITLE
feat(enterprise): AdvancedOverflowModule — searchable/MRU overflow tab switcher (MVP)

### DIFF
--- a/__generated__/dockview-core-exports.txt
+++ b/__generated__/dockview-core-exports.txt
@@ -10,6 +10,7 @@ AddPaneviewComponentOptions
 AddSplitviewComponentOptions
 AdvancedDnDModule
 AdvancedDnDService
+AdvancedOverflowRenderParams
 AnchorPosition
 AnchoredBox
 AnnouncementEvent
@@ -124,6 +125,9 @@ GroupviewPanelState
 HeaderPartInitParameters
 IAdvancedDnDHost
 IAdvancedDnDService
+IAdvancedOverflowHost
+IAdvancedOverflowRenderContext
+IAdvancedOverflowService
 IAutoEdgeGroupHost
 IAutoEdgeGroupService
 IAutoHideEdgeGroupHost
@@ -164,6 +168,7 @@ ILayoutHistoryService
 IMultiRowTabsHost
 IMultiRowTabsService
 INodeDescriptor
+IOverflowRow
 IPanePart
 IPanel
 IPanelDeserializer

--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -55,6 +55,9 @@
                 // `?maxRows=N` caps the header at N rows (surplus spills to the
                 // dropdown).
                 const maxRowsParam = params.get('maxRows');
+                // `?overflow=advanced` enables the AdvancedOverflowModule
+                // (searchable / MRU overflow dropdown) so the advanced popover
+                // can be exercised; other specs are unaffected.
                 const overflow =
                     params.get('overflow') === 'wrap'
                         ? {
@@ -63,7 +66,9 @@
                                   ? { maxRows: Number(maxRowsParam) }
                                   : {}),
                           }
-                        : undefined;
+                        : params.get('overflow') === 'advanced'
+                          ? { search: true, mru: true }
+                          : undefined;
                 // `?smooth=1` turns on the smooth tab reorder animation (needed
                 // to exercise the 2-D cross-row wrap reorder path).
                 const theme =

--- a/e2e/tests/advanced-overflow.spec.ts
+++ b/e2e/tests/advanced-overflow.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * Advanced overflow (AdvancedOverflowModule): the free chevron dropdown is
+ * upgraded in place into a searchable / MRU command-palette tab switcher. Which
+ * tabs overflow is decided from measured widths, so this is real-browser only.
+ *
+ * The cross-window case is the load-bearing one: the popover must open via the
+ * group's window-bound `PopupService`, so it renders (and dismisses) inside a
+ * popped-out group's own document — never the opener's.
+ */
+test.describe('advanced overflow dropdown', () => {
+    const addOverflowingTabs = async (
+        page: Page,
+        count: number,
+        prefix: string
+    ) => {
+        await page.evaluate(
+            ({ count, prefix }) => {
+                for (let i = 0; i < count; i++) {
+                    (window as any).__dv.addPanel(`${prefix}-${i}`);
+                }
+            },
+            { count, prefix }
+        );
+    };
+
+    test('renders a searchable popover and filters rows', async ({ page }) => {
+        await page.setViewportSize({ width: 320, height: 500 });
+        await page.goto('/e2e/fixtures/index.html?overflow=advanced');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await addOverflowingTabs(page, 12, 'overflow-long-title');
+
+        const handle = page.locator('.dv-tabs-overflow-dropdown-default');
+        await expect(handle).toBeVisible();
+        await handle.click();
+
+        const popover = page.locator('.dv-tabs-overflow-advanced');
+        await expect(popover).toBeVisible();
+
+        const search = popover.locator('.dv-tabs-overflow-search');
+        await expect(search).toBeFocused();
+
+        // A discriminating substring narrows the list; a nonsense one empties it.
+        await search.fill('long-title-1');
+        await expect(popover.locator('[role="option"]')).not.toHaveCount(0);
+        await search.fill('zzz-no-match');
+        await expect(popover.locator('[role="option"]')).toHaveCount(0);
+
+        // Escape dismisses.
+        await search.press('Escape');
+        await expect(popover).toHaveCount(0);
+    });
+
+    test('arrow keys + Enter activate a hidden tab', async ({ page }) => {
+        await page.setViewportSize({ width: 320, height: 500 });
+        await page.goto('/e2e/fixtures/index.html?overflow=advanced');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await addOverflowingTabs(page, 12, 'kbd-long-title');
+
+        await page.locator('.dv-tabs-overflow-dropdown-default').click();
+        const popover = page.locator('.dv-tabs-overflow-advanced');
+        await expect(popover).toBeVisible();
+
+        const firstOption = popover.locator('[role="option"]').first();
+        const title = (await firstOption.textContent())!.trim();
+
+        const search = popover.locator('.dv-tabs-overflow-search');
+        await search.press('Enter'); // first option is active on open
+
+        await expect(page.locator('.dv-active-tab')).toHaveText(title);
+        await expect(popover).toHaveCount(0);
+    });
+
+    test('popover renders + dismisses inside a popped-out group', async ({
+        page,
+        context,
+    }) => {
+        await page.setViewportSize({ width: 400, height: 500 });
+        await page.goto('/e2e/fixtures/index.html?overflow=advanced');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await addOverflowingTabs(page, 20, 'pop-long-title');
+
+        const [popout] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__dv.popoutActiveGroup()),
+        ]);
+        await (popout as Page).waitForLoadState();
+
+        // Narrow the popout so its strip overflows regardless of default size.
+        await popout.setViewportSize({ width: 360, height: 500 });
+
+        const handle = popout.locator('.dv-tabs-overflow-dropdown-default');
+        await expect(handle).toBeVisible();
+        await handle.click();
+
+        // The popover renders in the POPOUT document (window-bound), not the
+        // opener — this is the cross-window binding under test.
+        const popover = popout.locator('.dv-tabs-overflow-advanced');
+        await expect(popover).toBeVisible();
+        await expect(page.locator('.dv-tabs-overflow-advanced')).toHaveCount(0);
+
+        // And it dismisses in the popout document.
+        await popout.locator('.dv-tabs-overflow-search').press('Escape');
+        await expect(popover).toHaveCount(0);
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/advancedOverflowSeam.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/advancedOverflowSeam.spec.ts
@@ -1,0 +1,116 @@
+import { fireEvent } from '@testing-library/dom';
+import { DockviewComponent } from '../../../../dockview/dockviewComponent';
+import { IContentRenderer } from '../../../../dockview/types';
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+// jsdom lacks scrollIntoView; the free row activation calls it on click.
+beforeAll(() => {
+    if (!Element.prototype.scrollIntoView) {
+        Element.prototype.scrollIntoView = function scrollIntoView() {
+            /* noop */
+        };
+    }
+});
+
+/**
+ * The overflow rendering seam: `TabsContainer.toggleDropdown` builds the popover
+ * body through `createOverflowRenderContext` and, when
+ * `accessor.advancedOverflowService` is present, hands it to the module;
+ * otherwise it renders the free flat list. No module is registered in core, so
+ * this proves the `?.`-guard falls through to the free helper — the byte-for-byte
+ * behaviour dockview shipped before the seam existed.
+ */
+describe('advanced overflow seam — free fallback (no module)', () => {
+    let container: HTMLElement;
+
+    const make = (): DockviewComponent => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(400, 300);
+        return dockview;
+    };
+
+    afterEach(() => {
+        container?.remove();
+    });
+
+    const openOverflow = (
+        dockview: DockviewComponent,
+        anyPanel: any,
+        ids: string[]
+    ): void => {
+        const overflowSet = new Set(ids);
+        anyPanel.group.model.header.setForcedOverflow((id: string) =>
+            overflowSet.has(id)
+        );
+        anyPanel.group.model.header.refreshOverflow();
+        const root = container.querySelector<HTMLElement>(
+            '.dv-tabs-overflow-dropdown-root'
+        );
+        if (root) {
+            fireEvent.click(root);
+        }
+    };
+
+    test('renders the free flat list (no advanced upgrade) with the overflow rows', () => {
+        const dockview = make();
+        expect(dockview.advancedOverflowService).toBeUndefined();
+
+        const panels = ['a', 'b', 'c'].map((id) =>
+            dockview.addPanel({ id, component: 'default', title: id })
+        );
+
+        openOverflow(dockview, panels[0], ['b', 'c']);
+
+        const body = container.querySelector('.dv-tabs-overflow-container');
+        expect(body).toBeTruthy();
+        // The module-only marker class must be absent.
+        expect(body!.classList.contains('dv-tabs-overflow-advanced')).toBe(
+            false
+        );
+        // No search input in the free path.
+        expect(body!.querySelector('.dv-tabs-overflow-search')).toBeNull();
+        // The clipped tabs render as rows.
+        expect(body!.querySelectorAll('.dv-tab').length).toBe(2);
+
+        dockview.dispose();
+    });
+
+    test('clicking a free row activates its panel and closes the popover', () => {
+        const dockview = make();
+        const panels = ['a', 'b', 'c'].map((id) =>
+            dockview.addPanel({ id, component: 'default', title: id })
+        );
+
+        openOverflow(dockview, panels[0], ['b', 'c']);
+
+        const row = Array.from(
+            container.querySelectorAll<HTMLElement>(
+                '.dv-tabs-overflow-container .dv-tab'
+            )
+        ).find((el) => el.textContent!.trim() === 'c')!;
+        fireEvent.click(row);
+
+        expect(panels[2].api.isActive).toBe(true);
+        expect(
+            container.querySelector('.dv-tabs-overflow-container')
+        ).toBeNull();
+
+        dockview.dispose();
+    });
+});

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.scss
@@ -586,3 +586,38 @@
         padding-left: 16px;
     }
 }
+
+/*
+ * Advanced overflow popover (AdvancedOverflowModule): the same container as the
+ * free list, upgraded in place with a search input, a scrollable listbox, and a
+ * keyboard-highlighted active row. Styles live in core so the module ships no
+ * CSS; they are inert unless the module renders this body.
+ */
+.dv-tabs-overflow-container.dv-tabs-overflow-advanced {
+    min-width: 220px;
+
+    .dv-tabs-overflow-search {
+        box-sizing: border-box;
+        width: 100%;
+        padding: 6px 8px;
+        border: none;
+        border-bottom: 1px solid var(--dv-tab-divider-color);
+        outline: none;
+        font-size: inherit;
+        font-family: inherit;
+        color: var(--dv-activegroup-visiblepanel-tab-color);
+        background-color: var(--dv-group-view-background-color);
+    }
+
+    .dv-tabs-overflow-list {
+        display: flex;
+        flex-direction: column;
+        outline: none;
+    }
+
+    .dv-tab.dv-tabs-overflow-option--focused {
+        outline: 1px solid var(--dv-tab-divider-color);
+        outline-offset: -1px;
+        background-color: var(--dv-icon-hover-background-color);
+    }
+}

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -25,6 +25,8 @@ import {
 } from './tabOverflowControl';
 import { DockviewHeaderDirection } from '../../options';
 import { applyTabGroupAccent } from '../../tabGroupAccent';
+import { IAdvancedOverflowRenderContext } from '../../moduleContracts';
+import { PopupService } from '../popupService';
 
 export interface TabDropIndexEvent {
     readonly event: DragEvent | PointerEvent;
@@ -514,145 +516,219 @@ export class TabsContainer
                 { capture: true }
             ),
             addDisposableListener(root, 'click', (event) => {
-                const el = document.createElement('div');
-                el.style.overflow = 'auto';
-                el.className = 'dv-tabs-overflow-container';
-
-                // Build lookup: panelId → tabGroup for overflow groups
-                const overflowGroupSet = new Set(this._overflowTabGroups);
-                const allTabGroups = this.group.model.getTabGroups();
-                const panelToGroup = new Map<
-                    string,
-                    (typeof allTabGroups)[0]
-                >();
-                for (const tg of allTabGroups) {
-                    if (overflowGroupSet.has(tg.id)) {
-                        for (const pid of tg.panelIds) {
-                            panelToGroup.set(pid, tg);
-                        }
-                    }
-                }
-
-                // Track which groups have already been rendered
-                const renderedGroups = new Set<string>();
-
-                for (const tab of this.tabs.tabs.filter((tab) =>
-                    this._overflowTabs.includes(tab.panel.id)
-                )) {
-                    const tg = panelToGroup.get(tab.panel.id);
-
-                    // If this tab belongs to an overflow group, render the
-                    // group header before its first member tab.
-                    if (tg && !renderedGroups.has(tg.id)) {
-                        renderedGroups.add(tg.id);
-
-                        const groupHeader = document.createElement('div');
-                        groupHeader.className = 'dv-tabs-overflow-group-header';
-
-                        const colorDot = document.createElement('span');
-                        colorDot.className = 'dv-tabs-overflow-group-color';
-                        applyTabGroupAccent(
-                            colorDot,
-                            tg.color,
-                            this.accessor.tabGroupColorPalette
-                        );
-                        groupHeader.appendChild(colorDot);
-
-                        const labelSpan = document.createElement('span');
-                        labelSpan.className = 'dv-tabs-overflow-group-label';
-                        labelSpan.textContent = tg.label || tg.id;
-                        groupHeader.appendChild(labelSpan);
-
-                        if (tg.collapsed) {
-                            const badge = document.createElement('span');
-                            badge.className =
-                                'dv-tabs-overflow-group-collapsed-badge';
-                            badge.textContent = `${tg.panelIds.length}`;
-                            groupHeader.appendChild(badge);
-                        }
-
-                        groupHeader.addEventListener('click', () => {
-                            this.accessor
-                                .getPopupServiceForGroup(this.group)
-                                .close();
-                            if (tg.collapsed) {
-                                tg.expand();
-                            }
-                            // Activate the first panel in the group
-                            const firstPanelId = tg.panelIds[0];
-                            if (firstPanelId) {
-                                const panel = this.group.panels.find(
-                                    (p) => p.id === firstPanelId
-                                );
-                                this.accessor.withOrigin('user', () =>
-                                    panel?.api.setActive()
-                                );
-                            }
-                        });
-
-                        el.appendChild(groupHeader);
-                    }
-
-                    const panelObject = this.group.panels.find(
-                        (panel) => panel === tab.panel
-                    )!;
-
-                    const tabComponent =
-                        panelObject.view.createTabRenderer('headerOverflow');
-
-                    const child = tabComponent.element;
-
-                    const wrapper = document.createElement('div');
-                    toggleClass(wrapper, 'dv-tab', true);
-                    toggleClass(
-                        wrapper,
-                        'dv-active-tab',
-                        panelObject.api.isActive
-                    );
-                    toggleClass(
-                        wrapper,
-                        'dv-inactive-tab',
-                        !panelObject.api.isActive
-                    );
-                    if (tg) {
-                        toggleClass(wrapper, 'dv-tab--grouped', true);
-                    }
-
-                    wrapper.addEventListener('click', (event) => {
-                        this.accessor
-                            .getPopupServiceForGroup(this.group)
-                            .close();
-
-                        if (event.defaultPrevented) {
-                            return;
-                        }
-
-                        if (tg?.collapsed) {
-                            tg.expand();
-                        }
-                        tab.element.scrollIntoView();
-                        this.accessor.withOrigin('user', () =>
-                            tab.panel.api.setActive()
-                        );
-                    });
-                    wrapper.appendChild(child);
-
-                    el.appendChild(wrapper);
-                }
-
                 const relativeParent = findRelativeZIndexParent(root);
+                const anchor = {
+                    x: event.clientX,
+                    y: event.clientY,
+                    zIndex: relativeParent?.style.zIndex
+                        ? `calc(${relativeParent.style.zIndex} * 2)`
+                        : undefined,
+                };
 
-                this.accessor
-                    .getPopupServiceForGroup(this.group)
-                    .openPopover(el, {
-                        x: event.clientX,
-                        y: event.clientY,
-                        zIndex: relativeParent?.style.zIndex
-                            ? `calc(${relativeParent.style.zIndex} * 2)`
-                            : undefined,
+                const context = this.createOverflowRenderContext(root, anchor);
+
+                // When the AdvancedOverflowModule is registered it upgrades the
+                // dropdown in place (search + MRU + keyboard), building AND
+                // opening the popover itself. Absent (the free path), core
+                // renders the flat list and opens it — byte-identical to before.
+                const advancedOverflow = this.accessor.advancedOverflowService;
+                if (advancedOverflow) {
+                    advancedOverflow.renderOverflow({
+                        group: this.group,
+                        overflowTabs: [...this._overflowTabs],
+                        overflowTabGroups: [...this._overflowTabGroups],
+                        context,
                     });
+                } else {
+                    context.open(this.renderFreeOverflowList(context));
+                }
             })
         );
+    }
+
+    /**
+     * Build the core row/header builders + popover control shared by the free
+     * overflow list and the advanced overflow module. Everything the module
+     * needs to rebuild the dropdown body in a custom order lives here, so the
+     * row DOM, group-header DOM, click-to-activate, and (critically) the
+     * window-bound popover open/close stay in core — the module never captures
+     * the wrong `window` for a popped-out group.
+     */
+    private createOverflowRenderContext(
+        root: HTMLElement,
+        anchor: { x: number; y: number; zIndex?: string }
+    ): IAdvancedOverflowRenderContext {
+        // Build lookup: panelId → tabGroup for overflow groups.
+        const overflowGroupSet = new Set(this._overflowTabGroups);
+        const allTabGroups = this.group.model.getTabGroups();
+        type OverflowTabGroup = (typeof allTabGroups)[number];
+        const panelToGroup = new Map<string, OverflowTabGroup>();
+        const groupById = new Map<string, OverflowTabGroup>();
+        for (const tg of allTabGroups) {
+            groupById.set(tg.id, tg);
+            if (overflowGroupSet.has(tg.id)) {
+                for (const pid of tg.panelIds) {
+                    panelToGroup.set(pid, tg);
+                }
+            }
+        }
+
+        const popup = (): PopupService =>
+            this.accessor.getPopupServiceForGroup(this.group);
+
+        const buildGroupHeader = (tg: OverflowTabGroup): HTMLElement => {
+            const groupHeader = document.createElement('div');
+            groupHeader.className = 'dv-tabs-overflow-group-header';
+
+            const colorDot = document.createElement('span');
+            colorDot.className = 'dv-tabs-overflow-group-color';
+            applyTabGroupAccent(
+                colorDot,
+                tg.color,
+                this.accessor.tabGroupColorPalette
+            );
+            groupHeader.appendChild(colorDot);
+
+            const labelSpan = document.createElement('span');
+            labelSpan.className = 'dv-tabs-overflow-group-label';
+            labelSpan.textContent = tg.label || tg.id;
+            groupHeader.appendChild(labelSpan);
+
+            if (tg.collapsed) {
+                const badge = document.createElement('span');
+                badge.className = 'dv-tabs-overflow-group-collapsed-badge';
+                badge.textContent = `${tg.panelIds.length}`;
+                groupHeader.appendChild(badge);
+            }
+
+            groupHeader.addEventListener('click', () => {
+                popup().close();
+                if (tg.collapsed) {
+                    tg.expand();
+                }
+                // Activate the first panel in the group.
+                const firstPanelId = tg.panelIds[0];
+                if (firstPanelId) {
+                    const panel = this.group.panels.find(
+                        (p) => p.id === firstPanelId
+                    );
+                    this.accessor.withOrigin('user', () =>
+                        panel?.api.setActive()
+                    );
+                }
+            });
+
+            return groupHeader;
+        };
+
+        return {
+            overflowGroupIdForPanel: (panelId) => panelToGroup.get(panelId)?.id,
+            buildGroupHeader: (tabGroupId) => {
+                const tg = groupById.get(tabGroupId);
+                if (!tg || !overflowGroupSet.has(tg.id)) {
+                    return undefined;
+                }
+                return buildGroupHeader(tg);
+            },
+            buildRow: (panelId) => {
+                const panel = this.group.panels.find((p) => p.id === panelId);
+                if (!panel) {
+                    return undefined;
+                }
+                const tab = this.tabs.tabs.find((t) => t.panel.id === panelId);
+                const tg = panelToGroup.get(panelId);
+
+                const tabComponent =
+                    panel.view.createTabRenderer('headerOverflow');
+                const child = tabComponent.element;
+
+                const wrapper = document.createElement('div');
+                toggleClass(wrapper, 'dv-tab', true);
+                toggleClass(wrapper, 'dv-active-tab', panel.api.isActive);
+                toggleClass(wrapper, 'dv-inactive-tab', !panel.api.isActive);
+                if (tg) {
+                    toggleClass(wrapper, 'dv-tab--grouped', true);
+                }
+
+                const doActivate = (): void => {
+                    if (tg?.collapsed) {
+                        tg.expand();
+                    }
+                    tab?.element.scrollIntoView();
+                    this.accessor.withOrigin('user', () =>
+                        panel.api.setActive()
+                    );
+                };
+
+                wrapper.addEventListener('click', (event) => {
+                    popup().close();
+                    if (event.defaultPrevented) {
+                        return;
+                    }
+                    doActivate();
+                });
+                wrapper.appendChild(child);
+
+                return {
+                    element: wrapper,
+                    panel,
+                    activate: () => {
+                        popup().close();
+                        doActivate();
+                    },
+                };
+            },
+            open: (body) => {
+                popup().openPopover(body, anchor);
+            },
+            close: () => popup().close(),
+            focusTrigger: () => {
+                // The chevron root isn't focusable by default; make it so the
+                // Esc-restores-focus behaviour lands somewhere sensible.
+                root.tabIndex = -1;
+                root.focus();
+            },
+        };
+    }
+
+    /**
+     * The free (module-absent) overflow list: the flat `.dv-tabs-overflow-container`
+     * body with a group header before the first member tab of each overflow
+     * group, in tab (DOM) order. Reuses the shared row/header builders so it
+     * stays identical to the advanced path's per-row DOM.
+     */
+    private renderFreeOverflowList(
+        context: IAdvancedOverflowRenderContext
+    ): HTMLElement {
+        const el = document.createElement('div');
+        el.style.overflow = 'auto';
+        el.className = 'dv-tabs-overflow-container';
+
+        // Track which groups have already been rendered.
+        const renderedGroups = new Set<string>();
+
+        for (const tab of this.tabs.tabs.filter((tab) =>
+            this._overflowTabs.includes(tab.panel.id)
+        )) {
+            const tgId = context.overflowGroupIdForPanel(tab.panel.id);
+
+            // If this tab belongs to an overflow group, render the group header
+            // before its first member tab.
+            if (tgId && !renderedGroups.has(tgId)) {
+                renderedGroups.add(tgId);
+                const header = context.buildGroupHeader(tgId);
+                if (header) {
+                    el.appendChild(header);
+                }
+            }
+
+            const row = context.buildRow(tab.panel.id);
+            if (row) {
+                el.appendChild(row.element);
+            }
+        }
+
+        return el;
     }
 
     updateDragAndDropState(): void {

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -103,6 +103,7 @@ import {
     SmartGuidesSnapTogetherEvent,
     ITabGroupChipsHost,
     IPinnedTabsService,
+    IAdvancedOverflowService,
 } from './moduleContracts';
 import { IHeaderActionsHost } from './headerActionsService';
 import { AnchoredBox, AnchorPosition, Box } from '../types';
@@ -1413,6 +1414,13 @@ export class DockviewComponent
         // Owned by PinnedTabsModule — undefined when the module is not
         // registered, so callers must `?.`-guard.
         return this._moduleRegistry.services.pinnedTabsService;
+    }
+
+    get advancedOverflowService(): IAdvancedOverflowService | undefined {
+        // Owned by AdvancedOverflowModule — undefined when the module is not
+        // registered, so callers must `?.`-guard (the free flat overflow list
+        // renders in that case).
+        return this._moduleRegistry.services.advancedOverflowService;
     }
 
     /**

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -27,6 +27,7 @@ import {
     SmartGuidesOptions,
 } from './options';
 import {
+    DockviewActivePanelChangeEvent,
     DockviewLayoutMutationEvent,
     DockviewLayoutMutationKind,
     DockviewOrigin,
@@ -623,4 +624,83 @@ export interface IPinnedTabsService extends IDisposable {
         panelId: string,
         index: number
     ): number;
+}
+
+// --- AdvancedOverflow ---
+
+/**
+ * One rendered overflow row: the free `headerOverflow` tab renderer wrapped with
+ * activate-on-click, built by core and reused by the advanced overflow list so
+ * the row DOM + behaviour stay identical to the free dropdown.
+ */
+export interface IOverflowRow {
+    /** The row wrapper (`.dv-tab`). Click-to-activate is already wired. */
+    readonly element: HTMLElement;
+    readonly panel: IDockviewPanel;
+    /**
+     * Expand the panel's tab group if collapsed, activate the panel (origin
+     * `'user'`) and close the popover — identical to clicking the row. Used by
+     * the keyboard controller (Enter).
+     */
+    activate(): void;
+}
+
+/**
+ * Core-provided builders handed to {@link IAdvancedOverflowService.renderOverflow}
+ * so the module can rebuild the free dropdown body (rows + group headers) in a
+ * custom order — search-filtered, MRU-ordered — without re-implementing the row
+ * DOM, the group-header DOM, or the window-bound popover open/close. The popover
+ * control stays in core so it renders in the correct document for popped-out
+ * groups (a `getPopupServiceForGroup(group)`-bound `PopupService`).
+ */
+export interface IAdvancedOverflowRenderContext {
+    /** Build a single overflow row for a panel id, or `undefined` if the panel
+     *  no longer exists in the group. */
+    buildRow(panelId: string): IOverflowRow | undefined;
+    /** Build the group-header element for an overflow tab-group id, or
+     *  `undefined` when it is not an overflow group. */
+    buildGroupHeader(tabGroupId: string): HTMLElement | undefined;
+    /** The overflow tab-group id a panel belongs to, or `undefined`. Used to
+     *  interleave group headers against the filtered set (same rule as free). */
+    overflowGroupIdForPanel(panelId: string): string | undefined;
+    /** Open `body` in the group's window-bound popover at the chevron anchor. */
+    open(body: HTMLElement): void;
+    /** Close the popover. */
+    close(): void;
+    /** Restore focus to the chevron trigger (Esc). */
+    focusTrigger(): void;
+}
+
+/** The argument to {@link IAdvancedOverflowService.renderOverflow}. */
+export interface AdvancedOverflowRenderParams {
+    readonly group: DockviewGroupPanel;
+    /** Overflow panel ids in free (tab DOM) order. */
+    readonly overflowTabs: string[];
+    /** Overflow tab-group ids. */
+    readonly overflowTabGroups: string[];
+    /** Core row/header builders + popover control (see the context type). */
+    readonly context: IAdvancedOverflowRenderContext;
+}
+
+/**
+ * The narrow surface the advanced overflow service reads from the host
+ * (`DockviewComponent`). The service self-wires MRU tracking off these events;
+ * the component never calls into it except through the rendering seam
+ * (`renderOverflow`).
+ */
+export interface IAdvancedOverflowHost {
+    readonly options: DockviewComponentOptions;
+    readonly onDidAddGroup: Event<DockviewGroupPanel>;
+    readonly onDidRemoveGroup: Event<DockviewGroupPanel>;
+    readonly onDidActivePanelChange: Event<DockviewActivePanelChangeEvent>;
+}
+
+/**
+ * Advanced overflow module service. When registered, the tab-overflow dropdown
+ * upgrades in place into a command-palette tab switcher (search + MRU +
+ * keyboard). Absent, core renders the free flat list unchanged.
+ */
+export interface IAdvancedOverflowService extends IDisposable {
+    /** Build AND open the advanced overflow popover for a group. */
+    renderOverflow(params: AdvancedOverflowRenderParams): void;
 }

--- a/packages/dockview-core/src/dockview/modules.ts
+++ b/packages/dockview-core/src/dockview/modules.ts
@@ -20,6 +20,7 @@ import { ILiveRegionService } from './liveRegionService';
 import {
     IKeyboardNavigationService,
     IAdvancedDnDService,
+    IAdvancedOverflowService,
     IAutoHideEdgeGroupService,
     IAutoEdgeGroupService,
     IContextMenuService,
@@ -52,6 +53,7 @@ export interface ServiceCollection {
     autoEdgeGroupService?: IAutoEdgeGroupService;
     multiRowTabsService?: IMultiRowTabsService;
     pinnedTabsService?: IPinnedTabsService;
+    advancedOverflowService?: IAdvancedOverflowService;
 }
 
 export interface DockviewModule<THost = unknown> {

--- a/packages/dockview-core/src/index.ts
+++ b/packages/dockview-core/src/index.ts
@@ -224,6 +224,11 @@ export {
     ITabGroupChipsService,
     IPinnedTabsHost,
     IPinnedTabsService,
+    IAdvancedOverflowHost,
+    IAdvancedOverflowService,
+    IAdvancedOverflowRenderContext,
+    AdvancedOverflowRenderParams,
+    IOverflowRow,
 } from './dockview/moduleContracts';
 export { resolveMessages } from './dockview/accessibilityMessages';
 export {

--- a/packages/dockview-enterprise/src/__tests__/advancedOverflow.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/advancedOverflow.spec.ts
@@ -1,0 +1,401 @@
+import { fireEvent } from '@testing-library/dom';
+import { DockviewComponent, IContentRenderer } from 'dockview-core';
+import { OverflowListView, matchesQuery } from '../advancedOverflowService';
+import { MruTracker } from '../mruTracker';
+
+// jsdom does not implement scrollIntoView; the core row activation + the view's
+// active-row scroll both call it. Stub it so those paths don't throw.
+beforeAll(() => {
+    if (!Element.prototype.scrollIntoView) {
+        Element.prototype.scrollIntoView = function scrollIntoView() {
+            /* noop */
+        };
+    }
+});
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        // noop
+    }
+    layout(): void {
+        // noop
+    }
+    dispose(): void {
+        // noop
+    }
+}
+
+// --- View-level helpers (a fake core render context) ---------------------------
+
+interface FakePanel {
+    id: string;
+    title?: string;
+}
+
+function makeFakeContext(activateSpy?: (id: string) => void) {
+    const opened: { body?: HTMLElement } = {};
+    const closed = { count: 0 };
+    const focused = { count: 0 };
+    const context = {
+        buildRow: (panelId: string) => {
+            const element = document.createElement('div');
+            element.className = 'dv-tab';
+            element.dataset.panelId = panelId;
+            element.textContent = panelId;
+            return {
+                element,
+                panel: { id: panelId } as any,
+                activate: () => activateSpy?.(panelId),
+            };
+        },
+        buildGroupHeader: () => undefined,
+        overflowGroupIdForPanel: () => undefined,
+        open: (body: HTMLElement) => {
+            opened.body = body;
+            document.body.appendChild(body);
+        },
+        close: () => {
+            closed.count++;
+            opened.body?.remove();
+        },
+        focusTrigger: () => {
+            focused.count++;
+        },
+    };
+    return { context, opened, closed, focused };
+}
+
+function makeParams(panels: FakePanel[], overflowTabs: string[], context: any) {
+    return {
+        group: {
+            id: 'g',
+            panels,
+        } as any,
+        overflowTabs,
+        overflowTabGroups: [] as string[],
+        context,
+    };
+}
+
+function optionRows(body: HTMLElement | undefined): string[] {
+    if (!body) {
+        return [];
+    }
+    return Array.from(
+        body.querySelectorAll<HTMLElement>('[role="option"]')
+    ).map((el) => el.dataset.panelId!);
+}
+
+describe('matchesQuery', () => {
+    test('case-insensitive substring; empty query matches all', () => {
+        expect(matchesQuery('Alpha', 'al')).toBe(true);
+        expect(matchesQuery('Alpha', 'PH')).toBe(true);
+        expect(matchesQuery('Alpha', 'z')).toBe(false);
+        expect(matchesQuery('Alpha', '')).toBe(true);
+        expect(matchesQuery('Alpha', '   ')).toBe(true);
+    });
+});
+
+describe('OverflowListView — search scope', () => {
+    afterEach(() => {
+        document.body
+            .querySelectorAll('.dv-tabs-overflow-container')
+            .forEach((el) => el.remove());
+    });
+
+    test("scope 'group' (search: true) makes the FULL group tab set matchable", () => {
+        const { context, opened } = makeFakeContext();
+        const panels = [
+            { id: 'a', title: 'alpha' },
+            { id: 'b', title: 'beta' },
+            { id: 'c', title: 'gamma' },
+        ];
+        // Only 'c' is actually clipped/overflowing.
+        const view = new OverflowListView(
+            makeParams(panels, ['c'], context),
+            { search: true },
+            new MruTracker(),
+            false
+        );
+        view.open();
+
+        // The full group set is rendered (switch to any tab), not just overflow.
+        expect(optionRows(opened.body).sort()).toEqual(['a', 'b', 'c']);
+        expect(
+            opened.body!.querySelector('.dv-tabs-overflow-search')
+        ).toBeTruthy();
+        view.dispose();
+    });
+
+    test("scope 'overflow' filters only the clipped/overflow set (free parity)", () => {
+        const { context, opened } = makeFakeContext();
+        const panels = [
+            { id: 'a', title: 'alpha' },
+            { id: 'b', title: 'beta' },
+            { id: 'c', title: 'gamma' },
+        ];
+        const view = new OverflowListView(
+            makeParams(panels, ['b', 'c'], context),
+            { search: { scope: 'overflow' } },
+            new MruTracker(),
+            false
+        );
+        view.open();
+
+        expect(optionRows(opened.body).sort()).toEqual(['b', 'c']);
+        view.dispose();
+    });
+
+    test('search disabled renders no input and shows the overflow set', () => {
+        const { context, opened } = makeFakeContext();
+        const panels = [
+            { id: 'a', title: 'alpha' },
+            { id: 'b', title: 'beta' },
+        ];
+        const view = new OverflowListView(
+            makeParams(panels, ['b'], context),
+            {},
+            new MruTracker(),
+            false
+        );
+        view.open();
+
+        expect(
+            opened.body!.querySelector('.dv-tabs-overflow-search')
+        ).toBeNull();
+        expect(optionRows(opened.body)).toEqual(['b']);
+        view.dispose();
+    });
+});
+
+describe('OverflowListView — MRU ordering', () => {
+    afterEach(() => {
+        document.body
+            .querySelectorAll('.dv-tabs-overflow-container')
+            .forEach((el) => el.remove());
+    });
+
+    test('rows are ordered most-recently-activated first when mru is on', () => {
+        const { context, opened } = makeFakeContext();
+        const panels = [
+            { id: 'a', title: 'a' },
+            { id: 'b', title: 'b' },
+            { id: 'c', title: 'c' },
+        ];
+        const mru = new MruTracker();
+        mru.attach('g', ['a', 'b', 'c']);
+        mru.activate('g', 'b'); // b most recent -> [b, a, c]
+
+        const view = new OverflowListView(
+            makeParams(panels, ['a', 'b', 'c'], context),
+            { search: true, mru: true },
+            mru,
+            true
+        );
+        view.open();
+
+        expect(optionRows(opened.body)).toEqual(['b', 'a', 'c']);
+        view.dispose();
+    });
+});
+
+describe('OverflowListView — search filtering + keyboard', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => {
+        jest.useRealTimers();
+        document.body
+            .querySelectorAll('.dv-tabs-overflow-container')
+            .forEach((el) => el.remove());
+    });
+
+    const setup = (activateSpy?: (id: string) => void) => {
+        const fake = makeFakeContext(activateSpy);
+        const panels = [
+            { id: 'a', title: 'alpha' },
+            { id: 'b', title: 'beta' },
+            { id: 'c', title: 'gamma' },
+        ];
+        const view = new OverflowListView(
+            makeParams(panels, ['a', 'b', 'c'], fake.context),
+            { search: true },
+            new MruTracker(),
+            false
+        );
+        view.open();
+        const input = fake.opened.body!.querySelector<HTMLInputElement>(
+            '.dv-tabs-overflow-search'
+        )!;
+        return { view, input, ...fake };
+    };
+
+    test('typing filters rows (debounced) by title substring', () => {
+        const { view, input, opened } = setup();
+        expect(optionRows(opened.body)).toEqual(['a', 'b', 'c']);
+
+        input.value = 'lph';
+        fireEvent.input(input);
+        jest.advanceTimersByTime(80);
+
+        expect(optionRows(opened.body)).toEqual(['a']); // only "alpha"
+        view.dispose();
+    });
+
+    test('arrow keys rove the active option and wrap; Enter activates it', () => {
+        const activated: string[] = [];
+        const { view, input, opened } = setup((id) => activated.push(id));
+        const body = opened.body!;
+
+        const focused = () =>
+            body.querySelector<HTMLElement>('.dv-tabs-overflow-option--focused')
+                ?.dataset.panelId;
+
+        // Initial active row is the first.
+        expect(focused()).toBe('a');
+
+        fireEvent.keyDown(body, { key: 'ArrowDown' });
+        expect(focused()).toBe('b');
+
+        fireEvent.keyDown(body, { key: 'ArrowUp' });
+        fireEvent.keyDown(body, { key: 'ArrowUp' }); // wrap past the top
+        expect(focused()).toBe('c');
+
+        fireEvent.keyDown(body, { key: 'Home' });
+        expect(focused()).toBe('a');
+        fireEvent.keyDown(body, { key: 'End' });
+        expect(focused()).toBe('c');
+
+        fireEvent.keyDown(body, { key: 'Enter' });
+        expect(activated).toEqual(['c']);
+        void input;
+        view.dispose();
+    });
+
+    test('Escape closes the popover and restores focus to the chevron', () => {
+        const { view, opened, closed, focused } = setup();
+        fireEvent.keyDown(opened.body!, { key: 'Escape' });
+        expect(closed.count).toBe(1);
+        expect(focused.count).toBe(1);
+        view.dispose();
+    });
+});
+
+// --- Full-component integration -----------------------------------------------
+
+describe('advanced overflow — full component integration', () => {
+    let container: HTMLElement;
+
+    const make = (overflow: any): DockviewComponent => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            overflow,
+        });
+        dockview.layout(400, 300);
+        return dockview;
+    };
+
+    afterEach(() => {
+        container?.remove();
+    });
+
+    /** Force `ids` into the overflow set so the chevron renders, then open it. */
+    const openOverflow = (
+        dockview: DockviewComponent,
+        anyPanel: any,
+        ids: string[]
+    ): HTMLElement | null => {
+        const overflowSet = new Set(ids);
+        anyPanel.group.model.header.setForcedOverflow((id: string) =>
+            overflowSet.has(id)
+        );
+        anyPanel.group.model.header.refreshOverflow();
+
+        const root = container.querySelector<HTMLElement>(
+            '.dv-tabs-overflow-dropdown-root'
+        );
+        if (root) {
+            fireEvent.click(root);
+        }
+        return container.querySelector<HTMLElement>(
+            '.dv-tabs-overflow-advanced'
+        );
+    };
+
+    test('the module upgrades the dropdown to the advanced (searchable) body', () => {
+        const dockview = make({ search: true, mru: true });
+        const panels = ['a', 'b', 'c', 'd'].map((id) =>
+            dockview.addPanel({ id, component: 'default', title: id })
+        );
+
+        const body = openOverflow(dockview, panels[0], ['c', 'd']);
+        expect(body).toBeTruthy();
+        expect(body!.querySelector('.dv-tabs-overflow-search')).toBeTruthy();
+        // scope 'group' (search: true) => every tab is reachable.
+        expect(body!.querySelectorAll('[role="option"]').length).toBe(4);
+
+        dockview.dispose();
+    });
+
+    test('MRU order reflects a user setActive sequence', () => {
+        const dockview = make({ search: true, mru: true });
+        const panels = ['a', 'b', 'c', 'd'].map((id) =>
+            dockview.addPanel({ id, component: 'default', title: id })
+        );
+
+        // User activations — the UI wraps tab activation in `withOrigin('user')`
+        // (a bare `setActive()` is origin 'api' and must not reorder recency).
+        dockview.withOrigin('user', () => panels[2].api.setActive()); // c
+        dockview.withOrigin('user', () => panels[1].api.setActive()); // b (most recent)
+
+        const body = openOverflow(dockview, panels[0], ['c', 'd']);
+        const order = Array.from(
+            body!.querySelectorAll<HTMLElement>('[role="option"]')
+        ).map((el) => el.textContent!.trim());
+
+        // b then c lead (most-recently activated first).
+        expect(order[0]).toBe('b');
+        expect(order[1]).toBe('c');
+
+        dockview.dispose();
+    });
+
+    test('clicking a row activates its panel and closes the popover', () => {
+        const dockview = make({ search: true, mru: true });
+        const panels = ['a', 'b', 'c', 'd'].map((id) =>
+            dockview.addPanel({ id, component: 'default', title: id })
+        );
+
+        const body = openOverflow(dockview, panels[0], ['c', 'd']);
+        const row = Array.from(
+            body!.querySelectorAll<HTMLElement>('[role="option"]')
+        ).find((el) => el.textContent!.trim() === 'd')!;
+
+        fireEvent.click(row);
+
+        expect(panels[3].api.isActive).toBe(true);
+        expect(
+            container.querySelector('.dv-tabs-overflow-advanced')
+        ).toBeNull();
+
+        dockview.dispose();
+    });
+
+    test('with the module registered the free flat list is not used', () => {
+        const dockview = make({ search: true });
+        const panels = ['a', 'b', 'c', 'd'].map((id) =>
+            dockview.addPanel({ id, component: 'default', title: id })
+        );
+
+        openOverflow(dockview, panels[0], ['c', 'd']);
+        // The advanced container carries the extra class; the plain free
+        // container would not.
+        const advanced = container.querySelector(
+            '.dv-tabs-overflow-container.dv-tabs-overflow-advanced'
+        );
+        expect(advanced).toBeTruthy();
+
+        dockview.dispose();
+    });
+});

--- a/packages/dockview-enterprise/src/__tests__/mruTracker.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/mruTracker.spec.ts
@@ -1,0 +1,127 @@
+import { MruTracker } from '../mruTracker';
+import { AdvancedOverflowService } from '../advancedOverflowService';
+
+describe('MruTracker', () => {
+    test('seeds from tab order on attach', () => {
+        const mru = new MruTracker();
+        mru.attach('g', ['a', 'b', 'c']);
+        expect(mru.order('g')).toEqual(['a', 'b', 'c']);
+    });
+
+    test('activate moves a panel to the front (most recent first)', () => {
+        const mru = new MruTracker();
+        mru.attach('g', ['a', 'b', 'c']);
+
+        mru.activate('g', 'c');
+        expect(mru.order('g')).toEqual(['c', 'a', 'b']);
+
+        mru.activate('g', 'a');
+        expect(mru.order('g')).toEqual(['a', 'c', 'b']);
+
+        // Re-activating the already-front panel is a no-op on order.
+        mru.activate('g', 'a');
+        expect(mru.order('g')).toEqual(['a', 'c', 'b']);
+    });
+
+    test('never-activated panels keep their seeded (tab) order behind activated ones', () => {
+        const mru = new MruTracker();
+        mru.attach('g', ['a', 'b', 'c', 'd']);
+        mru.activate('g', 'c');
+        // c is front; a, b, d keep their original relative order.
+        expect(mru.order('g')).toEqual(['c', 'a', 'b', 'd']);
+    });
+
+    test('activating an untracked panel adds it to the front', () => {
+        const mru = new MruTracker();
+        mru.attach('g', ['a', 'b']);
+        mru.activate('g', 'z');
+        expect(mru.order('g')).toEqual(['z', 'a', 'b']);
+    });
+
+    test('a cross-group activation leaves the source list and enters the destination', () => {
+        const mru = new MruTracker();
+        mru.attach('g1', ['a', 'b']);
+        mru.attach('g2', ['c', 'd']);
+
+        // Panel 'a' moves into g2 and is activated there.
+        mru.activate('g2', 'a');
+
+        expect(mru.order('g1')).toEqual(['b']);
+        expect(mru.order('g2')).toEqual(['a', 'c', 'd']);
+    });
+
+    test('remove prunes a panel from every group list', () => {
+        const mru = new MruTracker();
+        mru.attach('g1', ['a', 'b']);
+        mru.attach('g2', ['a', 'c']); // same id present in two lists (defensive)
+
+        mru.remove('a');
+
+        expect(mru.order('g1')).toEqual(['b']);
+        expect(mru.order('g2')).toEqual(['c']);
+    });
+
+    test('detach drops a group entirely', () => {
+        const mru = new MruTracker();
+        mru.attach('g', ['a']);
+        expect(mru.has('g')).toBe(true);
+        mru.detach('g');
+        expect(mru.has('g')).toBe(false);
+        expect(mru.order('g')).toEqual([]);
+    });
+
+    test('re-attach preserves existing recency and appends new ids at the back', () => {
+        const mru = new MruTracker();
+        mru.attach('g', ['a', 'b', 'c']);
+        mru.activate('g', 'c'); // -> [c, a, b]
+        mru.attach('g', ['a', 'b', 'c', 'd']); // re-attach with a new panel 'd'
+        expect(mru.order('g')).toEqual(['c', 'a', 'b', 'd']);
+    });
+});
+
+/**
+ * The `origin` filter lives in the service (it reads the event payload), so it
+ * is exercised through `AdvancedOverflowService.handleActivePanelChange`.
+ */
+describe('AdvancedOverflowService — MRU origin filter', () => {
+    const makeGroup = (id: string, panelIds: string[]): any => ({
+        id,
+        panels: panelIds.map((pid) => ({ id: pid })),
+        model: {
+            onDidRemovePanel: () => ({ dispose: () => undefined }),
+        },
+    });
+
+    const activation = (panelId: string, groupId: string, origin: string) => ({
+        origin,
+        panel: { id: panelId, group: { id: groupId } },
+    });
+
+    test("a user activation reorders recency; an 'api' activation does not", () => {
+        const service = new AdvancedOverflowService({} as any);
+        service.attachToGroup(makeGroup('g', ['a', 'b', 'c']));
+
+        // Programmatic (origin 'api') — must NOT reorder.
+        service.handleActivePanelChange(activation('c', 'g', 'api') as any);
+        expect(service.mru.order('g')).toEqual(['a', 'b', 'c']);
+
+        // User gesture — reorders.
+        service.handleActivePanelChange(activation('c', 'g', 'user') as any);
+        expect(service.mru.order('g')).toEqual(['c', 'a', 'b']);
+
+        service.dispose();
+    });
+
+    test('an activation with no panel (all tabs closed) is ignored', () => {
+        const service = new AdvancedOverflowService({} as any);
+        service.attachToGroup(makeGroup('g', ['a', 'b']));
+
+        service.handleActivePanelChange({
+            origin: 'user',
+            panel: undefined,
+        } as any);
+        expect(service.mru.order('g')).toEqual(['a', 'b']);
+
+        service.dispose();
+    });
+});

--- a/packages/dockview-enterprise/src/advancedOverflowService.ts
+++ b/packages/dockview-enterprise/src/advancedOverflowService.ts
@@ -1,0 +1,440 @@
+import {
+    DockviewCompositeDisposable as CompositeDisposable,
+    DockviewIDisposable as IDisposable,
+    DockviewGroupPanel,
+    DockviewOverflowOptions,
+    DockviewActivePanelChangeEvent,
+    AdvancedOverflowRenderParams,
+    IAdvancedOverflowHost,
+    IAdvancedOverflowService,
+    defineModule,
+} from 'dockview';
+import { MruTracker } from './mruTracker';
+
+const SEARCH_DEBOUNCE_MS = 80;
+
+const CONTAINER_CLASS = 'dv-tabs-overflow-container';
+const ADVANCED_CLASS = 'dv-tabs-overflow-advanced';
+const SEARCH_CLASS = 'dv-tabs-overflow-search';
+const LIST_CLASS = 'dv-tabs-overflow-list';
+const OPTION_FOCUSED_CLASS = 'dv-tabs-overflow-option--focused';
+
+interface ResolvedSearch {
+    readonly enabled: boolean;
+    readonly scope: 'group' | 'overflow';
+    readonly placeholder: string;
+}
+
+/** Resolve the `overflow.search` option into a concrete config. */
+function resolveSearch(
+    overflow: DockviewOverflowOptions | undefined
+): ResolvedSearch {
+    const search = overflow?.search;
+    if (search === true) {
+        return { enabled: true, scope: 'group', placeholder: 'Search tabs' };
+    }
+    if (typeof search === 'object' && search !== null) {
+        return {
+            enabled: true,
+            scope: search.scope === 'overflow' ? 'overflow' : 'group',
+            placeholder: search.placeholder ?? 'Search tabs',
+        };
+    }
+    return { enabled: false, scope: 'overflow', placeholder: '' };
+}
+
+/**
+ * Case-insensitive substring predicate over a panel's title. Exported for unit
+ * tests of the scope `group` vs `overflow` behaviour.
+ */
+export function matchesQuery(title: string, query: string): boolean {
+    const q = query.trim().toLowerCase();
+    if (q.length === 0) {
+        return true;
+    }
+    return title.toLowerCase().includes(q);
+}
+
+/**
+ * One popover's worth of advanced overflow UI: a focused search input, a
+ * `role="listbox"` of filtered / MRU-ordered rows (each row reusing the core
+ * `buildRow` so its DOM + behaviour match the free dropdown), and a keyboard
+ * controller. Constructed per popover-open and disposed on close.
+ */
+export class OverflowListView extends CompositeDisposable {
+    private readonly _body: HTMLElement;
+    private readonly _list: HTMLElement;
+    private readonly _input: HTMLInputElement | undefined;
+    /** The element that holds DOM focus + `aria-activedescendant`. */
+    private readonly _focusTarget: HTMLElement;
+    private readonly _search: ResolvedSearch;
+
+    /** Candidate panel ids (pre-filter, pre-order) — the search scope's set. */
+    private readonly _baseIds: string[];
+    private readonly _titleOf = new Map<string, string>();
+
+    /** The rendered rows in display order (group headers excluded). */
+    private _rows: {
+        id: string;
+        element: HTMLElement;
+        activate: () => void;
+    }[] = [];
+    private _activeIndex = -1;
+    private _debounce: { win: Window; handle: number } | undefined;
+
+    constructor(
+        private readonly params: AdvancedOverflowRenderParams,
+        overflow: DockviewOverflowOptions | undefined,
+        private readonly mru: MruTracker,
+        private readonly mruEnabled: boolean
+    ) {
+        super();
+
+        this._search = resolveSearch(overflow);
+
+        for (const panel of params.group.panels) {
+            this._titleOf.set(panel.id, panel.title ?? panel.id);
+        }
+
+        this._baseIds =
+            this._search.enabled && this._search.scope === 'group'
+                ? params.group.panels.map((p) => p.id)
+                : [...params.overflowTabs];
+
+        this._body = document.createElement('div');
+        this._body.style.overflow = 'auto';
+        this._body.className = `${CONTAINER_CLASS} ${ADVANCED_CLASS}`;
+
+        if (this._search.enabled) {
+            this._input = document.createElement('input');
+            this._input.type = 'text';
+            this._input.className = SEARCH_CLASS;
+            this._input.placeholder = this._search.placeholder;
+            this._input.setAttribute('role', 'combobox');
+            this._input.setAttribute('aria-autocomplete', 'list');
+            this._input.setAttribute('aria-expanded', 'true');
+            this._body.appendChild(this._input);
+            this._focusTarget = this._input;
+        } else {
+            // No input: the listbox itself is the focus target so keyboard nav
+            // still works.
+            this._focusTarget = document.createElement('div');
+        }
+
+        this._list = this._search.enabled
+            ? document.createElement('div')
+            : this._focusTarget;
+        this._list.className = LIST_CLASS;
+        this._list.setAttribute('role', 'listbox');
+        this._list.id = 'dv-tabs-overflow-listbox';
+        if (!this._search.enabled) {
+            this._list.tabIndex = 0;
+        }
+        this._body.appendChild(this._list);
+
+        this._focusTarget.setAttribute('aria-controls', this._list.id);
+
+        // Keydown on the body (bubble phase) so it fires before PopupService's
+        // window-level Enter/Escape dismissal — letting us intercept Enter to
+        // activate the highlighted row before the popover closes.
+        const onKeyDown = (event: KeyboardEvent): void =>
+            this._onKeyDown(event);
+        this._body.addEventListener('keydown', onKeyDown);
+
+        const onInput = (): void => this._scheduleFilter();
+        this._input?.addEventListener('input', onInput);
+
+        this.addDisposables({
+            dispose: () => {
+                this._body.removeEventListener('keydown', onKeyDown);
+                this._input?.removeEventListener('input', onInput);
+                if (this._debounce) {
+                    this._debounce.win.clearTimeout(this._debounce.handle);
+                    this._debounce = undefined;
+                }
+            },
+        });
+    }
+
+    /** Build the initial list and open the popover, focusing the search input. */
+    open(): void {
+        this._renderList('');
+        this.params.context.open(this._body);
+
+        const win = this._body.ownerDocument.defaultView;
+        const focus = (): void => {
+            this._focusTarget.focus();
+        };
+        // Focus on the next frame so the popover is mounted first.
+        if (win) {
+            win.requestAnimationFrame(focus);
+        } else {
+            focus();
+        }
+    }
+
+    private _scheduleFilter(): void {
+        const win = this._body.ownerDocument.defaultView;
+        if (!win) {
+            this._renderList(this._input?.value ?? '');
+            return;
+        }
+        if (this._debounce) {
+            win.clearTimeout(this._debounce.handle);
+        }
+        this._debounce = {
+            win,
+            handle: win.setTimeout(() => {
+                this._debounce = undefined;
+                this._renderList(this._input?.value ?? '');
+            }, SEARCH_DEBOUNCE_MS),
+        };
+    }
+
+    /** The base ids reordered by MRU (front = most recent), with never-activated
+     *  ids kept in their base (free clipped / DOM) order as the tiebreak. */
+    private _orderedIds(): string[] {
+        if (!this.mruEnabled) {
+            return this._baseIds;
+        }
+        const base = new Set(this._baseIds);
+        const seen = new Set<string>();
+        const result: string[] = [];
+        for (const id of this.mru.order(this.params.group.id)) {
+            if (base.has(id)) {
+                result.push(id);
+                seen.add(id);
+            }
+        }
+        for (const id of this._baseIds) {
+            if (!seen.has(id)) {
+                result.push(id);
+            }
+        }
+        return result;
+    }
+
+    private _renderList(query: string): void {
+        const { context } = this.params;
+
+        while (this._list.firstChild) {
+            this._list.removeChild(this._list.firstChild);
+        }
+        this._rows = [];
+
+        const filtered = this._orderedIds().filter((id) =>
+            matchesQuery(this._titleOf.get(id) ?? id, query)
+        );
+
+        const renderedGroups = new Set<string>();
+        for (const id of filtered) {
+            const tgId = context.overflowGroupIdForPanel(id);
+            if (tgId && !renderedGroups.has(tgId)) {
+                renderedGroups.add(tgId);
+                const header = context.buildGroupHeader(tgId);
+                if (header) {
+                    this._list.appendChild(header);
+                }
+            }
+
+            const row = context.buildRow(id);
+            if (!row) {
+                continue;
+            }
+            const index = this._rows.length;
+            row.element.setAttribute('role', 'option');
+            row.element.id = `dv-tabs-overflow-option-${index}`;
+            this._list.appendChild(row.element);
+            this._rows.push({
+                id,
+                element: row.element,
+                activate: row.activate,
+            });
+        }
+
+        this._setActiveIndex(this._rows.length > 0 ? 0 : -1);
+    }
+
+    private _setActiveIndex(index: number): void {
+        if (this._activeIndex >= 0 && this._activeIndex < this._rows.length) {
+            this._rows[this._activeIndex].element.classList.remove(
+                OPTION_FOCUSED_CLASS
+            );
+            this._rows[this._activeIndex].element.setAttribute(
+                'aria-selected',
+                'false'
+            );
+        }
+        this._activeIndex = index;
+        if (index < 0 || index >= this._rows.length) {
+            this._focusTarget.removeAttribute('aria-activedescendant');
+            return;
+        }
+        const row = this._rows[index];
+        row.element.classList.add(OPTION_FOCUSED_CLASS);
+        row.element.setAttribute('aria-selected', 'true');
+        this._focusTarget.setAttribute('aria-activedescendant', row.element.id);
+        row.element.scrollIntoView?.({ block: 'nearest' });
+    }
+
+    private _move(delta: number): void {
+        if (this._rows.length === 0) {
+            return;
+        }
+        const next =
+            (this._activeIndex + delta + this._rows.length) % this._rows.length;
+        this._setActiveIndex(next);
+    }
+
+    private _onKeyDown(event: KeyboardEvent): void {
+        const { context } = this.params;
+        switch (event.key) {
+            case 'ArrowDown':
+                event.preventDefault();
+                this._move(1);
+                break;
+            case 'ArrowUp':
+                event.preventDefault();
+                this._move(-1);
+                break;
+            case 'Home':
+                event.preventDefault();
+                this._setActiveIndex(this._rows.length > 0 ? 0 : -1);
+                break;
+            case 'End':
+                event.preventDefault();
+                this._setActiveIndex(this._rows.length - 1);
+                break;
+            case 'Enter': {
+                const active = this._rows[this._activeIndex];
+                if (active) {
+                    // Stop the event before PopupService's window-level Enter
+                    // dismissal sees it, or the popover would close *before* the
+                    // row activates.
+                    event.preventDefault();
+                    event.stopPropagation();
+                    active.activate();
+                }
+                break;
+            }
+            case 'Escape':
+                event.preventDefault();
+                event.stopPropagation();
+                context.close();
+                context.focusTrigger();
+                break;
+            case 'Tab':
+                // Trap focus within the popover — there is a single focus
+                // target (the search input or the listbox), so keep it there.
+                event.preventDefault();
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+/**
+ * Advanced overflow module service — one per component. Owns the MRU model
+ * (component-scoped, so recency survives a group closing) and constructs an
+ * {@link OverflowListView} per popover-open. Self-wires MRU tracking off the
+ * host's group / active-panel events via {@link init}.
+ */
+export class AdvancedOverflowService
+    extends CompositeDisposable
+    implements IAdvancedOverflowService
+{
+    private readonly _mru = new MruTracker();
+    private _activeView: OverflowListView | undefined;
+
+    constructor(private readonly host: IAdvancedOverflowHost) {
+        super();
+        this.addDisposables({
+            dispose: () => {
+                this._activeView?.dispose();
+                this._activeView = undefined;
+            },
+        });
+    }
+
+    /** The MRU model — exposed for the module's `init` wiring and unit tests. */
+    get mru(): MruTracker {
+        return this._mru;
+    }
+
+    /**
+     * Attach MRU tracking to a group: seed its recency list from the current
+     * tab order and prune closed panels. Returns a disposable that detaches on
+     * group removal.
+     */
+    attachToGroup(group: DockviewGroupPanel): IDisposable {
+        this._mru.attach(
+            group.id,
+            group.panels.map((p) => p.id)
+        );
+        return new CompositeDisposable(
+            group.model.onDidRemovePanel((e) => this._mru.remove(e.panel.id)),
+            { dispose: () => this._mru.detach(group.id) }
+        );
+    }
+
+    /** Record a user-driven activation into the MRU model. */
+    handleActivePanelChange(event: DockviewActivePanelChangeEvent): void {
+        // A programmatic `setActive` (origin !== 'user') must not reorder
+        // recency.
+        if (event.origin !== 'user' || !event.panel) {
+            return;
+        }
+        this._mru.activate(event.panel.group.id, event.panel.id);
+    }
+
+    renderOverflow(params: AdvancedOverflowRenderParams): void {
+        this._activeView?.dispose();
+        const view = new OverflowListView(
+            params,
+            this.host.options.overflow,
+            this._mru,
+            this.host.options.overflow?.mru === true
+        );
+        this._activeView = view;
+        view.open();
+    }
+}
+
+export const AdvancedOverflowModule = defineModule<
+    'advancedOverflowService',
+    IAdvancedOverflowHost
+>({
+    name: 'AdvancedOverflow',
+    serviceKey: 'advancedOverflowService',
+    create: (host) => new AdvancedOverflowService(host),
+    init: (host, service) => {
+        // `service` is the concrete instance created above; the slot types it
+        // as the narrow public interface (which exposes only `renderOverflow`),
+        // so narrow back to reach the MRU lifecycle hooks.
+        const svc = service as AdvancedOverflowService;
+        // Self-attach MRU tracking to existing and future groups; tear down when
+        // groups are removed. Mirrors TabGroupChipsModule's lifecycle.
+        const perGroupDisposables = new Map<DockviewGroupPanel, IDisposable>();
+        return new CompositeDisposable(
+            host.onDidAddGroup((group) => {
+                perGroupDisposables.set(group, svc.attachToGroup(group));
+            }),
+            host.onDidRemoveGroup((group) => {
+                perGroupDisposables.get(group)?.dispose();
+                perGroupDisposables.delete(group);
+            }),
+            host.onDidActivePanelChange((event) =>
+                svc.handleActivePanelChange(event)
+            ),
+            {
+                dispose: () => {
+                    for (const d of perGroupDisposables.values()) {
+                        d.dispose();
+                    }
+                    perGroupDisposables.clear();
+                },
+            }
+        );
+    },
+});

--- a/packages/dockview-enterprise/src/index.ts
+++ b/packages/dockview-enterprise/src/index.ts
@@ -8,6 +8,7 @@ import { AutoHideEdgeGroupModule } from './autoHideEdgeGroupService';
 import { AutoEdgeGroupModule } from './autoEdgeGroupService';
 import { MultiRowTabsModule } from './multiRowTabsService';
 import { PinnedTabsModule } from './pinnedTabsService';
+import { AdvancedOverflowModule } from './advancedOverflowService';
 import { KeyboardDockingModule } from './keyboardDockingService';
 import { LicenseModule } from './licenseService';
 
@@ -45,6 +46,13 @@ export {
     computePinnedFirstOrder,
 } from './pinnedTabsService';
 export {
+    AdvancedOverflowService,
+    OverflowListView,
+    AdvancedOverflowModule,
+    matchesQuery,
+} from './advancedOverflowService';
+export { MruTracker } from './mruTracker';
+export {
     KeyboardDockingService,
     KeyboardDockingModule,
 } from './keyboardDockingService';
@@ -73,6 +81,7 @@ export const Modules: DockviewModule<any>[] = [
     AutoEdgeGroupModule,
     MultiRowTabsModule,
     PinnedTabsModule,
+    AdvancedOverflowModule,
     KeyboardDockingModule,
     LicenseModule,
 ];

--- a/packages/dockview-enterprise/src/mruTracker.ts
+++ b/packages/dockview-enterprise/src/mruTracker.ts
@@ -1,0 +1,90 @@
+/**
+ * Most-recently-used ordering for overflow tab-switching, private to the
+ * advanced overflow module.
+ *
+ * Keeps, per group, the group's panel ids ordered by last activation — front is
+ * most recently activated. Component-scoped (one tracker per component) so
+ * recency survives a group closing and a panel moving between groups. There is
+ * no second consumer, so this deliberately stays a module-local model rather
+ * than a shared core primitive.
+ */
+export class MruTracker {
+    private readonly _byGroup = new Map<string, string[]>();
+
+    /**
+     * Seed a group's recency list from its current tab order (front = first
+     * tab). Called on group attach. Idempotent — re-seeding replaces the list,
+     * but existing recency is preserved for ids already tracked so a re-attach
+     * doesn't reset ordering.
+     */
+    attach(groupId: string, panelIds: readonly string[]): void {
+        const existing = this._byGroup.get(groupId);
+        if (!existing) {
+            this._byGroup.set(groupId, [...panelIds]);
+            return;
+        }
+        // Keep the recency of already-tracked ids; append any new ids in tab
+        // order at the (least-recent) end.
+        for (const id of panelIds) {
+            if (!existing.includes(id)) {
+                existing.push(id);
+            }
+        }
+    }
+
+    /** Drop a group's recency list — called when the group is removed. */
+    detach(groupId: string): void {
+        this._byGroup.delete(groupId);
+    }
+
+    /**
+     * Record an activation: move `panelId` to the front of `groupId`'s list.
+     * The panel is first removed from every other group's list so a cross-group
+     * move leaves the source list and enters the destination.
+     */
+    activate(groupId: string, panelId: string): void {
+        for (const [gid, ids] of this._byGroup) {
+            if (gid === groupId) {
+                continue;
+            }
+            const index = ids.indexOf(panelId);
+            if (index !== -1) {
+                ids.splice(index, 1);
+            }
+        }
+
+        let ids = this._byGroup.get(groupId);
+        if (!ids) {
+            ids = [];
+            this._byGroup.set(groupId, ids);
+        }
+        const existing = ids.indexOf(panelId);
+        if (existing !== -1) {
+            ids.splice(existing, 1);
+        }
+        ids.unshift(panelId);
+    }
+
+    /** Remove a panel from every group's list — called when a panel is closed. */
+    remove(panelId: string): void {
+        for (const ids of this._byGroup.values()) {
+            const index = ids.indexOf(panelId);
+            if (index !== -1) {
+                ids.splice(index, 1);
+            }
+        }
+    }
+
+    /**
+     * The recency order (front = most recent) for a group, or an empty list
+     * when the group is not tracked.
+     */
+    order(groupId: string): string[] {
+        return [...(this._byGroup.get(groupId) ?? [])];
+    }
+
+    /** Whether a group currently has a recency list. */
+    has(groupId: string): boolean {
+        return this._byGroup.has(groupId);
+    }
+}


### PR DESCRIPTION
## Description

Upgrades the free tab-overflow chevron dropdown, **in place**, into a command-palette tab switcher — a **search** box, **MRU** (most-recently-activated) ordering, and full **keyboard navigation** — provided by a new `AdvancedOverflowModule`. Same chevron trigger; only the popover body changes. When the module is absent, the free flat list renders exactly as today.

### Core seam extraction (free, no behaviour change)
- `TabsContainer.toggleDropdown`'s body-building is split into a shared `createOverflowRenderContext` (per-row + group-header builders, plus the **window-bound** popover open/close/focus) and `renderFreeOverflowList`.
- A single `?.`-guarded branch: when `accessor.advancedOverflowService` is present it builds **and** opens the popover; otherwise the free helper renders — byte-identical to before.
- The merged overflow composition — `(horizontal-clip ∪ forced-overflow) − excluded`, i.e. pinned (`setOverflowExclude`) + maxRows (`setForcedOverflow`) — is untouched; only *rendering* moved. Keeping the popover open/close in core avoids the popout window-binding trap (it renders in the popped-out group's document).
- New core contracts in `moduleContracts.ts` (`IAdvancedOverflowHost`/`IAdvancedOverflowService`, render context/params, `IOverflowRow`), the `advancedOverflowService` slot on `ServiceCollection`, and the component getter. Styling lives in core (`tabs.scss`); the module ships no CSS.

### The MRU model
- `MruTracker` (private to the module): per-group panel ids ordered by last activation, **component-scoped** so recency survives a group closing; a cross-group move re-homes the panel (leaves source list, enters destination). Seeded from tab order on group attach; reorders only on `origin === 'user'` activations.

### Service + view
- `AdvancedOverflowService` self-wires MRU off the host's `onDidAddGroup`/`onDidRemoveGroup`/`onDidActivePanelChange` (mirrors `TabGroupChipsModule.init`), and constructs an `OverflowListView` per popover-open: focused search input (scope `group` = full tab set vs `overflow` = clipped set, debounced ~80ms), MRU/clipped ordering reusing the core row builder, and a `role="listbox"` keyboard controller (↓/↑ rove + wrap, Home/End, Enter activates, Esc closes + restores chevron focus, Tab trapped). Enter is intercepted before `PopupService`'s Enter-dismissal so the row activates before the popover closes.

### Deferred (reserved / unwired, per MVP scope)
- Thumbnails (`overflow.thumbnails` / `OverflowThumbnailRenderer`) and the `onDidOverflow` event + `persistMru` serialization.

## Type of change

- [x] New feature

## Affected packages

- [x] `dockview-core`
- [x] `dockview` (vanilla JS) — re-exports the new core contracts
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`
- [x] `dockview-enterprise` (hosts the module)

## How to test

- Set `overflow: { search: true, mru: true }` and overflow a group's tab strip: the chevron dropdown becomes a searchable, MRU-ordered list with arrow/Enter/Esc navigation. Remove the module and the free flat list is unchanged.
- Unit / jsdom: `MruTracker` (move-to-front, add/remove, cross-group, `origin` filter), search predicate + scope (`group` vs `overflow`), MRU ordering, keyboard nav, and a full-component integration (open popover, filter, MRU reflects a `setActive` sequence, click activates + closes). Core has a free-fallback seam test proving the `?.`-guard renders the free list when the slot is undefined.
- e2e (`e2e/tests/advanced-overflow.spec.ts`): searchable popover + filtering, arrow/Enter activation, and the cross-window case — the advanced popover renders **and** dismisses inside a popped-out group's document.
- Removability is covered by the auto-generated `Modules` removability spec (the module is now in the bundle).

## Checklist

- [x] `yarn lint:fix` passes (0 errors)
- [x] `yarn format` passes
- [ ] `npm run gen` — no generated files affected by this change
- [x] `yarn test` passes (core + `dockview-enterprise` + e2e)
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented — none (additive; free path unchanged when the module is absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kNoUE25gJe1itCbKnN6oA

---
_Generated by [Claude Code](https://claude.ai/code/session_011kNoUE25gJe1itCbKnN6oA)_