### PR TITLE
Merge master into v8-branch (carry TypeDoc TS2345 fix)

### DIFF
--- a/packages/dockview-angular/package.json
+++ b/packages/dockview-angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-angular",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "description": "Angular docking layout manager — tabs, groups, grids, splitviews, drag and drop, floating panels",
     "keywords": [
         "splitview",
@@ -67,7 +67,7 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'"
     },
     "dependencies": {
-        "dockview": "^7.0.2"
+        "dockview": "^7.0.3"
     },
     "peerDependencies": {
         "@angular/common": ">=21.0.6",

--- a/packages/dockview-core/package.json
+++ b/packages/dockview-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-core",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "description": "Zero dependency layout manager supporting tabs, groups, grids and splitviews for vanilla TypeScript",
     "keywords": [
         "splitview",

--- a/packages/dockview-modules/package.json
+++ b/packages/dockview-modules/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-modules",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "private": true,
     "description": "Separable feature modules for dockview",
     "keywords": [
@@ -43,6 +43,6 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'"
     },
     "dependencies": {
-        "dockview-core": "^7.0.2"
+        "dockview-core": "^7.0.3"
     }
 }

--- a/packages/dockview-react/package.json
+++ b/packages/dockview-react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-react",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "description": "React docking layout manager — tabs, groups, grids, splitviews, drag and drop, floating panels",
     "keywords": [
         "splitview",
@@ -79,7 +79,7 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'"
     },
     "dependencies": {
-        "dockview": "^7.0.2"
+        "dockview": "^7.0.3"
     },
     "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/packages/dockview-vue/package.json
+++ b/packages/dockview-vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-vue",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "description": "Vue 3 docking layout manager — tabs, groups, grids, splitviews, drag and drop, floating panels",
     "keywords": [
         "splitview",
@@ -82,7 +82,7 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx,vue}'"
     },
     "dependencies": {
-        "dockview": "^7.0.2"
+        "dockview": "^7.0.3"
     },
     "peerDependencies": {
         "vue": "^3.4.0"

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -459,7 +459,11 @@ export class VuePart<T extends Record<string, any> = any> {
     init(): void {
         this._renderDisposable?.dispose();
         this._renderDisposable = this.registry
-            ? this.registry.mount(this.vueComponent, this.element, this.props)
+            ? this.registry.mount(
+                  this.vueComponent as VueComponent,
+                  this.element,
+                  this.props
+              )
             : mountVueComponent(
                   this.vueComponent,
                   this.parent,

--- a/packages/dockview/package.json
+++ b/packages/dockview/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "description": "Docking layout manager — tabs, groups, grids, splitviews, drag and drop, floating panels",
     "keywords": [
         "splitview",
@@ -74,9 +74,9 @@
         "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx}'"
     },
     "dependencies": {
-        "dockview-core": "^7.0.2"
+        "dockview-core": "^7.0.3"
     },
     "devDependencies": {
-        "dockview-modules": "^7.0.2"
+        "dockview-modules": "^7.0.3"
     }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dockview-docs",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "private": true,
     "scripts": {
         "build": "npm run build-templates && docusaurus build",
@@ -36,8 +36,8 @@
         "ag-grid-community": "^35.3.0",
         "ag-grid-react": "^35.3.0",
         "clsx": "^2.1.1",
-        "dockview": "^7.0.2",
-        "dockview-react": "^7.0.2",
+        "dockview": "^7.0.3",
+        "dockview-react": "^7.0.3",
         "prism-react-renderer": "^2.4.1",
         "react-dnd": "^16.0.1",
         "source-map-loader": "^5.0.0"


### PR DESCRIPTION
## Description

Merges `master` into `v8-branch` to carry over the TypeDoc `TS2345` fix from #1507, so the `deploy-docs` / typedoc step passes on v8-branch too. v8-branch has the identical failing construct (`VuePart` passing `VueComponent<T>` into the non-generic `registry.mount`) and the same resolved Vue 3.5.34, so it fails the same way without this.

`master` is 3 commits ahead of `v8-branch` (merge base `fa5c83c`):
- `b0c2ef0` chore(release): publish v7.0.3
- `d1682e8` fix(dockview-vue): cast component to non-generic VueComponent for registry.mount
- `94d5fb5` merge #1507

## ⚠️ Merge conflicts to resolve

A local dry-run merge surfaced 2 conflicts, both from the **v7.0.3 release commit** (`b0c2ef0`) — **not** from the TypeDoc fix:

- `packages/dockview-modules/package.json` — deleted on v8-branch, modified by the release on master (modify/delete)
- `packages/dockview/package.json` — version content conflict

These are release-versioning / package-structure decisions (v8-branch intentionally removed `dockview-modules`), so they're left for a maintainer to resolve rather than guessed at here. The `utils.ts` fix itself merges cleanly.

## Type of change

- [x] Bug fix
- [x] Build / CI / tooling

## Affected packages

- [x] `dockview-vue`

## How to test

After resolving the conflicts, from v8-branch: `yarn install` → `npx nx run-many -t build,build:bundle --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular` → `npx typedoc` should exit 0 with `Found 0 errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015SG5V9DWKhHzwsswjzTK79)_