### PR TITLE
docs: update contact email to info@dockview.dev

### DIFF
--- a/packages/docs/src/pages/contact.tsx
+++ b/packages/docs/src/pages/contact.tsx
@@ -429,8 +429,8 @@ export default function Contact(): JSX.Element {
                         Questions about licensing, Enterprise features or
                         anything else? Send us a message and we&rsquo;ll get back
                         to you. You can also email{' '}
-                        <a href="mailto:contact@dockview.dev">
-                            contact@dockview.dev
+                        <a href="mailto:info@dockview.dev">
+                            info@dockview.dev
                         </a>
                         .
                     </p>


### PR DESCRIPTION
## What
Update the contact page's displayed email (the `mailto:` link and its text) from `contact@dockview.dev` to `info@dockview.dev`, matching the licensing worker's new default contact recipient (`dockview-licencing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)