### PR TITLE
fix(dockview-core): route popout popup service per-window, not per-anchor (DV-43, DV-47)

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -277,6 +277,19 @@
                     popoutCount: () => dockview.getPopouts().length,
                     closeActivePopout: () =>
                         dockview.getPopouts()[0].group.api.close(),
+                    // Dock the popout window's anchor group back next to a
+                    // grid group — promotes a remaining popout member to anchor
+                    // while the window stays open (drives DV-47).
+                    dockPopoutAnchorNextTo: (targetId) => {
+                        const popoutGroup = dockview.getPopouts()[0].group;
+                        dockview.moveGroupOrPanel({
+                            from: { groupId: popoutGroup.id },
+                            to: {
+                                group: panels[targetId].api.group,
+                                position: 'right',
+                            },
+                        });
+                    },
                     undo: () => dockview.undo(),
                     redo: () => dockview.redo(),
                     canUndo: () => dockview.canUndo,

--- a/e2e/tests/popout-multi-window.spec.ts
+++ b/e2e/tests/popout-multi-window.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, Page, BrowserContext } from '@playwright/test';
+
+/**
+ * Cross-window popup-service routing (DV-43 / DV-47). A group's tab context
+ * menu must render in the window that group actually lives in — the opener for
+ * grid groups, the popout window for groups inside it — even when the group is
+ * not the popout's anchor (DV-43) and after the anchor is docked back out and a
+ * member is promoted (DV-47). jsdom reuses a single document, so only a real
+ * second window can verify which document the menu mounts in.
+ */
+test.describe('popout multi-window popup routing', () => {
+    async function popoutActiveGroup(
+        page: Page,
+        context: BrowserContext
+    ): Promise<Page> {
+        const [popout] = await Promise.all([
+            context.waitForEvent('page'),
+            page.evaluate(() => (window as any).__dv.popoutActiveGroup()),
+        ]);
+        await popout.waitForLoadState();
+        return popout;
+    }
+
+    test("DV-43: a non-anchor group's context menu renders in the popout window", async ({
+        page,
+        context,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.addPanel('alpha'));
+
+        const popout = await popoutActiveGroup(page, context);
+
+        // add a SECOND group ('beta') inside the popout — a non-anchor member
+        await page.evaluate(() => (window as any).__dv.splitIntoPopout('beta'));
+        await expect(
+            popout.locator('.dv-tab', { hasText: 'beta' })
+        ).toBeVisible();
+
+        // right-click beta's tab (in the popout) to open its context menu
+        await popout
+            .locator('.dv-tab', { hasText: 'beta' })
+            .click({ button: 'right' });
+
+        // the menu must mount in the popout document, not the opener
+        await expect(popout.locator('.dv-context-menu')).toBeVisible();
+        await expect(page.locator('.dv-context-menu')).toHaveCount(0);
+    });
+
+    test('DV-47: after the anchor docks back to the grid, the promoted member routes to the popout and the departed group to the opener', async ({
+        page,
+        context,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => {
+            (window as any).__dv.addPanel('home'); // grid group that stays
+            (window as any).__dv.addPanelAt('alpha', 'right'); // separate group
+        });
+
+        // pop out alpha's (active) group, then drag 'beta' into the popout
+        const popout = await popoutActiveGroup(page, context);
+        await page.evaluate(() => (window as any).__dv.splitIntoPopout('beta'));
+        await expect(
+            popout.locator('.dv-tab', { hasText: 'beta' })
+        ).toBeVisible();
+
+        // dock the ORIGINAL anchor (alpha's group) back to the grid → the
+        // window survives and promotes beta's group as the new anchor
+        await page.evaluate(() =>
+            (window as any).__dv.dockPopoutAnchorNextTo('home')
+        );
+        await expect(
+            page.locator('.dv-tab', { hasText: 'alpha' })
+        ).toBeVisible();
+        await expect(
+            popout.locator('.dv-tab', { hasText: 'beta' })
+        ).toBeVisible();
+
+        // the promoted member (beta) still routes its menu to the popout
+        await popout
+            .locator('.dv-tab', { hasText: 'beta' })
+            .click({ button: 'right' });
+        await expect(popout.locator('.dv-context-menu')).toBeVisible();
+        await expect(page.locator('.dv-context-menu')).toHaveCount(0);
+        await popout.keyboard.press('Escape');
+        await expect(popout.locator('.dv-context-menu')).toHaveCount(0);
+
+        // the departed group (alpha, now back in the grid) routes to the opener
+        await page
+            .locator('.dv-tab', { hasText: 'alpha' })
+            .click({ button: 'right' });
+        await expect(page.locator('.dv-context-menu')).toBeVisible();
+        await expect(popout.locator('.dv-context-menu')).toHaveCount(0);
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -6246,6 +6246,108 @@ describe('dockviewComponent', () => {
                 dockview.dispose();
             });
 
+            test('DV-43: a non-anchor group in a multi-group popout resolves the popout window popup service, not the main one', async () => {
+                window.open = () => setupMockWindow();
+                const dockview = make();
+                dockview.layout(1000, 500);
+
+                const panel1 = dockview.addPanel({
+                    id: 'panel_1',
+                    component: 'default',
+                });
+                const panel2 = dockview.addPanel({
+                    id: 'panel_2',
+                    component: 'default',
+                    position: { referencePanel: 'panel_1', direction: 'right' },
+                });
+
+                await dockview.addPopoutGroup(panel1.api.group);
+                // drag panel2's group into the popout → 2-group popout, anchor
+                // is panel1's group
+                dockview.moveGroupOrPanel({
+                    from: { groupId: panel2.group.id },
+                    to: { group: panel1.group, position: 'right' },
+                });
+
+                const mainPopupService = (dockview as any).popupService;
+                const anchorService = dockview.getPopupServiceForGroup(
+                    panel1.group
+                );
+                const memberService = dockview.getPopupServiceForGroup(
+                    panel2.group
+                );
+
+                // the anchor resolves to the popout window's own popup service
+                expect(anchorService).not.toBe(mainPopupService);
+                // and the non-anchor member shares that same service rather than
+                // falling back to the main window's (the DV-43 bug)
+                expect(memberService).toBe(anchorService);
+                expect(memberService).not.toBe(mainPopupService);
+
+                dockview.dispose();
+            });
+
+            test('DV-47: promoting a new anchor re-keys per-window popup-service resolution to the survivor', async () => {
+                const mockWindow = setupMockWindow();
+                window.open = () => mockWindow;
+
+                const dockview = make();
+                dockview.layout(1000, 500);
+
+                const panel1 = dockview.addPanel({
+                    id: 'panel_1',
+                    component: 'default',
+                });
+                const panel2 = dockview.addPanel({
+                    id: 'panel_2',
+                    component: 'default',
+                    position: { referencePanel: 'panel_1', direction: 'right' },
+                });
+                const panel3 = dockview.addPanel({
+                    id: 'panel_3',
+                    component: 'default',
+                    position: { referencePanel: 'panel_1', direction: 'right' },
+                });
+
+                await dockview.addPopoutGroup(panel1.api.group);
+                dockview.moveGroupOrPanel({
+                    from: { groupId: panel2.group.id },
+                    to: { group: panel1.group, position: 'right' },
+                });
+
+                const mainPopupService = (dockview as any).popupService;
+                const popoutService = dockview.getPopupServiceForGroup(
+                    panel1.group
+                );
+                expect(popoutService).not.toBe(mainPopupService);
+
+                // move the ORIGINAL anchor back to the grid → panel2 is promoted
+                dockview.moveGroupOrPanel({
+                    from: { groupId: panel1.group.id },
+                    to: { group: panel3.group, position: 'right' },
+                });
+                expect(panel1.api.location.type).toBe('grid');
+                expect(panel2.api.location.type).toBe('popout');
+
+                // the departed group no longer resolves to the popout service —
+                // it uses the main window again
+                expect(dockview.getPopupServiceForGroup(panel1.group)).toBe(
+                    mainPopupService
+                );
+                // the promoted anchor still resolves to the SAME popout service
+                expect(dockview.getPopupServiceForGroup(panel2.group)).toBe(
+                    popoutService
+                );
+
+                // the entry's anchor was reassigned to the survivor
+                const entry = (
+                    dockview as any
+                )._popoutWindowService.findByGroup(panel2.group);
+                expect(entry.popoutGroup).toBe(panel2.group);
+
+                dockview.dispose();
+            });
+
             test('closing a multi-group popout whose anchor came from a floating group docks all members to the grid (no split)', async () => {
                 const mockWindow = setupMockWindow();
                 window.open = () => mockWindow;

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -15,7 +15,12 @@ import {
 } from '../dnd/droptarget';
 import { tail, sequenceEquals } from '../array';
 import { DockviewPanel, IDockviewPanel } from './dockviewPanel';
-import { CompositeDisposable, Disposable, IDisposable } from '../lifecycle';
+import {
+    CompositeDisposable,
+    Disposable,
+    IDisposable,
+    MutableDisposable,
+} from '../lifecycle';
 import { Event, Emitter, addDisposableListener } from '../events';
 import { Watermark } from './components/watermark/watermark';
 import { IWatermarkRenderer, GroupviewPanelState } from './types';
@@ -85,7 +90,7 @@ import {
 } from './modules';
 import { AllModules } from './allModules';
 import { IFloatingGroupHost } from './floatingGroupService';
-import { IPopoutWindowHost } from './popoutWindowService';
+import { IPopoutWindowHost, PopoutGroupEntry } from './popoutWindowService';
 import { IWatermarkHost } from './watermarkService';
 import { IEdgeGroupServiceHost } from './edgeGroupService';
 import {
@@ -1761,8 +1766,12 @@ export class DockviewComponent
      * and dismisses on events from that window.
      */
     getPopupServiceForGroup(group: DockviewGroupPanel): PopupService {
+        // Resolve by window membership (DOM containment), not the anchor id, so
+        // every group in a multi-group popout — anchor or not, original or
+        // promoted after the anchor left — uses that window's popup service
+        // rather than falling back to the main window.
         return (
-            this._popoutWindowService?.getPopupService(group.id) ??
+            this._popoutWindowService?.findByGroup(group)?.popupService ??
             this.popupService
         );
     }
@@ -2036,22 +2045,18 @@ export class DockviewComponent
 
                 group.model.dropTargetContainer = dropTargetContainer;
 
-                // Each popout group needs its own popover service so that
+                // Each popout window needs its own popover service so that
                 // tab context menus, chip menus, and tab overflow menus
                 // render in the popout window (not the main window) and
                 // their pointerdown/keydown listeners fire on the right
-                // window for outside-click and Escape dismissal.
+                // window for outside-click and Escape dismissal. It is stored
+                // on the entry below and resolved per-member via
+                // `findByGroup`, so it is shared by every group in the window.
                 const popoutPopupService = new PopupService(
                     popoutContainer,
                     _window.window!
                 );
-                service.setPopupService(group.id, popoutPopupService);
-                popoutWindowDisposable.addDisposables(
-                    popoutPopupService,
-                    Disposable.from(() => {
-                        service.deletePopupService(group.id);
-                    })
-                );
+                popoutWindowDisposable.addDisposables(popoutPopupService);
 
                 group.model.location = {
                     type: 'popout',
@@ -2100,16 +2105,25 @@ export class DockviewComponent
                     );
                 }
 
-                popoutWindowDisposable.addDisposables(
-                    group.api.onDidActiveChange((event) => {
-                        if (event.isActive) {
+                // Focus routing follows the window's *current* anchor group.
+                // Hold it in a mutable disposable so it can be rebound to a new
+                // anchor when the original is dragged out of a multi-group
+                // popout (see `setAnchorGroup` on the entry below).
+                const focusRoutingDisposable = new MutableDisposable();
+                popoutWindowDisposable.addDisposables(focusRoutingDisposable);
+                const bindFocusRouting = (anchor: DockviewGroupPanel): void => {
+                    focusRoutingDisposable.value = new CompositeDisposable(
+                        anchor.api.onDidActiveChange((event) => {
+                            if (event.isActive) {
+                                _window.window?.focus();
+                            }
+                        }),
+                        anchor.api.onWillFocus(() => {
                             _window.window?.focus();
-                        }
-                    }),
-                    group.api.onWillFocus(() => {
-                        _window.window?.focus();
-                    })
-                );
+                        })
+                    );
+                };
+                bindFocusRouting(group);
 
                 // Holder so the close teardown (extracted below) can publish
                 // the group that was returned to the main grid back to the
@@ -2121,7 +2135,7 @@ export class DockviewComponent
                     referenceGroup &&
                     this.getPanel(referenceGroup.id);
 
-                const value = {
+                const value: PopoutGroupEntry = {
                     window: _window,
                     popoutGroup: group,
                     gridview: popoutGridview,
@@ -2132,6 +2146,13 @@ export class DockviewComponent
                     referenceGroup: isValidReferenceGroup
                         ? referenceGroup.id
                         : undefined,
+                    popupService: popoutPopupService,
+                    setAnchorGroup: (newAnchor: DockviewGroupPanel) => {
+                        value.popoutGroup = newAnchor;
+                        // Size/position events read `value.popoutGroup` live, so
+                        // only the focus subscription needs re-binding here.
+                        bindFocusRouting(newAnchor);
+                    },
                     disposable: {
                         dispose: () => {
                             popoutWindowDisposable.dispose();
@@ -2150,14 +2171,16 @@ export class DockviewComponent
                         this._onDidPopoutGroupSizeChange.fire({
                             width: _window.window!.innerWidth,
                             height: _window.window!.innerHeight,
-                            group,
+                            // the window's current anchor, which may have been
+                            // reassigned after the original anchor left
+                            group: value.popoutGroup,
                         });
                     }),
                     _onDidWindowPositionChange.event(() => {
                         this._onDidPopoutGroupPositionChange.fire({
                             screenX: _window.window!.screenX,
                             screenY: _window.window!.screenY,
-                            group,
+                            group: value.popoutGroup,
                         });
                     }),
                     addDisposableListener(_window.window!, 'resize', () => {
@@ -4304,8 +4327,10 @@ export class DockviewComponent
             }
             popout.gridview.remove(group);
             if (popout.popoutGroup === group) {
-                // The anchor left; promote a remaining member.
-                popout.popoutGroup = members.find((m) => m !== group)!;
+                // The anchor left; promote a remaining member and rebind the
+                // window's anchor-relative state (focus routing) to it. The
+                // popup service resolves per-member so needs no rebinding.
+                popout.setAnchorGroup(members.find((m) => m !== group)!);
             }
             return true;
         }

--- a/packages/dockview-core/src/dockview/popoutWindowService.ts
+++ b/packages/dockview-core/src/dockview/popoutWindowService.ts
@@ -28,6 +28,18 @@ export interface PopoutGroupEntry {
     dropTargetContainer: DropTargetAnchorContainer;
     getWindow: () => Window;
     popoutUrl?: string;
+    /**
+     * The window-scoped popup service shared by every group in this popout
+     * window (resolved per-member via {@link IPopoutWindowService.findByGroup}
+     * so overflow/context menus render in the correct window regardless of
+     * which group is the anchor).
+     */
+    popupService: PopupService;
+    /**
+     * Promote a new anchor group after the current one leaves the window,
+     * rebinding anchor-relative state (focus routing) to it.
+     */
+    setAnchorGroup: (group: DockviewGroupPanel) => void;
     disposable: { dispose: () => DockviewGroupPanel | undefined };
 }
 
@@ -55,10 +67,6 @@ export interface IPopoutWindowService extends IDisposable {
         overlayRenderContainer: OverlayRenderContainer
     ): IDisposable | undefined;
 
-    getPopupService(groupId: string): PopupService | undefined;
-    setPopupService(groupId: string, service: PopupService): void;
-    deletePopupService(groupId: string): void;
-
     readonly restorationPromise: Promise<void>;
     scheduleRestoration(
         delayMs: number,
@@ -75,7 +83,6 @@ export interface IPopoutWindowService extends IDisposable {
 export class PopoutWindowService implements IPopoutWindowService {
     private readonly _host: IPopoutWindowHost;
     private readonly _entries: PopoutGroupEntry[] = [];
-    private readonly _popupServices = new Map<string, PopupService>();
     private readonly _restorationCleanups = new Set<() => void>();
     private _restorationPromise: Promise<void> = Promise.resolve();
 
@@ -179,18 +186,6 @@ export class PopoutWindowService implements IPopoutWindowService {
         });
         observer.observe(gridview.element);
         return { dispose: () => observer.disconnect() };
-    }
-
-    getPopupService(groupId: string): PopupService | undefined {
-        return this._popupServices.get(groupId);
-    }
-
-    setPopupService(groupId: string, service: PopupService): void {
-        this._popupServices.set(groupId, service);
-    }
-
-    deletePopupService(groupId: string): void {
-        this._popupServices.delete(groupId);
     }
 
     scheduleRestoration(


### PR DESCRIPTION
## Description

Both bugs share one root cause: **per-window popout state was keyed to the window's "anchor" group instead of the window itself**, so a non-anchor member — and a member promoted to anchor after the original was detached — resolved the wrong window.

### Linear

Fixes DV-43
Fixes DV-47

### Bug fixes

| Issue | Bug | Fix |
|-------|-----|-----|
| **DV-43** | In a popout hosting >1 group, `getPopupServiceForGroup` resolved `getPopupService(group.id)` and the popout popup service was registered only under the *anchor* id — so a second group dragged into the popout had no entry and its overflow/context menu rendered in the **main** window | resolve via `findByGroup` (DOM containment, matches any member) and store the service on the popout entry; the per-group id map is deleted entirely |
| **DV-47** | When the anchor was dragged out of a multi-group popout, `detachFromNestedWindow` promoted a new anchor but left the popup-service key, the size/position event closures, and the focus subscription pinned to the **departed** group | containment resolution fixes the popup service with zero rebinding; size/position events now read the entry's live `popoutGroup`; a new `entry.setAnchorGroup` rebinds focus routing (via a `MutableDisposable`) to the promoted anchor, mirroring the floating-group path |

The fix *removes* moving parts (the `_popupServices` map + its `get/set/deletePopupService` API) rather than adding bookkeeping.

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

The popout symptom is **cross-window**, and jsdom reuses a single document — so it's tested at two layers, both **verified to fail without the fix**:

- **jsdom unit tests** (`dockviewComponent.spec.ts`) — resolution logic: a non-anchor member resolves the popout window's service (not the main one); after the anchor is moved out, the departed group resolves to the main window and the promoted survivor to the popout.
- **Playwright e2e** (`e2e/tests/popout-multi-window.spec.ts`, run via `yarn test:e2e`) — the observable cross-window behavior jsdom can't reach: a non-anchor group's context menu renders in the **popout** window; after the anchor docks back to the grid, the promoted member's menu routes to the popout while the departed group's menu routes to the opener. Ran green in real Chromium; both fail on the unpatched build.

Full suites pass: `dockview-core` 1223/1223, `dockview-enterprise` 374/374 (it consumes `getPopupServiceForGroup`). `lint` 0 errors, `format` clean, `gen` no drift.

> Note: `e2e/` is a manual harness (not wired into CI); it needs `nx run-many -t build:bundle -p dockview-core dockview dockview-enterprise` first, then `yarn test:e2e`.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JE1SmW4mWp6AdoNVbHprb)_