### PR TITLE
docs: enterprise setup page + v8 migration licence note; gitignore hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,11 @@ playwright/.cache/
 
 # Vite writes a transient bundled config next to vite.config.ts
 *.timestamp-*.mjs
+
+# Claude Code local state (machine-local settings + full worktree checkouts)
+.claude/settings.local.json
+.claude/worktrees/
+
+# Generated demo-recorder output (the recorder tooling itself is tracked)
+scripts/record/out/
+packages/docs/scripts/record/out/

--- a/packages/docs/docs/overview/enterprise-setup.mdx
+++ b/packages/docs/docs/overview/enterprise-setup.mdx
@@ -1,0 +1,77 @@
+---
+id: enterprise-setup
+title: Enterprise setup
+sidebar_position: 5
+description: How to install dockview-enterprise and apply a licence key.
+---
+
+The enterprise features (pinned tabs, multi-row and wrapping tabs, the drop-guide
+compass, smart guides, layout history, edge-group docking, context menus, and
+layout keyboard operability) ship in a separate package, `dockview-enterprise`,
+and are unlocked with a licence key. This page covers installing the package and
+applying your key. For the full list of what is free and what is enterprise, see
+[Licensing](/docs/overview/features).
+
+## Install
+
+`dockview-enterprise` is a drop-in superset of the free `dockview` package: it
+re-exports the whole `dockview` API and adds the enterprise features. Importing
+it registers those features for every dockview instance in your app.
+
+### JavaScript
+
+Install `dockview-enterprise` **instead of** `dockview` (not alongside it), and
+import from it wherever you would have imported from `dockview`:
+
+```sh
+npm install dockview-enterprise
+```
+
+The stylesheet is unchanged; the styles live in the core package that
+`dockview-enterprise` re-exports:
+
+```css
+@import 'dockview/dist/styles/dockview.css';
+```
+
+### React, Vue, or Angular
+
+Keep installing and importing your components from the framework binding
+(`dockview-react`, `dockview-vue`, or `dockview-angular`), and add
+`dockview-enterprise` next to it:
+
+```sh
+npm install dockview-enterprise
+```
+
+Then add a one-line side-effect import once, anywhere that runs at start-up
+(your entry point is a good place), to activate the enterprise features:
+
+```ts
+import 'dockview-enterprise';
+```
+
+## Apply your licence key
+
+Set your key once, before creating any dockview instance:
+
+```ts
+import { LicenseManager } from 'dockview-enterprise';
+
+LicenseManager.setLicenseKey('your-license-key');
+```
+
+That is the whole setup. With the package imported, the enterprise options become
+available on every `DockviewComponent`, and the key clears the watermark.
+
+## Running without a key
+
+The enterprise features never lock your app out. If no key is set, or the key is
+invalid or expired, dockview draws a small watermark in a corner and logs a single
+console message; every feature keeps working. Setting a valid key removes the
+watermark.
+
+## Getting a key
+
+[Start a free trial](/trial) for a short-dated key, or see
+[Licensing](/docs/overview/features) for plans and to buy.

--- a/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
+++ b/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
@@ -79,6 +79,17 @@ For clarity, none of the following changed in v8:
 All of v8's new capabilities are enabled through new `DockviewOptions` fields.
 They are off by default; set the ones you want:
 
+:::info Most of these need dockview-enterprise
+Pinned tabs, multi-row and wrapping tabs, the drop-guide compass, smart guides,
+layout history, and edge-group docking are enterprise features. They live in the
+`dockview-enterprise` package and need a licence key. On the free `dockview`
+package these options are inert (the console logs a note naming the package to
+install), so a v7 project that sets, say, `pinnedTabs` sees nothing happen until
+it adds the package. See [Enterprise setup](/docs/overview/enterprise-setup) to
+install and apply a key, and [Licensing](/docs/overview/features) for the full
+free-versus-enterprise list.
+:::
+
 | Option                 | Enables                                                                |
 | ---------------------- | ---------------------------------------------------------------------- |
 | `pinnedTabs`           | [Pinned tabs](/docs/core/panels/pinnedTabs)                            |

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -25,6 +25,7 @@ const sidebars = {
                 'overview/features',
                 'overview/quickstart',
                 'overview/installation',
+                'overview/enterprise-setup',
                 {
                     type: 'link',
                     label: "What's new",


### PR DESCRIPTION
## Summary
Two v8 readiness fixes surfaced by a docs/positioning review, plus repo hygiene.

A v7 upgrader following the migration guide would set an enterprise option (e.g. `pinnedTabs: true`), see nothing happen, and have no on-site page explaining these need `dockview-enterprise` + a licence key.

## Changes
- **New page** `overview/enterprise-setup.mdx`: install `dockview-enterprise` (JS: use it instead of `dockview`; frameworks: keep the binding + add `import 'dockview-enterprise'`), apply the key via `LicenseManager.setLicenseKey`, the watermark-not-lockout behaviour, and where to get a key. Wired into the Overview sidebar.
- **Migration guide**: a callout above the "New opt-in options" table flagging that most of those options are enterprise features needing the package + key, linking to setup and the licensing comparison.
- **.gitignore**: Claude local state (`settings.local.json`, `worktrees/`) and generated recorder `out/` dirs; the recorder tooling itself stays tracked.

All internal links verified to resolve; no em dashes (docs style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)