### PR TITLE
Merge master into v8-branch (brings #1410 tab-group chip re-drag fix)

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -383,6 +383,56 @@
                         });
                         return { groupId, tabGroupId: tabGroup.id };
                     },
+                    // Two tab groups (chips) in a single group so one can be
+                    // dragged past the other and back — the within-group move
+                    // that must stay repeatable (#1410). Flat order is
+                    // red,green,blue,yellow so the chips render Feature then
+                    // Monitoring. Returns the ids the spec needs.
+                    setupTwoTabGroupChips: () => {
+                        for (const id of ['red', 'green', 'blue', 'yellow']) {
+                            panels[id] = dockview.addPanel({
+                                id,
+                                component: 'default',
+                                title: id,
+                            });
+                        }
+                        const groupId = panels['red'].group.id;
+                        const feature = dockview.api.createTabGroup({
+                            groupId,
+                            label: 'Feature',
+                        });
+                        const monitoring = dockview.api.createTabGroup({
+                            groupId,
+                            label: 'Monitoring',
+                        });
+                        for (const panelId of ['red', 'green']) {
+                            dockview.api.addPanelToTabGroup({
+                                groupId,
+                                tabGroupId: feature.id,
+                                panelId,
+                            });
+                        }
+                        for (const panelId of ['blue', 'yellow']) {
+                            dockview.api.addPanelToTabGroup({
+                                groupId,
+                                tabGroupId: monitoring.id,
+                                panelId,
+                            });
+                        }
+                        return {
+                            groupId,
+                            featureId: feature.id,
+                            monitoringId: monitoring.id,
+                        };
+                    },
+                    // DOM order of the tab-group chip labels — reflects the
+                    // relative order of the tab groups in the strip.
+                    chipLabels: () =>
+                        Array.from(
+                            document.querySelectorAll(
+                                '.dv-tab-group-chip-label'
+                            )
+                        ).map((el) => el.textContent),
                     floatingCount: () => dockview.floatingGroups.length,
                     // Reload-safe maximize queries: read the live component, not
                     // the `panels` map (which is empty after a restore into a

--- a/e2e/tests/tab-group-chips.spec.ts
+++ b/e2e/tests/tab-group-chips.spec.ts
@@ -60,3 +60,70 @@ test.describe('tab-group chips', () => {
         await expect(chip).toBeVisible();
     });
 });
+
+/**
+ * #1410 — a tab group stays draggable after its first move. Committing a
+ * group-chip move disposes the chip's drag sources; a within-group reorder
+ * keeps the same chip element, so the sources must be re-armed or the chip
+ * becomes stuck after one move (real-browser only: the pointer backend
+ * computes drop zones from live geometry that jsdom can't produce).
+ */
+test.describe('tab-group chip repeated moves (#1410)', () => {
+    const chipLabels = (page: Page) =>
+        page.evaluate(() => (window as any).__dv.chipLabels());
+
+    // Drag the chip with the given label onto a target tab (dropping past a
+    // tab's inner edge inserts the whole group there), driving the pointer
+    // backend the same way `dnd-docking.spec.ts` drives tab drags.
+    const dragChipToTab = async (
+        page: Page,
+        label: string,
+        edge: 'first-left' | 'last-right'
+    ) => {
+        const c = (await page
+            .locator('.dv-tab-group-chip', { hasText: label })
+            .boundingBox())!;
+        const tab =
+            edge === 'first-left'
+                ? page.locator('.dv-tab').first()
+                : page.locator('.dv-tab').last();
+        const t = (await tab.boundingBox())!;
+        const to =
+            edge === 'first-left'
+                ? { x: t.x + 3, y: t.y + t.height / 2 }
+                : { x: t.x + t.width - 3, y: t.y + t.height / 2 };
+        await page.mouse.move(c.x + c.width / 2, c.y + c.height / 2);
+        await page.mouse.down();
+        await page.mouse.move(c.x + c.width / 2 + 6, c.y + c.height / 2, {
+            steps: 3,
+        });
+        await page.mouse.move(to.x, to.y, { steps: 16 });
+        await page.mouse.up();
+    };
+
+    test('a tab group can be moved, then moved again', async ({ page }) => {
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() =>
+            (window as any).__dv.setupTwoTabGroupChips()
+        );
+
+        await expect(page.locator('.dv-tab-group-chip')).toHaveCount(2);
+        expect(await chipLabels(page)).toEqual(['Feature', 'Monitoring']);
+
+        // First move: drag Feature past the last tab → Feature lands after
+        // Monitoring.
+        await dragChipToTab(page, 'Feature', 'last-right');
+        await expect
+            .poll(() => chipLabels(page))
+            .toEqual(['Monitoring', 'Feature']);
+
+        // Second move: drag Feature back before the first tab. Before the fix
+        // the chip's drag sources were disposed by the first move and never
+        // re-armed, so this drag did nothing and the order stayed put.
+        await dragChipToTab(page, 'Feature', 'first-left');
+        await expect
+            .poll(() => chipLabels(page))
+            .toEqual(['Feature', 'Monitoring']);
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1654,20 +1654,33 @@ describe('dockviewComponent', () => {
         dockview.dispose();
     });
 
-    // Regression test for #1410. A within-group tab-group move disposes the
+    // Regression tests for #1410. A within-group tab-group move disposes the
     // dragged chip's drag sources (`disposeChipDrag`) so the transfer
     // singleton is cleared synchronously — but, unlike a cross-group move,
     // the chip element itself survives the reorder. If the sources aren't
     // re-armed by the following `updateTabGroups()`, the chip keeps
     // `draggable=true` and fires a native `dragstart`, but no longer sets a
     // transfer payload — leaving the group undraggable after its first move.
-    test('within-group chip stays draggable after a move (#1410)', async () => {
+    //
+    // `setupTwoTabGroups` builds one group holding two tab groups (Feature +
+    // Monitoring), so relocating one is a within-group reorder, and returns
+    // the handles the tests drive the real commit path with.
+    async function setupTwoTabGroups(tabAnimation?: 'smooth' | 'default') {
         const container = document.createElement('div');
 
         const dockview = new DockviewComponent(container, {
             createComponent(options) {
                 return new PanelContentPartTest(options.id, options.name);
             },
+            ...(tabAnimation
+                ? {
+                      theme: {
+                          name: 'test',
+                          className: 'test',
+                          tabAnimation,
+                      } as any,
+                  }
+                : {}),
         });
         dockview.layout(1000, 1000);
 
@@ -1675,8 +1688,6 @@ describe('dockviewComponent', () => {
             dockview.addPanel({ id: `panel${i}`, component: 'default' });
         }
 
-        // Both tab groups live in the same group, so relocating one is a
-        // within-group reorder (moveTabGroup), not a cross-group move.
         const group = dockview.getGroupPanel('panel1')!.group;
         const feature = group.model.createTabGroup({
             label: 'Feature',
@@ -1694,30 +1705,75 @@ describe('dockviewComponent', () => {
         // Chips are rendered on a microtask via _scheduleTabGroupUpdate.
         await Promise.resolve();
 
+        const tabs = (group.model.header as any).tabs;
+        const manager = tabs._tabGroupManager;
         const featureChip = group.element.querySelector(
             '.dv-tab-group-chip'
         ) as HTMLElement;
         expect(featureChip).toBeTruthy();
 
-        // First drag: dragstart populates the transfer with the chip payload.
+        return {
+            dockview,
+            group,
+            feature,
+            monitoring,
+            tabs,
+            manager,
+            featureChip,
+        };
+    }
+
+    test('within-group chip stays draggable across repeated moves (#1410)', async () => {
+        const { dockview, group, feature, tabs, manager, featureChip } =
+            await setupTwoTabGroups();
+
+        // A committed group move disposes the chip's drag sources, so its
+        // entry is left without live sources until `update()` re-arms them.
+        const dragSourcesArmed = () => {
+            const entry = manager._chipRenderers.get(feature.id);
+            return !!entry?.html5DragSource && !!entry?.pointerDragSource;
+        };
+
+        // Two consecutive within-group moves, driving the real production
+        // commit path (`Tabs._commitGroupMove` → `disposeChipDrag` +
+        // `moveTabGroup` → `updateTabGroups()`), asserting the chip remains
+        // draggable each time. Before the fix only the first move worked.
+        for (let move = 0; move < 2; move++) {
+            fireEvent.dragStart(featureChip);
+            expect(getPanelData()?.tabGroupId).toBe(feature.id);
+            fireEvent.dragEnd(featureChip);
+
+            tabs._commitGroupMove(feature.id, group.model.panels.length);
+
+            // The same chip element survives (repositioned, not recreated)
+            // and both backends are re-armed.
+            expect(group.element.contains(featureChip)).toBe(true);
+            expect(dragSourcesArmed()).toBe(true);
+        }
+
+        // Final drag still works after the repeated moves.
         fireEvent.dragStart(featureChip);
         expect(getPanelData()?.tabGroupId).toBe(feature.id);
         fireEvent.dragEnd(featureChip);
 
-        // Commit a within-group move exactly as the tabs-list drop handler
-        // does: synchronously tear down the source chip's drag sources
-        // (`_commitGroupMove` → `disposeChipDrag`), then reorder — which
-        // re-syncs the chips via `updateTabGroups()`.
-        const manager = (group.model.header as any).tabs._tabGroupManager;
-        manager.disposeChipDrag(feature.id);
-        group.model.moveTabGroup(feature.id, group.model.panels.length);
+        dockview.dispose();
+    });
 
-        // The same chip element survives a within-group move (it is
-        // repositioned, not recreated).
+    test('within-group chip stays draggable after a move in smooth mode (#1410)', async () => {
+        // Matches the reported example config (tabAnimation: 'smooth'), which
+        // takes the FLIP branch of `_commitGroupMove`.
+        const { dockview, group, feature, tabs, featureChip } =
+            await setupTwoTabGroups('smooth');
+
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        tabs._commitGroupMove(feature.id, group.model.panels.length);
+
         expect(group.element.contains(featureChip)).toBe(true);
 
-        // Second drag must still populate the transfer payload — without the
-        // re-arm this is `undefined` and the group can no longer be moved.
+        // Second drag must still populate the transfer payload.
         fireEvent.dragStart(featureChip);
         expect(getPanelData()?.tabGroupId).toBe(feature.id);
         fireEvent.dragEnd(featureChip);

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1654,6 +1654,77 @@ describe('dockviewComponent', () => {
         dockview.dispose();
     });
 
+    // Regression test for #1410. A within-group tab-group move disposes the
+    // dragged chip's drag sources (`disposeChipDrag`) so the transfer
+    // singleton is cleared synchronously — but, unlike a cross-group move,
+    // the chip element itself survives the reorder. If the sources aren't
+    // re-armed by the following `updateTabGroups()`, the chip keeps
+    // `draggable=true` and fires a native `dragstart`, but no longer sets a
+    // transfer payload — leaving the group undraggable after its first move.
+    test('within-group chip stays draggable after a move (#1410)', async () => {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                return new PanelContentPartTest(options.id, options.name);
+            },
+        });
+        dockview.layout(1000, 1000);
+
+        for (let i = 1; i <= 4; i++) {
+            dockview.addPanel({ id: `panel${i}`, component: 'default' });
+        }
+
+        // Both tab groups live in the same group, so relocating one is a
+        // within-group reorder (moveTabGroup), not a cross-group move.
+        const group = dockview.getGroupPanel('panel1')!.group;
+        const feature = group.model.createTabGroup({
+            label: 'Feature',
+            color: 'blue',
+        });
+        group.model.addPanelToTabGroup(feature.id, 'panel1');
+        group.model.addPanelToTabGroup(feature.id, 'panel2');
+        const monitoring = group.model.createTabGroup({
+            label: 'Monitoring',
+            color: 'purple',
+        });
+        group.model.addPanelToTabGroup(monitoring.id, 'panel3');
+        group.model.addPanelToTabGroup(monitoring.id, 'panel4');
+
+        // Chips are rendered on a microtask via _scheduleTabGroupUpdate.
+        await Promise.resolve();
+
+        const featureChip = group.element.querySelector(
+            '.dv-tab-group-chip'
+        ) as HTMLElement;
+        expect(featureChip).toBeTruthy();
+
+        // First drag: dragstart populates the transfer with the chip payload.
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        // Commit a within-group move exactly as the tabs-list drop handler
+        // does: synchronously tear down the source chip's drag sources
+        // (`_commitGroupMove` → `disposeChipDrag`), then reorder — which
+        // re-syncs the chips via `updateTabGroups()`.
+        const manager = (group.model.header as any).tabs._tabGroupManager;
+        manager.disposeChipDrag(feature.id);
+        group.model.moveTabGroup(feature.id, group.model.panels.length);
+
+        // The same chip element survives a within-group move (it is
+        // repositioned, not recreated).
+        expect(group.element.contains(featureChip)).toBe(true);
+
+        // Second drag must still populate the transfer payload — without the
+        // re-arm this is `undefined` and the group can no longer be moved.
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        dockview.dispose();
+    });
+
     test('remove group', () => {
         dockview.layout(500, 1000);
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1654,6 +1654,133 @@ describe('dockviewComponent', () => {
         dockview.dispose();
     });
 
+    // Regression tests for #1410. A within-group tab-group move disposes the
+    // dragged chip's drag sources (`disposeChipDrag`) so the transfer
+    // singleton is cleared synchronously — but, unlike a cross-group move,
+    // the chip element itself survives the reorder. If the sources aren't
+    // re-armed by the following `updateTabGroups()`, the chip keeps
+    // `draggable=true` and fires a native `dragstart`, but no longer sets a
+    // transfer payload — leaving the group undraggable after its first move.
+    //
+    // `setupTwoTabGroups` builds one group holding two tab groups (Feature +
+    // Monitoring), so relocating one is a within-group reorder, and returns
+    // the handles the tests drive the real commit path with.
+    async function setupTwoTabGroups(tabAnimation?: 'smooth' | 'default') {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                return new PanelContentPartTest(options.id, options.name);
+            },
+            ...(tabAnimation
+                ? {
+                      theme: {
+                          name: 'test',
+                          className: 'test',
+                          tabAnimation,
+                      } as any,
+                  }
+                : {}),
+        });
+        dockview.layout(1000, 1000);
+
+        for (let i = 1; i <= 4; i++) {
+            dockview.addPanel({ id: `panel${i}`, component: 'default' });
+        }
+
+        const group = dockview.getGroupPanel('panel1')!.group;
+        const feature = group.model.createTabGroup({
+            label: 'Feature',
+            color: 'blue',
+        });
+        group.model.addPanelToTabGroup(feature.id, 'panel1');
+        group.model.addPanelToTabGroup(feature.id, 'panel2');
+        const monitoring = group.model.createTabGroup({
+            label: 'Monitoring',
+            color: 'purple',
+        });
+        group.model.addPanelToTabGroup(monitoring.id, 'panel3');
+        group.model.addPanelToTabGroup(monitoring.id, 'panel4');
+
+        // Chips are rendered on a microtask via _scheduleTabGroupUpdate.
+        await Promise.resolve();
+
+        const tabs = (group.model.header as any).tabs;
+        const manager = tabs._tabGroupManager;
+        const featureChip = group.element.querySelector(
+            '.dv-tab-group-chip'
+        ) as HTMLElement;
+        expect(featureChip).toBeTruthy();
+
+        return {
+            dockview,
+            group,
+            feature,
+            monitoring,
+            tabs,
+            manager,
+            featureChip,
+        };
+    }
+
+    test('within-group chip stays draggable across repeated moves (#1410)', async () => {
+        const { dockview, group, feature, tabs, manager, featureChip } =
+            await setupTwoTabGroups();
+
+        // A committed group move disposes the chip's drag sources, so its
+        // entry is left without live sources until `update()` re-arms them.
+        const dragSourcesArmed = () => {
+            const entry = manager._chipRenderers.get(feature.id);
+            return !!entry?.html5DragSource && !!entry?.pointerDragSource;
+        };
+
+        // Two consecutive within-group moves, driving the real production
+        // commit path (`Tabs._commitGroupMove` → `disposeChipDrag` +
+        // `moveTabGroup` → `updateTabGroups()`), asserting the chip remains
+        // draggable each time. Before the fix only the first move worked.
+        for (let move = 0; move < 2; move++) {
+            fireEvent.dragStart(featureChip);
+            expect(getPanelData()?.tabGroupId).toBe(feature.id);
+            fireEvent.dragEnd(featureChip);
+
+            tabs._commitGroupMove(feature.id, group.model.panels.length);
+
+            // The same chip element survives (repositioned, not recreated)
+            // and both backends are re-armed.
+            expect(group.element.contains(featureChip)).toBe(true);
+            expect(dragSourcesArmed()).toBe(true);
+        }
+
+        // Final drag still works after the repeated moves.
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        dockview.dispose();
+    });
+
+    test('within-group chip stays draggable after a move in smooth mode (#1410)', async () => {
+        // Matches the reported example config (tabAnimation: 'smooth'), which
+        // takes the FLIP branch of `_commitGroupMove`.
+        const { dockview, group, feature, tabs, featureChip } =
+            await setupTwoTabGroups('smooth');
+
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        tabs._commitGroupMove(feature.id, group.model.panels.length);
+
+        expect(group.element.contains(featureChip)).toBe(true);
+
+        // Second drag must still populate the transfer payload.
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        dockview.dispose();
+    });
+
     test('remove group', () => {
         dockview.layout(500, 1000);
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -1694,6 +1694,133 @@ describe('dockviewComponent', () => {
         dockview.dispose();
     });
 
+    // Regression tests for #1410. A within-group tab-group move disposes the
+    // dragged chip's drag sources (`disposeChipDrag`) so the transfer
+    // singleton is cleared synchronously — but, unlike a cross-group move,
+    // the chip element itself survives the reorder. If the sources aren't
+    // re-armed by the following `updateTabGroups()`, the chip keeps
+    // `draggable=true` and fires a native `dragstart`, but no longer sets a
+    // transfer payload — leaving the group undraggable after its first move.
+    //
+    // `setupTwoTabGroups` builds one group holding two tab groups (Feature +
+    // Monitoring), so relocating one is a within-group reorder, and returns
+    // the handles the tests drive the real commit path with.
+    async function setupTwoTabGroups(tabAnimation?: 'smooth' | 'default') {
+        const container = document.createElement('div');
+
+        const dockview = new DockviewComponent(container, {
+            createComponent(options) {
+                return new PanelContentPartTest(options.id, options.name);
+            },
+            ...(tabAnimation
+                ? {
+                      theme: {
+                          name: 'test',
+                          className: 'test',
+                          tabAnimation,
+                      } as any,
+                  }
+                : {}),
+        });
+        dockview.layout(1000, 1000);
+
+        for (let i = 1; i <= 4; i++) {
+            dockview.addPanel({ id: `panel${i}`, component: 'default' });
+        }
+
+        const group = dockview.getGroupPanel('panel1')!.group;
+        const feature = group.model.createTabGroup({
+            label: 'Feature',
+            color: 'blue',
+        });
+        group.model.addPanelToTabGroup(feature.id, 'panel1');
+        group.model.addPanelToTabGroup(feature.id, 'panel2');
+        const monitoring = group.model.createTabGroup({
+            label: 'Monitoring',
+            color: 'purple',
+        });
+        group.model.addPanelToTabGroup(monitoring.id, 'panel3');
+        group.model.addPanelToTabGroup(monitoring.id, 'panel4');
+
+        // Chips are rendered on a microtask via _scheduleTabGroupUpdate.
+        await Promise.resolve();
+
+        const tabs = (group.model.header as any).tabs;
+        const manager = tabs._tabGroupManager;
+        const featureChip = group.element.querySelector(
+            '.dv-tab-group-chip'
+        ) as HTMLElement;
+        expect(featureChip).toBeTruthy();
+
+        return {
+            dockview,
+            group,
+            feature,
+            monitoring,
+            tabs,
+            manager,
+            featureChip,
+        };
+    }
+
+    test('within-group chip stays draggable across repeated moves (#1410)', async () => {
+        const { dockview, group, feature, tabs, manager, featureChip } =
+            await setupTwoTabGroups();
+
+        // A committed group move disposes the chip's drag sources, so its
+        // entry is left without live sources until `update()` re-arms them.
+        const dragSourcesArmed = () => {
+            const entry = manager._chipRenderers.get(feature.id);
+            return !!entry?.html5DragSource && !!entry?.pointerDragSource;
+        };
+
+        // Two consecutive within-group moves, driving the real production
+        // commit path (`Tabs._commitGroupMove` → `disposeChipDrag` +
+        // `moveTabGroup` → `updateTabGroups()`), asserting the chip remains
+        // draggable each time. Before the fix only the first move worked.
+        for (let move = 0; move < 2; move++) {
+            fireEvent.dragStart(featureChip);
+            expect(getPanelData()?.tabGroupId).toBe(feature.id);
+            fireEvent.dragEnd(featureChip);
+
+            tabs._commitGroupMove(feature.id, group.model.panels.length);
+
+            // The same chip element survives (repositioned, not recreated)
+            // and both backends are re-armed.
+            expect(group.element.contains(featureChip)).toBe(true);
+            expect(dragSourcesArmed()).toBe(true);
+        }
+
+        // Final drag still works after the repeated moves.
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        dockview.dispose();
+    });
+
+    test('within-group chip stays draggable after a move in smooth mode (#1410)', async () => {
+        // Matches the reported example config (tabAnimation: 'smooth'), which
+        // takes the FLIP branch of `_commitGroupMove`.
+        const { dockview, group, feature, tabs, featureChip } =
+            await setupTwoTabGroups('smooth');
+
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        tabs._commitGroupMove(feature.id, group.model.panels.length);
+
+        expect(group.element.contains(featureChip)).toBe(true);
+
+        // Second drag must still populate the transfer payload.
+        fireEvent.dragStart(featureChip);
+        expect(getPanelData()?.tabGroupId).toBe(feature.id);
+        fireEvent.dragEnd(featureChip);
+
+        dockview.dispose();
+    });
+
     test('remove group', () => {
         dockview.layout(500, 1000);
 

--- a/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
@@ -792,4 +792,124 @@ describe('ShellManager', () => {
             shell.dispose();
         });
     });
+
+    describe('resize observer visibility guard (#1495)', () => {
+        // Reproduces #1495: a nested dockview whose `onlyWhenVisible` host
+        // panel is deactivated has its shell element hidden/detached, which
+        // fires a (0, 0) resize. Without a visibility guard that zero size is
+        // propagated to the edge-group splitview, clamping the edge group to
+        // its minimum size and losing the user's sizing.
+        let observerCallbacks: Array<(entries: any[]) => void>;
+        let rAFCallbacks: FrameRequestCallback[];
+        let originalResizeObserver: typeof window.ResizeObserver;
+
+        beforeEach(() => {
+            observerCallbacks = [];
+            rAFCallbacks = [];
+
+            originalResizeObserver = window.ResizeObserver;
+            (window as any).ResizeObserver = class {
+                constructor(cb: (entries: any[]) => void) {
+                    observerCallbacks.push(cb);
+                }
+                observe(): void {
+                    /* noop */
+                }
+                unobserve(): void {
+                    /* noop */
+                }
+                disconnect(): void {
+                    /* noop */
+                }
+            };
+
+            jest.spyOn(window, 'requestAnimationFrame').mockImplementation(
+                (cb) => {
+                    rAFCallbacks.push(cb);
+                    return rAFCallbacks.length;
+                }
+            );
+        });
+
+        afterEach(() => {
+            window.ResizeObserver = originalResizeObserver;
+            jest.restoreAllMocks();
+        });
+
+        function fireResize(width: number, height: number): void {
+            for (const cb of observerCallbacks) {
+                cb([{ contentRect: { width, height } }]);
+            }
+            const pending = [...rAFCallbacks];
+            rAFCallbacks = [];
+            for (const cb of pending) {
+                cb(performance.now());
+            }
+        }
+
+        function setVisible(shell: ShellManager, visible: boolean): void {
+            // jsdom does not compute offsetParent; drive it explicitly so the
+            // guard sees the shell as hidden (null) or visible (an element).
+            Object.defineProperty(shell.element, 'offsetParent', {
+                configurable: true,
+                get: () => (visible ? document.body : null),
+            });
+        }
+
+        // Build a shell with a real layout and an edge group sized to `size`
+        // (as an established sash drag would leave it), returning the shell.
+        function makeSizedShell(
+            position: 'left' | 'right',
+            size: number
+        ): ShellManager {
+            const shell = new ShellManager(
+                container,
+                dockviewElement,
+                layoutGrid
+            );
+            setVisible(shell, true);
+            fireResize(1000, 800);
+            shell.addEdgeView(position, { id: position }, makeGroup());
+            const splitview = (shell as any)._outerSplitview;
+            const index =
+                position === 'left'
+                    ? (shell as any)._leftIndex
+                    : (shell as any)._rightIndex;
+            splitview.resizeView(index, size);
+            return shell;
+        }
+
+        test('preserves the edge group size when the shell is hidden', () => {
+            const shell = makeSizedShell('right', 300);
+            expect(shell.toJSON().right!.size).toBe(300);
+
+            // Host panel deactivates: element hidden → (0, 0) resize fires.
+            setVisible(shell, false);
+            fireResize(0, 0);
+
+            // The size must be preserved, not clamped to the minimum.
+            expect(shell.toJSON().right!.size).toBe(300);
+
+            // Reactivating restores the same layout without any size change.
+            setVisible(shell, true);
+            fireResize(1000, 800);
+            expect(shell.toJSON().right!.size).toBe(300);
+
+            shell.dispose();
+        });
+
+        test('does not lay out at zero when detached from the document', () => {
+            const shell = makeSizedShell('left', 250);
+            expect(shell.toJSON().left!.size).toBe(250);
+
+            // offsetParent stays truthy but the element leaves the document —
+            // still a hidden/meaningless (0, 0) measurement.
+            shell.element.remove();
+            fireResize(0, 0);
+
+            expect(shell.toJSON().left!.size).toBe(250);
+
+            shell.dispose();
+        });
+    });
 });

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -64,9 +64,17 @@ export interface TabGroupManagerCallbacks {
 
 interface ChipRendererEntry {
     chip: ITabGroupChipRenderer;
-    /** Created by the manager so it can be toggled live on strategy changes. */
-    html5DragSource: IDragSource;
-    pointerDragSource: IDragSource;
+    /**
+     * Created by the manager so it can be toggled live on strategy changes.
+     * Undefined between an in-flight drag being torn down by
+     * `disposeChipDrag` and the following `update()` re-arming it — the chip
+     * element outlives a within-group move even though its drag sources do
+     * not. (#1410)
+     */
+    html5DragSource: IDragSource | undefined;
+    pointerDragSource: IDragSource | undefined;
+    /** Disposes the two drag sources + their shared dragend listener. */
+    dragSourcesDisposable: IDisposable | undefined;
     disposable: IDisposable;
     dropTarget: Droptarget;
 }
@@ -120,6 +128,7 @@ export class TabGroupManager {
             if (!activeGroupIds.has(groupId)) {
                 entry.chip.element.remove();
                 entry.chip.dispose();
+                entry.dragSourcesDisposable?.dispose();
                 entry.disposable.dispose();
                 this._chipRenderers.delete(groupId);
             }
@@ -278,9 +287,9 @@ export class TabGroupManager {
         const caps = resolveDndCapabilities(this._ctx.accessor.options);
         for (const entry of this._chipRenderers.values()) {
             entry.chip.element.draggable = caps.html5;
-            entry.html5DragSource.setDisabled(!caps.html5);
-            entry.pointerDragSource.setDisabled(!caps.pointer);
-            entry.pointerDragSource.setTouchOnly(!caps.pointerHandlesMouse);
+            entry.html5DragSource?.setDisabled(!caps.html5);
+            entry.pointerDragSource?.setDisabled(!caps.pointer);
+            entry.pointerDragSource?.setTouchOnly(!caps.pointerHandlesMouse);
         }
     }
 
@@ -290,8 +299,15 @@ export class TabGroupManager {
      * iframe shield are released before the cross-group move detaches
      * the chip (chip dispose is scheduled on a microtask via
      * `_scheduleTabGroupUpdate`, which is too late for callers that read
-     * `getPanelData()` synchronously after the move). This is idempotent;
-     * the subsequent `update()` will also dispose the sources.
+     * `getPanelData()` synchronously after the move).
+     *
+     * A cross-group move dissolves the source chip entirely, but a
+     * within-group reorder keeps the same chip element — so the sources are
+     * cleared to `undefined` here and the subsequent `update()` re-arms them
+     * via `_ensureChipForGroup`. Without that re-arm the chip would fire a
+     * native `dragstart` (the element keeps `draggable=true`) but never set
+     * a transfer payload, leaving the group permanently undraggable after
+     * its first move. (#1410)
      */
     disposeChipDrag(tabGroupId: string): void {
         const entry = this._chipRenderers.get(tabGroupId);
@@ -300,8 +316,10 @@ export class TabGroupManager {
         }
         // Optional-chained because tests may inject minimal entries
         // that skip the manager's normal `_ensureChipForGroup` flow.
-        entry.html5DragSource?.dispose();
-        entry.pointerDragSource?.dispose();
+        entry.dragSourcesDisposable?.dispose();
+        entry.html5DragSource = undefined;
+        entry.pointerDragSource = undefined;
+        entry.dragSourcesDisposable = undefined;
     }
 
     /** Cloned chip rect used as the pointer follow-finger ghost. */
@@ -331,6 +349,7 @@ export class TabGroupManager {
         for (const [, entry] of this._chipRenderers) {
             entry.chip.element.remove();
             entry.chip.dispose();
+            entry.dragSourcesDisposable?.dispose();
             entry.disposable.dispose();
         }
         this._chipRenderers.clear();
@@ -361,19 +380,20 @@ export class TabGroupManager {
         });
     }
 
-    private _ensureChipForGroup(tabGroup: ITabGroup): void {
-        if (this._chipRenderers.has(tabGroup.id)) {
-            return;
-        }
-
-        const createChip =
-            this._ctx.accessor.options.createTabGroupChipComponent;
-        const chip: ITabGroupChipRenderer = createChip
-            ? createChip(tabGroup)
-            : new TabGroupChip(this._ctx.accessor.tabGroupColorPalette);
-
-        chip.init({ tabGroup, api: this._ctx.accessor.api });
-
+    /**
+     * Create the HTML5 + pointer drag sources for a chip (and the direct
+     * dragend listener that clears the transfer synchronously). Extracted so
+     * both the initial chip build and the post-move re-arm in
+     * `_ensureChipForGroup` share one wiring path. (#1410)
+     */
+    private _createChipDragSources(
+        chip: ITabGroupChipRenderer,
+        tabGroup: ITabGroup
+    ): {
+        html5DragSource: IDragSource;
+        pointerDragSource: IDragSource;
+        disposable: IDisposable;
+    } {
         const caps = resolveDndCapabilities(this._ctx.accessor.options);
         chip.element.draggable = caps.html5;
 
@@ -441,13 +461,12 @@ export class TabGroupManager {
         // the listener survives chip disposal in the detach-then-dragend
         // cross-group path; `once: true` auto-removes after the single
         // dragend that we care about. (#1254)
-        chip.element.addEventListener(
-            'dragend',
-            () => {
-                panelTransfer.clearData(PanelTransfer.prototype);
-            },
-            { once: true }
-        );
+        const onDragEndClear = () => {
+            panelTransfer.clearData(PanelTransfer.prototype);
+        };
+        chip.element.addEventListener('dragend', onDragEndClear, {
+            once: true,
+        });
 
         const pointerDragSource = pointerBackend.createDragSource(
             chip.element,
@@ -468,6 +487,50 @@ export class TabGroupManager {
             }
         );
 
+        return {
+            html5DragSource,
+            pointerDragSource,
+            disposable: {
+                dispose: () => {
+                    html5DragSource.dispose();
+                    pointerDragSource.dispose();
+                    chip.element.removeEventListener('dragend', onDragEndClear);
+                },
+            },
+        };
+    }
+
+    private _ensureChipForGroup(tabGroup: ITabGroup): void {
+        const existing = this._chipRenderers.get(tabGroup.id);
+        if (existing) {
+            // A committed group move tears down the chip's drag sources via
+            // `disposeChipDrag`, but a within-group reorder keeps the same
+            // chip element alive. Re-arm the sources so the group stays
+            // draggable; without this the chip is stuck after its first
+            // move — `dragstart` still fires (the element keeps
+            // `draggable=true`) but no transfer payload is set. (#1410)
+            if (!existing.html5DragSource) {
+                const sources = this._createChipDragSources(
+                    existing.chip,
+                    tabGroup
+                );
+                existing.html5DragSource = sources.html5DragSource;
+                existing.pointerDragSource = sources.pointerDragSource;
+                existing.dragSourcesDisposable = sources.disposable;
+            }
+            return;
+        }
+
+        const createChip =
+            this._ctx.accessor.options.createTabGroupChipComponent;
+        const chip: ITabGroupChipRenderer = createChip
+            ? createChip(tabGroup)
+            : new TabGroupChip(this._ctx.accessor.tabGroupColorPalette);
+
+        chip.init({ tabGroup, api: this._ctx.accessor.api });
+
+        const dragSources = this._createChipDragSources(chip, tabGroup);
+
         const disposables: IDisposable[] = [
             tabGroup.onDidChange(() => {
                 chip.update?.({ tabGroup });
@@ -480,8 +543,6 @@ export class TabGroupManager {
             tabGroup.onDidCollapseChange(() => {
                 this._updateTabGroupClasses();
             }),
-            html5DragSource,
-            pointerDragSource,
         ];
 
         // Context menu: built-in TabGroupChip already aggregates right-click
@@ -490,8 +551,12 @@ export class TabGroupManager {
         // directly on their element.
         const onContextMenu = (event: MouseEvent) => {
             // A long-press on a chip should preempt the in-flight pointer
-            // drag and open the menu instead.
-            pointerDragSource.cancelPending();
+            // drag and open the menu instead. Resolve the source from the
+            // entry so a post-move re-armed source is cancelled, not the
+            // stale one captured at build time. (#1410)
+            this._chipRenderers
+                .get(tabGroup.id)
+                ?.pointerDragSource?.cancelPending();
             this._callbacks.onChipContextMenu(tabGroup, event);
         };
         if (chip instanceof TabGroupChip) {
@@ -556,8 +621,9 @@ export class TabGroupManager {
         const disposable = new CompositeDisposable(...disposables);
         this._chipRenderers.set(tabGroup.id, {
             chip,
-            html5DragSource,
-            pointerDragSource,
+            html5DragSource: dragSources.html5DragSource,
+            pointerDragSource: dragSources.pointerDragSource,
+            dragSourcesDisposable: dragSources.disposable,
             disposable,
             dropTarget,
         });

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -64,9 +64,17 @@ export interface TabGroupManagerCallbacks {
 
 interface ChipRendererEntry {
     chip: ITabGroupChipRenderer;
-    /** Created by the manager so it can be toggled live on strategy changes. */
-    html5DragSource: IDragSource;
-    pointerDragSource: IDragSource;
+    /**
+     * Created by the manager so it can be toggled live on strategy changes.
+     * Undefined between an in-flight drag being torn down by
+     * `disposeChipDrag` and the following `update()` re-arming it — the chip
+     * element outlives a within-group move even though its drag sources do
+     * not. (#1410)
+     */
+    html5DragSource: IDragSource | undefined;
+    pointerDragSource: IDragSource | undefined;
+    /** Disposes the two drag sources + their shared dragend listener. */
+    dragSourcesDisposable: IDisposable | undefined;
     disposable: IDisposable;
     dropTarget: Droptarget;
 }
@@ -120,6 +128,7 @@ export class TabGroupManager {
             if (!activeGroupIds.has(groupId)) {
                 entry.chip.element.remove();
                 entry.chip.dispose();
+                entry.dragSourcesDisposable?.dispose();
                 entry.disposable.dispose();
                 this._chipRenderers.delete(groupId);
             }
@@ -278,9 +287,9 @@ export class TabGroupManager {
         const caps = resolveDndCapabilities(this._ctx.accessor.options);
         for (const entry of this._chipRenderers.values()) {
             entry.chip.element.draggable = caps.html5;
-            entry.html5DragSource.setDisabled(!caps.html5);
-            entry.pointerDragSource.setDisabled(!caps.pointer);
-            entry.pointerDragSource.setTouchOnly(!caps.pointerHandlesMouse);
+            entry.html5DragSource?.setDisabled(!caps.html5);
+            entry.pointerDragSource?.setDisabled(!caps.pointer);
+            entry.pointerDragSource?.setTouchOnly(!caps.pointerHandlesMouse);
         }
     }
 
@@ -290,8 +299,15 @@ export class TabGroupManager {
      * iframe shield are released BEFORE the cross-group move detaches
      * the chip (chip dispose is scheduled on a microtask via
      * `_scheduleTabGroupUpdate`, which is too late for callers that read
-     * `getPanelData()` synchronously after the move). Idempotent — the
-     * subsequent `update()` will also dispose the sources.
+     * `getPanelData()` synchronously after the move).
+     *
+     * A cross-group move dissolves the source chip entirely, but a
+     * within-group reorder keeps the same chip element — so the sources are
+     * cleared to `undefined` here and the subsequent `update()` re-arms them
+     * via `_ensureChipForGroup`. Without that re-arm the chip would fire a
+     * native `dragstart` (the element keeps `draggable=true`) but never set
+     * a transfer payload, leaving the group permanently undraggable after
+     * its first move. (#1410)
      */
     disposeChipDrag(tabGroupId: string): void {
         const entry = this._chipRenderers.get(tabGroupId);
@@ -300,8 +316,10 @@ export class TabGroupManager {
         }
         // Optional-chained because tests may inject minimal entries
         // that skip the manager's normal `_ensureChipForGroup` flow.
-        entry.html5DragSource?.dispose();
-        entry.pointerDragSource?.dispose();
+        entry.dragSourcesDisposable?.dispose();
+        entry.html5DragSource = undefined;
+        entry.pointerDragSource = undefined;
+        entry.dragSourcesDisposable = undefined;
     }
 
     /** Cloned chip rect used as the pointer follow-finger ghost. */
@@ -331,6 +349,7 @@ export class TabGroupManager {
         for (const [, entry] of this._chipRenderers) {
             entry.chip.element.remove();
             entry.chip.dispose();
+            entry.dragSourcesDisposable?.dispose();
             entry.disposable.dispose();
         }
         this._chipRenderers.clear();
@@ -361,19 +380,20 @@ export class TabGroupManager {
         });
     }
 
-    private _ensureChipForGroup(tabGroup: ITabGroup): void {
-        if (this._chipRenderers.has(tabGroup.id)) {
-            return;
-        }
-
-        const createChip =
-            this._ctx.accessor.options.createTabGroupChipComponent;
-        const chip: ITabGroupChipRenderer = createChip
-            ? createChip(tabGroup)
-            : new TabGroupChip(this._ctx.accessor.tabGroupColorPalette);
-
-        chip.init({ tabGroup, api: this._ctx.accessor.api });
-
+    /**
+     * Create the HTML5 + pointer drag sources for a chip (and the direct
+     * dragend listener that clears the transfer synchronously). Extracted so
+     * both the initial chip build and the post-move re-arm in
+     * `_ensureChipForGroup` share one wiring path. (#1410)
+     */
+    private _createChipDragSources(
+        chip: ITabGroupChipRenderer,
+        tabGroup: ITabGroup
+    ): {
+        html5DragSource: IDragSource;
+        pointerDragSource: IDragSource;
+        disposable: IDisposable;
+    } {
         const caps = resolveDndCapabilities(this._ctx.accessor.options);
         chip.element.draggable = caps.html5;
 
@@ -441,13 +461,12 @@ export class TabGroupManager {
         // the listener survives chip disposal in the detach-then-dragend
         // cross-group path; `once: true` auto-removes after the single
         // dragend that we care about. (#1254)
-        chip.element.addEventListener(
-            'dragend',
-            () => {
-                panelTransfer.clearData(PanelTransfer.prototype);
-            },
-            { once: true }
-        );
+        const onDragEndClear = () => {
+            panelTransfer.clearData(PanelTransfer.prototype);
+        };
+        chip.element.addEventListener('dragend', onDragEndClear, {
+            once: true,
+        });
 
         const pointerDragSource = pointerBackend.createDragSource(
             chip.element,
@@ -468,6 +487,50 @@ export class TabGroupManager {
             }
         );
 
+        return {
+            html5DragSource,
+            pointerDragSource,
+            disposable: {
+                dispose: () => {
+                    html5DragSource.dispose();
+                    pointerDragSource.dispose();
+                    chip.element.removeEventListener('dragend', onDragEndClear);
+                },
+            },
+        };
+    }
+
+    private _ensureChipForGroup(tabGroup: ITabGroup): void {
+        const existing = this._chipRenderers.get(tabGroup.id);
+        if (existing) {
+            // A committed group move tears down the chip's drag sources via
+            // `disposeChipDrag`, but a within-group reorder keeps the same
+            // chip element alive. Re-arm the sources so the group stays
+            // draggable; without this the chip is stuck after its first
+            // move — `dragstart` still fires (the element keeps
+            // `draggable=true`) but no transfer payload is set. (#1410)
+            if (!existing.html5DragSource) {
+                const sources = this._createChipDragSources(
+                    existing.chip,
+                    tabGroup
+                );
+                existing.html5DragSource = sources.html5DragSource;
+                existing.pointerDragSource = sources.pointerDragSource;
+                existing.dragSourcesDisposable = sources.disposable;
+            }
+            return;
+        }
+
+        const createChip =
+            this._ctx.accessor.options.createTabGroupChipComponent;
+        const chip: ITabGroupChipRenderer = createChip
+            ? createChip(tabGroup)
+            : new TabGroupChip(this._ctx.accessor.tabGroupColorPalette);
+
+        chip.init({ tabGroup, api: this._ctx.accessor.api });
+
+        const dragSources = this._createChipDragSources(chip, tabGroup);
+
         const disposables: IDisposable[] = [
             tabGroup.onDidChange(() => {
                 chip.update?.({ tabGroup });
@@ -480,8 +543,6 @@ export class TabGroupManager {
             tabGroup.onDidCollapseChange(() => {
                 this._updateTabGroupClasses();
             }),
-            html5DragSource,
-            pointerDragSource,
         ];
 
         // Context menu: built-in TabGroupChip already aggregates right-click
@@ -490,8 +551,12 @@ export class TabGroupManager {
         // directly on their element.
         const onContextMenu = (event: MouseEvent) => {
             // A long-press on a chip should preempt the in-flight pointer
-            // drag and open the menu instead.
-            pointerDragSource.cancelPending();
+            // drag and open the menu instead. Resolve the source from the
+            // entry so a post-move re-armed source is cancelled, not the
+            // stale one captured at build time. (#1410)
+            this._chipRenderers
+                .get(tabGroup.id)
+                ?.pointerDragSource?.cancelPending();
             this._callbacks.onChipContextMenu(tabGroup, event);
         };
         if (chip instanceof TabGroupChip) {
@@ -556,8 +621,9 @@ export class TabGroupManager {
         const disposable = new CompositeDisposable(...disposables);
         this._chipRenderers.set(tabGroup.id, {
             chip,
-            html5DragSource,
-            pointerDragSource,
+            html5DragSource: dragSources.html5DragSource,
+            pointerDragSource: dragSources.pointerDragSource,
+            dragSourcesDisposable: dragSources.disposable,
             disposable,
             dropTarget,
         });

--- a/packages/dockview-core/src/dockview/dockviewShell.ts
+++ b/packages/dockview-core/src/dockview/dockviewShell.ts
@@ -6,7 +6,7 @@ import {
     Orientation,
     Splitview,
 } from '../splitview/splitview';
-import { watchElementResize } from '../dom';
+import { isInDocument, watchElementResize } from '../dom';
 
 export type EdgeGroupPosition = 'top' | 'bottom' | 'left' | 'right';
 
@@ -530,6 +530,28 @@ export class ShellManager implements IDisposable {
 
         this._disposables.addDisposables(
             watchElementResize(this._shellElement, (entry) => {
+                /**
+                 * When the shell (or an ancestor) becomes hidden — e.g. a
+                 * nested dockview whose `onlyWhenVisible` host panel is
+                 * deactivated — the element collapses to (0, 0) or is detached
+                 * from the DOM. Propagating that zero size would relayout the
+                 * edge-group splitview at 0, clamping the low-priority edge
+                 * groups down to their minimum size and destroying the user's
+                 * sizing. Skip these cases so sizes are preserved while hidden;
+                 * mirrors the guard in the `Resizable` base class. See #1495.
+                 *
+                 * offsetParent === null is equivalent to display: none on the
+                 * element or one of its ancestors.
+                 * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+                 */
+                if (!this._shellElement.offsetParent) {
+                    return;
+                }
+
+                if (!isInDocument(this._shellElement)) {
+                    return;
+                }
+
                 const width = Math.round(entry.contentRect.width);
                 const height = Math.round(entry.contentRect.height);
                 if (


### PR DESCRIPTION
## Description

Merges current `master` into `v8-branch`. The notable change master carries that `v8-branch` was missing is the **#1410** fix — a tab group could not be dragged again after being moved once, because committing a within-group chip move disposed the chip's drag sources and `_ensureChipForGroup` never re-armed them.

**Merge details:**
- One conflict, in `tabGroups.ts` — a doc comment on `disposeChipDrag` that both sides edited (v8 had a punctuation cleanup; master rewrote it to describe the new re-arm behavior). Resolved in favor of master's version, since the old "the subsequent `update()` will also dispose the sources" wording is no longer accurate.
- Everything else auto-merged.

**Fix verified in v8's structure:** v8 moved the commit orchestration into `tabReorderController.commitGroupMove`, which still calls `disposeChipDrag` on a within-group `moveTabGroup`, so the merged fix (re-arming the sources in `_ensureChipForGroup`) applies unchanged. The #1410 unit tests fail against v8's pre-fix `tabGroups.ts` and pass after the merge.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

- **Unit:** `within-group chip stays draggable across repeated moves (#1410)` and the smooth-mode variant in `dockviewComponent.spec.ts` — both drive the real `Tabs._commitGroupMove` path and assert the chip re-drags. Full dockview-core suite: **1271 passing**.
- **E2E (new):** `tab-group chip repeated moves (#1410)` in `e2e/tests/tab-group-chips.spec.ts` drags a chip past another group and back in a real browser (pointer backend), asserting the chip stays draggable across both moves. Verified it **fails against a pre-fix bundle** and passes after the merge.

Both the unit and e2e #1410 tests were confirmed red on the pre-fix source and green after.

## Checklist

- [x] `yarn test` passes (dockview-core: 1271)
- [x] New unit + e2e tests added
- [ ] `npm run gen` — n/a to this change
- [ ] Breaking changes are documented

Note: the pre-existing `multi-row-tabs` "vertical header" and `vue-keep-alive` e2e specs fail in my sandbox for environmental reasons (headless geometry / the dockview-vue UMD bundle not built locally); they fail identically without this change and are unrelated to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Heh7Wst7u9Vu6QbYE5uGAK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Heh7Wst7u9Vu6QbYE5uGAK)_