### PR TITLE
docs: fix Licensing feature-table discrepancies (DV-33)

### DIFF
--- a/packages/docs/docs/core/panels/tabGroups.mdx
+++ b/packages/docs/docs/core/panels/tabGroups.mdx
@@ -2,9 +2,6 @@
 title: 'Tab groups'
 description: Visually organise tabs within a group using coloured chips, with a custom colour palette, chip renderers, context menus, and serialization.
 sidebar_position: 12
-enterprise: true
-sidebar_custom_props:
-    enterprise: true
 ---
 
 import { CodeRunner } from '@site/src/components/ui/codeRunner';
@@ -264,6 +261,12 @@ tabGroup.onDidDestroy(() => {});
 
 Right-clicking a tab group chip can show a context menu. This is opt-in; no menu is shown unless
 `getTabGroupChipContextMenuItems` is provided. Return an empty array to suppress the menu for specific chips.
+
+:::info
+The chip context menu is rendered by the enterprise [context menu](/docs/core/panels/contextMenus)
+module. Everything else on this page (chips, colours, custom chip renderers, events, and
+serialization) is part of the free core; only this menu needs the enterprise package.
+:::
 
 <FrameworkSpecific framework="React">
     <DocRef

--- a/packages/docs/docs/overview/features.mdx
+++ b/packages/docs/docs/overview/features.mdx
@@ -47,8 +47,8 @@ hide_framework_selector: true
 | [Animated tab dragging](/docs/core/panels/tabs)              | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Multi-row tabs](/docs/core/panels/multiRowTabs)             |                                          | <span className="feature-check">✓</span> |
 | [Pinned tabs](/docs/core/panels/pinnedTabs)                  |                                          | <span className="feature-check">✓</span> |
-| [Tab group chips](/docs/core/panels/tabGroups)               |                                          | <span className="feature-check">✓</span> |
-| [Custom chip renderer](/docs/core/panels/tabGroups)          |                                          | <span className="feature-check">✓</span> |
+| [Tab group chips](/docs/core/panels/tabGroups)               | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| [Custom chip renderer](/docs/core/panels/tabGroups)          | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Tab context menus](/docs/core/panels/contextMenus)          |                                          | <span className="feature-check">✓</span> |
 | [Chip context menus](/docs/core/panels/contextMenus)         |                                          | <span className="feature-check">✓</span> |
 
@@ -63,8 +63,8 @@ hide_framework_selector: true
 | [Per-feature opt-out](/docs/core/dnd/disable)            | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Edge drop zones](/docs/core/dnd/dropPosition)           | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [DnD backend strategy](/docs/core/dnd/strategy)          | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| [Custom drop overlay](/docs/core/dnd/overlay)            |                                          | <span className="feature-check">✓</span> |
-| [Custom group drag preview](/docs/core/dnd/dragAndDrop)  |                                          | <span className="feature-check">✓</span> |
+| [Custom drop overlay](/docs/core/dnd/overlay)            | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| [Custom group drag preview](/docs/core/dnd/dragAndDrop)  | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Drop guide compass](/docs/core/dnd/dropGuide)           |                                          | <span className="feature-check">✓</span> |
 | [Smart guides](/docs/core/dnd/smartGuides)               |                                          | <span className="feature-check">✓</span> |
 
@@ -130,7 +130,7 @@ hide_framework_selector: true
 | [Runtime option updates](/docs/api/dockview/options)          | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Custom UI messages](/docs/api/dockview/options)              | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Full event surface](/docs/core/events)                       | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
-| [Keyboard navigation](/docs/api/dockview/overview)            | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| [Keyboard focus navigation](/docs/api/dockview/overview)            | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 
 ### Accessibility
 
@@ -139,6 +139,7 @@ hide_framework_selector: true
 | [ARIA roles and labels](/docs/advanced/accessibility)        | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Screen-reader announcements](/docs/advanced/accessibility)  | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
 | [Focus indicators](/docs/advanced/accessibility)             | <span className="feature-check">✓</span> | <span className="feature-check">✓</span> |
+| [Spatial keyboard navigation](/docs/advanced/keyboard)                  |                                          | <span className="feature-check">✓</span> |
 | [Keyboard docking](/docs/advanced/keyboard)                  |                                          | <span className="feature-check">✓</span> |
 
 ### Framework support


### PR DESCRIPTION
Fixes the feature-table discrepancies from DV-33 across both in-repo surfaces (the ticket's "external table" framing was stale; the table is `packages/docs/docs/overview/features.mdx`).

## Licensing comparison table (`overview/features.mdx`)
Four rows marked **free** features as Enterprise-only; corrected to show in both editions:
- Tab group chips (`TabGroupChipsModule`, core)
- Custom chip renderer (`createTabGroupChipComponent`, core option)
- Custom drop overlay (`AdvancedDnDModule`, reclassified free + moved to core)
- Custom group drag preview (rides the now-free AdvancedDnD)

The **Keyboard navigation** row (flagged by the ticket) is split: baseline *Keyboard focus navigation* stays free, and a new *Spatial keyboard navigation (F6)* row is marked Enterprise-only (matching the pro `KeyboardNavigationModule`). *Keyboard docking* was already correctly pro.

## Tab-groups docs page (`tabGroups.mdx`)
Removed the incorrect `enterprise: true` badge (tab groups are free core) and added a note that only the chip context menu (rendered by the pro `ContextMenuModule`) needs the enterprise package.

All other docs `enterprise:` flags were audited: `tabGroups` was the only wrong one; the other 10 are correct.

Linear: DV-33

🤖 Generated with [Claude Code](https://claude.com/claude-code)