### PR TITLE
docs(agents): add Linear issue workflow rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,3 +178,29 @@ Please reference docs @ [dockview.dev](https://dockview.dev).
 
 ## Breaking changes
 ```
+
+## Linear issue workflow
+
+When the work maps to a Linear issue (the user names an issue identifier such as
+`ABC-123`, or the task/branch references one), keep the issue's state in sync via
+the Linear MCP tools. Linear's native GitHub integration is the source of truth
+for status transitions; these steps make Claude's updates align with it and cover
+the in-session gaps.
+
+1.  **Starting work** — set the issue to **In Progress** (Linear `save_issue`
+    with `state: "In Progress"`) before making changes. Skip if it's already
+    In Progress / Done.
+2.  **Opening a PR** — include a Linear magic word for every issue the PR
+    resolves in the PR **description**, one per issue: `Fixes <ID>` /
+    `Closes <ID>` (e.g. `Fixes ABC-123`). This is what makes Linear auto-link
+    the PR and auto-complete the issue on merge, regardless of the branch name
+    (agent branches are assigned as `claude/...`, which Linear does not
+    auto-link). Put the magic words in the body even when the title already
+    mentions the identifier.
+3.  **On merge** — when a watched PR merges (the merge webhook arrives during a
+    session), set each resolved issue to **Done** (Linear `save_issue` with
+    `state: "Done"`) as a backup in case the native integration's status
+    mapping isn't configured. Idempotent — skip if already Done.
+
+Do not change Linear state for issues the user hasn't asked you to work on, and
+don't reopen or duplicate issues.


### PR DESCRIPTION
## Description

Adds a standing **"Linear issue workflow"** section to the root `AGENTS.md` so agent sessions keep a mapped Linear issue in sync with the work:

1. **Starting work** → set the issue to **In Progress** (skip if already In Progress/Done).
2. **Opening a PR** → include `Fixes <ID>` / `Closes <ID>` magic words in the PR description, which is what makes Linear auto-link the PR and auto-complete the issue on merge — needed because agent branches are named `claude/...`, which Linear does not auto-link.
3. **On merge** → set the issue **Done** as a backup when a watched PR merges.

Includes a guard not to change state for issues the user hasn't asked about, or reopen/duplicate issues. Generic to any Linear identifier (no board/prefix specifics).

Docs-only; no code or behaviour change.

## Type of change

- [x] Documentation

## Affected packages

_None — root `AGENTS.md` only._

## How to test

N/A — documentation. The guidance references existing Linear MCP tooling (`save_issue`) and Linear's native GitHub magic words.

## Checklist

- [ ] `yarn lint:fix` passes — n/a (docs only)
- [ ] `yarn format` passes — n/a (docs only)
- [ ] `npm run gen` has been run and generated files are up to date — n/a (no exports changed)
- [ ] `yarn test` passes — n/a (docs only)
- [x] I have added or updated tests where applicable — n/a
- [ ] Breaking changes are documented — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012NoeJKd8F3oU3RuyhgxRGC)_