### PR TITLE
fix: resolve six well-scoped bugs (Tier 3) across core and angular

### DIFF
--- a/packages/dockview-angular/src/__tests__/dockview-angular.component.spec.ts
+++ b/packages/dockview-angular/src/__tests__/dockview-angular.component.spec.ts
@@ -141,6 +141,34 @@ describe('DockviewAngularComponent', () => {
             expect(updateOptionsSpy).toHaveBeenCalledWith({ [key]: value });
         }
     });
+
+    it('honours a rebound [components] map after init', () => {
+        component.ngOnInit();
+        const api = component.getDockviewApi()!;
+
+        // rebind `components` to a brand-new object that adds a component under
+        // a name absent from the init-time map
+        const initial = component.components;
+        component.components = {
+            ...initial,
+            'added-later': getTestComponents()['test-panel'],
+        };
+        component.ngOnChanges({
+            components: {
+                currentValue: component.components,
+                previousValue: initial,
+                firstChange: false,
+                isFirstChange: () => false,
+            },
+        });
+
+        // the factory must see the new map, so adding a panel with the new
+        // component name resolves instead of throwing "not found in registry"
+        expect(() =>
+            api.addPanel({ id: 'p-added', component: 'added-later' })
+        ).not.toThrow();
+        expect(api.getPanel('p-added')).toBeDefined();
+    });
 });
 
 @Component({

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -142,9 +142,21 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     @Output() willDrop = new EventEmitter<DockviewWillDropEvent>();
 
     private dockviewApi?: DockviewApi;
+    private frameworkComponentFactory?: AngularFrameworkComponentFactory;
     private readonly lifecycleManager = new AngularLifecycleManager();
     private readonly injector = inject(Injector);
     private readonly environmentInjector = inject(EnvironmentInjector);
+
+    /** Inputs that feed the framework component factory (not core options). */
+    private static readonly COMPONENT_MAP_INPUTS = [
+        'components',
+        'tabComponents',
+        'watermarkComponent',
+        'defaultTabComponent',
+        'leftHeaderActionsComponent',
+        'rightHeaderActionsComponent',
+        'prefixHeaderActionsComponent',
+    ] as const;
 
     ngOnInit(): void {
         this.initializeDockview();
@@ -208,6 +220,24 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
 
             if (hasChanges) {
                 this.dockviewApi.updateOptions(coreChanges);
+            }
+
+            // Refresh the framework component factory when any component-map
+            // input is rebound, so a new `[components]` (etc.) map is honoured
+            // rather than leaving the factory pinned to the init-time snapshot.
+            const componentMapChanged =
+                DockviewAngularComponent.COMPONENT_MAP_INPUTS.some(
+                    (key) => changes[key] && !changes[key].isFirstChange()
+                );
+            if (componentMapChanged && this.frameworkComponentFactory) {
+                this.frameworkComponentFactory.updateComponents({
+                    components: this.components,
+                    tabComponents: this.tabComponents,
+                    watermarkComponent: this.watermarkComponent,
+                    headerActionsComponents:
+                        this.buildHeaderActionsComponents(),
+                    defaultTabComponent: this.defaultTabComponent,
+                });
             }
         }
     }
@@ -273,7 +303,10 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
         return coreOptions as DockviewOptions;
     }
 
-    private createFrameworkOptions(): DockviewFrameworkOptions {
+    private buildHeaderActionsComponents(): Record<
+        string,
+        Type<any> | TemplateRef<any>
+    > {
         const headerActionsComponents: Record<
             string,
             Type<any> | TemplateRef<any>
@@ -288,6 +321,11 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             headerActionsComponents['prefix'] =
                 this.prefixHeaderActionsComponent;
         }
+        return headerActionsComponents;
+    }
+
+    private createFrameworkOptions(): DockviewFrameworkOptions {
+        const headerActionsComponents = this.buildHeaderActionsComponents();
 
         const componentFactory = new AngularFrameworkComponentFactory(
             this.components,
@@ -298,6 +336,7 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             headerActionsComponents,
             this.defaultTabComponent
         );
+        this.frameworkComponentFactory = componentFactory;
 
         return {
             createComponent: (options) => {

--- a/packages/dockview-angular/src/lib/utils/component-factory.ts
+++ b/packages/dockview-angular/src/lib/utils/component-factory.ts
@@ -23,23 +23,37 @@ import { AngularPanePart } from '../paneview/angular-pane-part';
 
 export class AngularFrameworkComponentFactory {
     constructor(
-        private readonly components: Record<
-            string,
-            Type<any> | TemplateRef<any>
-        >,
+        private components: Record<string, Type<any> | TemplateRef<any>>,
         private readonly injector: Injector,
         private readonly environmentInjector?: EnvironmentInjector,
-        private readonly tabComponents?: Record<
+        private tabComponents?: Record<string, Type<any> | TemplateRef<any>>,
+        private watermarkComponent?: Type<any> | TemplateRef<any>,
+        private headerActionsComponents?: Record<
             string,
             Type<any> | TemplateRef<any>
         >,
-        private readonly watermarkComponent?: Type<any> | TemplateRef<any>,
-        private readonly headerActionsComponents?: Record<
-            string,
-            Type<any> | TemplateRef<any>
-        >,
-        private readonly defaultTabComponent?: Type<any> | TemplateRef<any>
+        private defaultTabComponent?: Type<any> | TemplateRef<any>
     ) {}
+
+    /**
+     * Refresh the component maps in place so that rebinding an `@Input()`
+     * component map (e.g. `[components]`) after init is honoured. The core
+     * calls the factory live on each panel creation, so updating these
+     * references is enough — no re-init required.
+     */
+    updateComponents(maps: {
+        components: Record<string, Type<any> | TemplateRef<any>>;
+        tabComponents?: Record<string, Type<any> | TemplateRef<any>>;
+        watermarkComponent?: Type<any> | TemplateRef<any>;
+        headerActionsComponents?: Record<string, Type<any> | TemplateRef<any>>;
+        defaultTabComponent?: Type<any> | TemplateRef<any>;
+    }): void {
+        this.components = maps.components;
+        this.tabComponents = maps.tabComponents;
+        this.watermarkComponent = maps.watermarkComponent;
+        this.headerActionsComponents = maps.headerActionsComponents;
+        this.defaultTabComponent = maps.defaultTabComponent;
+    }
 
     // For DockviewComponent
     createDockviewComponent(options: CreateComponentOptions): IContentRenderer {

--- a/packages/dockview-core/src/__tests__/dnd/pointer/pointerDragController.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/pointer/pointerDragController.spec.ts
@@ -217,6 +217,38 @@ describe('PointerDragController', () => {
         document.body.removeChild(targetEl);
     });
 
+    test('cancel() fires onDragEnd (dropped=false) so consumers reset', () => {
+        const controller = PointerDragController.getInstance();
+
+        const onDragEndEvent = jest.fn();
+        const dispose = controller.onDragEnd(onDragEndEvent);
+        const onDragEndCallback = jest.fn();
+
+        controller.beginDrag({
+            pointerEvent: makePointerEvent('pointermove', {
+                clientX: 5,
+                clientY: 5,
+            }),
+            source: document.createElement('div'),
+            getData: () => ({ dispose: jest.fn() }),
+            onDragEnd: onDragEndCallback,
+        });
+
+        // a second drag preempting the first calls cancel() internally; here
+        // we call it directly. It must still notify drag-end consumers.
+        controller.cancel();
+
+        expect(onDragEndCallback).toHaveBeenCalledTimes(1);
+        expect(onDragEndCallback).toHaveBeenLastCalledWith(
+            expect.objectContaining({ clientX: 5, clientY: 5 }),
+            false
+        );
+        expect(onDragEndEvent).toHaveBeenCalledTimes(1);
+        expect(controller.active).toBeUndefined();
+
+        dispose.dispose();
+    });
+
     test('events with a different pointerId are ignored mid-drag', () => {
         const controller = PointerDragController.getInstance();
 

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabs.spec.ts
@@ -816,6 +816,42 @@ describe('tabs', () => {
         });
     });
 
+    describe('setActivePanel scroll-into-view', () => {
+        test('scrolls to the active tab offsetLeft, accounting for gaps/margins', () => {
+            const { tabs } = createTabsForDropTest();
+
+            const panels = [
+                createMockPanel('p0'),
+                createMockPanel('p1'),
+                createMockPanel('p2'),
+            ];
+            panels.forEach((p) => tabs.openPanel(p));
+
+            const elements = (tabs as any)._tabs.map(
+                (t: any) => t.value.element as HTMLElement
+            );
+
+            // 25px gaps between tabs (margins / group chips) mean each tab's
+            // real offsetLeft exceeds the running sum of client widths
+            const offsets = [0, 125, 250];
+            elements.forEach((el: HTMLElement, i: number) => {
+                jest.spyOn(el, 'offsetLeft', 'get').mockReturnValue(offsets[i]);
+                jest.spyOn(el, 'offsetWidth', 'get').mockReturnValue(100);
+                jest.spyOn(el, 'clientWidth', 'get').mockReturnValue(100);
+            });
+
+            const tabsList = (tabs as any)._tabsList as HTMLElement;
+            jest.spyOn(tabsList, 'clientWidth', 'get').mockReturnValue(150);
+            tabsList.scrollLeft = 0;
+
+            // activating the last (overflowed) tab must scroll to its true
+            // offsetLeft (250), not the accumulated client-width sum (200)
+            tabs.setActivePanel(panels[2]);
+
+            expect(tabsList.scrollLeft).toBe(250);
+        });
+    });
+
     describe('showTabsOverflowControl', () => {
         test('disabling at runtime disposes the overflow observer', () => {
             const { tabs } = createTabsForDropTest();

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1943,6 +1943,42 @@ describe('dockviewComponent', () => {
     });
 
     describe('serialization', () => {
+        test('reuseExistingPanels replaces panel params rather than merging', () => {
+            const dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+
+            dockview.layout(1000, 1000);
+
+            dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                params: { a: 1, b: 2 },
+            });
+
+            const state = dockview.toJSON();
+            // the saved state drops `b`, keeping only `a`
+            (state.panels['panel1'] as any).params = { a: 9 };
+
+            dockview.fromJSON(state, { reuseExistingPanels: true });
+
+            // reuse must restore exactly the saved params (no stale `b: 2`),
+            // matching the non-reuse deserialization path
+            expect(dockview.getGroupPanel('panel1')!.params).toEqual({ a: 9 });
+
+            dockview.dispose();
+        });
+
         test('reuseExistingPanels true', () => {
             const parts: PanelContentPartTest[] = [];
 
@@ -11351,6 +11387,58 @@ describe('dockviewComponent', () => {
             expect(finalSize).toBe(initialSize);
 
             dv.dispose();
+        });
+
+        test('edge group size constraints survive a toJSON/fromJSON round-trip on a fresh component', () => {
+            const c1 = document.createElement('div');
+            const dv = new DockviewComponent(c1, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+            dv.layout(1000, 800);
+            dv.addEdgeGroup('right', {
+                id: 'right-group',
+                minimumSize: 150,
+                maximumSize: 400,
+            });
+
+            const state = dv.toJSON();
+            dv.dispose();
+
+            // a fresh component that has NOT called addEdgeGroup — fromJSON must
+            // auto-create the edge group with the serialized constraints
+            const c2 = document.createElement('div');
+            const fresh = new DockviewComponent(c2, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+            fresh.layout(1000, 800);
+            fresh.fromJSON(state);
+
+            const view = (fresh as any)._shellManager._rightView;
+            expect(view).toBeDefined();
+            expect(view.configuredMaximumSize).toBe(400);
+            expect(view.configuredMinimumSize).toBe(150);
+
+            fresh.dispose();
         });
 
         test('toJSON includes edgeGroups field for configured positions', () => {

--- a/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
@@ -178,6 +178,66 @@ describe('paneviewComponent', () => {
         paneview.dispose();
     });
 
+    test('re-expanding a collapsed pane restores its prior size, not the container width', () => {
+        const disposables = new CompositeDisposable();
+
+        const paneview = new PaneviewComponent(container, {
+            createComponent: (options) => {
+                switch (options.name) {
+                    case 'default':
+                        return new TestPanel(options.id, options.name);
+                    default:
+                        throw new Error('unsupported');
+                }
+            },
+        });
+
+        // a wide-ish, tall container: the cross-axis (width) is 300 while there
+        // is plenty of main-axis (height) room
+        paneview.layout(300, 900);
+
+        const panel1 = paneview.addPanel({
+            id: 'panel1',
+            component: 'default',
+            title: 'Panel 1',
+            isExpanded: true,
+        });
+        const panel2 = paneview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            title: 'Panel 2',
+            isExpanded: true,
+        });
+        paneview.addPanel({
+            id: 'panel3',
+            component: 'default',
+            title: 'Panel 3',
+            isExpanded: true,
+        });
+
+        let panel2Dimensions: PanelDimensionChangeEvent | undefined;
+        disposables.addDisposables(
+            panel2.api.onDidDimensionsChange((event) => {
+                panel2Dimensions = event;
+            })
+        );
+
+        // give panel2 a specific expanded height
+        panel2.api.setSize({ size: 150 });
+        expect(panel2Dimensions?.height).toBe(150);
+
+        // collapse then re-expand it
+        panel2.api.setExpanded(false);
+        panel2.api.setExpanded(true);
+
+        // it must return to its cached ~150 height, not jump to the 300px
+        // cross-axis container width (which would squeeze its siblings)
+        expect(panel2Dimensions?.height).toBe(150);
+
+        disposables.dispose();
+        paneview.dispose();
+    });
+
     test('serialization', () => {
         const paneview = new PaneviewComponent(container, {
             createComponent: (options) => {

--- a/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDragController.ts
@@ -37,6 +37,9 @@ export class PointerDragController extends CompositeDisposable {
         IPointerDropTargetHandle
     >();
     private _active: ActiveDrag | undefined;
+    /** The most recent pointer event of the active drag, used to build the
+     * drag-end event when a drag is cancelled (which carries no event). */
+    private _lastPointerEvent: PointerEvent | undefined;
     private _currentTarget: IPointerDropTargetHandle | undefined;
     private _dataDisposable: IDisposable | undefined;
     private _ghost: PointerGhost | undefined;
@@ -113,6 +116,7 @@ export class PointerDragController extends CompositeDisposable {
             startY: pointerEvent.clientY,
             source,
         };
+        this._lastPointerEvent = pointerEvent;
         this._onDragMoveCallback = args.onDragMove;
         this._onDragEndCallback = args.onDragEnd;
         this._dataDisposable = dataDisposable;
@@ -174,10 +178,28 @@ export class PointerDragController extends CompositeDisposable {
         if (!this._active) {
             return;
         }
+        // Capture before teardown clears them.
+        const onEnd = this._onDragEndCallback;
+        const lastEvent = this._lastPointerEvent;
+
         this._currentTarget?.handleDragLeave();
         this._teardown();
         this._dataDisposable?.dispose();
         this._dataDisposable = undefined;
+
+        // Fire the drag-end (dropped=false) so consumers reset, mirroring
+        // `_handleEnd`. Without this, a cancelled drag (e.g. a second touch
+        // preempting the first via `beginDrag`) never notifies the tab-reorder
+        // consumer, leaving its smooth-reorder transforms stuck.
+        if (lastEvent) {
+            const dragEvent: PointerDragEvent = {
+                clientX: lastEvent.clientX,
+                clientY: lastEvent.clientY,
+                pointerEvent: lastEvent,
+            };
+            onEnd?.(dragEvent, false);
+            this._onDragEnd.fire(dragEvent);
+        }
     }
 
     private _findTargetUnder(
@@ -203,6 +225,7 @@ export class PointerDragController extends CompositeDisposable {
     }
 
     private _handleMove(e: PointerEvent): void {
+        this._lastPointerEvent = e;
         this._ghost?.update(e.clientX, e.clientY);
 
         const dragEvent: PointerDragEvent = {
@@ -255,6 +278,7 @@ export class PointerDragController extends CompositeDisposable {
     private _teardown(): void {
         this._currentTarget = undefined;
         this._active = undefined;
+        this._lastPointerEvent = undefined;
         this._onDragMoveCallback = undefined;
         this._onDragEndCallback = undefined;
         this._ghost?.dispose();

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -826,38 +826,46 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
             tab.value.setActive(isActivePanel);
 
             if (isActivePanel) {
-                const element = tab.value.element;
-                const parentElement = element.parentElement!;
-
-                // Use the element's own offset (relative to the scroll
-                // container) rather than accumulating tab client sizes, which
-                // omits tab margins and any in-flow group chips between tabs
-                // and so undershoots the active tab's real position.
-                if (isVertical) {
-                    const start = element.offsetTop;
-                    if (
-                        start < parentElement.scrollTop ||
-                        start + element.offsetHeight >
-                            parentElement.scrollTop + parentElement.clientHeight
-                    ) {
-                        parentElement.scrollTop = start;
-                    }
-                } else {
-                    const start = element.offsetLeft;
-                    if (
-                        start < parentElement.scrollLeft ||
-                        start + element.offsetWidth >
-                            parentElement.scrollLeft + parentElement.clientWidth
-                    ) {
-                        parentElement.scrollLeft = start;
-                    }
-                }
+                this._scrollTabIntoView(tab.value.element, isVertical);
             }
         }
 
         // Reposition underlines so the wrap-around follows the new active tab
         if (this._tabGroupManager.groupUnderlines.size > 0) {
             this._tabGroupManager.positionUnderlines();
+        }
+    }
+
+    /**
+     * Scroll the active tab into view within its scroll container. Uses the
+     * element's own offset (relative to the container) rather than accumulating
+     * tab client sizes, which omits tab margins and any in-flow group chips
+     * between tabs and so undershoots the active tab's real position.
+     */
+    private _scrollTabIntoView(
+        element: HTMLElement,
+        isVertical: boolean
+    ): void {
+        const parentElement = element.parentElement;
+        if (!parentElement) {
+            return;
+        }
+
+        const start = isVertical ? element.offsetTop : element.offsetLeft;
+        const size = isVertical ? element.offsetHeight : element.offsetWidth;
+        const scrollStart = isVertical
+            ? parentElement.scrollTop
+            : parentElement.scrollLeft;
+        const clientSize = isVertical
+            ? parentElement.clientHeight
+            : parentElement.clientWidth;
+
+        if (start < scrollStart || start + size > scrollStart + clientSize) {
+            if (isVertical) {
+                parentElement.scrollTop = start;
+            } else {
+                parentElement.scrollLeft = start;
+            }
         }
     }
 

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -820,7 +820,6 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
 
     setActivePanel(panel: IDockviewPanel): void {
         const isVertical = this._direction === 'vertical';
-        let running = 0;
 
         for (const tab of this._tabs) {
             const isActivePanel = panel.id === tab.value.panel.id;
@@ -830,26 +829,30 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
                 const element = tab.value.element;
                 const parentElement = element.parentElement!;
 
+                // Use the element's own offset (relative to the scroll
+                // container) rather than accumulating tab client sizes, which
+                // omits tab margins and any in-flow group chips between tabs
+                // and so undershoots the active tab's real position.
                 if (isVertical) {
+                    const start = element.offsetTop;
                     if (
-                        running < parentElement.scrollTop ||
-                        running + element.clientHeight >
+                        start < parentElement.scrollTop ||
+                        start + element.offsetHeight >
                             parentElement.scrollTop + parentElement.clientHeight
                     ) {
-                        parentElement.scrollTop = running;
+                        parentElement.scrollTop = start;
                     }
-                } else if (
-                    running < parentElement.scrollLeft ||
-                    running + element.clientWidth >
-                        parentElement.scrollLeft + parentElement.clientWidth
-                ) {
-                    parentElement.scrollLeft = running;
+                } else {
+                    const start = element.offsetLeft;
+                    if (
+                        start < parentElement.scrollLeft ||
+                        start + element.offsetWidth >
+                            parentElement.scrollLeft + parentElement.clientWidth
+                    ) {
+                        parentElement.scrollLeft = start;
+                    }
                 }
             }
-
-            running += isVertical
-                ? tab.value.element.clientHeight
-                : tab.value.element.clientWidth;
         }
 
         // Reposition underlines so the wrap-around follows the new active tab

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3671,6 +3671,12 @@ export class DockviewComponent
                     id,
                     autoReveal: fixedData.autoReveal,
                     autoHide: fixedData.autoHide,
+                    // Restore the per-group geometry constraints; without these
+                    // the auto-created group reverts to defaults (maximumSize
+                    // Infinity, minimumSize collapsedSize+50).
+                    minimumSize: fixedData.minimumSize,
+                    maximumSize: fixedData.maximumSize,
+                    collapsedSize: fixedData.collapsedSize,
                 });
             }
         }

--- a/packages/dockview-core/src/dockview/dockviewPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewPanel.ts
@@ -245,7 +245,13 @@ export class DockviewPanel
         this._maximumWidth = state.maximumWidth;
         this._minimumWidth = state.minimumWidth;
 
-        this.update({ params: state.params ?? {} });
+        // Replace the params wholesale rather than merging via `update`:
+        // deserialization must restore exactly the saved params, so stale keys
+        // present on the reused live panel but absent from the saved state
+        // don't leak through (matching the fresh-panel `init` path).
+        this._params = state.params ?? {};
+        this.view.update({ params: this._params });
+
         this.setTitle(state.title ?? this.id);
         this.setRenderer(state.renderer ?? this.accessor.renderer);
         // Honour the serialized pinned flag only when pinning is enabled (see

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -48,6 +48,11 @@ export interface SerializedEdgeGroup {
     autoHide?: boolean;
     /** Per-group "tear down to zero footprint when emptied" flag. */
     autoReveal?: boolean;
+    /** User-configured geometry constraints (as passed to `addEdgeGroup`), so
+     *  they survive the auto-create fromJSON path. Absent = use the defaults. */
+    minimumSize?: number;
+    maximumSize?: number;
+    collapsedSize?: number;
 }
 
 export interface SerializedEdgeGroups {
@@ -142,6 +147,22 @@ export class EdgeGroupView implements IView {
 
     get collapsedSize(): number {
         return this._effectiveBaseCollapsed + this._gapAdd;
+    }
+
+    /** The user-configured (pre-gap) geometry constraints, for serialization.
+     *  These are the raw values passed to `addEdgeGroup` — unlike the effective
+     *  `minimumSize`/`maximumSize`/`collapsedSize` getters, which fold in the
+     *  theme gap and collapse-locking. */
+    get configuredMinimumSize(): number | undefined {
+        return this._baseMinimumSize;
+    }
+
+    get configuredMaximumSize(): number {
+        return this._expandedMaximumSize;
+    }
+
+    get configuredCollapsedSize(): number {
+        return this._baseCollapsedSize;
     }
 
     constructor(
@@ -856,6 +877,22 @@ export class ShellManager implements IDisposable {
     toJSON(): SerializedEdgeGroups {
         const edgeGroups: SerializedEdgeGroups = {};
 
+        // Persist the user-configured constraints so the auto-create fromJSON
+        // path restores them. Omit unconfigured/Infinity values (Infinity isn't
+        // JSON-representable) so they fall back to defaults on restore.
+        const constraints = (
+            view: EdgeGroupView
+        ): Pick<
+            SerializedEdgeGroup,
+            'minimumSize' | 'maximumSize' | 'collapsedSize'
+        > => ({
+            minimumSize: view.configuredMinimumSize,
+            maximumSize: Number.isFinite(view.configuredMaximumSize)
+                ? view.configuredMaximumSize
+                : undefined,
+            collapsedSize: view.configuredCollapsedSize,
+        });
+
         if (this._leftView && this._leftIndex !== undefined) {
             edgeGroups.left = {
                 size: this._leftView.isCollapsed
@@ -863,6 +900,7 @@ export class ShellManager implements IDisposable {
                     : this._outerSplitview.getViewSize(this._leftIndex),
                 visible: this._outerSplitview.isViewVisible(this._leftIndex),
                 collapsed: this._leftView.isCollapsed || undefined,
+                ...constraints(this._leftView),
             };
         }
         if (this._rightView && this._rightIndex !== undefined) {
@@ -872,6 +910,7 @@ export class ShellManager implements IDisposable {
                     : this._outerSplitview.getViewSize(this._rightIndex),
                 visible: this._outerSplitview.isViewVisible(this._rightIndex),
                 collapsed: this._rightView.isCollapsed || undefined,
+                ...constraints(this._rightView),
             };
         }
         if (this._topView) {
@@ -881,6 +920,7 @@ export class ShellManager implements IDisposable {
                     : this._middleColumn.getViewSize('top'),
                 visible: this._middleColumn.isViewVisible('top'),
                 collapsed: this._topView.isCollapsed || undefined,
+                ...constraints(this._topView),
             };
         }
         if (this._bottomView) {
@@ -890,6 +930,7 @@ export class ShellManager implements IDisposable {
                     : this._middleColumn.getViewSize('bottom'),
                 visible: this._middleColumn.isViewVisible('bottom'),
                 collapsed: this._bottomView.isCollapsed || undefined,
+                ...constraints(this._bottomView),
             };
         }
 

--- a/packages/dockview-core/src/paneview/paneviewPanel.ts
+++ b/packages/dockview-core/src/paneview/paneviewPanel.ts
@@ -74,6 +74,11 @@ export abstract class PaneviewPanel
     private _minimumBodySize: number;
     private _maximumBodySize: number;
     private _isExpanded = false;
+    /**
+     * The pane's main-axis size captured just before it was collapsed, so a
+     * later re-expand can restore that size instead of the cross-axis width.
+     */
+    private _expandedSize: number | undefined;
     protected header?: HTMLElement;
     protected body?: HTMLElement;
     private bodyPart?: IPanePart;
@@ -256,12 +261,21 @@ export abstract class PaneviewPanel
                 this.element.appendChild(this.body);
             }
         } else {
+            // cache the current (expanded) main-axis size before collapsing so
+            // a later re-expand can restore it
+            this._expandedSize = this._size;
             this.animationTimer = setTimeout(() => {
                 this.body?.remove();
             }, 200);
         }
 
-        this._onDidChange.fire(expanded ? { size: this.width } : {});
+        // On re-expand, request the cached expanded main-axis size rather than
+        // `this.width` (the cross-axis dimension, which for a vertical paneview
+        // is the container width and would squeeze siblings). Fall back to the
+        // previous behaviour when the pane has never been collapsed.
+        this._onDidChange.fire(
+            expanded ? { size: this._expandedSize ?? this.width } : {}
+        );
         this._onDidChangeExpansionState.fire(expanded);
     }
 


### PR DESCRIPTION
## Description

Third batch from the bug backlog — six moderate, single-component fixes across `dockview-core` and `dockview-angular`, each shipped with a test that fails without it.

### Linear

Fixes DV-46
Fixes DV-50
Fixes DV-53
Fixes DV-58
Fixes DV-56
Fixes DV-62

### Bug fixes

| Issue | Area | Bug | Fix |
|-------|------|-----|-----|
| **DV-46** | core / dockviewPanel | `updateFromStateModel` routed through the merge-based `update()`, so `reuseExistingPanels` leaked stale param keys absent from the saved state | replace params wholesale to match the fresh-panel `init` path |
| **DV-50** | core / paneviewPanel | re-expanding a collapsed pane fired `this.width` (the cross-axis container width) as its size, squeezing siblings | cache the main-axis size at collapse time and restore it on re-expand |
| **DV-53** | core / tabs | `setActivePanel` accumulated tab `clientWidth` to find the active tab, omitting tab margins and in-flow group chips, so the strip scrolled short | use the element's `offsetLeft`/`offsetTop` |
| **DV-58** | core / pointerDragController | `cancel()` tore down a drag without firing `onDragEnd`, so a preempted touch drag never reset the tab-reorder animation | fire `onDragEnd` (dropped=false) from `cancel`, mirroring `_handleEnd` |
| **DV-56** | core / dockviewShell + dockviewComponent | per-group edge constraints (min/max/collapsed) weren't serialized, so the auto-create `fromJSON` path reverted to defaults | persist and restore them |
| **DV-62** | angular | `ngOnChanges` ignored component-map inputs, so rebinding `[components]` left the factory pinned to the init snapshot and `addPanel` with a new component threw | refresh the factory's maps in place |

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [x] `dockview-angular`
- [ ] `docs`

## How to test

Each fix has a dedicated test that fails on the unpatched code and passes with the fix (verified by reverting only the source files and confirming each new test fails, then restoring):

- `dockview-core`: `dockviewComponent.spec.ts` (reuse params replace + edge-group constraints round-trip), `paneview/paneviewComponent.spec.ts` (re-expand restores size), `dockview/components/titlebar/tabs.spec.ts` (scroll to offsetLeft), `dnd/pointer/pointerDragController.spec.ts` (cancel fires onDragEnd)
- `dockview-angular`: `dockview-angular.component.spec.ts` (rebound `[components]` honoured)

Full suites pass: `dockview-core` 1218/1218, `dockview-angular` 131/131. `lint` 0 errors, `format` clean, `gen` no drift.

> Note: the angular tests require the `dockview` package to be built first (its `.d.ts` back the bindings), which CI's build job handles.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JE1SmW4mWp6AdoNVbHprb)_