### PR TITLE
docs(agents): bug fixes must not change expected behaviour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,15 @@ NX handles build ordering automatically via `dependsOn: ["^build"]`. The depende
 
 ### Code Quality
 
+-   **Bug fixes must not change expected behaviour.** A fix corrects the
+    defect and nothing else — it must not alter behaviours that are working as
+    intended, even when a broader "improvement" is tempting and tests still
+    pass. If the only way to fix a bug is to change a long-standing, relied-upon
+    behaviour (e.g. the even size redistribution when a panel/group closes), do
+    **not** silently change the default: stop and raise it with the maintainer,
+    and prefer gating any behavioural change behind an opt-in option. Passing
+    tests are necessary but not sufficient here — the absence of a test
+    asserting the old behaviour is not permission to change it.
 -   ESLint configuration extends recommended TypeScript rules
 -   Prettier for code formatting
 -   Linting targets source files in packages/\*/src/\*\* (excludes tests, docs, node_modules)


### PR DESCRIPTION
## What

Adds a rule to `AGENTS.md` under **Code Quality**: a bug fix corrects the defect and nothing else — it must not alter behaviours that work as intended, even when the test suite still passes.

## Why

Came out of the DV-36 investigation (panel/group sizes not preserved on close). The one-line fix — dropping `Sizing.Distribute` on group removal — preserves survivor ratios and passes all 1226 core tests, **but** it also changes a long-standing, relied-upon behaviour (even size redistribution when a panel/group closes) for everyone. That kind of change shouldn't land silently on the back of "the bug ticket asked for it" + "tests are green."

The rule codifies the guardrail:

> If the only way to fix a bug is to change a long-standing, relied-upon behaviour, do **not** silently change the default: stop and raise it with the maintainer, and prefer gating any behavioural change behind an opt-in option. Passing tests are necessary but not sufficient — the absence of a test asserting the old behaviour is not permission to change it.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JE1SmW4mWp6AdoNVbHprb)_