### PR TITLE
feat(a11y): explicit tab accessible name + in-move keyboard-docking hint

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/tab.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/tab.spec.ts
@@ -30,6 +30,72 @@ describe('tab', () => {
         expect(cut.element.className).toBe('dv-tab dv-inactive-tab');
     });
 
+    test('sets an explicit aria-label from the panel title so the name is not computed from contents (which would swallow the close button label)', () => {
+        const accessor = fromPartial<DockviewComponent>({
+            onDidOptionsChange: jest
+                .fn()
+                .mockReturnValue({ dispose: jest.fn() }),
+            options: {},
+        });
+        const groupMock = jest.fn();
+
+        const cut = new Tab(
+            { id: 'panelId', title: 'My Panel' } as IDockviewPanel,
+            accessor,
+            new groupMock()
+        );
+
+        expect(cut.element.getAttribute('aria-label')).toBe('My Panel');
+    });
+
+    test('aria-label falls back to the panel id when there is no title', () => {
+        const accessor = fromPartial<DockviewComponent>({
+            onDidOptionsChange: jest
+                .fn()
+                .mockReturnValue({ dispose: jest.fn() }),
+            options: {},
+        });
+        const groupMock = jest.fn();
+
+        const cut = new Tab(
+            { id: 'panelId' } as IDockviewPanel,
+            accessor,
+            new groupMock()
+        );
+
+        expect(cut.element.getAttribute('aria-label')).toBe('panelId');
+    });
+
+    test('aria-label follows onDidTitleChange', () => {
+        const accessor = fromPartial<DockviewComponent>({
+            onDidOptionsChange: jest
+                .fn()
+                .mockReturnValue({ dispose: jest.fn() }),
+            options: {},
+        });
+        const groupMock = jest.fn();
+
+        let titleListener: ((e: { title: string }) => void) | undefined;
+        const cut = new Tab(
+            fromPartial<IDockviewPanel>({
+                id: 'panelId',
+                title: 'Initial',
+                api: fromPartial({
+                    onDidTitleChange: (fn: (e: { title: string }) => void) => {
+                        titleListener = fn;
+                        return { dispose: jest.fn() };
+                    },
+                }),
+            }),
+            accessor,
+            new groupMock()
+        );
+
+        expect(cut.element.getAttribute('aria-label')).toBe('Initial');
+        titleListener?.({ title: 'Renamed' });
+        expect(cut.element.getAttribute('aria-label')).toBe('Renamed');
+    });
+
     test('that active tab has active-tab class', () => {
         const accessor = fromPartial<DockviewComponent>({
             onDidOptionsChange: jest

--- a/packages/dockview-core/src/dockview/components/tab/tab.ts
+++ b/packages/dockview-core/src/dockview/components/tab/tab.ts
@@ -86,6 +86,15 @@ export class Tab extends CompositeDisposable {
         this._element.id = nextTabId();
         this._element.setAttribute('role', 'tab');
         this._element.setAttribute('aria-selected', 'false');
+        // Give the tab an explicit accessible name (the panel title) so its
+        // WAI-ARIA name isn't computed from its subtree — otherwise it would
+        // swallow the close button's "Close {title}" label, and the tabpanel
+        // (which is `aria-labelledby` this tab) would inherit that clutter.
+        // Kept in sync with `onDidTitleChange` below.
+        this._element.setAttribute(
+            'aria-label',
+            this.panel.title ?? this.panel.id
+        );
         // Panel identity on the tab element so the multi-row wrap controller can
         // map a wrapped tab (read for its `offsetTop` row) back to its panel id
         // when computing the surplus set that spills to the overflow dropdown.
@@ -227,6 +236,12 @@ export class Tab extends CompositeDisposable {
             }),
             this.panel.api?.onDidChangePinned?.(() => {
                 this._updatePinnedClasses();
+            }) ?? { dispose: () => {} },
+            this.panel.api?.onDidTitleChange?.((event) => {
+                this._element.setAttribute(
+                    'aria-label',
+                    event.title ?? this.panel.id
+                );
             }) ?? { dispose: () => {} },
             addDisposableListener(this._element, 'dragend', () => {
                 // The shared onDragEnd handler already fires _onDragEnd via

--- a/packages/dockview-core/src/dockview/dockviewComponent.scss
+++ b/packages/dockview-core/src/dockview/dockviewComponent.scss
@@ -70,3 +70,32 @@
         color: var(--dv-activegroup-visiblepanel-tab-color);
     }
 }
+
+// Visible on-screen hint shown while a keyboard-docking move (Ctrl+M) is armed
+// — mirrors the screen-reader narration so sighted keyboard users get the same
+// "arrows / Enter / Escape" guidance. Purely visual (the element is
+// aria-hidden; the LiveRegion speaks the same text). Restyle or hide via this
+// class.
+.dv-keyboard-docking-hint {
+    position: absolute;
+    left: 50%;
+    bottom: 8px;
+    transform: translateX(-50%);
+    z-index: 100;
+    max-width: 90%;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    line-height: 1.4;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    pointer-events: none;
+    background-color: var(
+        --dv-context-menu-background-color,
+        var(--dv-group-view-background-color)
+    );
+    color: var(--dv-activegroup-visiblepanel-tab-color);
+    border: 1px solid var(--dv-tab-divider-color);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}

--- a/packages/dockview-enterprise/src/__tests__/keyboardDocking.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/keyboardDocking.spec.ts
@@ -106,6 +106,32 @@ describe('accessibility: keyboard docking', () => {
         expect(dockview.groups).toHaveLength(2);
     });
 
+    test('shows a visible on-screen hint mirroring the narration and removes it on cancel', () => {
+        make(true);
+        twoGroups();
+        const hint = (): HTMLElement | null =>
+            container.querySelector('.dv-keyboard-docking-hint');
+
+        expect(hint()).toBeNull();
+
+        // Target phase: the on-screen hint carries the same guidance the
+        // LiveRegion speaks, and is aria-hidden so it is not announced twice.
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+        expect(hint()?.textContent).toContain('Moving P2');
+        expect(hint()?.textContent).toContain('Escape to cancel');
+        expect(hint()?.getAttribute('aria-hidden')).toBe('true');
+
+        // Follows the phase change into the edge phase.
+        fireEvent.keyDown(dockview.element, { key: 'ArrowRight' });
+        fireEvent.keyDown(dockview.element, { key: 'Enter' });
+        expect(hint()?.textContent).toContain('Tab into');
+
+        // Removed once the move ends (edge → target → cancel).
+        fireEvent.keyDown(dockview.element, { key: 'Escape' });
+        fireEvent.keyDown(dockview.element, { key: 'Escape' });
+        expect(hint()).toBeNull();
+    });
+
     test('renders the drop preview during the move and clears it on cancel', () => {
         make(true);
         twoGroups();

--- a/packages/dockview-enterprise/src/keyboardDockingService.ts
+++ b/packages/dockview-enterprise/src/keyboardDockingService.ts
@@ -84,6 +84,8 @@ export class KeyboardDockingService
 {
     private _move: MoveState | null = null;
     private _preview: IDisposable | undefined;
+    /** On-screen hint mirroring the SR narration during an armed move. */
+    private _hint: HTMLElement | undefined;
 
     constructor(private readonly host: IKeyboardNavigationHost) {
         super();
@@ -285,18 +287,20 @@ export class KeyboardDockingService
 
         const name = group.activePanel?.title ?? group.id;
         const m = this._messages;
-        if (move.phase === 'target') {
-            this.host.announce(
-                m.movePickTarget(
-                    this._label(move.source),
-                    name,
-                    move.groupIndex + 1,
-                    move.groups.length
-                )
-            );
-        } else {
-            this.host.announce(m.movePickEdge(move.position, name));
-        }
+        const message =
+            move.phase === 'target'
+                ? m.movePickTarget(
+                      this._label(move.source),
+                      name,
+                      move.groupIndex + 1,
+                      move.groups.length
+                  )
+                : m.movePickEdge(move.position, name);
+        // The same guidance goes to assistive tech (LiveRegion) and to the
+        // on-screen hint, so sighted keyboard users see the arrows/Enter/Escape
+        // affordance the narration describes.
+        this.host.announce(message);
+        this._showHint(message);
     }
 
     private _commit(): void {
@@ -337,6 +341,7 @@ export class KeyboardDockingService
 
     private _exit(): void {
         this._clearPreview();
+        this._hideHint();
         this._move = null;
         this.host.rootElement.removeAttribute(KEYBOARD_MOVE_ATTRIBUTE);
     }
@@ -344,6 +349,28 @@ export class KeyboardDockingService
     private _clearPreview(): void {
         this._preview?.dispose();
         this._preview = undefined;
+    }
+
+    /**
+     * Show a visible on-screen hint carrying the same guidance the LiveRegion
+     * speaks. `aria-hidden` because the LiveRegion already announces it (avoids
+     * a double read); it is a purely visual affordance. Styleable via
+     * `.dv-keyboard-docking-hint`.
+     */
+    private _showHint(text: string): void {
+        if (!this._hint) {
+            const doc = this.host.rootElement.ownerDocument;
+            this._hint = doc.createElement('div');
+            this._hint.className = 'dv-keyboard-docking-hint';
+            this._hint.setAttribute('aria-hidden', 'true');
+            this.host.rootElement.appendChild(this._hint);
+        }
+        this._hint.textContent = text;
+    }
+
+    private _hideHint(): void {
+        this._hint?.remove();
+        this._hint = undefined;
     }
 
     private _consume(e: KeyboardEvent): void {


### PR DESCRIPTION
Two small, self-contained accessibility improvements from the manual screen-reader pass (VoiceOver/Safari).

## 1. Explicit tab accessible name (fix)
The `role="tab"` element had no `aria-label`, so its accessible name was computed from its subtree and swallowed the close button's `"Close {title}"` label. Because the tabpanel is `aria-labelledby` the tab, it inherited the clutter too — a screen reader read **"Explorer Close Explorer, tab"** and **"Explorer Close Explorer, tab panel"**.

Fix: set `aria-label = panel.title` (falling back to the panel id) on the tab element, kept in sync via `onDidTitleChange`. Verified at runtime (the tab and tabpanel now read the clean title); 3 regression tests added.

## 2. Visible in-move keyboard-docking hint (feature)
During a `Ctrl+M` keyboard move, sighted keyboard users got **no on-screen cue** — the "arrows / Enter / Escape" guidance existed only in the screen-reader narration. This mirrors that exact narration into a visible `.dv-keyboard-docking-hint` at the bottom of the dock, updating through the target/edge phases and removed on commit/cancel.

- `aria-hidden` so the LiveRegion doesn't announce it twice
- Reuses the message catalog (i18n / `messages` overrides apply for free)
- Default-on, styleable via the class
- Verified end-to-end in a real browser through the full lifecycle; 1 unit test added.

## Notes
- Two related target-size findings from the same pass (close button 19×19; ~4px sashes/handles) were reviewed and left as documented **WCAG 2.5.8 exceptions** (equivalent keyboard/menu controls; pointer-precision) — no code change, since a fixed 24px min would force taller headers on shorter tab-height layouts.
- Full suites green: dockview-core 1164, dockview-enterprise 325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)