### PR TITLE
fix(dockview-enterprise): keep vertical wrap header sized to its columns on resize

### DIFF
--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -612,6 +612,63 @@ test.describe('multi-row tabs (wrap mode)', () => {
         expect(m.clipped).toBe(0);
     });
 
+    // KNOWN BUG — vertical wrap header does not re-grow its cross-size on a
+    // container resize. The header's width is sized to the column count present
+    // when wrap was applied; when the container later resizes and the tabs
+    // reflow into MORE columns, the header width stays stale, so the surplus
+    // columns spill out of the header container and render over the panel
+    // content. (Initial render is fine — the header grows correctly then; only
+    // a subsequent resize desyncs it.)
+    //
+    // Captured as `fixme` so it doesn't fail CI. Remove `.fixme` once the header
+    // cross-size tracks the reflowed column count on resize.
+    test.fixme(
+        'vertical header: columns reflowed by a resize stay inside the header',
+        async ({ page }) => {
+            // Initial layout: 24 tabs under a left header wrap into a handful of
+            // columns and the header grows to fit them.
+            await setupVertical(page);
+            await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
+
+            const before = await page.evaluate(() => {
+                const header = document.querySelector(
+                    '.dv-tabs-and-actions-container'
+                ) as HTMLElement;
+                const tabs = Array.from(
+                    document.querySelectorAll<HTMLElement>('.dv-tab')
+                );
+                const cols = new Set(tabs.map((t) => t.offsetLeft)).size;
+                const hb = header.getBoundingClientRect();
+                const escaped = tabs.filter(
+                    (t) => t.getBoundingClientRect().right > hb.right + 1
+                ).length;
+                return { cols, escaped };
+            });
+            expect(before.escaped).toBe(0);
+
+            // Shrink the viewport so the (shorter) group reflows the tabs into
+            // more columns than the header was originally sized for.
+            await page.setViewportSize({ width: 900, height: 700 });
+            await expect
+                .poll(() => columnCount(page))
+                .toBeGreaterThan(before.cols);
+
+            // The reflowed columns must remain inside the header container — no
+            // tab may spill past the header's edge over the content.
+            const escaped = await page.evaluate(() => {
+                const header = document.querySelector(
+                    '.dv-tabs-and-actions-container'
+                ) as HTMLElement;
+                const hb = header.getBoundingClientRect();
+                return Array.from(
+                    document.querySelectorAll<HTMLElement>('.dv-tab')
+                ).filter((t) => t.getBoundingClientRect().right > hb.right + 1)
+                    .length;
+            });
+            expect(escaped).toBe(0);
+        }
+    );
+
     test('Arrow Up/Down move focus between wrapped rows', async ({ page }) => {
         await setup(page);
 

--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -570,10 +570,7 @@ test.describe('multi-row tabs (wrap mode)', () => {
         );
         expect(reported).toBeTruthy();
         expect(reported.width).toBeCloseTo(contentBox.width, 0);
-        expect(reported.width).toBeCloseTo(
-            groupBox.width - headerBox.width,
-            0
-        );
+        expect(reported.width).toBeCloseTo(groupBox.width - headerBox.width, 0);
     });
 
     test('vertical header: wrapped columns are not clipped by the strip', async ({
@@ -634,9 +631,7 @@ test.describe('multi-row tabs (wrap mode)', () => {
             return {
                 cols: new Set(tabs.map((t) => t.offsetLeft)).size,
                 headerWidth: Math.round(hb.width),
-                contentLeft: Math.round(
-                    content.getBoundingClientRect().left
-                ),
+                contentLeft: Math.round(content.getBoundingClientRect().left),
                 escaped: tabs.filter(
                     (t) => t.getBoundingClientRect().right > hb.right + 1
                 ).length,
@@ -654,17 +649,21 @@ test.describe('multi-row tabs (wrap mode)', () => {
         expect(before.escaped).toBe(0);
 
         // Shrink the viewport so the (shorter) group reflows the tabs into more
-        // columns than the header was originally sized for.
+        // columns than the header was originally sized for. Retry the whole
+        // assertion until the reflow + header re-pin + relayout settle (the pin
+        // lands a frame after the column count changes).
         await page.setViewportSize({ width: 900, height: 700 });
-        await expect.poll(() => columnCount(page)).toBeGreaterThan(before.cols);
-
-        const after = await headerMetrics(page);
-        // The header re-grew to hold the extra columns ...
-        expect(after.headerWidth).toBeGreaterThan(before.headerWidth);
-        // ... every column stays inside it (nothing spills over the content) ...
-        expect(after.escaped).toBe(0);
-        // ... and the content starts exactly at the widened header's edge.
-        expect(after.contentLeft).toBeCloseTo(after.headerWidth, 0);
+        await expect(async () => {
+            const after = await headerMetrics(page);
+            // More columns than before ...
+            expect(after.cols).toBeGreaterThan(before.cols);
+            // ... the header re-grew to hold them ...
+            expect(after.headerWidth).toBeGreaterThan(before.headerWidth);
+            // ... every column stays inside it (nothing spills over content) ...
+            expect(after.escaped).toBe(0);
+            // ... and the content starts exactly at the widened header's edge.
+            expect(after.contentLeft).toBeCloseTo(after.headerWidth, 0);
+        }).toPass();
     });
 
     test('vertical header: the header shrinks back when a resize removes columns', async ({
@@ -676,21 +675,23 @@ test.describe('multi-row tabs (wrap mode)', () => {
         await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
         const initial = await headerMetrics(page);
 
-        // Shrink → strictly more columns, a wider header.
+        // Shrink → strictly more columns, a wider header (retry until settled).
         await page.setViewportSize({ width: 900, height: 700 });
-        await expect
-            .poll(() => columnCount(page))
-            .toBeGreaterThan(initial.cols);
+        await expect(async () => {
+            const m = await headerMetrics(page);
+            expect(m.cols).toBeGreaterThan(initial.cols);
+            expect(m.headerWidth).toBeGreaterThan(initial.headerWidth);
+        }).toPass();
         const narrow = await headerMetrics(page);
-        expect(narrow.headerWidth).toBeGreaterThan(initial.headerWidth);
 
         // Enlarge again → the columns (and the header width) must come back down.
         await page.setViewportSize({ width: 1280, height: 720 });
-        await expect.poll(() => columnCount(page)).toBeLessThan(narrow.cols);
-
-        const wide = await headerMetrics(page);
-        expect(wide.headerWidth).toBeLessThan(narrow.headerWidth);
-        expect(wide.escaped).toBe(0);
+        await expect(async () => {
+            const wide = await headerMetrics(page);
+            expect(wide.cols).toBeLessThan(narrow.cols);
+            expect(wide.headerWidth).toBeLessThan(narrow.headerWidth);
+            expect(wide.escaped).toBe(0);
+        }).toPass();
     });
 
     test('Arrow Up/Down move focus between wrapped rows', async ({ page }) => {

--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -612,62 +612,86 @@ test.describe('multi-row tabs (wrap mode)', () => {
         expect(m.clipped).toBe(0);
     });
 
-    // KNOWN BUG — vertical wrap header does not re-grow its cross-size on a
-    // container resize. The header's width is sized to the column count present
-    // when wrap was applied; when the container later resizes and the tabs
-    // reflow into MORE columns, the header width stays stale, so the surplus
-    // columns spill out of the header container and render over the panel
-    // content. (Initial render is fine — the header grows correctly then; only
-    // a subsequent resize desyncs it.)
-    //
-    // Captured as `fixme` so it doesn't fail CI. Remove `.fixme` once the header
-    // cross-size tracks the reflowed column count on resize.
-    test.fixme(
-        'vertical header: columns reflowed by a resize stay inside the header',
-        async ({ page }) => {
-            // Initial layout: 24 tabs under a left header wrap into a handful of
-            // columns and the header grows to fit them.
-            await setupVertical(page);
-            await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
-
-            const before = await page.evaluate(() => {
-                const header = document.querySelector(
-                    '.dv-tabs-and-actions-container'
-                ) as HTMLElement;
-                const tabs = Array.from(
-                    document.querySelectorAll<HTMLElement>('.dv-tab')
-                );
-                const cols = new Set(tabs.map((t) => t.offsetLeft)).size;
-                const hb = header.getBoundingClientRect();
-                const escaped = tabs.filter(
+    // Regression: a vertical wrap header must re-grow its cross-size (width)
+    // when a container resize reflows the tabs into more columns. Its `auto`
+    // width can't account for the wrap (the strip wraps on its indefinite
+    // percentage height), so without the module pinning the width the surplus
+    // columns overflow the header and render over the panel content. The
+    // `MultiRowTabsService` sizes the header to `columns x lineThickness` on the
+    // reflow to keep every column inside it.
+    const headerMetrics = (page) =>
+        page.evaluate(() => {
+            const header = document.querySelector(
+                '.dv-tabs-and-actions-container'
+            ) as HTMLElement;
+            const content = document.querySelector(
+                '.dv-content-container'
+            ) as HTMLElement;
+            const hb = header.getBoundingClientRect();
+            const tabs = Array.from(
+                document.querySelectorAll<HTMLElement>('.dv-tab')
+            );
+            return {
+                cols: new Set(tabs.map((t) => t.offsetLeft)).size,
+                headerWidth: Math.round(hb.width),
+                contentLeft: Math.round(
+                    content.getBoundingClientRect().left
+                ),
+                escaped: tabs.filter(
                     (t) => t.getBoundingClientRect().right > hb.right + 1
-                ).length;
-                return { cols, escaped };
-            });
-            expect(before.escaped).toBe(0);
+                ).length,
+            };
+        });
 
-            // Shrink the viewport so the (shorter) group reflows the tabs into
-            // more columns than the header was originally sized for.
-            await page.setViewportSize({ width: 900, height: 700 });
-            await expect
-                .poll(() => columnCount(page))
-                .toBeGreaterThan(before.cols);
+    test('vertical header: columns reflowed by a resize stay inside the header', async ({
+        page,
+    }) => {
+        // Initial layout: 24 tabs under a left header wrap into a handful of
+        // columns and the header grows to fit them — nothing overflows.
+        await setupVertical(page);
+        await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
+        const before = await headerMetrics(page);
+        expect(before.escaped).toBe(0);
 
-            // The reflowed columns must remain inside the header container — no
-            // tab may spill past the header's edge over the content.
-            const escaped = await page.evaluate(() => {
-                const header = document.querySelector(
-                    '.dv-tabs-and-actions-container'
-                ) as HTMLElement;
-                const hb = header.getBoundingClientRect();
-                return Array.from(
-                    document.querySelectorAll<HTMLElement>('.dv-tab')
-                ).filter((t) => t.getBoundingClientRect().right > hb.right + 1)
-                    .length;
-            });
-            expect(escaped).toBe(0);
-        }
-    );
+        // Shrink the viewport so the (shorter) group reflows the tabs into more
+        // columns than the header was originally sized for.
+        await page.setViewportSize({ width: 900, height: 700 });
+        await expect.poll(() => columnCount(page)).toBeGreaterThan(before.cols);
+
+        const after = await headerMetrics(page);
+        // The header re-grew to hold the extra columns ...
+        expect(after.headerWidth).toBeGreaterThan(before.headerWidth);
+        // ... every column stays inside it (nothing spills over the content) ...
+        expect(after.escaped).toBe(0);
+        // ... and the content starts exactly at the widened header's edge.
+        expect(after.contentLeft).toBeCloseTo(after.headerWidth, 0);
+    });
+
+    test('vertical header: the header shrinks back when a resize removes columns', async ({
+        page,
+    }) => {
+        // Grow the header (more columns) then enlarge the viewport again: the
+        // header must release the reclaimed width, not stay stuck wide.
+        await setupVertical(page);
+        await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
+        const initial = await headerMetrics(page);
+
+        // Shrink → strictly more columns, a wider header.
+        await page.setViewportSize({ width: 900, height: 700 });
+        await expect
+            .poll(() => columnCount(page))
+            .toBeGreaterThan(initial.cols);
+        const narrow = await headerMetrics(page);
+        expect(narrow.headerWidth).toBeGreaterThan(initial.headerWidth);
+
+        // Enlarge again → the columns (and the header width) must come back down.
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await expect.poll(() => columnCount(page)).toBeLessThan(narrow.cols);
+
+        const wide = await headerMetrics(page);
+        expect(wide.headerWidth).toBeLessThan(narrow.headerWidth);
+        expect(wide.escaped).toBe(0);
+    });
 
     test('Arrow Up/Down move focus between wrapped rows', async ({ page }) => {
         await setup(page);

--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -476,6 +476,142 @@ test.describe('multi-row tabs (wrap mode)', () => {
         await expect(list).not.toHaveClass(/dv-tabs-container--wrap/);
     });
 
+    // Header `right` is the mirror of `left`: columns wrap the same way but the
+    // strip hugs the right edge and the content sits to its left. The existing
+    // vertical coverage only drives `left`, so this guards the mirrored axis.
+    const setupVerticalRight = async (page, count = 24) => {
+        await page.goto('/e2e/fixtures/index.html?overflow=wrap');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(
+            (n) => (window as any).__dv.setupWrapTabs(n),
+            count
+        );
+        await page.evaluate(() =>
+            (window as any).__dv.setHeaderPosition('right')
+        );
+    };
+
+    test('vertical header (right): tabs wrap into columns, header hugs the right edge, content sits left', async ({
+        page,
+    }) => {
+        await setupVerticalRight(page);
+
+        const tabsList = page.locator('.dv-tabs-container').first();
+        await expect(tabsList).toHaveClass(/dv-tabs-container-vertical/);
+        await expect(tabsList).toHaveClass(/dv-tabs-container--wrap/);
+        await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
+
+        const groupBox = (await page
+            .locator('.dv-groupview')
+            .first()
+            .boundingBox())!;
+        const headerBox = (await page
+            .locator('.dv-tabs-and-actions-container')
+            .first()
+            .boundingBox())!;
+        const contentBox = (await page
+            .locator('.dv-content-container')
+            .first()
+            .boundingBox())!;
+
+        // Multi-column header pinned to the group's right edge ...
+        expect(headerBox.width).toBeGreaterThan(0);
+        expect(Math.round(headerBox.x + headerBox.width)).toBeCloseTo(
+            Math.round(groupBox.x + groupBox.width),
+            0
+        );
+        // ... with the content filling the remaining width to its left.
+        expect(Math.round(contentBox.x)).toBeCloseTo(Math.round(groupBox.x), 0);
+        expect(contentBox.width).toBeCloseTo(
+            groupBox.width - headerBox.width,
+            0
+        );
+    });
+
+    test('vertical header: content shrinks to the area beside the multi-column header', async ({
+        page,
+    }) => {
+        // The vertical analogue of the horizontal "content shrinks below the
+        // multi-row header" case: the active panel must be laid out against the
+        // width left over beside the grown header, not the header-inclusive
+        // group box.
+        await setupVertical(page);
+        await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
+
+        const groupBox = (await page
+            .locator('.dv-groupview')
+            .first()
+            .boundingBox())!;
+        const headerBox = (await page
+            .locator('.dv-tabs-and-actions-container')
+            .first()
+            .boundingBox())!;
+        const contentBox = (await page
+            .locator('.dv-content-container')
+            .first()
+            .boundingBox())!;
+
+        // The header grew wider than a single column.
+        const colW = await page.evaluate(() =>
+            parseFloat(
+                getComputedStyle(
+                    document.querySelector(
+                        '.dv-tabs-and-actions-container'
+                    ) as HTMLElement
+                ).getPropertyValue('--dv-tabs-and-actions-container-height')
+            )
+        );
+        expect(headerBox.width).toBeGreaterThan(colW);
+
+        // The active panel was sized to the shrunk content area (group width
+        // minus the multi-column header), not the full group width.
+        const reported = await page.evaluate(() =>
+            (window as any).__dv.panelDimensions('wrap-tab-23')
+        );
+        expect(reported).toBeTruthy();
+        expect(reported.width).toBeCloseTo(contentBox.width, 0);
+        expect(reported.width).toBeCloseTo(
+            groupBox.width - headerBox.width,
+            0
+        );
+    });
+
+    test('vertical header: wrapped columns are not clipped by the strip', async ({
+        page,
+    }) => {
+        // "Renders well" invariant for lots of tabs: with an uncapped wrap the
+        // strip must widen to hold every column so no tab box escapes it (the
+        // failure mode is columns overflowing a fixed-width strip and vanishing).
+        await setupVertical(page, 'overflow=wrap', 40);
+        await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
+
+        const m = await page.evaluate(() => {
+            const list = document.querySelector(
+                '.dv-tabs-container'
+            ) as HTMLElement;
+            const box = list.getBoundingClientRect();
+            const tabs = Array.from(
+                list.querySelectorAll<HTMLElement>('.dv-tab')
+            );
+            const clipped = tabs.filter((t) => {
+                const r = t.getBoundingClientRect();
+                return r.left < box.left - 1 || r.right > box.right + 1;
+            });
+            return {
+                tabCount: tabs.length,
+                clipped: clipped.length,
+                scrollWidth: list.scrollWidth,
+                clientWidth: list.clientWidth,
+            };
+        });
+
+        expect(m.tabCount).toBe(40);
+        // No column overflows the strip's own width ...
+        expect(m.scrollWidth).toBeLessThanOrEqual(m.clientWidth + 1);
+        // ... so every tab stays visible inside it.
+        expect(m.clipped).toBe(0);
+    });
+
     test('Arrow Up/Down move focus between wrapped rows', async ({ page }) => {
         await setup(page);
 

--- a/packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts
@@ -358,6 +358,130 @@ describe('multi-row tabs (wrap mode)', () => {
         dockview.dispose();
     });
 
+    /**
+     * Vertical (edge-group) wrap headers can't size their width from CSS alone —
+     * the strip wraps on its indefinite percentage height, so flex intrinsic
+     * sizing resolves the header `auto` width for a single column and the surplus
+     * columns overflow. The controller compensates by pinning the header width to
+     * `columns x lineThickness`. The wrapping geometry itself is e2e-only, so here
+     * the column offsets + the line-thickness var are stamped and only the pin
+     * arithmetic / clearing is asserted.
+     */
+    const makeVertical = (
+        overflow: DockviewComponent['options']['overflow']
+    ): DockviewComponent => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            overflow,
+            defaultHeaderPosition: 'left',
+        });
+        dockview.layout(1000, 1000);
+        return dockview;
+    };
+
+    const headerOf = (list: HTMLElement): HTMLElement =>
+        list.closest('.dv-tabs-and-actions-container') as HTMLElement;
+
+    test('vertical header: the header width is pinned to the wrapped column count', () => {
+        const dockview = makeVertical({ mode: 'wrap' });
+        const ids = ['p0', 'p1', 'p2', 'p3', 'p4', 'p5'];
+        const first = dockview.addPanel({ id: ids[0], component: 'default' });
+        for (const id of ids.slice(1)) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+        const header = headerOf(list);
+        // The per-column thickness comes from a theme var; stamp it inline.
+        header.style.setProperty(
+            '--dv-tabs-and-actions-container-height',
+            '35px'
+        );
+        // 3 columns of two tabs each (vertical-rl → right-to-left offsets).
+        stampCols(list, [88, 88, 44, 44, 0, 0]);
+
+        // Re-apply to trigger a measure with the stamped geometry in place.
+        dockview.updateOptions({ overflow: { mode: 'wrap' } });
+
+        // 3 columns x 35px = 105px.
+        expect(header.style.width).toBe('105px');
+
+        dockview.dispose();
+    });
+
+    test('vertical header: maxRows caps the pinned header width', () => {
+        const dockview = makeVertical({ mode: 'wrap', maxRows: 2 });
+        const ids = ['p0', 'p1', 'p2', 'p3', 'p4', 'p5'];
+        const first = dockview.addPanel({ id: ids[0], component: 'default' });
+        for (const id of ids.slice(1)) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+        const header = headerOf(list);
+        header.style.setProperty(
+            '--dv-tabs-and-actions-container-height',
+            '35px'
+        );
+        // 3 natural columns, but the cap is 2.
+        stampCols(list, [88, 88, 44, 44, 0, 0]);
+
+        dockview.updateOptions({ overflow: { mode: 'wrap', maxRows: 2 } });
+
+        // Capped at 2 columns x 35px = 70px (matches the CSS max-width cap).
+        expect(header.style.width).toBe('70px');
+
+        dockview.dispose();
+    });
+
+    test('flipping a wrapped vertical header to horizontal clears the pinned width', () => {
+        const dockview = makeVertical({ mode: 'wrap' });
+        const ids = ['p0', 'p1', 'p2', 'p3'];
+        const first = dockview.addPanel({ id: ids[0], component: 'default' });
+        for (const id of ids.slice(1)) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+        const header = headerOf(list);
+        header.style.setProperty(
+            '--dv-tabs-and-actions-container-height',
+            '35px'
+        );
+        stampCols(list, [44, 44, 0, 0]);
+        dockview.updateOptions({ overflow: { mode: 'wrap' } });
+        expect(header.style.width).toBe('70px');
+
+        // Flip to a horizontal header — its height stays CSS-driven, so the
+        // explicit width must be released.
+        first.group.api.setHeaderPosition('top');
+        expect(header.style.width).toBe('');
+
+        dockview.dispose();
+    });
+
+    test('turning wrap off clears the pinned vertical header width', () => {
+        const dockview = makeVertical({ mode: 'wrap' });
+        const first = dockview.addPanel({ id: 'p0', component: 'default' });
+        for (const id of ['p1', 'p2', 'p3']) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+        const header = headerOf(list);
+        header.style.setProperty(
+            '--dv-tabs-and-actions-container-height',
+            '35px'
+        );
+        stampCols(list, [44, 44, 0, 0]);
+        dockview.updateOptions({ overflow: { mode: 'wrap' } });
+        expect(header.style.width).toBe('70px');
+
+        // Tear wrap down — the pinned width must be removed with the wrap classes.
+        dockview.updateOptions({ overflow: { mode: 'dropdown' } });
+        expect(header.style.width).toBe('');
+
+        dockview.dispose();
+    });
+
     test('removing a group disposes its wrap controller without throwing', () => {
         const dockview = make({ mode: 'wrap' });
         const a = dockview.addPanel({ id: 'a', component: 'default' });

--- a/packages/dockview-enterprise/src/multiRowTabsService.ts
+++ b/packages/dockview-enterprise/src/multiRowTabsService.ts
@@ -15,6 +15,9 @@ function isWrapMode(overflow: DockviewOverflowOptions | undefined): boolean {
 
 const VERTICAL_TABS_CLASS = 'dv-tabs-container-vertical';
 const TAB_CLASS = 'dv-tab';
+const HEADER_CLASS = 'dv-tabs-and-actions-container';
+/** The per-line thickness var (row height / column width) core sizes tabs by. */
+const LINE_SIZE_VARIABLE = '--dv-tabs-and-actions-container-height';
 
 /**
  * The wrapped-row neighbour of `current` one row up or down, or `undefined` when
@@ -373,7 +376,45 @@ class WrapController extends CompositeDisposable {
 
         if (effectiveRows !== this._rowCount) {
             this._rowCount = effectiveRows;
+            // Pin the header cross-size before relaying out so content sizing
+            // (which subtracts the header's rendered size) sees the right value.
+            this.sizeVerticalHeader(list, effectiveRows);
             this.host.relayoutGroup(this.group);
+        }
+    }
+
+    /**
+     * Pin a vertical (edge-group) header's WIDTH to the wrapped column count.
+     *
+     * A horizontal header grows its height to fit wrapped rows purely in CSS:
+     * the strip's width is definite, so flex-wrap intrinsic sizing accounts for
+     * the rows. A vertical header can't — the strip wraps on its (percentage)
+     * height, which is indefinite during intrinsic-width resolution, so the
+     * header's `auto` width is computed for a single column and stays clamped
+     * when a resize reflows the tabs into more columns. The surplus columns then
+     * overflow the header and render over the panel content.
+     *
+     * Setting the width explicitly to `columns x lineThickness` makes the header
+     * contain its columns; core's content sizing (group width minus the header's
+     * now-correct width) follows. Capped wrap passes the capped column count, so
+     * the header stops growing at the cap exactly as the CSS max-width does. A
+     * horizontal header clears the property (its height stays CSS-driven), which
+     * also undoes any width left over from a runtime orientation flip.
+     */
+    private sizeVerticalHeader(list: HTMLElement, columns: number): void {
+        const header = list.closest<HTMLElement>(`.${HEADER_CLASS}`);
+        if (!header) {
+            return;
+        }
+        if (!this._vertical) {
+            header.style.removeProperty('width');
+            return;
+        }
+        const lineSize = parseFloat(
+            getComputedStyle(header).getPropertyValue(LINE_SIZE_VARIABLE)
+        );
+        if (Number.isFinite(lineSize) && lineSize > 0) {
+            header.style.width = `${columns * lineSize}px`;
         }
     }
 
@@ -398,6 +439,11 @@ class WrapController extends CompositeDisposable {
         if (list) {
             list.classList.remove(WRAP_CLASS, CAPPED_CLASS);
             list.style.removeProperty(MAX_ROWS_VAR);
+            // Drop the explicit width pinned on the vertical header (if any) so
+            // the header returns to its CSS-driven single-line size.
+            list.closest<HTMLElement>(`.${HEADER_CLASS}`)?.style.removeProperty(
+                'width'
+            );
         }
     }
 }

--- a/packages/dockview-enterprise/src/multiRowTabsService.ts
+++ b/packages/dockview-enterprise/src/multiRowTabsService.ts
@@ -410,7 +410,7 @@ class WrapController extends CompositeDisposable {
             header.style.removeProperty('width');
             return;
         }
-        const lineSize = parseFloat(
+        const lineSize = Number.parseFloat(
             getComputedStyle(header).getPropertyValue(LINE_SIZE_VARIABLE)
         );
         if (Number.isFinite(lineSize) && lineSize > 0) {


### PR DESCRIPTION
## Description

Fixes a rendering bug in **multi-row (wrap) tabs** under a **vertical (edge-group) header**: after a container resize, tab columns overflowed the header and rendered over the panel content.

**Root cause.** A horizontal wrap header grows its *height* to fit wrapped rows purely in CSS, because the strip's width is definite so flex-wrap intrinsic sizing accounts for the rows. A vertical header can't: the strip wraps on its *percentage height*, which is indefinite during intrinsic-width resolution, so the header's `auto` width is resolved for a single column. The initial layout happens to be correct, but when a resize reflows the tabs into more columns the header width stays clamped and the surplus columns spill over the content.

Confirmed precisely: with 24 tabs under a left header, shrinking the viewport reflows 6 → 8 columns while `header.offsetWidth` stayed 210 (`scrollWidth` 280), leaving 8 tabs escaping over the content.

**Fix.** `WrapController` (in `multiRowTabsService.ts`) now pins the vertical header's width to `columns × lineThickness` whenever the effective column count changes — using the *capped* count when `overflow.maxRows` is set, so it matches the existing CSS max-width cap. A horizontal header clears the property (its height stays CSS-driven; this also undoes any width left from a runtime orientation flip); teardown restores the CSS-driven single-line size. `dockview-core` is untouched.

Verified across resizes: the header grows 210 → 280 (escaped **8 → 0**), the content repositions to the header edge, and it shrinks back to 210 when the viewport enlarges again.

This branch also adds broader Playwright coverage for vertical multi-row headers, which had only been exercised at the `left` position: the `right` position, content sizing beside the multi-column header, and a no-clipping invariant.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

> Also affects **`dockview-enterprise`** (`MultiRowTabsService`), which isn't a checkbox above.

## How to test

The change is covered by the e2e suite (`e2e/tests/multi-row-tabs.spec.ts`). Build the bundles the fixture loads, then run Playwright:

```bash
yarn nx run-many -t build:bundle -p dockview-core dockview dockview-enterprise
yarn test:e2e --grep "multi-row tabs"
```

New/updated specs:
- `vertical header: columns reflowed by a resize stay inside the header` — the regression guard (fails on the pre-fix build with ~8 tabs escaping).
- `vertical header: the header shrinks back when a resize removes columns`.
- `vertical header (right): tabs wrap into columns, header hugs the right edge, content sits left`.
- `vertical header: content shrinks to the area beside the multi-column header`.
- `vertical header: wrapped columns are not clipped by the strip`.

Manual repro: open a group with the header on the left and `overflow: { mode: 'wrap' }`, add ~24 tabs so they wrap into columns, then shrink the window — before the fix the extra columns render over the content.

## Checklist

- [x] `yarn lint:fix` passes (eslint clean on changed source)
- [x] `yarn format` passes (prettier clean on changed files)
- [ ] `npm run gen` has been run and generated files are up to date (n/a — no generated surface touched)
- [x] `yarn test` passes (dockview-core: 149 relevant unit tests; dockview-enterprise: 375 unit tests; e2e multi-row-tabs: 20)
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByJN9mPbxKDpEhgdMUMpvM)_