### PR TITLE
test(e2e): fix pinned-overflow spec for DV-11 + correct e2e build docs

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,11 +17,16 @@ main document, so a popout there is not a genuine second window.)
 
 ## Running
 
-The fixture loads the UMD bundles from `dist/`, so build them first:
+The fixtures load the UMD bundles from `dist/`, so build them first. The
+`index.html` fixture pulls in `dockview` (which bundles `dockview-core`) and
+`dockview-enterprise`; the `vue.html` fixture additionally pulls in the
+`dockview-vue` UMD bundle (produced by its `build:js`/vite target, not
+`build:bundle`):
 
 ```bash
-yarn nx run-many -t build:bundle -p dockview-core dockview-enterprise
-yarn playwright install chromium   # first time only
+yarn nx run-many -t build:bundle -p dockview-core dockview dockview-enterprise
+yarn nx run dockview-vue:build:js   # the dockview-vue.umd.js the vue fixture loads
+yarn playwright install chromium    # first time only
 yarn test:e2e
 ```
 

--- a/e2e/tests/pinned-tabs.spec.ts
+++ b/e2e/tests/pinned-tabs.spec.ts
@@ -286,7 +286,7 @@ test.describe('pinned tabs', () => {
         expect(compact.width).toBeLessThan(normal.width);
     });
 
-    test('overflow: a pinned tab is excluded from the overflow dropdown', async ({
+    test('overflow: a clipped pinned tab surfaces under the Pinned header, not the general list', async ({
         page,
     }) => {
         await page.setViewportSize({ width: 250, height: 500 });
@@ -308,8 +308,20 @@ test.describe('pinned tabs', () => {
 
         // Unpinned tabs overflow into the dropdown…
         await expect(overflow.locator('.dv-tab')).not.toHaveCount(0);
-        // …but the pinned panel is never listed there.
-        await expect(overflow).not.toContainText('panel-7');
+
+        // …and the clipped pinned tab stays reachable, surfaced under a
+        // dedicated "Pinned" header (DV-11) rather than dumped into the general
+        // list. It is excluded from the unpinned rows and never duplicated: it
+        // appears exactly once, as the row directly beneath the Pinned header.
+        const pinnedHeader = overflow.locator('.dv-tabs-overflow-pinned-header');
+        await expect(pinnedHeader).toBeVisible();
+        await expect(pinnedHeader).toContainText('Pinned');
+        await expect(
+            overflow.locator('.dv-tabs-overflow-pinned-header + .dv-tab')
+        ).toContainText('panel-7');
+        await expect(
+            overflow.getByText('panel-7', { exact: true })
+        ).toHaveCount(1);
     });
 
     test('a pinned tab sorts ahead of unpinned tabs', async ({ page }) => {


### PR DESCRIPTION
## Description

Confirms the Playwright e2e suite passes and fixes the two failures found:

1. **Stale `pinned-tabs` spec.** `overflow: a pinned tab is excluded from the overflow dropdown` predated the DV-11 *"pinned-among-themselves overflow section"* feature (`782a617`), which intentionally surfaces a clipped pinned tab under a dedicated **"Pinned"** header in the overflow dropdown instead of leaving it unreachable. The old spec asserted the pinned tab never appeared in the container at all, so it broke once that feature landed (confirmed a stale test, not a product regression — the feature's own unit tests cover the new behaviour). Reworked to assert the current intent: the clipped pinned tab surfaces exactly once, under `.dv-tabs-overflow-pinned-header`, and stays out of the general (unpinned) overflow rows. Renamed the spec to match.

2. **Incomplete e2e README build instructions.** The fixtures load the `dockview` and `dockview-vue` UMD bundles too — the latter from vite's `build:js`, not the no-op `build:bundle` — so the `vue-keep-alive` specs need those built. The previous instructions only built `dockview-core` and `dockview-enterprise`, leaving the vue fixture's bundle missing (the specs timed out). Documented the full set.

With both fixes, the full suite is green (108 passed).

## Type of change

- [x] Bug fix (test correctness)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation (e2e README)
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

(No package source changed — only the `e2e/` test + README.)

## How to test

```bash
yarn nx run-many -t build:bundle -p dockview-core dockview dockview-enterprise
yarn nx run dockview-vue:build:js
yarn test:e2e
```

All 108 e2e tests pass. The reworked spec lives at `e2e/tests/pinned-tabs.spec.ts:289`.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test:e2e` passes (108 passed)
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016J2Q4fkfdrHrdqM1z5Ny1D)_