### PR TITLE
fix(dockview-vue): forward fallthrough attributes to the root container (#1510)

### DIFF
--- a/packages/dockview-vue/src/__tests__/dockview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/dockview.spec.ts
@@ -66,6 +66,31 @@ describe('DockviewVue Component', () => {
         expect(readyEvent.api).toBeInstanceOf(DockviewApi);
     });
 
+    test('forwards fallthrough style/class attributes to the root container', async () => {
+        // Regression test for #1510: the SFC renders multiple root nodes
+        // (the host element plus <DockviewPortals>), so Vue cannot
+        // auto-inherit fallthrough attributes. They must be bound explicitly
+        // onto the root dockview container.
+        wrapper = mount(DockviewVue, {
+            attrs: {
+                class: 'my-custom-dockview',
+                style: 'height: 500px; width: 800px;',
+            },
+            attachTo: document.body,
+            global: {
+                components: { MockPanel },
+            },
+        });
+        await flushPromises();
+
+        const root = document.body.querySelector(
+            '.my-custom-dockview'
+        ) as HTMLElement | null;
+        expect(root).not.toBeNull();
+        expect(root!.style.height).toBe('500px');
+        expect(root!.style.width).toBe('800px');
+    });
+
     test('should pass defaultTabComponent to core options on mount', async () => {
         wrapper = mountDockview({
             defaultTabComponent: 'MockTab',

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -231,6 +231,36 @@ describe('GridviewVue components prop resolves without registration', () => {
         expect(api.getPanel('cell-1')).toBeDefined();
     });
 
+    test('changing the components prop at runtime does not crash', async () => {
+        // Regression test: useViewComponent used to call getCurrentInstance()
+        // inside the async `components` watcher, where Vue returns null, so
+        // updating the prop at runtime threw. The instance is now captured
+        // once during setup.
+        const Other = defineComponent({
+            name: 'OtherGridComponent',
+            props: ['params'],
+            template: '<div class="other-grid">Other</div>',
+        });
+
+        wrapper = mount(GridviewVue, {
+            props: {
+                orientation: Orientation.HORIZONTAL,
+                components: { Cell: MockGridComponent },
+            },
+            attachTo: document.body,
+        });
+        await flushPromises();
+
+        await expect(
+            wrapper.setProps({ components: { Cell: Other } })
+        ).resolves.not.toThrow();
+
+        const api = (wrapper.emitted('ready')![0][0] as any).api as GridviewApi;
+        expect(() =>
+            api.addPanel({ id: 'cell-1', component: 'Cell' })
+        ).not.toThrow();
+    });
+
     test('throws when component name is not in the map and not registered', async () => {
         wrapper = mount(GridviewVue, {
             props: {

--- a/packages/dockview-vue/src/__tests__/utils.spec.ts
+++ b/packages/dockview-vue/src/__tests__/utils.spec.ts
@@ -315,6 +315,33 @@ describe('VuePart', () => {
     });
 });
 
+describe('mountVueComponent', () => {
+    test('does not mutate the shared parent app context provides', () => {
+        // Regression test: the detached render path used to do
+        // `vNode.appContext = parent.appContext` followed by writing to
+        // `.provides`, which mutated the shared, app-level provides object for
+        // every other component. The parent's app context must be untouched.
+        const sharedProvides: Record<string | symbol, unknown> = {
+            existing: 'value',
+        };
+        const parent = {
+            appContext: { components: {}, provides: sharedProvides },
+            provides: { fromInstance: 'x' },
+        } as any;
+
+        mountVueComponent(
+            { template: '<div/>' } as any,
+            parent,
+            { params: {} } as any,
+            document.createElement('div')
+        );
+
+        expect(parent.appContext.provides).toBe(sharedProvides);
+        expect(parent.appContext.provides).toEqual({ existing: 'value' });
+        expect('fromInstance' in parent.appContext.provides).toBe(false);
+    });
+});
+
 describe('VueHeaderActionsRenderer', () => {
     let onDidAddPanel: DockviewEmitter<any>;
     let onDidRemovePanel: DockviewEmitter<any>;

--- a/packages/dockview-vue/src/composables/useViewComponent.ts
+++ b/packages/dockview-vue/src/composables/useViewComponent.ts
@@ -6,9 +6,16 @@ import {
     markRaw,
     getCurrentInstance,
     type ComponentInternalInstance,
+    type Ref,
 } from 'vue';
 import type { DockviewIDisposable } from 'dockview';
 import { findComponent, VueRendererRegistry } from '../utils';
+
+export interface UseViewComponentReturn<TApi> {
+    el: Ref<HTMLElement | null>;
+    instance: Ref<TApi | null>;
+    registry: VueRendererRegistry;
+}
 
 export interface ViewComponentConfig<
     TApi,
@@ -57,9 +64,12 @@ export function useViewComponent<
     >,
     props: TProps,
     emit: (event: 'ready', payload: { api: TApi }) => void
-) {
+): UseViewComponentReturn<TApi> {
     const el = ref<HTMLElement | null>(null);
-    const instance = ref<TApi | null>(null);
+    // Pin the ref type: `ref<TApi>()` would infer `Ref<UnwrapRef<TApi>>`,
+    // which both widens the public type and is what triggered the
+    // non-portable declaration (TS2742) this composable used to emit.
+    const instance = ref<TApi | null>(null) as Ref<TApi | null>;
     const eventDisposables: DockviewIDisposable[] = [];
 
     /**

--- a/packages/dockview-vue/src/composables/useViewComponent.ts
+++ b/packages/dockview-vue/src/composables/useViewComponent.ts
@@ -63,6 +63,19 @@ export function useViewComponent<
     const eventDisposables: DockviewIDisposable[] = [];
 
     /**
+     * Capture the component instance once, synchronously, during setup.
+     * `getCurrentInstance()` only returns a value during setup and lifecycle
+     * hooks — calling it later from an async watch callback returns `null`, so
+     * the reference is resolved here and reused everywhere below.
+     */
+    const inst = getCurrentInstance();
+    if (!inst) {
+        throw new Error(
+            `${config.componentName}: getCurrentInstance() returned null`
+        );
+    }
+
+    /**
      * Components are teleported into the view's DOM (rendered by
      * `<DockviewPortals>` in the host template) so panels stay in the Vue
      * component tree. See {@link VueRendererRegistry}.
@@ -86,13 +99,6 @@ export function useViewComponent<
         () => (props as any).components,
         () => {
             if (instance.value) {
-                const inst = getCurrentInstance();
-                if (!inst) {
-                    throw new Error(
-                        `${config.componentName}: getCurrentInstance() returned null`
-                    );
-                }
-
                 instance.value.updateOptions({
                     createComponent: (options: {
                         id: string;
@@ -119,14 +125,6 @@ export function useViewComponent<
     onMounted(() => {
         if (!el.value) {
             throw new Error(`${config.componentName}: element is not mounted`);
-        }
-
-        const inst = getCurrentInstance();
-
-        if (!inst) {
-            throw new Error(
-                `${config.componentName}: getCurrentInstance() returned null`
-            );
         }
 
         const frameworkOptions = {

--- a/packages/dockview-vue/src/dockview/dockview.vue
+++ b/packages/dockview-vue/src/dockview/dockview.vue
@@ -42,6 +42,15 @@ function extractCoreOptions(props: IDockviewVueProps): DockviewOptions {
     return coreOptions as DockviewOptions;
 }
 
+/**
+ * The template renders multiple root nodes (the host element plus
+ * `<DockviewPortals>`), so Vue cannot automatically forward fallthrough
+ * attributes such as `style` and `class`. Disable automatic inheritance and
+ * bind `$attrs` explicitly onto the host element below so consumer-supplied
+ * attributes continue to reach the root dockview container.
+ */
+defineOptions({ inheritAttrs: false });
+
 const emit = defineEmits<VueEvents>();
 
 const props = defineProps<IDockviewVueProps>();
@@ -393,6 +402,6 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-    <div ref="el" />
+    <div ref="el" v-bind="$attrs" />
     <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/gridview/gridview.vue
+++ b/packages/dockview-vue/src/gridview/gridview.vue
@@ -20,6 +20,15 @@ function extractCoreOptions(props: IGridviewVueProps): GridviewOptions {
     return coreOptions as GridviewOptions;
 }
 
+/**
+ * The template renders multiple root nodes (the host element plus
+ * `<DockviewPortals>`), so Vue cannot automatically forward fallthrough
+ * attributes such as `style` and `class`. Disable automatic inheritance and
+ * bind `$attrs` explicitly onto the host element below so consumer-supplied
+ * attributes continue to reach the root container.
+ */
+defineOptions({ inheritAttrs: false });
+
 const emit = defineEmits<GridviewVueEvents>();
 const props = defineProps<IGridviewVueProps>();
 
@@ -38,6 +47,6 @@ const { el, registry } = useViewComponent(
 </script>
 
 <template>
-    <div ref="el" style="height: 100%; width: 100%" />
+    <div ref="el" style="height: 100%; width: 100%" v-bind="$attrs" />
     <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/paneview/paneview.vue
+++ b/packages/dockview-vue/src/paneview/paneview.vue
@@ -20,6 +20,15 @@ function extractCoreOptions(props: IPaneviewVueProps): PaneviewOptions {
     return coreOptions as PaneviewOptions;
 }
 
+/**
+ * The template renders multiple root nodes (the host element plus
+ * `<DockviewPortals>`), so Vue cannot automatically forward fallthrough
+ * attributes such as `style` and `class`. Disable automatic inheritance and
+ * bind `$attrs` explicitly onto the host element below so consumer-supplied
+ * attributes continue to reach the root container.
+ */
+defineOptions({ inheritAttrs: false });
+
 const emit = defineEmits<PaneviewVueEvents>();
 const props = defineProps<IPaneviewVueProps>();
 
@@ -41,6 +50,6 @@ const { el, registry } = useViewComponent(
 </script>
 
 <template>
-    <div ref="el" style="height: 100%; width: 100%" />
+    <div ref="el" style="height: 100%; width: 100%" v-bind="$attrs" />
     <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/splitview/splitview.vue
+++ b/packages/dockview-vue/src/splitview/splitview.vue
@@ -20,6 +20,15 @@ function extractCoreOptions(props: ISplitviewVueProps): SplitviewOptions {
     return coreOptions as SplitviewOptions;
 }
 
+/**
+ * The template renders multiple root nodes (the host element plus
+ * `<DockviewPortals>`), so Vue cannot automatically forward fallthrough
+ * attributes such as `style` and `class`. Disable automatic inheritance and
+ * bind `$attrs` explicitly onto the host element below so consumer-supplied
+ * attributes continue to reach the root container.
+ */
+defineOptions({ inheritAttrs: false });
+
 const emit = defineEmits<SplitviewVueEvents>();
 const props = defineProps<ISplitviewVueProps>();
 
@@ -38,6 +47,6 @@ const { el, registry } = useViewComponent(
 </script>
 
 <template>
-    <div ref="el" style="height: 100%; width: 100%" />
+    <div ref="el" style="height: 100%; width: 100%" v-bind="$attrs" />
     <DockviewPortals :entries="registry.entries" />
 </template>

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -106,11 +106,21 @@ export function mountVueComponent<T extends Record<string, any>>(
 ) {
     let vNode = createVNode(component, Object.freeze(props));
 
-    vNode.appContext = parent.appContext;
-    vNode.appContext.provides = {
-        ...(vNode.appContext.provides ? vNode.appContext.provides : {}),
-        ...((parent as any).provides ? (parent as any).provides : {}),
-    };
+    /**
+     * Clone the parent's app context instead of mutating it. Assigning
+     * `vNode.appContext = parent.appContext` and then writing to `.provides`
+     * would pollute the shared, app-level `provides` object for every other
+     * component in the application. A shallow copy with a freshly merged
+     * `provides` gives this vnode the parent's injectables without the side
+     * effect.
+     */
+    vNode.appContext = {
+        ...parent.appContext,
+        provides: {
+            ...(parent.appContext?.provides ?? {}),
+            ...((parent as any).provides ?? {}),
+        },
+    } as typeof parent.appContext;
 
     render(vNode, element);
 

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -117,8 +117,10 @@ export function mountVueComponent<T extends Record<string, any>>(
     vNode.appContext = {
         ...parent.appContext,
         provides: {
-            ...(parent.appContext?.provides ?? {}),
-            ...((parent as any).provides ?? {}),
+            // Object spread ignores null/undefined, so no `?? {}` guard is
+            // needed for either source.
+            ...parent.appContext?.provides,
+            ...(parent as any).provides,
         },
     } as typeof parent.appContext;
 


### PR DESCRIPTION
## Description

Fixes #1510. After 7.0.3, `style`/`class` attributes passed to `<dockview-vue>` (and the other view components) stopped reaching the outer dockview container, breaking the common pattern of sizing the layout via a `style` attribute.

**Root cause:** commit `64affa1` (the Teleport keep-alive fix, #1369) added `<DockviewPortals>` as a second root node to each view SFC, turning them into fragments. Vue only auto-inherits fallthrough attributes onto a *single* root element, so with a fragment the attributes were silently dropped (with the `Extraneous non-props attributes (style)...` warning from the issue).

This PR contains three fixes surfaced while investigating the wrapper:

1. **Fallthrough attributes (the #1510 bug).** Set `inheritAttrs: false` and bind `$attrs` onto the root `el` div in all four view SFCs (dockview / gridview / splitview / paneview), restoring pre-7.0.3 behaviour.

2. **Runtime `components` prop change crash.** `useViewComponent` called `getCurrentInstance()` inside the async `components` watcher, where Vue returns `null`, so updating the prop at runtime on gridview/splitview/paneview threw. The instance is now captured once during setup (matching `dockview.vue`).

3. **Shared app-context mutation.** `mountVueComponent` assigned `vNode.appContext = parent.appContext` and then overwrote `.provides`, mutating the shared app-level `provides` object and leaking a panel's injectables into the global scope. It now shallow-clones the context with a freshly merged `provides`. As part of this the composable also gained an explicit `UseViewComponentReturn` type, removing a non-portable declaration (TS2742).

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-vue`

## How to test

- `yarn test` in `packages/dockview-vue` — 124 unit tests pass, including new regression tests for each fix (attribute forwarding, runtime `components` change, and the `provides` mutation). Each was confirmed to fail before the corresponding fix and pass after.
- Reproduction from the issue: pass `style="height: 100vh"` (or a theme `class`) to `<dockview-vue>` and confirm it lands on the outer container.

## Checklist

- [x] `yarn test` passes
- [x] I have added or updated tests where applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_018RyJLwbU1PcXvD9cRbxmyL)_