### PR TITLE
fix: resolve five well-scoped bugs across core and react packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,17 @@ NX handles build ordering automatically via `dependsOn: ["^build"]`. The depende
 -   Prettier for code formatting
 -   Linting targets source files in packages/\*/src/\*\* (excludes tests, docs, node_modules)
 -   Current rules focus on TypeScript best practices while allowing some flexibility
+-   **SonarCloud must introduce no new issues.** Every PR runs a SonarCloud
+    analysis (the `sonar` check). A PR is not ready to merge while it reports
+    any new issues, even if the Quality Gate still passes — treat "New issues:
+    0" as the bar, not just a green gate. Before pushing, self-review the diff
+    for the smells Sonar flags (redundant `?? {}` / `|| {}` in a spread,
+    unused code, needless casts, cognitive-complexity spikes) and fix them in
+    the same PR. If Sonar reports a new issue, fix it (or, if genuinely a false
+    positive, mark it Won't Fix / Accepted in SonarCloud with a justification)
+    before merging. Fetch the exact findings from
+    `https://sonarcloud.io/api/issues/search?componentKeys=mathuo_dockview&pullRequest=<PR>&issueStatuses=OPEN,CONFIRMED&resolved=false`
+    rather than trusting the summary comment, which can lag a commit behind.
 
 ## Development Notes
 
@@ -190,13 +201,24 @@ the in-session gaps.
 1.  **Starting work** — set the issue to **In Progress** (Linear `save_issue`
     with `state: "In Progress"`) before making changes. Skip if it's already
     In Progress / Done.
-2.  **Opening a PR** — include a Linear magic word for every issue the PR
-    resolves in the PR **description**, one per issue: `Fixes <ID>` /
-    `Closes <ID>` (e.g. `Fixes ABC-123`). This is what makes Linear auto-link
-    the PR and auto-complete the issue on merge, regardless of the branch name
-    (agent branches are assigned as `claude/...`, which Linear does not
-    auto-link). Put the magic words in the body even when the title already
-    mentions the identifier.
+2.  **Opening a PR — link the issue(s).** How to link depends on how many
+    issues the PR resolves:
+    -   **Exactly one issue** — put the identifier in the **branch name** and
+        the **PR title** (e.g. branch `matthew/dv-52-maximum-width`, title
+        `fix(DV-52): maximumWidth axis swap`). Prefer the branch name Linear
+        generates for the issue ("Copy git branch name") so linking is
+        automatic on push. If the branch name can't carry the identifier — most
+        often an agent branch assigned as `claude/...`, which Linear does not
+        auto-link — fall back to a `Fixes <ID>` magic word in the description.
+    -   **More than one issue** — a branch name/title can only carry one
+        identifier, so instead add a Linear magic word for **every** issue in
+        the PR **description**, one per line: `Fixes <ID>` / `Closes <ID>`
+        (e.g. `Fixes ABC-123`).
+
+    Magic words (`Fixes` / `Closes` / `Resolves`) are what auto-complete the
+    issue on merge; a bare identifier in the title/branch links the PR but
+    relies on the integration's PR-merged→Done status mapping to close it. When
+    in doubt, include the magic word.
 3.  **On merge** — when a watched PR merges (the merge webhook arrives during a
     session), set each resolved issue to **Done** (Linear `save_issue` with
     `state: "Done"`) as a backup in case the native integration's status

--- a/packages/dockview-core/src/__tests__/events.spec.ts
+++ b/packages/dockview-core/src/__tests__/events.spec.ts
@@ -44,6 +44,24 @@ describe('events', () => {
             expect(value).toBeUndefined();
         });
 
+        it('should still notify remaining listeners when one unsubscribes during dispatch', () => {
+            const emitter = new Emitter<number>();
+
+            let bReceived: number | undefined = undefined;
+
+            const a = emitter.event(() => {
+                // a self-disposing (fire-once) listener registered before b
+                a.dispose();
+            });
+            emitter.event((x) => {
+                bReceived = x;
+            });
+
+            emitter.fire(42);
+
+            expect(bReceived).toBe(42);
+        });
+
         it('should replay last value in replay mode', () => {
             const emitter = new Emitter<number>({ replay: true });
             let value: number | undefined = undefined;

--- a/packages/dockview-core/src/__tests__/gridview/gridview.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridview.spec.ts
@@ -66,6 +66,24 @@ describe('gridview', () => {
         expect(container.childNodes).toHaveLength(0);
     });
 
+    test('maximumWidth and maximumHeight return their respective axis', () => {
+        const gridview = new Gridview(
+            false,
+            { separatorBorder: '' },
+            Orientation.HORIZONTAL
+        );
+        gridview.layout(1000, 1000);
+
+        const view = new MockGridview();
+        view.maximumWidth = 500;
+        view.maximumHeight = Number.MAX_VALUE;
+
+        gridview.addView(view, Sizing.Distribute, [0]);
+
+        expect(gridview.maximumWidth).toBe(500);
+        expect(gridview.maximumHeight).toBe(Number.MAX_VALUE);
+    });
+
     test('insertOrthogonalSplitviewAtRoot #1', () => {
         const gridview = new Gridview(
             false,

--- a/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
@@ -562,6 +562,27 @@ describe('paneviewComponent', () => {
         expect(paneview.disableResizing).toBeTruthy();
     });
 
+    test('that disableAutoResizing can be toggled via updateOptions', () => {
+        const paneview = new PaneviewComponent(container, {
+            createComponent: (options) => {
+                switch (options.name) {
+                    case 'default':
+                        return new TestPanel(options.id, options.name);
+                    default:
+                        throw new Error('unsupported');
+                }
+            },
+        });
+
+        expect(paneview.disableResizing).toBeFalsy();
+
+        paneview.updateOptions({ disableAutoResizing: true });
+        expect(paneview.disableResizing).toBeTruthy();
+
+        paneview.updateOptions({ disableAutoResizing: false });
+        expect(paneview.disableResizing).toBeFalsy();
+    });
+
     test('that setVisible toggles visiblity', () => {
         const paneview = new PaneviewComponent(container, {
             createComponent: (options) => {

--- a/packages/dockview-core/src/events.ts
+++ b/packages/dockview-core/src/events.ts
@@ -170,7 +170,10 @@ export class Emitter<T> implements IDisposable {
         if (this.options?.replay) {
             this._last = e;
         }
-        for (const listener of this._listeners) {
+        // iterate over a snapshot so that a listener disposing its own (or a
+        // sibling's) subscription during dispatch doesn't cause the live array
+        // to shift underneath the loop and skip the following listener
+        for (const listener of this._listeners.slice()) {
             listener.callback(e);
         }
     }

--- a/packages/dockview-core/src/gridview/gridview.ts
+++ b/packages/dockview-core/src/gridview/gridview.ts
@@ -375,7 +375,7 @@ export class Gridview implements IDisposable {
     }
 
     get maximumWidth(): number {
-        return this.root.maximumHeight;
+        return this.root.maximumWidth;
     }
 
     get maximumHeight(): number {

--- a/packages/dockview-core/src/paneview/paneviewComponent.ts
+++ b/packages/dockview-core/src/paneview/paneviewComponent.ts
@@ -251,7 +251,7 @@ export class PaneviewComponent extends Resizable implements IPaneviewComponent {
             this._classNames.setClassNames(options.className ?? '');
         }
 
-        if ('disableResizing' in options) {
+        if ('disableAutoResizing' in options) {
             this.disableResizing = options.disableAutoResizing ?? false;
         }
 

--- a/packages/dockview-react/src/__tests__/dockview/defaultTab.spec.tsx
+++ b/packages/dockview-react/src/__tests__/dockview/defaultTab.spec.tsx
@@ -236,6 +236,85 @@ describe('defaultTab', () => {
         expect(element.querySelector('.dv-tab-pin')).toBeNull();
     });
 
+    test('that a middle-click closes the tab', async () => {
+        const api = fromPartial<DockviewPanelApi>({
+            close: jest.fn(),
+            onDidTitleChange: jest
+                .fn()
+                .mockImplementation(() => Disposable.NONE),
+            onDidChangePinned: jest
+                .fn()
+                .mockImplementation(() => Disposable.NONE),
+        });
+        const containerApi = fromPartial<DockviewApi>({});
+        const params = {};
+
+        render(
+            <DockviewDefaultTab
+                tabLocation="header"
+                api={api}
+                containerApi={containerApi}
+                params={params}
+            />
+        );
+
+        const element = await screen.getByTestId('dockview-dv-default-tab');
+
+        // jsdom has no PointerEvent and testing-library's fireEvent.pointer*
+        // drops `button`, so dispatch MouseEvents (which carry `button`) with
+        // the pointer event type names React listens to.
+        fireEvent(
+            element,
+            new MouseEvent('pointerdown', { button: 1, bubbles: true })
+        );
+        fireEvent(
+            element,
+            new MouseEvent('pointerup', { button: 1, bubbles: true })
+        );
+
+        expect(api.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('that a middle-click aborted by leaving the tab does not close it', async () => {
+        const api = fromPartial<DockviewPanelApi>({
+            close: jest.fn(),
+            onDidTitleChange: jest
+                .fn()
+                .mockImplementation(() => Disposable.NONE),
+            onDidChangePinned: jest
+                .fn()
+                .mockImplementation(() => Disposable.NONE),
+        });
+        const containerApi = fromPartial<DockviewApi>({});
+        const params = {};
+
+        render(
+            <DockviewDefaultTab
+                tabLocation="header"
+                api={api}
+                containerApi={containerApi}
+                params={params}
+            />
+        );
+
+        const element = await screen.getByTestId('dockview-dv-default-tab');
+
+        // press the middle button, then drag the pointer off the tab (which
+        // should cancel the pending close) before releasing. React derives
+        // onPointerLeave from the native pointerout event.
+        fireEvent(
+            element,
+            new MouseEvent('pointerdown', { button: 1, bubbles: true })
+        );
+        fireEvent.pointerOut(element);
+        fireEvent(
+            element,
+            new MouseEvent('pointerup', { button: 1, bubbles: true })
+        );
+
+        expect(api.close).toHaveBeenCalledTimes(0);
+    });
+
     test('has close button when hideClose=false', async () => {
         const api = fromPartial<DockviewPanelApi>({
             onDidTitleChange: jest

--- a/packages/dockview-react/src/__tests__/dockview/dockview.spec.tsx
+++ b/packages/dockview-react/src/__tests__/dockview/dockview.spec.tsx
@@ -45,6 +45,29 @@ describe('gridview react', () => {
         expect(api).toBeTruthy();
     });
 
+    test('that passing defaultTabComponent does not mutate the caller-owned tabComponents object', () => {
+        const tabComponents: Record<string, React.FunctionComponent<any>> = {
+            myTab: () => <div />,
+        };
+
+        const defaultTabComponent = () => <div />;
+
+        const onReady = () => {
+            // noop
+        };
+
+        render(
+            <DockviewReact
+                components={components}
+                tabComponents={tabComponents}
+                defaultTabComponent={defaultTabComponent}
+                onReady={onReady}
+            />
+        );
+
+        expect(Object.keys(tabComponents)).toEqual(['myTab']);
+    });
+
     test('is sized to container', () => {
         const el = document.createElement('div');
 

--- a/packages/dockview-react/src/dockview/defaultTab.tsx
+++ b/packages/dockview-react/src/dockview/defaultTab.tsx
@@ -97,7 +97,11 @@ export const DockviewDefaultTab: React.FunctionComponent<
 
     const _onPointerUp = React.useCallback(
         (event: React.PointerEvent<HTMLDivElement>) => {
-            if (isMiddleMouseButton && event.button === 1 && !hideClose) {
+            if (
+                isMiddleMouseButton.current &&
+                event.button === 1 &&
+                !hideClose
+            ) {
                 isMiddleMouseButton.current = false;
                 onClose(event);
             }

--- a/packages/dockview-react/src/dockview/dockview.tsx
+++ b/packages/dockview-react/src/dockview/dockview.tsx
@@ -145,7 +145,7 @@ export const DockviewReact = React.forwardRef(
                 return;
             }
 
-            const frameworkTabComponents = props.tabComponents ?? {};
+            const frameworkTabComponents = { ...props.tabComponents };
 
             if (props.defaultTabComponent) {
                 frameworkTabComponents[DEFAULT_REACT_TAB] =
@@ -346,7 +346,7 @@ export const DockviewReact = React.forwardRef(
                 return;
             }
 
-            const frameworkTabComponents = props.tabComponents ?? {};
+            const frameworkTabComponents = { ...props.tabComponents };
 
             if (props.defaultTabComponent) {
                 frameworkTabComponents[DEFAULT_REACT_TAB] =


### PR DESCRIPTION
## Description

Fixes five small, well-scoped bugs from the backlog (DV-52, DV-66, DV-51, DV-60, DV-61). Each is a single-site change shipped with a test that fails without the fix.

Also bundles two documentation updates to `AGENTS.md`: a refined Linear PR-linking convention (branch name + title for a single issue, magic words for multiple) and a rule that PRs must introduce no new SonarCloud issues.

### Linear

Fixes DV-52
Fixes DV-66
Fixes DV-51
Fixes DV-60
Fixes DV-61

### Bug fixes

| Issue | Package | Bug | Fix |
|-------|---------|-----|-----|
| **DV-52** | `dockview-core` gridview | `Gridview.maximumWidth` returned `this.root.maximumHeight` — an axis swap that propagated to the public `GridviewApi`/`DockviewApi` `maximumWidth` | return `this.root.maximumWidth` |
| **DV-66** | `dockview-core` events | `Emitter.fire()` iterated the live listener array, so a listener disposing a subscription during dispatch shifted the array and skipped the following listener | iterate over a `.slice()` snapshot |
| **DV-51** | `dockview-core` paneview | `PaneviewComponent.updateOptions` guarded on `'disableResizing' in options` — a key never present (the public option is `disableAutoResizing`) — so the flag couldn't be toggled at runtime | guard on `'disableAutoResizing'` |
| **DV-60** | `dockview-react` defaultTab | `_onPointerUp` tested the `isMiddleMouseButton` ref object (always truthy) instead of its `.current`, so the pointer-leave abort flag was never consulted and any middle-button pointerup closed the tab | read `.current` |
| **DV-61** | `dockview-react` dockview | the init and tab-components-update effects aliased and mutated the caller-owned `props.tabComponents` object, injecting an internal `DEFAULT_REACT_TAB` key | copy before writing (`{ ...props.tabComponents }`) |

## Type of change

- [x] Bug fix
- [x] Documentation

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [x] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

Each fix has a dedicated test that fails on the unpatched code and passes with the fix:

- `dockview-core`: `events.spec.ts` (re-entrant unsubscribe), `gridview/gridview.spec.ts` (`maximumWidth`/`maximumHeight` axes), `paneview/paneviewComponent.spec.ts` (`updateOptions` toggle)
- `dockview-react`: `dockview/defaultTab.spec.tsx` (middle-click + leave-to-abort), `dockview/dockview.spec.tsx` (no mutation of caller-owned `tabComponents`)

Verified by reverting only the source files (keeping the new tests) and confirming each test fails, then restoring. Full suites pass: `dockview-core` 1207/1207, `dockview-react` 48/48.

> Note (test infra): jsdom has no `PointerEvent` and testing-library's `fireEvent.pointer*` drops `button`, so the defaultTab tests dispatch `MouseEvent`s with the pointer event type names (and `pointerOut` for React's derived `onPointerLeave`).

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)