### PR TITLE
fix(core): overflow tab select no longer scrolls the whole dockview out of view

### DIFF
--- a/e2e/tests/tab-overflow-dropdown.spec.ts
+++ b/e2e/tests/tab-overflow-dropdown.spec.ts
@@ -45,4 +45,70 @@ test.describe('tab overflow dropdown', () => {
         // …and the dropdown closes.
         await expect(overflow).toHaveCount(0);
     });
+
+    /**
+     * Regression: selecting a hidden tab must not scroll the *page*. The
+     * activation used to call a bare `scrollIntoView()` (which defaults to
+     * `block: 'start'`) on the now-active tab; when the dockview sits low in a
+     * scrollable page that scrolled the document to pull the tab to the top,
+     * dragging the whole dockview upward and largely out of the viewport. The
+     * fix pins it to `block: 'nearest'` so only the tab strip reveals the tab
+     * horizontally. jsdom has no layout/scrolling, so this needs a real browser.
+     */
+    test('selecting a hidden tab does not scroll the page', async ({
+        page,
+    }) => {
+        await page.setViewportSize({ width: 300, height: 500 });
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+
+        // Put the dockview low in a scrollable page: a spacer above pushes the
+        // tab strip ~200px down (still within the viewport), and the page is
+        // taller than the viewport so the document itself can scroll.
+        await page.evaluate(() => {
+            const style = document.createElement('style');
+            style.textContent =
+                'html, body { height: auto; } #app { height: 250px; }';
+            document.head.appendChild(style);
+            const app = document.getElementById('app')!;
+            const spacerTop = document.createElement('div');
+            spacerTop.style.height = '200px';
+            const spacerBottom = document.createElement('div');
+            spacerBottom.style.height = '600px';
+            app.parentNode!.insertBefore(spacerTop, app);
+            app.after(spacerBottom);
+            window.scrollTo(0, 0);
+        });
+
+        await page.evaluate(() => {
+            for (let i = 0; i < 12; i++)
+                (window as any).__dv.addPanel('panel-long-title-' + i);
+        });
+
+        // Preconditions: the page really is scrollable and starts at the top.
+        expect(
+            await page.evaluate(
+                () => document.documentElement.scrollHeight > window.innerHeight
+            )
+        ).toBe(true);
+        expect(await page.evaluate(() => window.scrollY)).toBe(0);
+
+        const handle = page.locator('.dv-tabs-overflow-dropdown-default');
+        await expect(handle).toBeVisible();
+        await handle.click();
+
+        const overflow = page.locator('.dv-tabs-overflow-container');
+        await expect(overflow).toBeVisible();
+        const hiddenTab = overflow.locator('.dv-tab').first();
+        const title = (await hiddenTab.textContent())!.trim();
+        await hiddenTab.click();
+
+        // Behaviour preserved: the picked tab activates and the dropdown closes.
+        await expect(page.locator('.dv-active-tab')).toHaveText(title);
+        await expect(overflow).toHaveCount(0);
+
+        // The guard: the page did NOT scroll. Under the old bug the document
+        // scrolled by ~200px (the tab strip's offset), yanking the dockview up.
+        expect(await page.evaluate(() => window.scrollY)).toBeLessThan(50);
+    });
 });

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -654,7 +654,16 @@ export class TabsContainer
                     if (tg?.collapsed) {
                         tg.expand();
                     }
-                    tab?.element.scrollIntoView();
+                    // `block: 'nearest'` keeps this from scrolling ancestor
+                    // scroll containers (incl. the page) vertically — a bare
+                    // scrollIntoView() defaults to `block: 'start'`, which
+                    // yanks the whole dockview up when it sits low in a
+                    // scrollable page. We only want to reveal the tab
+                    // horizontally within the tab strip.
+                    tab?.element.scrollIntoView({
+                        block: 'nearest',
+                        inline: 'nearest',
+                    });
                     this.accessor.withOrigin('user', () =>
                         panel.api.setActive()
                     );


### PR DESCRIPTION
## Problem

Selecting a hidden tab from the tab-overflow dropdown ran a bare `tab.element.scrollIntoView()`. With no options that defaults to `block: 'start'`, which scrolls **every** scrollable ancestor — including the document — to align the tab to the top of the viewport.

When the dockview sits low in a scrollable page (the same situation that makes the overflow popover reposition upward to avoid the bottom edge), the browser satisfies `block: 'start'` by scrolling the **page**, dragging the entire dockview upward and largely out of view.

## Fix

`packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts`

```ts
tab?.element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
```

The only effective change is `block: 'start'` → `block: 'nearest'`. `inline` was already `'nearest'` by default, so revealing the newly-activated tab **horizontally** within the strip is unchanged; `block: 'nearest'` skips the vertical page scroll when the tab is already visible. Applies to both mouse and keyboard activation (both route through `doActivate`).

## Test

Adds an e2e regression test in `e2e/tests/tab-overflow-dropdown.spec.ts` — real-browser only, since jsdom has no layout/scrolling. It places the dockview low in a scrollable page (spacer above + fixed-height `#app` + spacer below), selects an overflowed tab, and asserts `window.scrollY` stays put.

Verified as a genuine guard: reverting the fix in the built bundle makes the new test fail with `Received: 200` (the exact page-shift), while the existing activation test still passes; with the fix both are green.

- Core unit: `tabsContainer` 79/79
- e2e: `tab-overflow-dropdown` 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)