### PR TITLE
fix(docs): Vue examples now follow the site light/dark theme

### DIFF
--- a/packages/docs/templates/dockview/advanced-overflow/vue/src/index.ts
+++ b/packages/docs/templates/dockview/advanced-overflow/vue/src/index.ts
@@ -74,7 +74,8 @@ const App = defineComponent({
           <button @click="addPanel">Add Tab</button>
         </div>
         <dockview-vue
-          class="example-dock ${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+          class="example-dock"
+          className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
           :overflow="{ mode: 'dropdown', search: { placeholder: 'Search tabs…' }, mru: true }"
           @ready="onReady"
         >

--- a/packages/docs/templates/dockview/auto-edge-groups/vue/src/index.ts
+++ b/packages/docs/templates/dockview/auto-edge-groups/vue/src/index.ts
@@ -65,7 +65,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         :dockToEdgeGroups="true"
         :autoHideEdgeGroups="true"
         @ready="onReady"

--- a/packages/docs/templates/dockview/auto-hide-edge-groups/vue/src/index.ts
+++ b/packages/docs/templates/dockview/auto-hide-edge-groups/vue/src/index.ts
@@ -102,7 +102,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         :autoHideEdgeGroups="true"
         @ready="onReady"
       >

--- a/packages/docs/templates/dockview/basic/vue/src/index.ts
+++ b/packages/docs/templates/dockview/basic/vue/src/index.ts
@@ -79,7 +79,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%; height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
       >
       </dockview-vue>`,

--- a/packages/docs/templates/dockview/constraints/vue/src/index.ts
+++ b/packages/docs/templates/dockview/constraints/vue/src/index.ts
@@ -116,7 +116,7 @@ const App = defineComponent({
     },
     template: `
         <dockview-vue
-            class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+            className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
             @ready="onReady"
             style="width: 100%; height: 100%;">
         </dockview-vue>

--- a/packages/docs/templates/dockview/context-menu/vue/src/index.ts
+++ b/packages/docs/templates/dockview/context-menu/vue/src/index.ts
@@ -97,7 +97,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
         :getTabContextMenuItems="getTabContextMenuItems"
       />`,

--- a/packages/docs/templates/dockview/custom-header/vue/src/index.ts
+++ b/packages/docs/templates/dockview/custom-header/vue/src/index.ts
@@ -148,7 +148,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
       >
       </dockview-vue>`,

--- a/packages/docs/templates/dockview/dnd-events/vue/src/index.ts
+++ b/packages/docs/templates/dockview/dnd-events/vue/src/index.ts
@@ -172,7 +172,8 @@ const App = defineComponent({
                 </button>
             </div>
             <dockview-vue
-                class="example-dock ${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+                class="example-dock"
+                className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
                 @ready="onReady">
             </dockview-vue>
         </div>

--- a/packages/docs/templates/dockview/dnd-external/vue/src/index.ts
+++ b/packages/docs/templates/dockview/dnd-external/vue/src/index.ts
@@ -207,7 +207,8 @@ const App = defineComponent({
                 </template>
             </div>
             <dockview-vue
-                class="example-dock ${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+                class="example-dock"
+                className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
                 :dnd-edges="{ size: { value: 100, type: 'pixels' }, activationSize: { value: 5, type: 'percentage' } }"
                 @ready="onReady"
                 @didDrop="onDidDrop">

--- a/packages/docs/templates/dockview/drop-guide/vue/src/index.ts
+++ b/packages/docs/templates/dockview/drop-guide/vue/src/index.ts
@@ -74,7 +74,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         :dndGuide="true"
         @ready="onReady"
       >

--- a/packages/docs/templates/dockview/edge-groups/vue/src/index.ts
+++ b/packages/docs/templates/dockview/edge-groups/vue/src/index.ts
@@ -162,7 +162,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%; height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
         rightHeaderActionsComponent="rightAction"
       >

--- a/packages/docs/templates/dockview/floating-groups/vue/src/index.ts
+++ b/packages/docs/templates/dockview/floating-groups/vue/src/index.ts
@@ -290,7 +290,8 @@ const App = defineComponent({
         <button @click="onToggleEnabled">{{ (disableFloatingGroups ? 'Enable' : 'Disable') + ' floating groups' }}</button>
       </div>
       <dockview-vue
-        class="example-dock ${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        class="example-dock"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
         :floatingGroupBounds="bounds"
         :disableFloatingGroups="disableFloatingGroups"

--- a/packages/docs/templates/dockview/full-width-tab/vue/src/index.ts
+++ b/packages/docs/templates/dockview/full-width-tab/vue/src/index.ts
@@ -116,7 +116,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         single-tab-mode="fullwidth"
         @ready="onReady"
       >

--- a/packages/docs/templates/dockview/group-actions/vue/src/index.ts
+++ b/packages/docs/templates/dockview/group-actions/vue/src/index.ts
@@ -140,7 +140,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
         leftHeaderActionsComponent="leftAction"
         rightHeaderActionsComponent="rightAction"

--- a/packages/docs/templates/dockview/header-position/vue/src/index.ts
+++ b/packages/docs/templates/dockview/header-position/vue/src/index.ts
@@ -93,7 +93,7 @@ const App = defineComponent({
     },
     template: `
         <dockview-vue
-            class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+            className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
             defaultHeaderPosition="bottom"
             @ready="onReady"
             style="width: 100%; height: 100%;">

--- a/packages/docs/templates/dockview/iframe/vue/src/index.ts
+++ b/packages/docs/templates/dockview/iframe/vue/src/index.ts
@@ -90,7 +90,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
       >
       </dockview-vue>`,

--- a/packages/docs/templates/dockview/keyboard/vue/src/index.ts
+++ b/packages/docs/templates/dockview/keyboard/vue/src/index.ts
@@ -100,7 +100,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         :keyboardNavigation="keyboardNavigation"
         @ready="onReady"
       >

--- a/packages/docs/templates/dockview/layout-history/vue/src/index.ts
+++ b/packages/docs/templates/dockview/layout-history/vue/src/index.ts
@@ -119,7 +119,8 @@ const App = defineComponent({
           <button @click="addPanel">Add Panel</button>
         </div>
         <dockview-vue
-          class="example-dock ${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+          class="example-dock"
+          className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
           :layoutHistory="{ enabled: true, undoableProgrammaticMutations: true }"
           @ready="onReady"
         >

--- a/packages/docs/templates/dockview/layout/vue/src/index.ts
+++ b/packages/docs/templates/dockview/layout/vue/src/index.ts
@@ -119,7 +119,8 @@ const App = defineComponent({
           <button @click="clearLayout">Reset Layout</button>
         </div>
         <dockview-vue
-          class="example-dock ${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+          class="example-dock"
+          className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
           watermarkComponent="watermark"
           @ready="onReady"
         >

--- a/packages/docs/templates/dockview/locked/vue/src/index.ts
+++ b/packages/docs/templates/dockview/locked/vue/src/index.ts
@@ -80,7 +80,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
         :locked="true"
       ></dockview-vue>`,

--- a/packages/docs/templates/dockview/maximize-group/vue/src/index.ts
+++ b/packages/docs/templates/dockview/maximize-group/vue/src/index.ts
@@ -200,7 +200,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
         leftHeaderActionsComponent="leftAction"
         rightHeaderActionsComponent="rightAction"

--- a/packages/docs/templates/dockview/nested/vue/src/index.ts
+++ b/packages/docs/templates/dockview/nested/vue/src/index.ts
@@ -99,7 +99,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
       ></dockview-vue>`,
 });

--- a/packages/docs/templates/dockview/pinned-tabs/vue/src/index.ts
+++ b/packages/docs/templates/dockview/pinned-tabs/vue/src/index.ts
@@ -80,7 +80,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         :pinnedTabs="pinnedTabs"
         @ready="onReady"
       >

--- a/packages/docs/templates/dockview/popout-group/vue/src/index.ts
+++ b/packages/docs/templates/dockview/popout-group/vue/src/index.ts
@@ -215,7 +215,7 @@ const App = defineComponent({
       <div class="example-dock">
         <dockview-vue
           style="width:100%;height:100%"
-          class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+          className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
           @ready="onReady"
           :floatingGroupBounds="bounds"
           leftHeaderActionsComponent="leftAction"

--- a/packages/docs/templates/dockview/render-mode/vue/src/index.ts
+++ b/packages/docs/templates/dockview/render-mode/vue/src/index.ts
@@ -95,7 +95,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
       ></dockview-vue>`,
 });

--- a/packages/docs/templates/dockview/resize-container/vue/src/index.ts
+++ b/packages/docs/templates/dockview/resize-container/vue/src/index.ts
@@ -129,7 +129,7 @@ const App = defineComponent({
           <div :style="styleObject">
             <dockview-vue
               style="width:100%;height:100%"
-              class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+              className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
               @ready="onReady"
               :disableFloatingGroups=true
             ></dockview-vue>

--- a/packages/docs/templates/dockview/resize/vue/src/index.ts
+++ b/packages/docs/templates/dockview/resize/vue/src/index.ts
@@ -118,7 +118,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
       ></dockview-vue>`,
 });

--- a/packages/docs/templates/dockview/scrollbars/vue/src/index.ts
+++ b/packages/docs/templates/dockview/scrollbars/vue/src/index.ts
@@ -80,7 +80,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
         :disableFloatingGroups="true"
       ></dockview-vue>`,

--- a/packages/docs/templates/dockview/smart-guides/vue/src/index.ts
+++ b/packages/docs/templates/dockview/smart-guides/vue/src/index.ts
@@ -83,7 +83,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         :smartGuides="smartGuides"
         @ready="onReady"
       >

--- a/packages/docs/templates/dockview/tab-overflow/vue/src/index.ts
+++ b/packages/docs/templates/dockview/tab-overflow/vue/src/index.ts
@@ -116,7 +116,8 @@ const App = defineComponent({
           </button>
         </div>
         <dockview-vue
-          class="example-dock ${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+          class="example-dock"
+          className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
           :overflow="{ mode }"
           :pinnedTabs="{ enabled: true }"
           :getTabContextMenuItems="getTabContextMenuItems"

--- a/packages/docs/templates/dockview/tabview/vue/src/index.ts
+++ b/packages/docs/templates/dockview/tabview/vue/src/index.ts
@@ -88,7 +88,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
         :disableFloatingGroups=true
       ></dockview-vue>`,

--- a/packages/docs/templates/dockview/update-parameters/vue/src/index.ts
+++ b/packages/docs/templates/dockview/update-parameters/vue/src/index.ts
@@ -149,7 +149,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
       ></dockview-vue>`,
 });

--- a/packages/docs/templates/dockview/update-title/vue/src/index.ts
+++ b/packages/docs/templates/dockview/update-title/vue/src/index.ts
@@ -92,7 +92,7 @@ const App = defineComponent({
     template: `
       <dockview-vue
         style="width:100%;height:100%"
-        class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+        className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
         @ready="onReady"
       ></dockview-vue>`,
 });

--- a/packages/docs/templates/dockview/watermark/vue/src/index.ts
+++ b/packages/docs/templates/dockview/watermark/vue/src/index.ts
@@ -111,7 +111,7 @@ const App = defineComponent({
         <div class="example-dock">
           <dockview-vue
             style="width:100%;height:100%"
-            class="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
+            className="${(window as any).__dockviewThemeClass ?? 'dockview-theme-abyss'}"
             @ready="onReady"
             watermarkComponent="watermarkComponent"
           ></dockview-vue>


### PR DESCRIPTION
## Description

The Vue live examples rendered dark even when the docs site was in light mode (e.g. `/docs/core/panels/multiRowTabs?framework=vue`).

### Root cause

The Vue examples passed the theme as a fallthrough `class` on `<dockview-vue>`:

```html
<dockview-vue class="example-dock dockview-theme-light" ... />
```

dockview-core themes its shell element, defaulting to abyss (dark). The fallthrough `class` lands on the outer host element, **outside** the shell, so the shell's darker default won and the dock rendered dark regardless of the site mode. React and Angular pass the theme as the `className` **prop**, which dockview-core applies to the inner element **inside** the shell where it wins (TypeScript uses the `theme` option directly).

### Fix

Route the theme through the `className` prop in all 34 Vue examples to match React/Angular, keeping `example-dock` (or the inline height style) on `class` so the dock still gets its size through attribute fallthrough:

```html
<dockview-vue class="example-dock" className="dockview-theme-light" ... />
```

`className` is a `DockviewOptions` field, so `dockview-vue` already forwards it into the core option. No library change.

### Verification

Loaded all 35 Vue examples in light mode in a real browser: the nearest theme class to the dock is now `dockview-theme-light` (was `dockview-theme-abyss`).

## Type of change

- [x] Bug fix
- [x] Documentation

## Affected packages

- [x] `docs`

## How to test

Open any Vue live example with the site in light mode: the dock renders light. (Or with a local dev server, load `/templates/dockview/basic/vue/index.html?colorMode=light`.)

## Checklist

- [ ] `yarn lint:fix` / `yarn format` — n/a, files live under `packages/docs`, excluded from lint/format and not checked by CI
- [ ] Breaking changes are documented — n/a

## Note

The cross-framework smoke suite (#1471) has a matching theme assertion that guards this exact bug; it is scoped there once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFPcCn11Au4qu7YUyiCWMF)_