### PR TITLE
fix(core): sash and scrollbar cannot be dragged inside a popout window

### DIFF
--- a/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
+++ b/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
@@ -677,6 +677,61 @@ describe('splitview', () => {
         expect(removeEventListenerSpy).toHaveBeenCalledTimes(4);
     });
 
+    test("dnd: sash drag follows pointer events in the element's own document", () => {
+        // A popout window (api.addPopoutGroup) has its own document, and the
+        // group's element is moved into it. The sash's pointer events are then
+        // dispatched into THAT document — so listeners bound to the global
+        // document never fire and the sash cannot be dragged.
+        const otherDocument = document.implementation.createHTMLDocument();
+        const otherContainer = otherDocument.createElement('div');
+        otherDocument.body.appendChild(otherContainer);
+
+        const splitview = new Splitview(otherContainer, {
+            orientation: Orientation.HORIZONTAL,
+            proportionalLayout: false,
+        });
+        splitview.layout(400, 500);
+
+        const view1 = new Testview(0, 1000);
+        const view2 = new Testview(0, 1000);
+
+        splitview.addView(view1);
+        splitview.addView(view2);
+
+        const sashElement = otherContainer
+            .getElementsByClassName('dv-sash')
+            .item(0) as HTMLElement;
+
+        expect(sashElement).toBeTruthy();
+        expect([view1.size, view2.size]).toEqual([200, 200]);
+
+        fireEvent(
+            sashElement,
+            new MouseEvent('pointerdown', { clientX: 50, clientY: 100 })
+        );
+
+        // expect a delta move of 70 - 50 = 20, driven from the owning document
+        fireEvent(
+            otherDocument,
+            new MouseEvent('pointermove', { clientX: 70, clientY: 110 })
+        );
+        expect([view1.size, view2.size]).toEqual([220, 180]);
+
+        fireEvent(
+            otherDocument,
+            new MouseEvent('pointerup', { clientX: 70, clientY: 110 })
+        );
+
+        // the drag has ended, so further moves must not resize
+        fireEvent(
+            otherDocument,
+            new MouseEvent('pointermove', { clientX: 100, clientY: 110 })
+        );
+        expect([view1.size, view2.size]).toEqual([220, 180]);
+
+        splitview.dispose();
+    });
+
     test('should restore iframe pointer events on contextmenu during sash drag', () => {
         const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
         const removeEventListenerSpy = jest.spyOn(

--- a/packages/dockview-core/src/scrollbar.ts
+++ b/packages/dockview-core/src/scrollbar.ts
@@ -89,17 +89,19 @@ export class Scrollbar extends CompositeDisposable {
                     this.calculateScrollbarStyles();
                 };
 
+                const doc = this.element.ownerDocument;
+
                 const onEnd = () => {
                     toggleClass(this.element, 'dv-scrollable-scrolling', false);
 
-                    document.removeEventListener('pointermove', onPointerMove);
-                    document.removeEventListener('pointerup', onEnd);
-                    document.removeEventListener('pointercancel', onEnd);
+                    doc.removeEventListener('pointermove', onPointerMove);
+                    doc.removeEventListener('pointerup', onEnd);
+                    doc.removeEventListener('pointercancel', onEnd);
                 };
 
-                document.addEventListener('pointermove', onPointerMove);
-                document.addEventListener('pointerup', onEnd);
-                document.addEventListener('pointercancel', onEnd);
+                doc.addEventListener('pointermove', onPointerMove);
+                doc.addEventListener('pointerup', onEnd);
+                doc.addEventListener('pointercancel', onEnd);
             }),
             addDisposableListener(this.element, 'scroll', () => {
                 this.calculateScrollbarStyles();

--- a/packages/dockview-core/src/splitview/splitview.ts
+++ b/packages/dockview-core/src/splitview/splitview.ts
@@ -543,6 +543,8 @@ export class Splitview {
                     this.layoutViews();
                 };
 
+                const doc = sash.ownerDocument;
+
                 const end = () => {
                     for (const item of this.viewItems) {
                         item.enabled = true;
@@ -552,18 +554,18 @@ export class Splitview {
 
                     this.saveProportions();
 
-                    document.removeEventListener('pointermove', onPointerMove);
-                    document.removeEventListener('pointerup', end);
-                    document.removeEventListener('pointercancel', end);
-                    document.removeEventListener('contextmenu', end);
+                    doc.removeEventListener('pointermove', onPointerMove);
+                    doc.removeEventListener('pointerup', end);
+                    doc.removeEventListener('pointercancel', end);
+                    doc.removeEventListener('contextmenu', end);
 
                     this._onDidSashEnd.fire(undefined);
                 };
 
-                document.addEventListener('pointermove', onPointerMove);
-                document.addEventListener('pointerup', end);
-                document.addEventListener('pointercancel', end);
-                document.addEventListener('contextmenu', end);
+                doc.addEventListener('pointermove', onPointerMove);
+                doc.addEventListener('pointerup', end);
+                doc.addEventListener('pointercancel', end);
+                doc.addEventListener('contextmenu', end);
             };
 
             sash.addEventListener('pointerdown', onPointerStart);


### PR DESCRIPTION
## Description

Fixes #1477.

Inside a popout window (`api.addPopoutGroup`), a splitview **sash cannot be dragged** — the drag arms and then nothing moves, so two groups docked side by side in a popout are stuck at their initial ratio. `Scrollbar` has the identical defect, so the tab-bar overflow scrollbar can't be dragged there either.

**Cause.** `Splitview` registers the sash's `pointerdown` on the **sash element**, but registers the follow-up listeners on the **global `document`** (`splitview.ts` ~L563):

```ts
document.addEventListener('pointermove', onPointerMove);
document.addEventListener('pointerup', end);
document.addEventListener('pointercancel', end);
document.addEventListener('contextmenu', end);
```

A popout window has its own document. `addPopoutGroup` moves the group's element into it (`popoutContainer.appendChild(...)`, which adopts the node), so a sash living there dispatches pointer events into the *popout's* document, never the opener's. `pointerdown` still fires (it's on the element, which travelled with it), so the drag arms — but `pointermove`/`pointerup` never arrive, `resize()` is never called and `end()` never runs. `scrollbar.ts` (~L100) repeats the pattern.

**Why it's easy to miss:** the symptom discriminates purely on *document*, and fails silently — no error, no console output.

| placement | element's document | sash drag |
|---|---|---|
| grid | main window's | works |
| floating group | main window's | works |
| **popout group** | **the popout window's** | **dead** |

Floating groups render into the main document, so the global `document` happens to be right for them. Only popout groups cross a document boundary.

**Fix.** Resolve the owning document from the element — `sash.ownerDocument` / `this.element.ownerDocument`. It's captured **once per drag** into a `const` closed over by both the `addEventListener` and its matching `removeEventListener`, so a listener can't be added on one document and removed from another (strictly no worse than today, which uses the same global for both). `ownerDocument` is correct at `pointerdown`: cross-document `appendChild` adopts the node, so a sash inside the popout container already carries that window's document by the time it can receive a pointer event.

## Reproduction

1. `api.addPopoutGroup(group)` to open a group in its own window.
2. Drag a second panel into that window and drop it to the side, so the popout hosts two groups with a sash between them.
3. Try to drag the sash — it doesn't move. The same steps in a floating group work.

Found against `7.0.2` (latest published) and reproduced in current `master`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## Notes

- **Kept deliberately minimal.** The same `ownerDocument` resolution is duplicated across the two call sites rather than factored out. I have a variant that adds an `addPointerDragListeners(element, { onPointerMove, onEnd, endOnContextMenu })` helper to `dom.ts` (where `getDockviewTheme` / `isInDocument` already live): it owns the listener lifecycle and auto-removes on end, so both call sites lose their add/remove bookkeeping (net **+83/−29** across three files, with the call sites shrinking), and it makes the invariant structural — the document is resolved once per drag, so the add and the matching remove can't target different documents. Happy to push that instead if you'd prefer it; I led with the minimal fix so the bug fix isn't blocked on a refactor opinion.
- `overlay.ts` still binds `pointermove`/`pointerup` to the global `window` for floating-group move/resize. Not a bug today (floating groups live in the main window), but it's the same class and would bite if a floating group inside a popout window ever became reachable — left untouched here.
## Test

`splitview.spec.ts` gains **`dnd: sash drag follows pointer events in the element's own document`** — it builds a `Splitview` inside a second document (`document.implementation.createHTMLDocument()`), which is the shape a popout window has, and drives a real sash drag from that document.

It **fails on `master`** (the views never resize — `[200, 200]` instead of `[220, 180]`, because the `pointermove` never reaches the listener bound to the global document) and passes with the fix.

The existing `dnd: pointer events to move sash` test dispatches on the global `document`, where `sash.ownerDocument === document`, so it passes either way and cannot catch this — which is why the bug survived.

No real second window is needed: the bug is about *which document* the listeners land on, and jsdom's second `Document` reproduces that exactly.

`dockview-core`: **1079 tests / 61 suites pass**, and the change is prettier-clean.
