### PR TITLE
fix(popout): don't double-offset restored popout position on multi-monitor

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
@@ -140,3 +140,156 @@ describe('popout lifecycle', () => {
         dockview2.dispose();
     });
 });
+
+/**
+ * Popout window placement in screen coordinates. A supplied / restored
+ * `position` (from `PopoutWindow.dimensions()`, i.e. screenX/screenY) is
+ * already absolute, whereas a fresh popout is placed from the source element's
+ * viewport-relative rect and must be offset by the opener window's own screen
+ * position. Regression guard for the multi-monitor double-offset where the
+ * opener offset was added to an already-absolute restored position.
+ */
+describe('popout screen positioning', () => {
+    let container: HTMLElement;
+    let dockview: DockviewComponent;
+    let restoreScreen: (() => void)[];
+
+    function setOpenerScreenPosition(x: number, y: number): void {
+        for (const [key, value] of [
+            ['screenX', x],
+            ['screenY', y],
+        ] as const) {
+            const original = Object.getOwnPropertyDescriptor(window, key);
+            Object.defineProperty(window, key, {
+                value,
+                configurable: true,
+            });
+            restoreScreen.push(() => {
+                if (original) {
+                    Object.defineProperty(window, key, original);
+                } else {
+                    delete (window as unknown as Record<string, unknown>)[key];
+                }
+            });
+        }
+    }
+
+    function captureOpenFeatures(): { current: string | undefined } {
+        const ref: { current: string | undefined } = { current: undefined };
+        window.open = ((
+            _url?: string | URL,
+            _target?: string,
+            features?: string
+        ) => {
+            ref.current = features;
+            return setupMockWindow();
+        }) as typeof window.open;
+        return ref;
+    }
+
+    function feature(features: string | undefined, key: string): number {
+        const match = new RegExp(`(?:^|,)${key}=(-?\\d+)`).exec(features ?? '');
+        return match ? Number(match[1]) : NaN;
+    }
+
+    beforeEach(() => {
+        restoreScreen = [];
+        container = document.createElement('div');
+        dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview.layout(1000, 1000);
+    });
+
+    afterEach(() => {
+        dockview.dispose();
+        restoreScreen.forEach((fn) => fn());
+    });
+
+    test('a fresh popout is offset by the opener window screen position', async () => {
+        setOpenerScreenPosition(1600, 200);
+        const features = captureOpenFeatures();
+
+        const panel = dockview.addPanel({ id: 'p1', component: 'default' });
+        await dockview.addPopoutGroup(panel);
+
+        // jsdom performs no layout, so the source element's rect is at (0, 0);
+        // the opener's screen offset must still be applied so the popout opens
+        // over the source rather than at the primary monitor's origin.
+        expect(feature(features.current, 'left')).toBe(1600);
+        expect(feature(features.current, 'top')).toBe(200);
+    });
+
+    test('a supplied absolute position is not double-offset by the opener screen position', async () => {
+        // Opener sits on a secondary monitor. This is the case that regressed:
+        // a restored position is already absolute, so adding the opener offset
+        // again previously produced left = 1600 + 2200 = 3800.
+        setOpenerScreenPosition(1600, 200);
+        const features = captureOpenFeatures();
+
+        const panel = dockview.addPanel({ id: 'p1', component: 'default' });
+        await dockview.addPopoutGroup(panel, {
+            position: { left: 2200, top: 300, width: 400, height: 500 },
+        });
+
+        expect(feature(features.current, 'left')).toBe(2200);
+        expect(feature(features.current, 'top')).toBe(300);
+        expect(feature(features.current, 'width')).toBe(400);
+        expect(feature(features.current, 'height')).toBe(500);
+    });
+
+    test('a serialized popout round-trips and restores at its saved screen position (no double-offset)', async () => {
+        // 1. Serialize a popout whose window reports an absolute screen
+        //    position — as a window dragged onto a secondary monitor would.
+        const POPOUT_SCREEN_X = 2200;
+        const POPOUT_SCREEN_Y = 300;
+        window.open = (() => {
+            const win = setupMockWindow();
+            Object.defineProperty(win, 'screenX', {
+                value: POPOUT_SCREEN_X,
+                configurable: true,
+            });
+            Object.defineProperty(win, 'screenY', {
+                value: POPOUT_SCREEN_Y,
+                configurable: true,
+            });
+            return win;
+        }) as typeof window.open;
+
+        const panel = dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        await dockview.addPopoutGroup(panel);
+
+        const json = dockview.toJSON();
+        // the popout descriptor stores the window's absolute screen coordinates
+        // (PopoutWindow.dimensions() -> screenX/screenY)
+        expect(json.popoutGroups?.[0].position?.left).toBe(POPOUT_SCREEN_X);
+        expect(json.popoutGroups?.[0].position?.top).toBe(POPOUT_SCREEN_Y);
+
+        // 2. Restore into a fresh component whose opener sits on a secondary
+        //    monitor. The saved position is already absolute, so restoration
+        //    must NOT add the opener screen offset again (the DV-39 defect:
+        //    left would become 1600 + 2200 = 3800). This exercises the real
+        //    fromJSON -> deserializePopoutWindows -> addPopoutGroup path, not
+        //    just the supplied-position branch.
+        setOpenerScreenPosition(1600, 200);
+        const features = captureOpenFeatures();
+
+        const container2 = document.createElement('div');
+        const dockview2 = new DockviewComponent(container2, {
+            createComponent: () => new TestPanel(),
+        });
+        dockview2.layout(1000, 1000);
+        dockview2.fromJSON(json);
+
+        // popout restoration is queued on a timer; let it fire
+        for (let i = 0; i < 50 && features.current === undefined; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+
+        expect(feature(features.current, 'left')).toBe(POPOUT_SCREEN_X);
+        expect(feature(features.current, 'top')).toBe(POPOUT_SCREEN_Y);
+
+        dockview2.dispose();
+    });
+});

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1323,19 +1323,33 @@ export class DockviewComponent
         const theme = getDockviewTheme(this.gridview.element);
         const element = this.element;
 
+        // Always returns absolute *screen* coordinates. A caller-supplied /
+        // restored `position` is already in screen space — it originates from
+        // PopoutWindow.dimensions() (screenX/screenY). A fresh popout is
+        // positioned from the source element's viewport-relative rect, so it
+        // is offset here by the opener window's own screen position. Doing the
+        // normalisation in one place keeps the window construction below
+        // coordinate-space agnostic; previously the opener offset was added
+        // unconditionally at construction, double-offsetting a restored popout
+        // whenever the opener sat on a non-primary monitor (screenX/Y != 0).
         function getBox(): Box {
             if (options?.position) {
                 return options.position;
             }
 
-            if (itemToPopout instanceof DockviewGroupPanel) {
-                return itemToPopout.element.getBoundingClientRect();
-            }
+            const sourceElement =
+                itemToPopout instanceof DockviewGroupPanel
+                    ? itemToPopout.element
+                    : (itemToPopout.group?.element ?? element);
 
-            if (itemToPopout.group) {
-                return itemToPopout.group.element.getBoundingClientRect();
-            }
-            return element.getBoundingClientRect();
+            const rect = sourceElement.getBoundingClientRect();
+
+            return {
+                left: window.screenX + rect.left,
+                top: window.screenY + rect.top,
+                width: rect.width,
+                height: rect.height,
+            };
         }
 
         const box: Box = getBox();
@@ -1354,8 +1368,8 @@ export class DockviewComponent
             theme ?? '',
             {
                 url: resolvedPopoutUrl ?? '/popout.html',
-                left: window.screenX + box.left,
-                top: window.screenY + box.top,
+                left: box.left,
+                top: box.top,
                 width: box.width,
                 height: box.height,
                 onDidOpen: options?.onDidOpen,
@@ -1639,7 +1653,7 @@ export class DockviewComponent
                     _onDidWindowPositionChange.event(() => {
                         this._onDidPopoutGroupPositionChange.fire({
                             screenX: _window.window!.screenX,
-                            screenY: _window.window!.screenX,
+                            screenY: _window.window!.screenY,
                             group,
                         });
                     }),


### PR DESCRIPTION
## Description

A popout window's position is serialized as **absolute screen coordinates** — `PopoutWindow.dimensions()` reads `screenX`/`screenY`. On restore, that saved position was passed into `addPopoutGroup(...)` and then had the opener window's `screenX`/`screenY` **added to it again** when the window was constructed. As a result, a restored (or explicitly supplied via the public `position` option) popout opened offset by the opener's screen position — visibly wrong whenever the opener sat on a non-primary monitor (`screenX`/`screenY` != 0). On a single primary monitor `screenX`/`screenY` are ~0, so the bug was invisible there.

The fix normalises coordinate spaces in one place. `getBox()` now always returns absolute screen coordinates:
- a supplied/restored `position` is already absolute and is returned as-is;
- a fresh popout's viewport-relative `getBoundingClientRect()` is offset by the opener's screen position there.

Window construction then uses the box directly instead of adding the opener offset a second time.

Also fixes a copy-paste typo where `onDidPopoutGroupPositionChange` reported `screenY` as the window's `screenX`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

Automated (added in this PR, `packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts`, `describe('popout screen positioning')`):
- a **fresh** popout is still offset by the opener window screen position;
- a **supplied/restored absolute position** is opened at those coordinates and is **not** double-offset by the opener screen position.

Both tests were confirmed to fail against the previous behaviour (the restore case computed `left = 1600 + 2200 = 3800` instead of `2200`) and to pass with the fix. Full `dockview-core` suite passes (1080 tests).

Manual: on a multi-monitor setup, pop a group out into its own window on a secondary monitor, save the layout (`toJSON`), reload and restore (`fromJSON`) — the popout should reopen where it was, not shifted by the opener window's screen offset.

## Checklist

- [x] `yarn lint:fix` passes (0 errors)
- [x] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date <!-- not run: no public API/signature changes, behaviour-only fix -->
- [x] `yarn test` passes (`dockview-core`)
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented <!-- none: no API change. It does correct where an existing multi-monitor layout restores a popout, which is the intended fix. -->

Fixes DV-39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01348YrnzDQQugTCarDwKCuT

---
_Generated by [Claude Code](https://claude.ai/code/session_01348YrnzDQQugTCarDwKCuT)_