### PR TITLE
fix(dockview-core): round-trip hidden views instead of serializing size 0 (DV-48, DV-55)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -11441,6 +11441,46 @@ describe('dockviewComponent', () => {
             fresh.dispose();
         });
 
+        test('an expanded-but-hidden edge group serializes its cached size, not 0', () => {
+            const c = document.createElement('div');
+            const dv = new DockviewComponent(c, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+            });
+            dv.layout(1000, 800);
+            dv.addEdgeGroup('right', {
+                id: 'right-group',
+                initialSize: 250,
+                minimumSize: 100,
+            });
+            dv.addPanel({
+                id: 'right-p1',
+                component: 'default',
+                position: { referenceGroup: 'right-group' },
+            });
+            dv.getEdgeGroup('right')!.expand();
+
+            // hide the expanded edge group — getViewSize now reports 0
+            dv.setEdgeGroupVisible('right', false);
+
+            const json = dv.toJSON();
+            expect(json.edgeGroups!.right!.visible).toBe(false);
+            // the fix: serialize the cached visible size rather than 0, so
+            // re-showing restores the prior width instead of snapping to min
+            expect(json.edgeGroups!.right!.size).toBeGreaterThan(100);
+
+            dv.dispose();
+        });
+
         test('toJSON includes edgeGroups field for configured positions', () => {
             const c = document.createElement('div');
             const dv = createFixedDockview(c, ['left', 'top']);

--- a/packages/dockview-core/src/__tests__/gridview/gridview.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridview.spec.ts
@@ -84,6 +84,50 @@ describe('gridview', () => {
         expect(gridview.maximumHeight).toBe(Number.MAX_VALUE);
     });
 
+    test('a nested branch with all children hidden round-trips hidden, not visible at size 0', () => {
+        const gridview = new Gridview(
+            false,
+            { separatorBorder: '' },
+            Orientation.HORIZONTAL
+        );
+        gridview.layout(1000, 1000);
+
+        gridview.addView(new MockGridview(), Sizing.Distribute, [0]);
+        gridview.addView(new MockGridview(), Sizing.Distribute, [1]);
+        // split the [1] leaf into a nested branch of two leaves
+        gridview.addView(new MockGridview(), Sizing.Distribute, [1, 0]);
+
+        // hide both children of the nested branch → the branch auto-hides
+        gridview.setViewVisible([1, 0], false);
+        gridview.setViewVisible([1, 1], false);
+
+        const serialized = gridview.serialize();
+        const branch = (serialized.root as any).data[1];
+        expect(branch.type).toBe('branch');
+        // the fix: branch carries its visibility + cached size (was undefined)
+        expect(branch.visible).toBe(false);
+        expect(branch.size).toBeGreaterThan(0);
+
+        // round-trip into a fresh gridview; the branch must load hidden, so
+        // re-serializing preserves visible:false (rather than a visible size-0
+        // branch that no longer round-trips)
+        const restored = new Gridview(
+            false,
+            { separatorBorder: '' },
+            Orientation.HORIZONTAL
+        );
+        restored.layout(1000, 1000);
+        restored.deserialize(serialized, {
+            fromJSON: () => new MockGridview(),
+        });
+
+        const reserialized = restored.serialize();
+        const restoredBranch = (reserialized.root as any).data[1];
+        expect(restoredBranch.type).toBe('branch');
+        expect(restoredBranch.visible).toBe(false);
+        expect(restoredBranch.size).toBeGreaterThan(0);
+    });
+
     test('insertOrthogonalSplitviewAtRoot #1', () => {
         const gridview = new Gridview(
             false,

--- a/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
@@ -238,6 +238,53 @@ describe('paneviewComponent', () => {
         paneview.dispose();
     });
 
+    test('a hidden pane round-trips hidden at its cached size, not size 0', () => {
+        const paneview = new PaneviewComponent(container, {
+            createComponent: (options) => {
+                switch (options.name) {
+                    case 'default':
+                        return new TestPanel(options.id, options.name);
+                    default:
+                        throw new Error('unsupported');
+                }
+            },
+        });
+
+        paneview.layout(300, 600);
+
+        paneview.addPanel({
+            id: 'panel1',
+            component: 'default',
+            title: 'Panel 1',
+            isExpanded: true,
+        });
+        const panel2 = paneview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            title: 'Panel 2',
+            isExpanded: true,
+        });
+
+        // hide panel2 — getViewSize now reports 0, but its real size is cached
+        paneview.setVisible(panel2, false);
+
+        const json = paneview.toJSON();
+        const v2 = json.views.find((v) => v.data.id === 'panel2')!;
+        expect(v2.visible).toBe(false);
+        expect(v2.size).toBeGreaterThan(0);
+
+        // round-trip: the pane must reload hidden at its cached size
+        paneview.fromJSON(json);
+        paneview.layout(300, 600);
+
+        const json2 = paneview.toJSON();
+        const v2b = json2.views.find((v) => v.data.id === 'panel2')!;
+        expect(v2b.visible).toBe(false);
+        expect(v2b.size).toBeGreaterThan(0);
+
+        paneview.dispose();
+    });
+
     test('serialization', () => {
         const paneview = new PaneviewComponent(container, {
             createComponent: (options) => {

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -442,6 +442,14 @@ class MiddleColumnView implements IView, IDisposable {
         return 0;
     }
 
+    getViewCachedVisibleSize(position: 'top' | 'bottom'): number | undefined {
+        const index = position === 'top' ? this._topIndex : this._bottomIndex;
+        if (index !== undefined) {
+            return this._splitview.getViewCachedVisibleSize(index);
+        }
+        return undefined;
+    }
+
     resizeView(position: 'top' | 'bottom', size: number): void {
         const index = position === 'top' ? this._topIndex : this._bottomIndex;
         if (index !== undefined) {
@@ -893,42 +901,82 @@ export class ShellManager implements IDisposable {
             collapsedSize: view.configuredCollapsedSize,
         });
 
+        // Record the size to restore the group to. An expanded-but-hidden
+        // group reports getViewSize 0, so fall back to its cached visible size
+        // (then lastExpandedSize) — otherwise re-showing snaps to minimumSize.
+        const expandedSize = (
+            view: EdgeGroupView,
+            isVisible: boolean,
+            liveSize: number,
+            cachedVisibleSize: number | undefined
+        ): number => {
+            if (view.isCollapsed) {
+                return view.lastExpandedSize;
+            }
+            if (!isVisible) {
+                return cachedVisibleSize ?? view.lastExpandedSize;
+            }
+            return liveSize;
+        };
+
         if (this._leftView && this._leftIndex !== undefined) {
+            const visible = this._outerSplitview.isViewVisible(this._leftIndex);
             edgeGroups.left = {
-                size: this._leftView.isCollapsed
-                    ? this._leftView.lastExpandedSize
-                    : this._outerSplitview.getViewSize(this._leftIndex),
-                visible: this._outerSplitview.isViewVisible(this._leftIndex),
+                size: expandedSize(
+                    this._leftView,
+                    visible,
+                    this._outerSplitview.getViewSize(this._leftIndex),
+                    this._outerSplitview.getViewCachedVisibleSize(
+                        this._leftIndex
+                    )
+                ),
+                visible,
                 collapsed: this._leftView.isCollapsed || undefined,
                 ...constraints(this._leftView),
             };
         }
         if (this._rightView && this._rightIndex !== undefined) {
+            const visible = this._outerSplitview.isViewVisible(
+                this._rightIndex
+            );
             edgeGroups.right = {
-                size: this._rightView.isCollapsed
-                    ? this._rightView.lastExpandedSize
-                    : this._outerSplitview.getViewSize(this._rightIndex),
-                visible: this._outerSplitview.isViewVisible(this._rightIndex),
+                size: expandedSize(
+                    this._rightView,
+                    visible,
+                    this._outerSplitview.getViewSize(this._rightIndex),
+                    this._outerSplitview.getViewCachedVisibleSize(
+                        this._rightIndex
+                    )
+                ),
+                visible,
                 collapsed: this._rightView.isCollapsed || undefined,
                 ...constraints(this._rightView),
             };
         }
         if (this._topView) {
+            const visible = this._middleColumn.isViewVisible('top');
             edgeGroups.top = {
-                size: this._topView.isCollapsed
-                    ? this._topView.lastExpandedSize
-                    : this._middleColumn.getViewSize('top'),
-                visible: this._middleColumn.isViewVisible('top'),
+                size: expandedSize(
+                    this._topView,
+                    visible,
+                    this._middleColumn.getViewSize('top'),
+                    this._middleColumn.getViewCachedVisibleSize('top')
+                ),
+                visible,
                 collapsed: this._topView.isCollapsed || undefined,
                 ...constraints(this._topView),
             };
         }
         if (this._bottomView) {
+            const visible = this._middleColumn.isViewVisible('bottom');
             edgeGroups.bottom = {
-                size: this._bottomView.isCollapsed
-                    ? this._bottomView.lastExpandedSize
-                    : this._middleColumn.getViewSize('bottom'),
-                visible: this._middleColumn.isViewVisible('bottom'),
+                size: expandedSize(
+                    this._bottomView,
+                    visible,
+                    this._middleColumn.getViewSize('bottom'),
+                    this._middleColumn.getViewCachedVisibleSize('bottom')
+                ),
+                visible,
                 collapsed: this._bottomView.isCollapsed || undefined,
                 ...constraints(this._bottomView),
             };

--- a/packages/dockview-core/src/gridview/branchNode.ts
+++ b/packages/dockview-core/src/gridview/branchNode.ts
@@ -13,7 +13,6 @@ import {
 } from '../splitview/splitview';
 import { Emitter, Event } from '../events';
 import { INodeDescriptor } from './gridview';
-import { LeafNode } from './leafNode';
 import { Node } from './types';
 import { CompositeDisposable, IDisposable, Disposable } from '../lifecycle';
 
@@ -177,8 +176,10 @@ export class BranchNode extends CompositeDisposable implements IView {
                     return {
                         view: childDescriptor.node,
                         size: childDescriptor.node.size,
+                        // Honour an explicit `visible` flag for branch children
+                        // too (not just leaves), so a hidden sub-grid restores
+                        // hidden with its cached size rather than visible at 0.
                         visible:
-                            childDescriptor.node instanceof LeafNode &&
                             childDescriptor.visible !== undefined
                                 ? childDescriptor.visible
                                 : true,

--- a/packages/dockview-core/src/gridview/gridview.ts
+++ b/packages/dockview-core/src/gridview/gridview.ts
@@ -228,6 +228,7 @@ export interface GridLeafNode<T extends IGridView> {
 export interface GridBranchNode<T extends IGridView> {
     readonly children: GridNode<T>[];
     readonly box: { width: number; height: number };
+    readonly cachedVisibleSize: number | undefined;
 }
 
 export type GridNode<T extends IGridView> = GridLeafNode<T> | GridBranchNode<T>;
@@ -265,11 +266,25 @@ const serializeBranchNode = <T extends IGridView>(
         return { type: 'leaf', data: node.view.toJSON(), size };
     }
 
+    const data = node.children.map((c) =>
+        serializeBranchNode(c, orthogonal(orientation))
+    );
+
+    // A branch that is hidden in its parent (all its children collapsed) has a
+    // cached visible size; carry it through symmetrically with leaf nodes so
+    // the branch round-trips hidden instead of loading visible at size 0.
+    if (typeof node.cachedVisibleSize === 'number') {
+        return {
+            type: 'branch',
+            data,
+            size: node.cachedVisibleSize,
+            visible: false,
+        };
+    }
+
     return {
         type: 'branch',
-        data: node.children.map((c) =>
-            serializeBranchNode(c, orthogonal(orientation))
-        ),
+        data,
         size,
     };
 };
@@ -285,6 +300,7 @@ export interface ISerializedBranchNode {
     type: 'branch';
     data: ISerializedNode[];
     size: number;
+    visible?: boolean;
 }
 
 export type ISerializedNode = ISerializedLeafNode | ISerializedBranchNode;
@@ -827,7 +843,7 @@ export class Gridview implements IDisposable {
             );
         }
 
-        return { box, children };
+        return { box, children, cachedVisibleSize };
     }
 
     private progmaticSelect(location: number[], reverse = false): LeafNode {

--- a/packages/dockview-core/src/paneview/paneview.ts
+++ b/packages/dockview-core/src/paneview/paneview.ts
@@ -142,6 +142,10 @@ export class Paneview extends CompositeDisposable implements IDisposable {
         return this.splitview.getViewSize(index);
     }
 
+    getViewCachedVisibleSize(index: number): number | undefined {
+        return this.splitview.getViewCachedVisibleSize(index);
+    }
+
     public getPanes(): PaneviewPanel[] {
         return this.splitview.getViews();
     }

--- a/packages/dockview-core/src/paneview/paneviewComponent.ts
+++ b/packages/dockview-core/src/paneview/paneviewComponent.ts
@@ -40,6 +40,9 @@ export interface SerializedPaneviewPanel {
     };
     size: number;
     expanded?: boolean;
+    /** Absent/true = visible; false = the pane was hidden via setVisible and
+     *  `size` holds its cached pre-hide size. */
+    visible?: boolean;
 }
 
 export interface SerializedPaneview {
@@ -351,14 +354,23 @@ export class PaneviewComponent extends Resizable implements IPaneviewComponent {
         const views: SerializedPaneviewPanel[] = this.paneview
             .getPanes()
             .map((view, i) => {
-                const size = this.paneview.getViewSize(i);
+                // A pane hidden via setVisible(false) reports getViewSize 0;
+                // its real (pre-hide) size lives in the cached visible size.
+                // Serialize that plus a `visible: false` flag so it round-trips
+                // hidden at its prior size rather than visible at size 0.
+                const cachedVisibleSize =
+                    this.paneview.getViewCachedVisibleSize(i);
+                const hidden = typeof cachedVisibleSize === 'number';
                 return {
-                    size,
+                    size: hidden
+                        ? cachedVisibleSize
+                        : this.paneview.getViewSize(i),
                     data: view.toJSON(),
                     minimumSize: minimum(view.minimumBodySize),
                     maximumSize: maximum(view.maximumBodySize),
                     headerSize: view.headerSize,
                     expanded: view.isExpanded(),
+                    ...(hidden ? { visible: false } : {}),
                 };
             });
 
@@ -440,7 +452,11 @@ export class PaneviewComponent extends Resizable implements IPaneviewComponent {
                         this._onDidAddView.fire(panel);
                     }, 0);
 
-                    return { size: view.size, view: panel };
+                    return {
+                        size: view.size,
+                        view: panel,
+                        visible: view.visible,
+                    };
                 }),
             },
         });


### PR DESCRIPTION
## Description

First cluster of Tier 4 — two issues that share one root cause: a splitview view hidden via `setVisible(false)` reports `getViewSize` **0**, so its real pre-hide size (held in the view's `cachedVisibleSize`) was lost on serialize and it reloaded **visible at size 0**. The fix carries the cached size + a `visible` flag through, symmetrically with the existing leaf-node handling.

### Linear

Fixes DV-48
Fixes DV-55

### Bug fixes

| Issue | Area | Bug | Fix |
|-------|------|-----|-----|
| **DV-48** | core / gridview | a `BranchNode` that auto-hides when all its children are hidden serialized with **no** visibility info, so it reloaded visible at size 0 and a re-shown inner panel stayed clipped (stuck-collapsed sub-grid) | add `cachedVisibleSize` to `GridBranchNode` + `visible` to `ISerializedBranchNode`; retain the branch's cached size in `_getViews`; emit `visible:false` in `serializeBranchNode`'s branch path; honour `childDescriptor.visible` for branch children (not just leaves) in the `BranchNode` constructor |
| **DV-55** | core / paneview + edge groups | same class in two more components — a hidden pane and an expanded-but-hidden edge group each serialized size 0; for edge groups `restoreExpandedSize(0)` then made re-show snap to `minimumSize` | serialize the cached visible size + `visible:false` and honour it on restore (new `Paneview.getViewCachedVisibleSize` and `MiddleColumnView.getViewCachedVisibleSize`) |

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

Each fix has a round-trip test that fails on the unpatched code and passes with the fix (verified by reverting only the source files and confirming each fails, then restoring):

- `gridview/gridview.spec.ts` — a nested branch with all children hidden round-trips hidden (not visible at size 0)
- `paneview/paneviewComponent.spec.ts` — a hidden pane round-trips hidden at its cached size
- `dockview/dockviewComponent.spec.ts` — an expanded-but-hidden edge group serializes its cached size, not 0

Full suites pass: `dockview-core` 1221/1221, and the framework wrappers are unaffected (`dockview-react` 48, `dockview-vue` 124, `dockview-angular` 131). `lint` 0 errors, `format` clean, `gen` no drift.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JE1SmW4mWp6AdoNVbHprb)_