### PR TITLE
fix: resolve eight well-scoped bugs (Tier 2) across core and vue

### DIFF
--- a/packages/dockview-core/src/__tests__/dnd/ghost.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/ghost.spec.ts
@@ -28,4 +28,33 @@ describe('ghost', () => {
         expect(element.className).toBe('');
         expect(element.parentElement).toBeNull();
     });
+
+    test('that the ghost is appended to the provided owner document', () => {
+        const dataTransferMock = jest.fn<Partial<DataTransfer>, []>(() => {
+            return {
+                setDragImage: jest.fn(),
+            };
+        });
+
+        // a distinct document, standing in for a popout window
+        const popoutDocument =
+            document.implementation.createHTMLDocument('popout');
+
+        const element = document.createElement('div');
+        const dataTransfer = <DataTransfer>new dataTransferMock();
+
+        addGhostImage(dataTransfer, element, {
+            ownerDocument: popoutDocument,
+        });
+
+        // must be appended to the popout document, not the main one, or the
+        // browser ignores the cross-document setDragImage element
+        expect(element.parentElement).toBe(popoutDocument.body);
+        expect(document.body.contains(element)).toBe(false);
+        expect(dataTransfer.setDragImage).toHaveBeenCalledWith(element, 0, 0);
+
+        jest.runAllTimers();
+
+        expect(element.parentElement).toBeNull();
+    });
 });

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
@@ -815,4 +815,20 @@ describe('tabs', () => {
             expect(tabsList.classList.contains('dv-vertical')).toBeFalsy();
         });
     });
+
+    describe('showTabsOverflowControl', () => {
+        test('disabling at runtime disposes the overflow observer', () => {
+            const { tabs } = createTabsForDropTest();
+
+            // constructed with the control off
+            expect((tabs as any)._observerDisposable.value).toBeUndefined();
+
+            tabs.showTabsOverflowControl = true;
+            expect((tabs as any)._observerDisposable.value).toBeDefined();
+
+            // turning it back off must tear down the observer/scroll listener
+            tabs.showTabsOverflowControl = false;
+            expect((tabs as any)._observerDisposable.value).toBeUndefined();
+        });
+    });
 });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -12352,4 +12352,77 @@ describe('group header direction change signal (DV-14 unblocker)', () => {
 
         dv.dispose();
     });
+
+    test('fromJSON with malformed input does not destroy the existing layout', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                switch (options.name) {
+                    case 'default':
+                        return new PanelContentPartTest(
+                            options.id,
+                            options.name
+                        );
+                    default:
+                        throw new Error(`unsupported`);
+                }
+            },
+        });
+
+        dockview.layout(1000, 1000);
+
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        dockview.addPanel({ id: 'panel2', component: 'default' });
+
+        expect(dockview.panels.length).toBe(2);
+
+        // an object with no `grid` is malformed; fromJSON must reject it
+        // *before* clearing the live layout
+        expect(() => dockview.fromJSON({} as any)).toThrow();
+
+        // the pre-existing layout must survive the failed load
+        expect(dockview.panels.length).toBe(2);
+        expect(dockview.getGroupPanel('panel1')).toBeTruthy();
+        expect(dockview.getGroupPanel('panel2')).toBeTruthy();
+
+        dockview.dispose();
+    });
+
+    test('fromJSON degrades gracefully when a group references a missing panel id', () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                switch (options.name) {
+                    case 'default':
+                        return new PanelContentPartTest(
+                            options.id,
+                            options.name
+                        );
+                    default:
+                        throw new Error(`unsupported`);
+                }
+            },
+        });
+
+        dockview.layout(1000, 1000);
+
+        dockview.addPanel({ id: 'panel1', component: 'default' });
+        dockview.addPanel({ id: 'panel2', component: 'default' });
+
+        const serialized = dockview.toJSON();
+
+        // corrupt the state: the group still references 'panel2' in its views
+        // but its panel state is absent from the panels map
+        delete (serialized.panels as any)['panel2'];
+
+        // must not throw on the missing panel; the valid panel still loads
+        expect(() => dockview.fromJSON(serialized)).not.toThrow();
+
+        expect(dockview.getGroupPanel('panel1')).toBeTruthy();
+        expect(dockview.getGroupPanel('panel2')).toBeFalsy();
+
+        dockview.dispose();
+    });
 });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -12375,14 +12375,14 @@ describe('group header direction change signal (DV-14 unblocker)', () => {
         dockview.addPanel({ id: 'panel1', component: 'default' });
         dockview.addPanel({ id: 'panel2', component: 'default' });
 
-        expect(dockview.panels.length).toBe(2);
+        expect(dockview.panels).toHaveLength(2);
 
         // an object with no `grid` is malformed; fromJSON must reject it
         // *before* clearing the live layout
         expect(() => dockview.fromJSON({} as any)).toThrow();
 
         // the pre-existing layout must survive the failed load
-        expect(dockview.panels.length).toBe(2);
+        expect(dockview.panels).toHaveLength(2);
         expect(dockview.getGroupPanel('panel1')).toBeTruthy();
         expect(dockview.getGroupPanel('panel2')).toBeTruthy();
 

--- a/packages/dockview-core/src/__tests__/lifecycle.spec.ts
+++ b/packages/dockview-core/src/__tests__/lifecycle.spec.ts
@@ -28,6 +28,21 @@ describe('lifecycle', () => {
         mutableDisposable.dispose();
     });
 
+    test('that MutableDisposable.value exposes the current disposable', () => {
+        const mutableDisposable = new MutableDisposable();
+
+        // nothing set yet
+        expect(mutableDisposable.value).toBeUndefined();
+
+        const disposable = { dispose: () => {} };
+        mutableDisposable.value = disposable;
+        expect(mutableDisposable.value).toBe(disposable);
+
+        // disposing clears it back to "no value"
+        mutableDisposable.dispose();
+        expect(mutableDisposable.value).toBeUndefined();
+    });
+
     test('composite disposable', () => {
         const d1 = {
             dispose: jest.fn(),

--- a/packages/dockview-core/src/__tests__/paneview/paneview.spec.ts
+++ b/packages/dockview-core/src/__tests__/paneview/paneview.spec.ts
@@ -105,6 +105,47 @@ describe('paneview', () => {
         disposable.dispose();
     });
 
+    test('reordering a pane does not leak its expansion-state listener', () => {
+        const paneview = new Paneview(container, {
+            orientation: Orientation.HORIZONTAL,
+        });
+
+        const makePanel = (id: string) =>
+            new TestPanel({
+                id,
+                component: 'component',
+                headerComponent: 'headerComponent',
+                orientation: Orientation.VERTICAL,
+                isExpanded: true,
+                isHeaderVisible: true,
+                headerSize: 22,
+                minimumBodySize: 0,
+                maximumBodySize: Number.MAX_SAFE_INTEGER,
+            });
+
+        const view1 = makePanel('id1');
+        const view2 = makePanel('id2');
+
+        paneview.addPane(view1);
+        paneview.addPane(view2);
+
+        // reorder view1 a few times; each move must not leak a listener
+        paneview.moveView(0, 1);
+        paneview.moveView(1, 0);
+        paneview.moveView(0, 1);
+
+        let changes = 0;
+        const disposable = paneview.onDidChange(() => changes++);
+
+        // a single expansion toggle should fire exactly one change event, not
+        // one-per-leaked-listener (N + 1)
+        view1.setExpanded(false);
+        expect(changes).toBe(1);
+
+        disposable.dispose();
+        paneview.dispose();
+    });
+
     test('dispose of paneview', () => {
         expect(container.childNodes).toHaveLength(0);
 

--- a/packages/dockview-core/src/dnd/backend.ts
+++ b/packages/dockview-core/src/dnd/backend.ts
@@ -141,6 +141,7 @@ class Html5DragSource extends CompositeDisposable implements IDragSource {
                     addGhostImage(event.dataTransfer, ghost.element, {
                         x: ghost.offsetX ?? 0,
                         y: ghost.offsetY ?? 0,
+                        ownerDocument: this.el.ownerDocument ?? undefined,
                     });
                     if (ghost.dispose) {
                         // addGhostImage removes the element from the DOM on

--- a/packages/dockview-core/src/dnd/ghost.ts
+++ b/packages/dockview-core/src/dnd/ghost.ts
@@ -3,7 +3,7 @@ import { addClasses, removeClasses } from '../dom';
 export function addGhostImage(
     dataTransfer: DataTransfer,
     ghostElement: HTMLElement,
-    options?: { x?: number; y?: number }
+    options?: { x?: number; y?: number; ownerDocument?: Document }
 ): void {
     // class dockview provides to force ghost image to be drawn on a different layer and prevent weird rendering issues
     addClasses(ghostElement, 'dv-dragged');
@@ -11,7 +11,12 @@ export function addGhostImage(
     // move the element off-screen initially otherwise it may in some cases be rendered at (0,0) momentarily
     ghostElement.style.top = '-9999px';
 
-    document.body.appendChild(ghostElement);
+    // Append to the drag source's own document. Per spec a setDragImage
+    // element that is cross-document relative to the drag's DataTransfer is
+    // ignored, so a drag initiated inside a popout window must use the popout
+    // document, not the main one.
+    const ownerDocument = options?.ownerDocument ?? document;
+    ownerDocument.body.appendChild(ghostElement);
     dataTransfer.setDragImage(ghostElement, options?.x ?? 0, options?.y ?? 0);
 
     setTimeout(() => {

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -291,6 +291,11 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
                     }
                 })
             );
+        } else {
+            // Disabling the control at runtime must tear down the observer and
+            // scroll listener, otherwise they keep firing toggleDropdown (which
+            // bypasses the refreshOverflow flag guard) and leak until disposal.
+            this._observerDisposable.value = Disposable.NONE;
         }
     }
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3353,6 +3353,25 @@ export class DockviewComponent
         // issue #1304.
         this._popoutWindowService?.cancelPendingRestorations();
 
+        // Validate the input shape *before* mutating the live layout. Both the
+        // reuseExistingPanels setup below and clear() destroy the current
+        // layout, so any validation that runs after them (and outside the
+        // restoration try/catch) would leave the component empty on malformed
+        // input instead of failing safely.
+        if (typeof data !== 'object' || data === null) {
+            throw new Error(
+                'dockview: serialized layout must be a non-null object'
+            );
+        }
+
+        if (
+            !data.grid ||
+            data.grid.root?.type !== 'branch' ||
+            !Array.isArray(data.grid.root.data)
+        ) {
+            throw new Error('dockview: root must be of type branch');
+        }
+
         const existingPanels = new Map<string, IDockviewPanel>();
 
         let tempGroup: DockviewGroupPanel | undefined;
@@ -3395,17 +3414,7 @@ export class DockviewComponent
 
         this.clear();
 
-        if (typeof data !== 'object' || data === null) {
-            throw new Error(
-                'dockview: serialized layout must be a non-null object'
-            );
-        }
-
         const { grid, panels, activeGroup } = data;
-
-        if (grid.root.type !== 'branch' || !Array.isArray(grid.root.data)) {
-            throw new Error('dockview: root must be of type branch');
-        }
 
         try {
             // take note of the existing dimensions
@@ -3447,6 +3456,17 @@ export class DockviewComponent
                      * due to a corruption of input data.
                      */
 
+                    /**
+                     * Skip a view whose panel state is missing from the panels
+                     * map rather than passing `undefined` to the deserializer
+                     * (which would dereference `panelData.id` and throw,
+                     * aborting the whole layout restore). Mirrors the guard on
+                     * the edge-group deserialization path.
+                     */
+                    if (!panels[child]) {
+                        continue;
+                    }
+
                     const existingPanel = existingPanels.get(child);
 
                     if (tempGroup && existingPanel) {
@@ -3465,9 +3485,10 @@ export class DockviewComponent
                     }
                 }
 
-                for (let i = 0; i < views.length; i++) {
-                    const panel = createdPanels[i];
-
+                // Iterate the panels that were actually created (a view whose
+                // panel state was missing is skipped above), keeping this loop
+                // aligned with `createdPanels` rather than the raw `views`.
+                for (const panel of createdPanels) {
                     const isActive =
                         typeof activeView === 'string' &&
                         activeView === panel.id;

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3449,23 +3449,23 @@ export class DockviewComponent
 
                 const createdPanels: IDockviewPanel[] = [];
 
-                for (const child of views) {
+                /**
+                 * Skip any view whose panel state is missing from the panels
+                 * map rather than passing `undefined` to the deserializer
+                 * (which would dereference `panelData.id` and throw, aborting
+                 * the whole layout restore). Mirrors the guard on the
+                 * edge-group deserialization path.
+                 */
+                const presentViews = views.filter(
+                    (child: string) => panels[child]
+                );
+
+                for (const child of presentViews) {
                     /**
                      * Run the deserializer step seperately since this may fail to due corrupted external state.
                      * In running this section first we avoid firing lots of 'add' events in the event of a failure
                      * due to a corruption of input data.
                      */
-
-                    /**
-                     * Skip a view whose panel state is missing from the panels
-                     * map rather than passing `undefined` to the deserializer
-                     * (which would dereference `panelData.id` and throw,
-                     * aborting the whole layout restore). Mirrors the guard on
-                     * the edge-group deserialization path.
-                     */
-                    if (!panels[child]) {
-                        continue;
-                    }
 
                     const existingPanel = existingPanels.get(child);
 

--- a/packages/dockview-core/src/lifecycle.ts
+++ b/packages/dockview-core/src/lifecycle.ts
@@ -56,6 +56,12 @@ export class CompositeDisposable {
 export class MutableDisposable implements IDisposable {
     private _disposable = Disposable.NONE;
 
+    get value(): IDisposable | undefined {
+        return this._disposable === Disposable.NONE
+            ? undefined
+            : this._disposable;
+    }
+
     set value(disposable: IDisposable) {
         if (this._disposable) {
             this._disposable.dispose();

--- a/packages/dockview-core/src/paneview/paneview.ts
+++ b/packages/dockview-core/src/paneview/paneview.ts
@@ -168,6 +168,12 @@ export class Paneview extends CompositeDisposable implements IDisposable {
 
         const view = this.removePane(from, { skipDispose: true });
 
+        // `skipDispose` keeps the pane alive but also leaves its old
+        // expansion-state listener attached; dispose that listener here since
+        // the addPane below installs a fresh one, otherwise every move orphans
+        // a live subscription and duplicates the layout-change events.
+        view.disposable.dispose();
+
         this.skipAnimation = true;
         try {
             this.addPane(view.pane, view.pane.size, to, false);

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -247,4 +247,46 @@ describe('GridviewVue components prop resolves without registration', () => {
             api.addPanel({ id: 'bad', component: 'NotRegistered' })
         ).toThrow("Failed to find Vue Component 'NotRegistered'");
     });
+
+    test('changing the components prop at runtime refreshes the map without throwing', async () => {
+        const errors: unknown[] = [];
+
+        wrapper = mount(GridviewVue, {
+            props: {
+                orientation: Orientation.HORIZONTAL,
+                components: { Cell: MockGridComponent },
+            },
+            attachTo: document.body,
+            global: {
+                config: {
+                    // the components watcher previously re-called
+                    // getCurrentInstance() during the scheduler flush (returns
+                    // null) and threw; Vue routes that to the app error handler
+                    errorHandler: (err: unknown) => errors.push(err),
+                },
+            },
+        });
+        await flushPromises();
+
+        const Extra = defineComponent({
+            name: 'ExtraComponent',
+            props: ['params', 'api', 'containerApi'],
+            template: '<div class="mock-extra">Extra</div>',
+        });
+
+        // swap in a brand-new components object (new reference) at runtime
+        await wrapper.setProps({
+            components: { Cell: MockGridComponent, Extra },
+        });
+        await flushPromises();
+
+        expect(errors).toEqual([]);
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as GridviewApi;
+
+        expect(() =>
+            api.addPanel({ id: 'extra-1', component: 'Extra' })
+        ).not.toThrow();
+        expect(api.getPanel('extra-1')).toBeDefined();
+    });
 });

--- a/packages/dockview-vue/src/__tests__/renderers-registry.spec.ts
+++ b/packages/dockview-vue/src/__tests__/renderers-registry.spec.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from 'vitest';
+import {
+    DockviewEmitter,
+    DockviewGroupPanel,
+    DockviewGroupPanelApi,
+    DockviewGroupPanelModel,
+    IDockviewPanel,
+} from 'dockview';
+import {
+    VueHeaderActionsRenderer,
+    VueTabGroupChipRenderer,
+    VueRendererRegistry,
+} from '../utils';
+
+/**
+ * These exercise the teleport `VueRendererRegistry` path with the real Vue
+ * runtime (no vue mock), so the registry's shallow top-level params merge is
+ * observable via `registry.entries[0].props.value`.
+ */
+describe('registry renderers retain params across partial updates', () => {
+    const mockComponent = {
+        template: '<div>renderer</div>',
+        props: ['params'],
+    } as any;
+    const mockParent = {
+        appContext: { components: {}, provides: {} },
+        provides: {},
+    } as any;
+
+    test('VueHeaderActionsRenderer.updateLocation keeps the enriched props', () => {
+        const onDidAddPanel = new DockviewEmitter<any>();
+        const onDidRemovePanel = new DockviewEmitter<any>();
+        const onDidActivePanelChange = new DockviewEmitter<any>();
+        const onDidActiveChange = new DockviewEmitter<any>();
+        const onDidLocationChange = new DockviewEmitter<any>();
+
+        const panels = [{ id: 'panel-1' } as IDockviewPanel];
+
+        const groupModel = {
+            onDidAddPanel: onDidAddPanel.event,
+            onDidRemovePanel: onDidRemovePanel.event,
+            onDidActivePanelChange: onDidActivePanelChange.event,
+            get panels() {
+                return panels;
+            },
+            get activePanel() {
+                return panels[0];
+            },
+            headerPosition: 'top',
+        } as Partial<DockviewGroupPanelModel> as DockviewGroupPanelModel;
+
+        const groupApi = {
+            onDidActiveChange: onDidActiveChange.event,
+            onDidLocationChange: onDidLocationChange.event,
+            location: { type: 'grid' },
+            get isActive() {
+                return true;
+            },
+        } as Partial<DockviewGroupPanelApi> as DockviewGroupPanelApi;
+
+        const groupPanel = {
+            api: groupApi,
+            model: groupModel,
+        } as Partial<DockviewGroupPanel> as DockviewGroupPanel;
+
+        const registry = new VueRendererRegistry();
+
+        const renderer = new VueHeaderActionsRenderer(
+            mockComponent,
+            mockParent,
+            groupPanel,
+            registry
+        );
+
+        renderer.init({
+            api: groupPanel.api,
+            containerApi: {} as any,
+            group: groupPanel as any,
+        });
+
+        // a location change (float/popout) must not wipe the enriched props
+        onDidLocationChange.fire({ location: { type: 'floating' } });
+
+        const params = registry.entries[0].props.value.params;
+        expect(params.location).toEqual({ type: 'floating' });
+        expect(params.panels).toBe(panels);
+        expect(params.api).toBe(groupPanel.api);
+        expect(params.group).toBe(groupPanel);
+
+        renderer.dispose();
+        onDidAddPanel.dispose();
+        onDidRemovePanel.dispose();
+        onDidActivePanelChange.dispose();
+        onDidActiveChange.dispose();
+        onDidLocationChange.dispose();
+    });
+
+    test('VueTabGroupChipRenderer.update keeps the api', () => {
+        const registry = new VueRendererRegistry();
+
+        const renderer = new VueTabGroupChipRenderer(
+            mockComponent,
+            mockParent,
+            registry
+        );
+
+        const api = { id: 'container-api' } as any;
+
+        renderer.init({ tabGroup: { id: 'g1' } as any, api });
+        renderer.update({ tabGroup: { id: 'g2' } as any });
+
+        const params = registry.entries[0].props.value.params;
+        expect(params.tabGroup.id).toBe('g2');
+        expect(params.api).toBe(api);
+
+        renderer.dispose();
+    });
+});

--- a/packages/dockview-vue/src/composables/useViewComponent.ts
+++ b/packages/dockview-vue/src/composables/useViewComponent.ts
@@ -63,6 +63,19 @@ export function useViewComponent<
     const eventDisposables: DockviewIDisposable[] = [];
 
     /**
+     * Capture the component instance synchronously during `setup`. Watcher
+     * callbacks run via Vue's scheduler flush, where `getCurrentInstance()`
+     * returns null, so re-calling it there would throw and silently abort the
+     * update. Cache it once here and reuse it everywhere below.
+     */
+    const vueInstance = getCurrentInstance();
+    if (!vueInstance) {
+        throw new Error(
+            `${config.componentName}: getCurrentInstance() returned null`
+        );
+    }
+
+    /**
      * Components are teleported into the view's DOM (rendered by
      * `<DockviewPortals>` in the host template) so panels stay in the Vue
      * component tree. See {@link VueRendererRegistry}.
@@ -86,20 +99,13 @@ export function useViewComponent<
         () => (props as any).components,
         () => {
             if (instance.value) {
-                const inst = getCurrentInstance();
-                if (!inst) {
-                    throw new Error(
-                        `${config.componentName}: getCurrentInstance() returned null`
-                    );
-                }
-
                 instance.value.updateOptions({
                     createComponent: (options: {
                         id: string;
                         name?: string;
                     }) => {
                         const component = findComponent(
-                            inst,
+                            vueInstance,
                             options.name!,
                             (props as any).components
                         );
@@ -107,7 +113,7 @@ export function useViewComponent<
                             options.id,
                             options.name,
                             component! as any,
-                            inst,
+                            vueInstance,
                             registry
                         );
                     },
@@ -121,18 +127,10 @@ export function useViewComponent<
             throw new Error(`${config.componentName}: element is not mounted`);
         }
 
-        const inst = getCurrentInstance();
-
-        if (!inst) {
-            throw new Error(
-                `${config.componentName}: getCurrentInstance() returned null`
-            );
-        }
-
         const frameworkOptions = {
             createComponent(options: { id: string; name?: string }) {
                 const component = findComponent(
-                    inst,
+                    vueInstance,
                     options.name!,
                     (props as any).components
                 );
@@ -140,7 +138,7 @@ export function useViewComponent<
                     options.id,
                     options.name,
                     component! as any,
-                    inst,
+                    vueInstance,
                     registry
                 );
             },

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -360,7 +360,13 @@ export class VueHeaderActionsRenderer
     }
 
     private updateLocation(location: DockviewGroupLocation): void {
-        this._renderDisposable?.update({ params: { location } });
+        // Send the full enriched props (with the new location applied) rather
+        // than a bare `{ params: { location } }`, which the registry's shallow
+        // top-level merge would use to replace the entire params object and
+        // drop panels/activePanel/group/api/etc. until the next full update.
+        this._renderDisposable?.update({
+            params: { ...this.buildEnrichedProps(), location },
+        });
     }
 }
 
@@ -396,7 +402,10 @@ export class VueTabGroupChipRenderer
         this.element.style.display = 'inline-flex';
     }
 
+    private _api: DockviewApi | undefined;
+
     init(params: { tabGroup: ITabGroup; api: DockviewApi }): void {
+        this._api = params.api;
         this.mount({
             params: {
                 tabGroup: params.tabGroup,
@@ -406,8 +415,11 @@ export class VueTabGroupChipRenderer
     }
 
     update(params: { tabGroup: ITabGroup }): void {
+        // Re-send `api` alongside the new tabGroup; the registry replaces the
+        // whole params object on update, so a bare `{ tabGroup }` would drop
+        // the api after the first chip update.
         this._renderDisposable?.update({
-            params: { tabGroup: params.tabGroup },
+            params: { tabGroup: params.tabGroup, api: this._api },
         });
     }
 


### PR DESCRIPTION
## Description

Second batch from the bug backlog — eight small, single-site fixes across `dockview-core` and `dockview-vue`, each shipped with a test that fails without it.

### Linear

Fixes DV-65
Fixes DV-44
Fixes DV-45
Fixes DV-54
Fixes DV-49
Fixes DV-59
Fixes DV-63
Fixes DV-64

### Bug fixes

| Issue | Area | Bug | Fix |
|-------|------|-----|-----|
| **DV-65** | core / lifecycle | `MutableDisposable` had a set-only `value` accessor, so `Overlay.cancelPendingDrag`'s `if (!this._dragMove.value)` guard read `undefined` and always returned early (dead code) | add a `value` getter (returns `undefined` for the `NONE` sentinel) |
| **DV-44** | core / dockviewComponent | `fromJSON` ran `clear()` + the reuse-panels setup **before** validating input, so malformed data (e.g. `{}`) wiped the live layout then threw outside the restore try/catch | validate `grid`/`root` before any mutation |
| **DV-45** | core / dockviewComponent | `fromJSON` passed `panels[child]` straight to the deserializer; a `views` entry with no panel state threw and aborted the whole restore | skip the missing panel (mirroring the edge-group guard), iterate `createdPanels` to stay aligned |
| **DV-54** | core / tabs | the `showTabsOverflowControl` setter never disposed the `OverflowObserver`/scroll listener when disabled at runtime — they leaked and kept firing `toggleDropdown` | clear the observer on the `false` path |
| **DV-49** | core / paneview | `moveView` used `skipDispose:true` then `addPane`, orphaning the old expansion-state listener (one leaked per reorder, duplicating layout events) | dispose the old listener before re-adding |
| **DV-59** | core / dnd | `addGhostImage` always appended to the main document, so a drag started in a popout window showed no custom drag image (cross-document `setDragImage` is ignored) | thread the source's `ownerDocument` through and append there |
| **DV-63** | vue / useViewComponent | the `components`-prop watcher re-called `getCurrentInstance()` during the scheduler flush (returns `null`) and threw, silently aborting the update | capture the instance once at `setup` and reuse it |
| **DV-64** | vue / utils | `VueHeaderActionsRenderer.updateLocation` and `VueTabGroupChipRenderer.update` sent bare partial `params`, which the registry's shallow merge used to replace the whole `params` object (dropping enriched props / `api`) | send the full merged props |

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [x] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

Each fix has a dedicated test that fails on the unpatched code and passes with the fix (verified by reverting only the source files and confirming each new test fails, then restoring):

- `dockview-core`: `lifecycle.spec.ts` (MutableDisposable getter), `dockviewComponent.spec.ts` (malformed / missing-panel `fromJSON`), `dockview/components/titlebar/tabs.spec.ts` (overflow observer disposed), `paneview/paneview.spec.ts` (reorder listener leak), `dnd/ghost.spec.ts` (owner document)
- `dockview-vue`: `gridview.spec.ts` (runtime `components` swap), `renderers-registry.spec.ts` (renderer param retention)

Full suites pass: `dockview-core` 1213/1213, `dockview-vue` 124/124. `lint` 0 errors, `format` clean, `gen` no drift.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JE1SmW4mWp6AdoNVbHprb)_