### PR TITLE
fix(docs): repoint live-example SystemJS mappings at the shipped bundles + resolution guard

### DIFF
--- a/packages/docs/scripts/buildTemplates.mjs
+++ b/packages/docs/scripts/buildTemplates.mjs
@@ -102,6 +102,114 @@ const START_FILE = {
     angular: 'app/index.ts',
 };
 
+// The `main` file each mapped package resolves to, mirrored from the SystemJS
+// boilerplates in static/example-runner/*/systemjs.config.js. Nothing fails
+// loudly when a boilerplate points at a path the build no longer produces: the
+// browser just 404s (or serves a stale orphan) at runtime. So the paths here
+// must be kept in step with those boilerplates and are asserted below.
+const PACKAGE_MAIN = {
+    'dockview-core': 'dist/package/main.cjs.js',
+    dockview: 'dist/package/main.cjs.js',
+    'dockview-enterprise': 'dist/package/main.cjs.js',
+    'dockview-react': 'dist/package/main.cjs.js',
+    'dockview-vue': 'dist/dockview-vue.es.js',
+    'dockview-angular': 'dist/fesm2022/dockview-angular.mjs',
+};
+
+// Set to bypass the resolution check (e.g. an offline build). Off by default:
+// the whole point of the guard is to fail a docs build that would ship dead
+// example imports.
+const SKIP_MAIN_CHECK = process.env.SKIP_TEMPLATE_MAIN_CHECK === 'true';
+
+// Every package mapped by any framework, deduped.
+function mappedPackages() {
+    const packages = new Set();
+    for (const framework of FRAMEWORKS) {
+        for (const pkg of Object.keys(DOCKVIEW_CDN[framework].remote)) {
+            packages.add(pkg);
+        }
+    }
+    return [...packages];
+}
+
+// Assert every mapped package `main` actually resolves before any template is
+// written. --local checks the file on disk under the package's dist/; remote
+// HEADs the CDN URL and fails on >= 400. The remote check catches both a stale
+// mapping and a docs deploy that runs ahead of the npm publish (either of which
+// would 404 every example that imports the package). Kept cheap: a handful of
+// HEADs, run in parallel, honouring the DOCKVIEW_VERSION override.
+async function assertMainsResolve() {
+    if (SKIP_MAIN_CHECK) {
+        console.warn(
+            '[buildTemplates] SKIP_TEMPLATE_MAIN_CHECK set, skipping package main resolution check'
+        );
+        return;
+    }
+
+    const packages = mappedPackages();
+    const failures = [];
+
+    // Config drift: a package is mapped but has no known main file here.
+    for (const pkg of packages) {
+        if (!PACKAGE_MAIN[pkg]) {
+            failures.push({
+                pkg,
+                where: `missing from PACKAGE_MAIN in ${path.basename(
+                    fileURLToPath(import.meta.url)
+                )}`,
+            });
+        }
+    }
+
+    if (USE_LOCAL_CDN) {
+        for (const pkg of packages) {
+            const rel = PACKAGE_MAIN[pkg];
+            if (!rel) continue;
+            const abs = path.join(__dirname, '..', '..', pkg, rel);
+            if (!fs.existsSync(abs)) {
+                failures.push({ pkg, where: abs });
+            }
+        }
+    } else {
+        await Promise.all(
+            packages.map(async (pkg) => {
+                const rel = PACKAGE_MAIN[pkg];
+                if (!rel) return;
+                const url = `https://cdn.jsdelivr.net/npm/${pkg}@${DOCKVIEW_VERSION}/${rel}`;
+                try {
+                    const res = await fetch(url, { method: 'HEAD' });
+                    if (res.status >= 400) {
+                        failures.push({ pkg, where: url, status: res.status });
+                    }
+                } catch (err) {
+                    failures.push({ pkg, where: url, status: err.message });
+                }
+            })
+        );
+    }
+
+    if (failures.length > 0) {
+        const lines = failures.map((f) => {
+            const status = f.status ? ` (${f.status})` : '';
+            const version = USE_LOCAL_CDN ? 'local' : `@${DOCKVIEW_VERSION}`;
+            return `  - ${f.pkg}${version} -> ${f.where}${status}`;
+        });
+        const hint = USE_LOCAL_CDN
+            ? 'Build the packages first (npm run build && npm run build:bundle in each of dockview-core, dockview, dockview-react, dockview-enterprise).'
+            : 'Check these versions are published to npm. The docs must not deploy ahead of the npm publish, or every example that imports the package 404s. Use DOCKVIEW_VERSION to test a prerelease.';
+        throw new Error(
+            `[buildTemplates] ${failures.length} mapped package main file(s) do not resolve:\n` +
+                `${lines.join('\n')}\n${hint}`
+        );
+    }
+
+    console.log(
+        `[buildTemplates] verified ${packages.length} package main files resolve (${
+            USE_LOCAL_CDN ? 'local disk' : `jsdelivr @${DOCKVIEW_VERSION}`
+        })`
+    );
+}
+
 const template = fs
     .readFileSync(path.join(__dirname, './template.html'))
     .toString();
@@ -223,5 +331,16 @@ async function buildTemplates() {
     fs.writeFileSync(path.join(output, 'index.html'), index);
 }
 
-// Run the build
-buildTemplates().catch(console.error);
+// Run the build. Assert the mapped package main files resolve first, then
+// generate the templates. Any failure must exit non-zero so a broken mapping or
+// an unpublished version fails the docs build loudly rather than shipping dead
+// example imports.
+async function run() {
+    await assertMainsResolve();
+    await buildTemplates();
+}
+
+run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/packages/docs/static/example-runner/dockview-angular-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-angular-boilerplate/systemjs.config.js
@@ -61,15 +61,19 @@
             app: {
                 defaultExtension: 'ts',
             },
+            // dockview-core is resolved transitively via `dockview`;
+            // dockview-enterprise is imported directly for its named exports
+            // (e.g. `LicenseManager`). Both resolve to the rolldown
+            // `dist/package` bundle, which sets `__esModule` (via rolldown's
+            // `esModule: true`). SystemJS 0.21 only exposes named exports from a
+            // CJS module when that marker is present.
             'dockview-core': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },
-            // `dockview-enterprise`: tsc `dist/cjs` build so SystemJS sees the
-            // named exports (e.g. `LicenseManager`). Examples that use it import it.
             'dockview-enterprise': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },

--- a/packages/docs/static/example-runner/dockview-react-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-react-boilerplate/systemjs.config.js
@@ -46,21 +46,20 @@
             app: {
                 defaultExtension: 'tsx',
             },
-            // dockview-core and dockview-react are imported directly by example
-            // code via ES named imports, so they must use the tsc `dist/cjs`
-            // build, which sets `__esModule` (SystemJS 0.21 only exposes named
-            // exports from a CJS module when that flag is present). `dockview`
-            // is consumed only via `require()` from dockview-react, so it uses
-            // the inlined `dist/package` bundle.
+            // dockview-core, dockview-react and dockview-enterprise are imported
+            // directly by example code via ES named imports (e.g.
+            // `LicenseManager` from enterprise), and `dockview` is required by
+            // dockview-react. All resolve to the rolldown `dist/package` bundle,
+            // which sets `__esModule` (via rolldown's `esModule: true`).
+            // SystemJS 0.21 only exposes named exports from a CJS module when
+            // that marker is present.
             'dockview-core': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },
-            // `dockview-enterprise`: tsc `dist/cjs` build so SystemJS sees the
-            // named exports (e.g. `LicenseManager`). Examples that use it import it.
             'dockview-enterprise': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },
@@ -70,7 +69,7 @@
                 defaultExtension: 'js',
             },
             'dockview-react': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },

--- a/packages/docs/static/example-runner/dockview-typescript-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-typescript-boilerplate/systemjs.config.js
@@ -39,15 +39,19 @@
             app: {
                 defaultExtension: 'ts',
             },
+            // dockview-core is resolved transitively via `dockview`;
+            // dockview-enterprise is imported directly for its named exports
+            // (e.g. `LicenseManager`). Both resolve to the rolldown
+            // `dist/package` bundle, which sets `__esModule` (via rolldown's
+            // `esModule: true`). SystemJS 0.21 only exposes named exports from a
+            // CJS module when that marker is present.
             'dockview-core': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },
-            // `dockview-enterprise`: tsc `dist/cjs` build so SystemJS sees the
-            // named exports (e.g. `LicenseManager`). Examples that use it import it.
             'dockview-enterprise': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },

--- a/packages/docs/static/example-runner/dockview-vue-boilerplate/systemjs.config.js
+++ b/packages/docs/static/example-runner/dockview-vue-boilerplate/systemjs.config.js
@@ -43,15 +43,19 @@
             app: {
                 defaultExtension: 'ts',
             },
+            // dockview-core is resolved transitively via `dockview`;
+            // dockview-enterprise is imported directly for its named exports
+            // (e.g. `LicenseManager`). Both resolve to the rolldown
+            // `dist/package` bundle, which sets `__esModule` (via rolldown's
+            // `esModule: true`). SystemJS 0.21 only exposes named exports from a
+            // CJS module when that marker is present.
             'dockview-core': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },
-            // `dockview-enterprise`: tsc `dist/cjs` build so SystemJS sees the
-            // named exports (e.g. `LicenseManager`). Examples that use it import it.
             'dockview-enterprise': {
-                main: './dist/cjs/index.js',
+                main: './dist/package/main.cjs.js',
                 format: 'cjs',
                 defaultExtension: 'js',
             },


### PR DESCRIPTION
## Description

**Release blocker: released packages ship no `dist/cjs` JS, so v8 would have 404'd every docs live example in production, not just the enterprise ones.**

The docs live examples were silently running stale JavaScript, which made a *correct* fix look broken.

Commit `048371940` ("build: optimise published package outputs", DV-76) set `emitDeclarationOnly: true` on the CJS tsconfigs of `dockview-core`, `dockview`, `dockview-react` and `dockview-enterprise`. tsc stopped emitting `dist/cjs/*.js` and now refreshes only `.d.ts`. The real JS is the rolldown bundle at `dist/package/main.cjs.js`, which each package's `package.json` `main` already points at, and the `files` allowlist publishes only `dist/cjs/**/*.d.ts`.

But all four example-runner SystemJS boilerplates still resolved `dockview-core` / `dockview-enterprise` (and `dockview-react` in the React one) to `./dist/cjs/index.js`. Those `.js` files lingered locally as orphans from the last pre-DV-76 build (`clean` is rarely run), so SystemJS kept serving them, frozen at a stale date per package. A clean build or a released package has no `dist/cjs` JS at all, so those mappings 404.

Visible symptom that surfaced this: PR #1467 fixed the vertical tab-wrap "staircase" by pinning `--dv-wrap-vertical-tab-height` from enterprise's `WrapController`. The fix is correct and on the branch, but the browser ran the stale enterprise bundle, which never sets the variable, so the SCSS hit its `auto` fallback (the staircase) at `/docs/core/panels/multiRowTabs`.

### The fix

Repoint the `dockview-core` and `dockview-enterprise` mappings (plus `dockview-react` in the React boilerplate) from `./dist/cjs/index.js` to `./dist/package/main.cjs.js` in all four boilerplates. `dockview`, `dockview-vue` (`dist/dockview-vue.es.js`) and `dockview-angular` (`dist/fesm2022/…`) mappings are unchanged. Comments corrected: the bundles carry `__esModule` via rolldown's `esModule: true`, which SystemJS 0.21 requires before it exposes named exports from a CJS module.

### The guard (`buildTemplates.mjs`)

Nothing failed loudly when a boilerplate pointed at a path the build no longer produced; that is why this hid for a day. Added a build-time assertion that every mapped package `main` actually resolves before any template is written:

- `--local`: the file exists on disk under the package's `dist/`.
- remote/CDN: a parallel HEAD of each `<pkg>@<version>/dist/…` URL, failing on ≥ 400.

It fails the build loudly with the offending package, version and URL, honours the `DOCKVIEW_VERSION` override, and the build invocation now exits non-zero on failure instead of swallowing the error (`.catch(console.error)`). This catches both a stale mapping and a docs deploy that runs ahead of the npm publish.

## Findings (Q1–Q3, evidence)

Verification method: Playwright sweep of all 142 generated `index.html` pages (36 react, 35 typescript, 35 vue, 36 angular) against a local server serving the freshly built `dist/package` bundles. Console errors, page errors and HTTP ≥ 400 responses captured per page and categorised.

**Q1 — does the fix hold across every example? Yes.** With the fix: **137 / 142 mount cleanly, 0 module-resolution failures on any dockview package.** The 5 non-mounts are pre-existing example-source issues, not resolution:

| Example | Category | Cause |
| --- | --- | --- |
| `react/full-width-tab`, `react/iframe` | example source | `React.createElement is not a function` — both use `import * as React` (namespace import). Only 2 of 36 react examples do; the other 34 use `import React from` and mount. The `react` UMD mapping was not changed. |
| `react/demo-dockview` | example source | 404 on `defaultLayout.ts.tsx` — the example imports `./defaultLayout.ts` with an explicit extension that collides with SystemJS `defaultExtension: tsx`. (demo-dockview is the react+angular-only `/demo` example.) |
| `angular/demo-dockview`, `angular/layout-history` | see Q2 | `NG0202` |

To prove none of the 5 were caused by the repoint, I ran a controlled baseline: reverted the boilerplates to `./dist/cjs/index.js` and populated `dist/cjs/index.js` with the same bundle bytes so the OLD mapping resolves. Result was **identical**: same 137 / 142, same 5 failures, same 6 NG0202. The residual failures are independent of the `dist/cjs` ↔ `dist/package` choice.

**Q2 — are the Angular `NG0202` errors pre-existing? Yes, pre-existing and unrelated to module resolution. Not fixed in this pass.** 6 of 36 angular examples throw `NG0202: This constructor is not compatible with Angular Dependency Injection` (demo-dockview, layout-history, maximize-group, popout-group, render-mode, update-title); 4 of them still mount the dock. It is decorator-metadata loss when the SystemJS TypeScript transpiler transpiles the example's own components in the browser, hitting only examples with constructor injection. The `dockview-angular` mapping was not changed, and the controlled baseline above yields the same 6 NG0202 whether the mapping points at `dist/cjs` or `dist/package` — so the repoint is not the cause.

**Q3 — is the CDN version pin sound for v8? Yes, once v8 is published, with one residual risk now folded into the guard.** The pin maps every package to `https://cdn.jsdelivr.net/npm/<pkg>@<version>`. HEAD probes at the current `7.0.2`:

- 200: `dockview-core`, `dockview`, `dockview-react`, `dockview-vue`, `dockview-angular` (5 / 6 resolve).
- 404: `dockview-enterprise@7.0.2` (only `0.0.0` and one prerelease are published).

This is expected and self-resolving: enterprise ships in v8 with fixed versioning, so v8 mints `dockview-enterprise@8.x` alongside the others and all 6 resolve. Not "fixed" here. The residual risk is real: **the docs must not deploy ahead of the npm publish, or every enterprise example 404s.** The guard's remote HEAD check enforces exactly this — at `7.0.2` today it fails with a single clear line for `dockview-enterprise`, and `deploy-docs.yml` (which does not build enterprise and relies on the published CDN version) now cannot deploy before enterprise is on npm.

## Type of change

- [x] Bug fix
- [x] Documentation
- [x] Build / CI / tooling

## Affected packages

- [x] `docs`

## How to test

- `cd packages/docs && npm run build-templates:local` after building the `dist/package` bundles → guard prints `verified 6 package main files resolve (local disk)` and generates templates.
- `DOCKVIEW_VERSION=7.0.2 npm run build-templates` → guard fails with exit 1 on `dockview-enterprise@7.0.2` (404), demonstrating the deploy-ahead-of-publish guard.
- Load any generated `static/templates/dockview/<id>/<framework>/index.html`; the dock mounts with no dockview-package 404s.

## Checklist

- [ ] `yarn lint:fix` passes — n/a, docs package is deliberately excluded from lint/format and CI does not check it
- [ ] `yarn format` passes — n/a, same reason
- [ ] `npm run gen` has been run and generated files are up to date — n/a, no generated source touched (`static/templates/` is build output, not committed)
- [x] `yarn test` — `npx jest --selectProjects dockview-enterprise -t wrap` → 33/33 pass
- [ ] I have added or updated tests where applicable — the guard is exercised via `build-templates`; no unit-test harness exists for this script
- [ ] Breaking changes are documented — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFPcCn11Au4qu7YUyiCWMF)_