### PR TITLE
fix(enterprise): re-resolve keyboard-docking target against the live grid (DV-57)

### DIFF
--- a/packages/dockview-enterprise/src/__tests__/keyboardDocking.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/keyboardDocking.spec.ts
@@ -158,6 +158,60 @@ describe('accessibility: keyboard docking', () => {
         expect(container.querySelector('.dv-drop-target')).toBeNull();
     });
 
+    test('a group removed mid-move re-resolves the target against the live grid', () => {
+        make(true);
+        // three side-by-side groups; pC is active → the move starts on pC's group
+        dockview.addPanel({ id: 'pA', component: 'default', title: 'A' });
+        dockview.addPanel({
+            id: 'pB',
+            component: 'default',
+            title: 'B',
+            position: { direction: 'right' },
+        });
+        dockview.addPanel({
+            id: 'pC',
+            component: 'default',
+            title: 'C',
+            position: { direction: 'right' },
+        });
+        expect(dockview.groups).toHaveLength(3);
+
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+        // step the target off the source's own group onto a neighbour
+        fireEvent.keyDown(dockview.element, { key: 'ArrowLeft' });
+
+        const previewed = dockview.groups.find(
+            (g) => !!g.element.querySelector('.dv-drop-target')
+        )!;
+        expect(previewed).toBeDefined();
+        expect(previewed).not.toBe(dockview.getGroupPanel('pC')!.group);
+
+        // remove the previewed target out from under the armed move
+        dockview.removeGroup(previewed);
+        expect(dockview.groups).toHaveLength(2);
+
+        // A phase change (Enter) re-renders the *same* target index. Against a
+        // stale snapshot that index is now the removed, disposed group: the
+        // preview would be drawn on a detached element no longer in the layout
+        // (and in a real DOM the disposed drop-target teardown throws out of the
+        // keydown handler, stranding the move). The fix re-resolves against the
+        // live grid, so the preview lands on a group that is still present.
+        expect(() => {
+            fireEvent.keyDown(dockview.element, { key: 'Enter' });
+        }).not.toThrow();
+
+        const previewedAfter = dockview.groups.find(
+            (g) => !!g.element.querySelector('.dv-drop-target')
+        );
+        expect(previewedAfter).toBeDefined();
+
+        // the move stays coherent: committing docks into that live group and
+        // tears down cleanly (attribute cleared, no dangling overlay).
+        fireEvent.keyDown(dockview.element, { key: 'Enter' });
+        expect(dockview.element.hasAttribute('data-dv-kbd-moving')).toBeFalsy();
+        expect(container.querySelector('.dv-drop-target')).toBeNull();
+    });
+
     test('Ctrl+Shift+F floats the moving panel from the target phase', () => {
         make(true);
         dockview.addPanel({ id: 'p1', component: 'default', title: 'P1' });

--- a/packages/dockview-enterprise/src/keyboardDockingService.ts
+++ b/packages/dockview-enterprise/src/keyboardDockingService.ts
@@ -21,7 +21,10 @@ type DockPhase = 'target' | 'edge';
 
 interface MoveState {
     readonly source: IDockviewPanel;
-    readonly groups: DockviewGroupPanel[];
+    // Re-resolved against the live grid on each render/commit rather than held
+    // as a fixed snapshot, so a group removed mid-move can't leave this
+    // pointing at a disposed group.
+    groups: DockviewGroupPanel[];
     groupIndex: number;
     phase: DockPhase;
     position: Position;
@@ -279,9 +282,40 @@ export class KeyboardDockingService
         }
     }
 
+    /**
+     * Re-resolve the targeted group against the *live* grid. A group can be
+     * removed between arm-time and now (auto-close timer, programmatic
+     * `removeGroup`, collaborative edit); re-reading `host.groups` and clamping
+     * the index keeps the move pointing at a real, undisposed group instead of
+     * a stale snapshot entry. Returns `undefined` when no groups remain.
+     */
+    private _resolveTargetGroup(): DockviewGroupPanel | undefined {
+        const move = this._move!;
+        move.groups = this.host.groups;
+        if (move.groups.length === 0) {
+            return undefined;
+        }
+        move.groupIndex = Math.min(
+            Math.max(move.groupIndex, 0),
+            move.groups.length - 1
+        );
+        return move.groups[move.groupIndex];
+    }
+
+    private _abortMove(): void {
+        this._exit();
+        this.host.announce(this._messages.moveCancelled());
+        this._restoreFocus();
+    }
+
     private _render(): void {
         const move = this._move!;
-        const group = move.groups[move.groupIndex];
+        const group = this._resolveTargetGroup();
+        if (!group) {
+            // every candidate group was removed mid-move — bail out cleanly
+            this._abortMove();
+            return;
+        }
         this._clearPreview();
         this._preview = this.host.showDropPreview(group, move.position);
 
@@ -305,7 +339,11 @@ export class KeyboardDockingService
 
     private _commit(): void {
         const move = this._move!;
-        const group = move.groups[move.groupIndex];
+        const group = this._resolveTargetGroup();
+        if (!group) {
+            this._abortMove();
+            return;
+        }
         const position = move.position;
         const source = move.source;
         const name = group.activePanel?.title ?? group.id;
@@ -347,7 +385,12 @@ export class KeyboardDockingService
     }
 
     private _clearPreview(): void {
-        this._preview?.dispose();
+        try {
+            this._preview?.dispose();
+        } catch {
+            // the previewed group may already have been disposed (removed
+            // mid-move), which can throw from its drop-target teardown
+        }
         this._preview = undefined;
     }
 


### PR DESCRIPTION
## Problem

The two-phase `Ctrl+M` keyboard move (`keyboardDockingService.ts`) captured `groups = this.host.groups` at arm time and held it as a **fixed snapshot**, never subscribing to group removal. If a group was removed mid-move — auto-close timer, programmatic `removeGroup`, or a collaborative edit — the next arrow/Enter/Escape ran `_render()` → `showDropPreview(move.groups[move.groupIndex], …)` against a **disposed** group.

- In a real DOM the disposed group's drop-target teardown **throws out of the document keydown handler**, leaving `KEYBOARD_MOVE_ATTRIBUTE` set and a dangling overlay — the move is stranded and the navigation module stays stood-down.
- Even without a throw, arrow-cycling could preview a group that is no longer in the layout.

Unlike `_commit()`, `_render()`/`_clearPreview()` had no try/catch.

## Fix

Resolve the target **live** rather than from a stale snapshot:

- `_resolveTargetGroup()` re-reads `host.groups` and clamps `groupIndex` on every `_render()` and `_commit()`, returning `undefined` when every candidate group is gone.
- `_render()`/`_commit()` abort cleanly (`_abortMove()` → exit, announce cancelled, restore focus) when no group remains.
- `_clearPreview()` is guarded so a disposed group's drop-target teardown can't throw.
- `MoveState.groups` is no longer `readonly` (it is re-pointed at the live array each resolve).

## Test

`keyboardDocking.spec.ts` — *"a group removed mid-move re-resolves the target against the live grid"*: arms a move across three groups, steps the target onto a neighbour, removes that previewed group out from under the move, then fires a phase-change `Enter`. With the stale snapshot the preview is redrawn on the detached/disposed group (not among live `dockview.groups`); the fix re-resolves so the preview lands on a group still present, the move commits, and the attribute/overlay are torn down cleanly.

Verified failing-first: the test fails on `v8-branch` (`previewedAfter` is `undefined`) and passes with the fix. Full `dockview-enterprise` suite: 375 passed.

Fixes DV-57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JE1SmW4mWp6AdoNVbHprb)_