### PR TITLE
docs: remove internal module references in favour of free/enterprise framing

### DIFF
--- a/packages/docs/docs/core/groups/autoHideEdgeGroups.mdx
+++ b/packages/docs/docs/core/groups/autoHideEdgeGroups.mdx
@@ -117,7 +117,7 @@ api.pinEdgeGroup('left');
 api.autoHideEdgeGroup('left');
 ```
 
-`peekEdgeGroup` and `pinEdgeGroup` require the auto-hide edge groups module and are no-ops without it; `autoHideEdgeGroup` collapses the group in all cases.
+`peekEdgeGroup` and `pinEdgeGroup` require the enterprise auto-hide edge groups feature and are no-ops without it; `autoHideEdgeGroup` collapses the group in all cases.
 
 ## Observing the peek state
 

--- a/packages/docs/docs/core/panels/advancedOverflow.mdx
+++ b/packages/docs/docs/core/panels/advancedOverflow.mdx
@@ -10,12 +10,12 @@ sidebar_custom_props:
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
 The default [overflow dropdown](/docs/core/panels/tabOverflow) is a flat list of the
-tabs that no longer fit. The Advanced Overflow module upgrades that same dropdown, in
-place, into a command-palette style tab switcher: a search box that filters the
-group's tabs, most-recently-used ordering, and full keyboard navigation. The chevron
-trigger and the count badge are unchanged; only the popover body changes. When the
-module is absent the plain list renders exactly as before, so these fields are safe to
-leave set.
+tabs that no longer fit. Advanced overflow, an enterprise feature, upgrades that same
+dropdown, in place, into a command-palette style tab switcher: a search box that
+filters the group's tabs, most-recently-used ordering, and full keyboard navigation.
+The chevron trigger and the count badge are unchanged; only the popover body changes.
+Without `dockview-enterprise` the plain list renders exactly as before, so these
+fields are safe to leave set.
 
 All three capabilities live on the shared [`overflow`](/docs/core/panels/tabOverflow)
 option.
@@ -98,7 +98,7 @@ When [pinned tabs](/docs/core/panels/pinnedTabs) are enabled and the pinned bloc
 itself overflows the strip, the clipped pinned tabs appear in a dedicated **Pinned**
 section at the top of the dropdown, above the search and most-recently-used list, and
 are counted in the chevron badge. This matches the plain dropdown, which shows the same
-section when the advanced module is absent.
+section without `dockview-enterprise`.
 
 ## Thumbnails
 
@@ -106,11 +106,11 @@ section when the advanced module is absent.
 
 :::warning
 `thumbnails` is not yet implemented. Setting it has no effect today; `search` and
-`mru` are the shipping capabilities of this module.
+`mru` are the shipping capabilities of this feature.
 :::
 
 ## See also
 
-- [Tab overflow](/docs/core/panels/tabOverflow): the default dropdown this module upgrades.
+- [Tab overflow](/docs/core/panels/tabOverflow): the default dropdown this feature upgrades.
 - [Multi-row tabs](/docs/core/panels/multiRowTabs): wrap tabs onto extra rows instead of collapsing them.
 - [Pinned tabs](/docs/core/panels/pinnedTabs): the source of the dropdown's "Pinned" section.

--- a/packages/docs/docs/core/panels/contextMenus.mdx
+++ b/packages/docs/docs/core/panels/contextMenus.mdx
@@ -16,9 +16,9 @@ builder returns a list mixing built-in string shortcuts with your own custom
 items.
 
 :::info Enterprise feature
-Context menus are provided by the `ContextMenuModule` in the
+Context menus are an enterprise feature, available in the
 [`dockview-enterprise`](/docs/overview/features) package. Importing
-`dockview-enterprise` registers the module for every Dockview instance in the
+`dockview-enterprise` enables them for every Dockview instance in the
 process. Without it, `getTabContextMenuItems` and
 `getTabGroupChipContextMenuItems` are ignored and no menu appears.
 :::

--- a/packages/docs/docs/core/panels/multiRowTabs.mdx
+++ b/packages/docs/docs/core/panels/multiRowTabs.mdx
@@ -76,10 +76,10 @@ api.updateOptions({ overflow: { mode: 'wrap' } });
 </FrameworkSpecific>
 
 :::info
-`overflow.mode: 'wrap'` is provided by the multi-row tabs module, which is included
-in the default `dockview` bundle. If you assemble your own set of modules and omit
-it, `mode: 'wrap'` is ignored and the standard single-row strip with the dropdown is
-used instead; no error, no regression.
+`overflow.mode: 'wrap'` is an enterprise feature. With `dockview-enterprise`
+imported it is enabled for every Dockview instance; without it, `mode: 'wrap'` is
+ignored and the standard single-row strip with the dropdown is used instead; no
+error, no regression.
 :::
 
 ### `maxRows`
@@ -98,8 +98,8 @@ const api = createDockview(element, {
 api.updateOptions({ overflow: { mode: 'wrap', maxRows: 3 } });
 ```
 
-`maxRows` is provided by the same `MultiRowTabsModule` as `mode: 'wrap'`, so it is
-only honoured in wrap mode; it has no effect on the single-row dropdown.
+`maxRows` is part of the same enterprise multi-row tabs feature as `mode: 'wrap'`, so
+it is only honoured in wrap mode; it has no effect on the single-row dropdown.
 
 ### Reordering across rows
 
@@ -120,9 +120,9 @@ flips between a horizontal and a vertical header re-wraps to match.
 
 The `overflow` block also carries `search`, `mru`, and `thumbnails` fields that turn
 the dropdown into a searchable, most-recently-used tab switcher. `search` and `mru`
-ship in the `AdvancedOverflowModule`; `thumbnails` is still reserved and has no effect
-yet. These compose with wrap mode: tabs that spill past `maxRows` land in the same
-enhanced dropdown. See [Advanced overflow](/docs/core/panels/advancedOverflow).
+are part of the enterprise advanced overflow feature; `thumbnails` is still reserved
+and has no effect yet. These compose with wrap mode: tabs that spill past `maxRows`
+land in the same enhanced dropdown. See [Advanced overflow](/docs/core/panels/advancedOverflow).
 
 ## See also
 

--- a/packages/docs/docs/core/panels/tabGroups.mdx
+++ b/packages/docs/docs/core/panels/tabGroups.mdx
@@ -263,8 +263,8 @@ Right-clicking a tab group chip can show a context menu. This is opt-in; no menu
 `getTabGroupChipContextMenuItems` is provided. Return an empty array to suppress the menu for specific chips.
 
 :::info
-The chip context menu is rendered by the enterprise [context menu](/docs/core/panels/contextMenus)
-module. Everything else on this page (chips, colours, custom chip renderers, events, and
+The chip context menu is an enterprise [context menu](/docs/core/panels/contextMenus)
+feature. Everything else on this page (chips, colours, custom chip renderers, events, and
 serialization) is part of the free core; only this menu needs the enterprise package.
 :::
 


### PR DESCRIPTION
## Description

Several docs pages described enterprise features as being provided by internal "modules" (`ContextMenuModule`, `MultiRowTabsModule`, `AdvancedOverflowModule`, the auto-hide edge groups module). Modules are an internal implementation concept; from a user's perspective there is only the free version and the enterprise version. This PR rewords those passages to describe each feature purely in terms of the free core and the `dockview-enterprise` package.

Pages updated:

- `contextMenus.mdx` — "provided by the `ContextMenuModule`… registers the module" → "an enterprise feature… enables them"
- `tabGroups.mdx` — "rendered by the enterprise context menu module" → "an enterprise context menu feature"
- `multiRowTabs.mdx` — dropped `MultiRowTabsModule` / `AdvancedOverflowModule` / "assemble your own set of modules"; reframed as the enterprise multi-row tabs / advanced overflow features
- `advancedOverflow.mdx` — "The Advanced Overflow module… when the module is absent" → "Advanced overflow, an enterprise feature… without `dockview-enterprise`"
- `autoHideEdgeGroups.mdx` — "require the auto-hide edge groups module" → "require the enterprise auto-hide edge groups feature"

The graceful-degradation behaviour each passage described (the option is ignored when the feature isn't present) is preserved, just anchored to the enterprise package rather than internal module registration.

Genuinely unrelated matches were left untouched: Angular's `NgModule`/`BrowserModule` in code samples, JS "module-load time", and the `dockview-core` vs `dockview` npm-package distinction in the v7 migration guide.

## Type of change

- [x] Documentation

## Affected packages

- [x] `docs`

## How to test

Prose-only changes. Review the reworded passages on the five pages listed above, or build the docs site (`yarn build` in `packages/docs`) and confirm the pages render.

## Checklist

- [ ] I have added or updated tests where applicable (n/a — docs prose only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZtK5HCbRSP77fP5VtAEN

---
_Generated by [Claude Code](https://claude.ai/code/session_017EZtK5HCbRSP77fP5VtAEN)_