### PR TITLE
fix(dockview-vue): forward fallthrough attributes onto the host element

### DIFF
--- a/packages/dockview-vue/src/__tests__/dockview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/dockview.spec.ts
@@ -556,4 +556,29 @@ describe('DockviewVue components prop (issue #1301)', () => {
             api.addPanel({ id: 'panel-2', component: 'Panel', title: 'P2' })
         ).not.toThrow();
     });
+
+    test('forwards fallthrough attributes (class/style) onto the host element', async () => {
+        // Regression guard: the component renders two root nodes (the host
+        // element and the `<DockviewPortals>` teleport host), so Vue cannot
+        // auto-inherit fallthrough attributes. Without inheritAttrs:false plus
+        // an explicit v-bind="$attrs" on the host, a consumer's
+        // `<dockview-vue class="dockview-theme-abyss">` lands on nothing,
+        // leaving the dock unstyled and zero-height (fallout from #1369, which
+        // added the second root node).
+        wrapper = mount(DockviewVue, {
+            attrs: { class: 'dockview-theme-test', 'data-example': 'dock' },
+            attachTo: document.body,
+            global: { components: { MockPanel } },
+        });
+        await flushPromises();
+
+        const host = document.querySelector(
+            '.dockview-theme-test'
+        ) as HTMLElement | null;
+        expect(host).not.toBeNull();
+        expect(host!.getAttribute('data-example')).toBe('dock');
+        // the forwarded attributes land on the dockview host itself, not some
+        // detached node: the initialised dock lives inside it
+        expect(host!.querySelector('.dv-dockview')).not.toBeNull();
+    });
 });

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -290,3 +290,23 @@ describe('GridviewVue components prop resolves without registration', () => {
         expect(api.getPanel('extra-1')).toBeDefined();
     });
 });
+
+test('forwards fallthrough attributes onto the host element (multi-root inheritance regression)', async () => {
+    // The component has two root nodes (host element + <DockviewPortals>), so
+    // Vue cannot auto-inherit fallthrough attributes. inheritAttrs:false plus
+    // v-bind="$attrs" on the host restores it; without them a consumer's
+    // `class`/`style` (e.g. a theme class) would land on nothing (see #1369).
+    const wrapper = mount(GridviewVue, {
+        attrs: { class: 'dockview-theme-test', 'data-example': 'gridview' },
+        attachTo: document.body,
+    });
+    await flushPromises();
+
+    const host = document.querySelector(
+        '.dockview-theme-test'
+    ) as HTMLElement | null;
+    expect(host).not.toBeNull();
+    expect(host!.getAttribute('data-example')).toBe('gridview');
+
+    wrapper.unmount();
+});

--- a/packages/dockview-vue/src/__tests__/paneview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/paneview.spec.ts
@@ -230,3 +230,23 @@ describe('PaneviewVue components prop resolves without registration', () => {
         ).toThrow("Failed to find Vue Component 'NotRegistered'");
     });
 });
+
+test('forwards fallthrough attributes onto the host element (multi-root inheritance regression)', async () => {
+    // The component has two root nodes (host element + <DockviewPortals>), so
+    // Vue cannot auto-inherit fallthrough attributes. inheritAttrs:false plus
+    // v-bind="$attrs" on the host restores it; without them a consumer's
+    // `class`/`style` (e.g. a theme class) would land on nothing (see #1369).
+    const wrapper = mount(PaneviewVue, {
+        attrs: { class: 'dockview-theme-test', 'data-example': 'paneview' },
+        attachTo: document.body,
+    });
+    await flushPromises();
+
+    const host = document.querySelector(
+        '.dockview-theme-test'
+    ) as HTMLElement | null;
+    expect(host).not.toBeNull();
+    expect(host!.getAttribute('data-example')).toBe('paneview');
+
+    wrapper.unmount();
+});

--- a/packages/dockview-vue/src/__tests__/splitview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/splitview.spec.ts
@@ -190,3 +190,23 @@ describe('SplitviewVue components prop resolves without registration', () => {
         ).toThrow("Failed to find Vue Component 'NotRegistered'");
     });
 });
+
+test('forwards fallthrough attributes onto the host element (multi-root inheritance regression)', async () => {
+    // The component has two root nodes (host element + <DockviewPortals>), so
+    // Vue cannot auto-inherit fallthrough attributes. inheritAttrs:false plus
+    // v-bind="$attrs" on the host restores it; without them a consumer's
+    // `class`/`style` (e.g. a theme class) would land on nothing (see #1369).
+    const wrapper = mount(SplitviewVue, {
+        attrs: { class: 'dockview-theme-test', 'data-example': 'splitview' },
+        attachTo: document.body,
+    });
+    await flushPromises();
+
+    const host = document.querySelector(
+        '.dockview-theme-test'
+    ) as HTMLElement | null;
+    expect(host).not.toBeNull();
+    expect(host!.getAttribute('data-example')).toBe('splitview');
+
+    wrapper.unmount();
+});

--- a/packages/dockview-vue/src/dockview/dockview.vue
+++ b/packages/dockview-vue/src/dockview/dockview.vue
@@ -49,6 +49,13 @@ const emit = defineEmits<VueEvents>();
 
 const props = defineProps<IDockviewVueProps>();
 
+// The template has two root nodes (the dockview host element and the
+// `<DockviewPortals>` teleport host), so Vue cannot auto-inherit fallthrough
+// attributes. Disable automatic inheritance and bind `$attrs` (class, style,
+// id, ...) explicitly onto the host element below, otherwise a consumer's
+// `<dockview-vue class="dockview-theme-abyss">` would land on nothing.
+defineOptions({ inheritAttrs: false });
+
 const el = ref<HTMLElement | null>(null);
 const instance = ref<DockviewApi | null>(null);
 const eventDisposables: DockviewIDisposable[] = [];
@@ -396,6 +403,6 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-    <div ref="el" />
+    <div ref="el" v-bind="$attrs" />
     <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/gridview/gridview.vue
+++ b/packages/dockview-vue/src/gridview/gridview.vue
@@ -26,6 +26,11 @@ function extractCoreOptions(props: IGridviewVueProps): GridviewOptions {
 const emit = defineEmits<GridviewVueEvents>();
 const props = defineProps<IGridviewVueProps>();
 
+// Two root nodes (host element + `<DockviewPortals>`) prevent Vue from
+// auto-inheriting fallthrough attributes, so bind `$attrs` (class, style, ...)
+// onto the host element explicitly below.
+defineOptions({ inheritAttrs: false });
+
 const { el, registry } = useViewComponent(
     {
         componentName: 'gridview-vue',
@@ -41,6 +46,6 @@ const { el, registry } = useViewComponent(
 </script>
 
 <template>
-    <div ref="el" style="height: 100%; width: 100%" />
+    <div ref="el" style="height: 100%; width: 100%" v-bind="$attrs" />
     <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/paneview/paneview.vue
+++ b/packages/dockview-vue/src/paneview/paneview.vue
@@ -26,6 +26,11 @@ function extractCoreOptions(props: IPaneviewVueProps): PaneviewOptions {
 const emit = defineEmits<PaneviewVueEvents>();
 const props = defineProps<IPaneviewVueProps>();
 
+// Two root nodes (host element + `<DockviewPortals>`) prevent Vue from
+// auto-inheriting fallthrough attributes, so bind `$attrs` (class, style, ...)
+// onto the host element explicitly below.
+defineOptions({ inheritAttrs: false });
+
 const { el, registry } = useViewComponent(
     {
         componentName: 'paneview-vue',
@@ -44,6 +49,6 @@ const { el, registry } = useViewComponent(
 </script>
 
 <template>
-    <div ref="el" style="height: 100%; width: 100%" />
+    <div ref="el" style="height: 100%; width: 100%" v-bind="$attrs" />
     <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/splitview/splitview.vue
+++ b/packages/dockview-vue/src/splitview/splitview.vue
@@ -26,6 +26,11 @@ function extractCoreOptions(props: ISplitviewVueProps): SplitviewOptions {
 const emit = defineEmits<SplitviewVueEvents>();
 const props = defineProps<ISplitviewVueProps>();
 
+// Two root nodes (host element + `<DockviewPortals>`) prevent Vue from
+// auto-inheriting fallthrough attributes, so bind `$attrs` (class, style, ...)
+// onto the host element explicitly below.
+defineOptions({ inheritAttrs: false });
+
 const { el, registry } = useViewComponent(
     {
         componentName: 'splitview-vue',
@@ -41,6 +46,6 @@ const { el, registry } = useViewComponent(
 </script>
 
 <template>
-    <div ref="el" style="height: 100%; width: 100%" />
+    <div ref="el" style="height: 100%; width: 100%" v-bind="$attrs" />
     <DockviewPortals :entries="registry.entries" />
 </template>


### PR DESCRIPTION
## Description

Every Vue live example on the docs site rendered blank below the controls (e.g. `/docs/core/panels/multiRowTabs?framework=vue`), accompanied by a console warning:

> [Vue warn]: Extraneous non-props attributes (class) were passed to component but could not be automatically inherited because component renders fragment or text root nodes. at `<Dockview class="example-dock dockview-theme-light" ...>`

### Root cause

Since #1369 ("mount panels via Teleport so keep-alive lifecycle works") the `Dockview`, `Gridview`, `Splitview` and `Paneview` components render **two root nodes**: the host element and the `<DockviewPortals>` teleport host.

```vue
<template>
    <div ref="el" />
    <DockviewPortals :entries="registry.entries" />
</template>
```

Vue cannot auto-inherit fallthrough attributes on a multi-root component, so a consumer's `<dockview-vue class="dockview-theme-abyss">` no longer applied the class to the dock element. `dockview.vue` has no fallback height (the siblings set an inline `height: 100%`), so the dock collapsed to zero height and rendered blank. In the docs the example binds `class="example-dock <theme>"` onto the component; with fallthrough broken, neither the flex-height class nor the theme reached the dock.

This is not related to the recent docs SystemJS change (#1468) — that never touched `dockview-vue`. Reverting the docs mapping reproduces the same blank render; making the old mapping resolve produces the same blank render. The cause is the two-root template.

### Fix

Set `inheritAttrs: false` and bind `$attrs` (class, style, id, ...) explicitly onto the host element in all four components:

```vue
defineOptions({ inheritAttrs: false });
// ...
<div ref="el" v-bind="$attrs" />
```

This restores the pre-#1369 fallthrough behaviour. Verified in a browser against the docs examples: the multiRowTabs Vue dock now renders with the tabs wrapped into rows and the theme applied; `basic` and the other 34 Vue examples render correctly.

### Tests

A regression test per component mounts with a fallthrough `class`/attribute and asserts it lands on the host element. Each one **fails without the fix** and passes with it (verified by removing the `v-bind` and re-running). `128 passed` for the `dockview-vue` project.

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-vue`

## How to test

- `npx nx run dockview-vue:test` → 128 pass, including the four new `forwards fallthrough attributes onto the host element` tests.
- In the docs, open any Vue live example (e.g. multiRowTabs, `?framework=vue`): the dock renders and is themed, and the Vue "Extraneous non-props attributes" warning is gone.

## Checklist

- [x] `format:check` passes (`nx run dockview-vue:format:check`)
- [x] `lint` passes (`nx run dockview-vue:lint`)
- [x] `test` passes (`nx run dockview-vue:test`, 128 tests)
- [x] I have added or updated tests where applicable

## Follow-up

A cross-framework e2e smoke test (assert each generated template renders with a non-zero bounding box and no console/module-resolution errors, across react/vue/angular/typescript) would have caught both this and the earlier SystemJS staleness bug. Tracking it as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFPcCn11Au4qu7YUyiCWMF)_