### PR TITLE
fix(dockview-vue): fix TypeDoc TS2345 failure in registry.mount call

### DIFF
--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -459,7 +459,11 @@ export class VuePart<T extends Record<string, any> = any> {
     init(): void {
         this._renderDisposable?.dispose();
         this._renderDisposable = this.registry
-            ? this.registry.mount(this.vueComponent, this.element, this.props)
+            ? this.registry.mount(
+                  this.vueComponent as VueComponent,
+                  this.element,
+                  this.props
+              )
             : mountVueComponent(
                   this.vueComponent,
                   this.parent,


### PR DESCRIPTION
## Description

The `deploy-docs` workflow was failing on `master` at the `npm run docs` step (`typedoc`), which type-checks each package during API doc generation:

```
packages/dockview-vue/src/utils.ts:462:35 - error TS2345:
  Argument of type 'VueComponent<T>' is not assignable to parameter of type 'VueComponent<any>'.
```

`VuePart<T>` passes `this.vueComponent` (typed `VueComponent<T>` = `DefineComponent<T>`) into `VueRendererRegistry.mount`, whose parameter is the non-generic `VueComponent` (= `DefineComponent<any>`). The code hadn't changed since #1369, but a newer Vue 3.5.x pulled in by the v7.0.3 lockfile refresh tightened `DefineComponent` so that `DefineComponent<T>` is no longer assignable to `DefineComponent<any>` — turning a previously-green construct red on `master`.

`mount()` stores the component type-erased (`markRaw` into a non-generic field), so this casts at the call site to match every other call site in the file. The non-registry branch keeps full `T` inference via the generic `mountVueComponent`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [x] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [x] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

Reproduced locally: `yarn install` → build packages (`npx nx run-many -t build,build:bundle --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular`) → `npx typedoc`.

- Before: typedoc exits 3 with the `TS2345` error above.
- After: typedoc exits 0, `Found 0 errors` (the 70 warnings are pre-existing "referenced but not documented" notes, unrelated).

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015SG5V9DWKhHzwsswjzTK79)_