### PR TITLE
fix(core): keep tab overflow dropdown hover within the tab strip

### DIFF
--- a/packages/dockview-core/src/dockview/components/titlebar/tabOverflowControl.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabOverflowControl.scss
@@ -1,5 +1,9 @@
 .dv-tabs-overflow-dropdown-default {
     height: 100%;
+    // Keep the padding inside the 100% header height. Without border-box the
+    // vertical padding is added on top of `height: 100%`, making the control
+    // taller than the header so its hover background spills below the tab strip.
+    box-sizing: border-box;
     color: var(--dv-activegroup-hiddenpanel-tab-color);
 
     margin: var(--dv-tab-margin);


### PR DESCRIPTION
## Description

The tab overflow dropdown control (the "⌄ N" chevron) rendered ~8px taller than the header in every non-spaced theme, so its `:hover` background spilled below the tab strip into the panel content area.

**Root cause:** `.dv-tabs-overflow-dropdown-default` uses `height: 100%` to fill the header but had no `box-sizing`. With the default `content-box`, its `padding: 0.25rem 0.5rem` was added *on top of* the full-header 100% height, making the box taller than the header. (Regular `.dv-tab` never hit this — it sets `box-sizing: border-box` and has no fixed height. The `*-spaced` themes dodged it by overriding `height: unset`.)

**Fix:** add `box-sizing: border-box` so the padding sits inside the 100% height.

Before / after (light theme) — grey hover box spilling below the strip vs. contained:

| Before | After |
|---|---|
| dropdown 43px in a 35px header → 8px overflow | dropdown 35px, flush with header |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

1. Use any non-spaced theme (e.g. `dockview-theme-light`).
2. Add enough tabs to a group that the overflow dropdown ("⌄ N") appears.
3. Hover the dropdown — the grey hover background should stay within the tab strip and no longer bleed into the content area below.

Verified by compiling the SCSS and measuring the dropdown vs. header box in headless Chromium across all 18 themes:
- All 12 non-spaced themes overflowed by 8px before the change and measure 0px overflow after (`vs`, with its 20px header, went 28px → 20px).
- All 6 `*-spaced` themes were never affected and measure identically before/after (they use `height: unset`, so `box-sizing` on an auto-height box is a no-op).

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented

> Note: this is a one-line SCSS-source change (`packages/dockview-core/src/dockview/components/titlebar/tabOverflowControl.scss`); the shipped `dist` CSS is regenerated by the build. Verification above was visual/measurement-based rather than via the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFnPt28jEmyyK43gbMQ2i

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFnPt28jEmyyK43gbMQ2i)_