### PR TITLE
fix(dockview-core): commit pointer/touch smooth tab reorder on single-row headers (DV-42)

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsAnimation.spec.ts
@@ -2137,5 +2137,56 @@ describe('tabs - animation', () => {
         // source now owns the iframe shield + panelTransfer cleanup via
         // its internal MutableDisposables, fired by the controller's own
         // teardown when the drag ends.
+
+        test('pointer/touch smooth reorder commits on a single-row header', () => {
+            const { tabs } = createTabs({ tabAnimation: 'smooth' });
+            tabs.openPanel(createMockPanel('a'), 0);
+            tabs.openPanel(createMockPanel('b'), 1);
+
+            const tabAEl = (tabs as any)._tabs[0].value.element as HTMLElement;
+            const tabsList = (tabs as any)._tabsList as HTMLElement;
+
+            // start a pointer/touch drag on tab 'a' → initialises _animState
+            (tabs as any)._tabs[0].value._onDragStart.fire(
+                new PointerEvent('pointerdown', {
+                    pointerId: 1,
+                    pointerType: 'touch',
+                    clientX: 0,
+                    clientY: 0,
+                })
+            );
+            // the drag has settled on insertion index 2 (after 'b')
+            (tabs as any)._animState.currentInsertionIndex = 2;
+
+            // the pointer is released inside the tab strip (single-row, no wrap)
+            jest.spyOn(document, 'elementFromPoint').mockReturnValue(tabsList);
+
+            const drops: TabDropIndexEvent[] = [];
+            tabs.onDrop((e) => drops.push(e));
+
+            // end the pointer drag over the strip via the controller
+            const controller = PointerDragController.getInstance();
+            controller.beginDrag({
+                pointerEvent: new PointerEvent('pointerdown', {
+                    pointerId: 1,
+                    pointerType: 'touch',
+                }),
+                source: tabAEl,
+                getData: () => ({ dispose: jest.fn() }),
+            });
+            window.dispatchEvent(
+                new PointerEvent('pointerup', {
+                    pointerId: 1,
+                    pointerType: 'touch',
+                    clientX: 100,
+                    clientY: 10,
+                })
+            );
+
+            // single-row smooth mode must commit the reorder (previously it had
+            // no pointer commit path, so the tab snapped back and no drop fired)
+            expect(drops).toHaveLength(1);
+            expect(drops[0].index).toBe(1);
+        });
     });
 });

--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -245,18 +245,19 @@ export class TabReorderController extends CompositeDisposable {
         clientY: number;
         pointerEvent: PointerEvent;
     }): void {
-        // Multi-row wrap intra-group reorder — the pointer-backend analog of the
-        // HTML5 tabs-list `drop` commit. In smooth wrap the per-tab pointer drop
-        // target doesn't latch a drop state for the intra-group drag, so its
-        // `onDrop` never fires; commit the reorder from the computed 2-D
-        // insertion index when the drag ends over the strip. This can't
-        // double-commit: `tab.onDrop` nulls `_animState` before this runs (the
-        // backend calls `handleDrop` before `onDragEnd`), so if the per-tab path
-        // *did* fire, `_animState` is already null and this is skipped. (HTML5
-        // wrap drops commit via the tabs-list `drop` listener, which likewise
-        // reads `currentInsertionIndex`.)
+        // Smooth-mode intra-group reorder — the pointer-backend analog of the
+        // HTML5 tabs-list `drop` commit. In smooth mode the per-tab pointer
+        // drop target doesn't latch a drop state for the intra-group drag, so
+        // its `onDrop` never fires; commit the reorder from the computed
+        // insertion index when the drag ends over the strip. This covers both
+        // single-row and multi-row wrap layouts (single-row previously had no
+        // pointer commit path at all, so the tab snapped back on release). It
+        // can't double-commit: `tab.onDrop` nulls `_animState` before this runs
+        // (the backend calls `handleDrop` before `onDragEnd`), so if the per-tab
+        // path *did* fire, `_animState` is already null and this is skipped; in
+        // default (non-smooth) mode `_animState` is never set for an intra-group
+        // drag, so this path is inert there too.
         if (
-            this._wrapMode &&
             e &&
             this._animState &&
             // intra-group single-tab reorder only: `sourceIndex === -1` is a
@@ -269,7 +270,7 @@ export class TabReorderController extends CompositeDisposable {
             this._animState.currentInsertionIndex !== null &&
             this.isPointInsideTabsList(e.clientX, e.clientY)
         ) {
-            this.commitWrapReorder(e.pointerEvent);
+            this.commitPointerReorder(e.pointerEvent);
         }
         this._pointerInsideTabsList = false;
         this.resetDragAnimation();
@@ -281,9 +282,10 @@ export class TabReorderController extends CompositeDisposable {
         return !!el && this._tabsList.contains(el);
     }
 
-    /** Commit a wrap-mode intra-group reorder from the current 2-D insertion
-     *  index (adjusted for the source's own position), then clear drag state. */
-    private commitWrapReorder(event: PointerEvent): void {
+    /** Commit a smooth-mode intra-group reorder from the current insertion
+     *  index (adjusted for the source's own position), then clear drag state.
+     *  Used by the pointer backend for both single-row and wrap layouts. */
+    private commitPointerReorder(event: PointerEvent): void {
         const animState = this._animState;
         if (!animState || animState.currentInsertionIndex === null) {
             return;


### PR DESCRIPTION
## Description

An intra-group single-tab reorder driven by the **pointer/touch** backend with `tabAnimation: 'smooth'` on a normal **single-row** header never committed — the gap animated during the drag but the tab snapped back on release and no `onDrop` fired.

### Linear

Fixes DV-42

### Root cause

The pointer backend's only commit-on-end (`TabReorderController.handlePointerDragEnd`) was gated on `_wrapMode`, so single-row (non-wrap) layouts had **no** pointer commit path at all. In smooth mode the per-tab pointer drop target also doesn't latch a drop state for the intra-group drag, so its `onDrop` never fired either. (Releasing over the empty/void header area still committed via the void drop target, which masked the bug in casual testing.)

### Fix

Drop the `_wrapMode` gate so the existing insertion-index commit runs for both single-row and wrap layouts (renamed `commitWrapReorder` → `commitPointerReorder`, since it's no longer wrap-specific). This can't double-commit:
- `tab.onDrop` nulls `_animState` before `onDragEnd` runs, so if a per-tab path *did* fire, this is skipped;
- in default (non-smooth) mode `_animState` is never set for an intra-group drag, so the path is inert there.

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

`tabsAnimation.spec.ts` — "pointer/touch smooth reorder commits on a single-row header": drives a pointer/touch drag (via the tab's `_onDragStart` + `PointerDragController` end) in single-row smooth mode and asserts the reorder `onDrop` fires with the computed index. Fails on the unpatched code (no drop), passes with the fix (verified by reverting the source and re-running).

Full suite: `dockview-core` 1222/1222 (255/255 titlebar). `lint` 0 errors, `format` clean, `gen` no drift.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JE1SmW4mWp6AdoNVbHprb)_