### PR TITLE
fix(dockview-vue): avoid mutating shared app context + e2e attribute forwarding (#1510)

### DIFF
--- a/e2e/fixtures/vue-attrs-views.html
+++ b/e2e/fixtures/vue-attrs-views.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>dockview-vue (grid/split/pane) attribute-forwarding e2e fixture</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                height: 100%;
+                width: 100%;
+            }
+            /* Each view host is sized by its own SFC's static
+               `style="height: 100%; width: 100%"`, so it fills the wrapper
+               below. The forwarded `class`/`style` (outline) is what these
+               specs assert on — a fallthrough regression drops the custom
+               class and outline even though the static size keeps it visible. */
+            .wrapper {
+                width: 300px;
+                height: 200px;
+            }
+        </style>
+
+        <link
+            rel="stylesheet"
+            href="/packages/dockview-core/dist/styles/dockview.css"
+        />
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <!-- Globals loaded in dependency order (see vue.html for the rationale). -->
+        <script src="/node_modules/vue/dist/vue.global.js"></script>
+        <script src="/packages/dockview/dist/dockview.js"></script>
+        <script src="/packages/dockview-vue/dist/dockview-vue.umd.cjs"></script>
+
+        <script>
+            (function () {
+                const { createApp } = window.Vue;
+                const { GridviewVue, SplitviewVue, PaneviewVue } =
+                    window['dockview-vue'];
+                const { Orientation } = window.dockview;
+
+                const Panel = {
+                    name: 'Panel',
+                    props: ['params'],
+                    template: `<div class="vue-panel"></div>`,
+                };
+
+                let readyCount = 0;
+                const markReady = () => {
+                    readyCount++;
+                    if (readyCount === 3) {
+                        window.__ready = true;
+                    }
+                };
+
+                const Root = {
+                    name: 'Root',
+                    components: { GridviewVue, SplitviewVue, PaneviewVue },
+                    setup() {
+                        return {
+                            components: { panel: Panel },
+                            horizontal: Orientation.HORIZONTAL,
+                            markReady,
+                        };
+                    },
+                    /**
+                     * Each view receives a fallthrough `class` and `style`
+                     * (a red outline). Both must land on that view's host
+                     * `<div ref="el">` — the outer container — as in
+                     * dockview-vue < 7.0.3 (issue #1510). The composable-based
+                     * views (grid/split/pane) share the same host-binding code
+                     * path as <DockviewVue>, so they must forward too.
+                     */
+                    template: `
+                        <div class="wrapper">
+                            <GridviewVue
+                                class="custom-gridview-host"
+                                style="outline: 3px solid rgb(255, 0, 0);"
+                                :orientation="horizontal"
+                                :components="components"
+                                @ready="markReady"
+                            />
+                        </div>
+                        <div class="wrapper">
+                            <SplitviewVue
+                                class="custom-splitview-host"
+                                style="outline: 3px solid rgb(255, 0, 0);"
+                                :orientation="horizontal"
+                                :components="components"
+                                @ready="markReady"
+                            />
+                        </div>
+                        <div class="wrapper">
+                            <PaneviewVue
+                                class="custom-paneview-host"
+                                style="outline: 3px solid rgb(255, 0, 0);"
+                                :components="components"
+                                @ready="markReady"
+                            />
+                        </div>`,
+                };
+
+                createApp(Root).mount('#app');
+
+                // For each view: does the element carrying the forwarded class
+                // own the view's inner container (matches-or-contains it)? That
+                // proves the class landed on the real host `<div ref="el">`.
+                const ownsContainer = (hostClass, containerClass) => {
+                    const host = document.querySelector('.' + hostClass);
+                    if (!host) return null;
+                    return (
+                        host.matches('.' + containerClass) ||
+                        !!host.querySelector('.' + containerClass)
+                    );
+                };
+                const outlineColor = (hostClass) => {
+                    const host = document.querySelector('.' + hostClass);
+                    return host ? getComputedStyle(host).outlineColor : null;
+                };
+
+                window.__views = {
+                    gridview: () => ({
+                        ownsContainer: ownsContainer(
+                            'custom-gridview-host',
+                            'dv-grid-view'
+                        ),
+                        outlineColor: outlineColor('custom-gridview-host'),
+                    }),
+                    splitview: () => ({
+                        ownsContainer: ownsContainer(
+                            'custom-splitview-host',
+                            'dv-split-view-container'
+                        ),
+                        outlineColor: outlineColor('custom-splitview-host'),
+                    }),
+                    paneview: () => ({
+                        ownsContainer: ownsContainer(
+                            'custom-paneview-host',
+                            'dv-pane-container'
+                        ),
+                        outlineColor: outlineColor('custom-paneview-host'),
+                    }),
+                };
+            })();
+        </script>
+    </body>
+</html>

--- a/e2e/fixtures/vue-attrs.html
+++ b/e2e/fixtures/vue-attrs.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>dockview-vue attribute-forwarding e2e fixture</title>
+        <style>
+            html,
+            body,
+            #app {
+                margin: 0;
+                height: 100%;
+                width: 100%;
+            }
+            /* Deliberately NO `#app > div { height/width }` rule here (unlike
+               vue.html). The DockviewVue host element is sized ONLY by the
+               `style` attribute passed to `<DockviewVue>` below. So if
+               fallthrough of `style` to the host `<div ref="el">` ever
+               regresses (issue #1510), the host collapses to 0x0,
+               `api.layout(clientWidth, clientHeight)` sees 0 and nothing
+               renders — which the spec detects. */
+            .vue-panel {
+                height: 100%;
+                box-sizing: border-box;
+                padding: 8px;
+            }
+        </style>
+
+        <link
+            rel="stylesheet"
+            href="/packages/dockview-core/dist/styles/dockview.css"
+        />
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <!-- Globals loaded in dependency order (see vue.html for the rationale). -->
+        <script src="/node_modules/vue/dist/vue.global.js"></script>
+        <script src="/packages/dockview/dist/dockview.js"></script>
+        <script src="/packages/dockview-vue/dist/dockview-vue.umd.cjs"></script>
+
+        <script>
+            (function () {
+                const { createApp, ref } = window.Vue;
+                const { DockviewVue } = window['dockview-vue'];
+
+                const Panel = {
+                    name: 'Panel',
+                    props: ['params'],
+                    template: `<div class="vue-panel">{{ params.api.id }}</div>`,
+                };
+
+                let dvApi = null;
+
+                const Root = {
+                    name: 'Root',
+                    components: { DockviewVue },
+                    setup() {
+                        return {
+                            components: { panel: Panel },
+                            onReady: (event) => {
+                                dvApi = event.api;
+                                dvApi.addPanel({
+                                    id: 'one',
+                                    component: 'panel',
+                                    title: 'one',
+                                });
+                                window.__ready = true;
+                            },
+                        };
+                    },
+                    /**
+                     * `class` and `style` here are non-prop (fallthrough)
+                     * attributes. They must land on the host `<div ref="el">`
+                     * — the outer dockview container — exactly as they did
+                     * before 7.0.3 (issue #1510). The 3px red outline gives the
+                     * spec a computed style to assert on; the 100% height/width
+                     * is what actually sizes the layout.
+                     */
+                    template: `
+                        <DockviewVue
+                            class="custom-dockview-host"
+                            style="height: 100%; width: 100%; outline: 3px solid rgb(255, 0, 0);"
+                            :components="components"
+                            @ready="onReady"
+                        />`,
+                };
+
+                createApp(Root).mount('#app');
+
+                window.__attrs = {
+                    hostRect: () => {
+                        const host = document.querySelector(
+                            '.custom-dockview-host'
+                        );
+                        if (!host) return null;
+                        const r = host.getBoundingClientRect();
+                        return { width: r.width, height: r.height };
+                    },
+                    // The host must own the dockview root (a `.dv-dockview`
+                    // descendant) — proving the class landed on the container,
+                    // not some unrelated node.
+                    hostHasDockview: () =>
+                        !!document.querySelector(
+                            '.custom-dockview-host .dv-dockview'
+                        ),
+                    hostOutlineColor: () => {
+                        const host = document.querySelector(
+                            '.custom-dockview-host'
+                        );
+                        return host
+                            ? getComputedStyle(host).outlineColor
+                            : null;
+                    },
+                };
+            })();
+        </script>
+    </body>
+</html>

--- a/e2e/tests/vue-attribute-forwarding.spec.ts
+++ b/e2e/tests/vue-attribute-forwarding.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * dockview-vue fallthrough attribute forwarding, in a real browser.
+ *
+ * Regression coverage for issue #1510: after 7.0.3 the view SFCs render two
+ * root nodes (the host element plus `<DockviewPortals>`), turning each into a
+ * fragment. Vue only auto-inherits fallthrough attributes (`class`, `style`,
+ * ...) onto a SINGLE root, so `<dockview-vue style="...">` silently stopped
+ * reaching the outer dockview container. The fix sets `inheritAttrs: false`
+ * and binds `$attrs` onto the host `<div ref="el">`.
+ *
+ * The fixture (e2e/fixtures/vue-attrs.html) sizes the layout ONLY through a
+ * `style` attribute on `<DockviewVue>` — no CSS sizes the host otherwise — so
+ * if forwarding regresses the host collapses to 0x0 and nothing renders, which
+ * the size assertions below catch. jsdom unit tests
+ * (packages/dockview-vue/src/__tests__/dockview.spec) assert the attributes
+ * land on the element; these prove the layout actually works as a result.
+ */
+test.describe('dockview-vue fallthrough attribute forwarding', () => {
+    const open = async (page: Page) => {
+        await page.goto('/e2e/fixtures/vue-attrs.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+    };
+
+    test('forwards class and style from <DockviewVue> onto the host container', async ({
+        page,
+    }) => {
+        await open(page);
+
+        // The `class` fell through: the host element exists and is the outer
+        // container that owns the dockview root (`.dv-dockview` descendant).
+        const host = page.locator('.custom-dockview-host');
+        await expect(host).toHaveCount(1);
+        await expect(
+            page.locator('.custom-dockview-host .dv-dockview')
+        ).toHaveCount(1);
+
+        // The `style` fell through: the inline outline is applied.
+        expect(
+            await page.evaluate(() => (window as any).__attrs.hostOutlineColor())
+        ).toBe('rgb(255, 0, 0)');
+
+        // ...and — the real point of #1510 — the `height/width: 100%` in that
+        // style sized the host, so the layout actually rendered. Without the
+        // forwarding fix the host would be 0x0 here.
+        const rect = await page.evaluate(() =>
+            (window as any).__attrs.hostRect()
+        );
+        expect(rect.width).toBeGreaterThan(100);
+        expect(rect.height).toBeGreaterThan(100);
+
+        // The panel content is visible, end to end.
+        await expect(page.locator('.vue-panel')).toBeVisible();
+    });
+});
+
+/**
+ * The same forwarding must hold for the other three view components
+ * (gridview / splitview / paneview), which share the host-binding code path
+ * via `useViewComponent`. Their SFCs statically size the host, so instead of
+ * a size check these assert the forwarded `class` landed on the real host
+ * (it owns the view's inner container) and the `style` outline applied.
+ */
+test.describe('dockview-vue fallthrough attribute forwarding (grid/split/pane)', () => {
+    const open = async (page: Page) => {
+        await page.goto('/e2e/fixtures/vue-attrs-views.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+    };
+
+    for (const view of ['gridview', 'splitview', 'paneview'] as const) {
+        test(`forwards class and style onto the ${view} host container`, async ({
+            page,
+        }) => {
+            await open(page);
+
+            const result = await page.evaluate(
+                (v) => (window as any).__views[v](),
+                view
+            );
+
+            // `class` fell through onto the host, which owns the inner
+            // view container (`.dv-grid-view` / `.dv-split-view-container` /
+            // `.dv-pane-container`).
+            expect(result.ownsContainer).toBe(true);
+            // `style` fell through.
+            expect(result.outlineColor).toBe('rgb(255, 0, 0)');
+        });
+    }
+});

--- a/packages/dockview-vue/src/__tests__/utils.spec.ts
+++ b/packages/dockview-vue/src/__tests__/utils.spec.ts
@@ -315,6 +315,33 @@ describe('VuePart', () => {
     });
 });
 
+describe('mountVueComponent', () => {
+    test('does not mutate the shared parent app context provides', () => {
+        // Regression test: the detached render path used to do
+        // `vNode.appContext = parent.appContext` followed by writing to
+        // `.provides`, which mutated the shared, app-level provides object for
+        // every other component. The parent's app context must be untouched.
+        const sharedProvides: Record<string | symbol, unknown> = {
+            existing: 'value',
+        };
+        const parent = {
+            appContext: { components: {}, provides: sharedProvides },
+            provides: { fromInstance: 'x' },
+        } as any;
+
+        mountVueComponent(
+            { template: '<div/>' } as any,
+            parent,
+            { params: {} } as any,
+            document.createElement('div')
+        );
+
+        expect(parent.appContext.provides).toBe(sharedProvides);
+        expect(parent.appContext.provides).toEqual({ existing: 'value' });
+        expect('fromInstance' in parent.appContext.provides).toBe(false);
+    });
+});
+
 describe('VueHeaderActionsRenderer', () => {
     let onDidAddPanel: DockviewEmitter<any>;
     let onDidRemovePanel: DockviewEmitter<any>;

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -106,11 +106,21 @@ export function mountVueComponent<T extends Record<string, any>>(
 ) {
     let vNode = createVNode(component, Object.freeze(props));
 
-    vNode.appContext = parent.appContext;
-    vNode.appContext.provides = {
-        ...(vNode.appContext.provides ? vNode.appContext.provides : {}),
-        ...((parent as any).provides ? (parent as any).provides : {}),
-    };
+    /**
+     * Clone the parent's app context instead of mutating it. Assigning
+     * `vNode.appContext = parent.appContext` and then writing to `.provides`
+     * would pollute the shared, app-level `provides` object for every other
+     * component in the application. A shallow copy with a freshly merged
+     * `provides` gives this vnode the parent's injectables without the side
+     * effect.
+     */
+    vNode.appContext = {
+        ...parent.appContext,
+        provides: {
+            ...(parent.appContext?.provides ?? {}),
+            ...((parent as any).provides ?? {}),
+        },
+    } as typeof parent.appContext;
 
     render(vNode, element);
 

--- a/packages/dockview-vue/src/utils.ts
+++ b/packages/dockview-vue/src/utils.ts
@@ -117,8 +117,10 @@ export function mountVueComponent<T extends Record<string, any>>(
     vNode.appContext = {
         ...parent.appContext,
         provides: {
-            ...(parent.appContext?.provides ?? {}),
-            ...((parent as any).provides ?? {}),
+            // Object spread ignores null/undefined, so no `?? {}` guard is
+            // needed for either source.
+            ...parent.appContext?.provides,
+            ...(parent as any).provides,
         },
     } as typeof parent.appContext;
 


### PR DESCRIPTION
## Description

Companion to #1511 (which targets `master`), porting the outstanding part of the #1510 work onto `v8-branch` and adding real-browser e2e coverage.

`v8-branch` already carries most of the wrapper fixes independently (commit `0763271` added the `$attrs` fallthrough forwarding to all four SFCs; `1d4ca9f` added the `getCurrentInstance` capture and the typed composable). The only fix not yet present here was the shared app-context mutation, so this PR:

1. **Shared app-context mutation.** `mountVueComponent` now clones the parent's app context instead of assigning it by reference and overwriting `.provides`, which mutated the shared, app-level `provides` object and leaked a panel's injectables into the global scope for every other component. Includes a unit regression test.

2. **e2e coverage for #1510.** New Playwright fixtures + spec assert that `class`/`style` passed to every view component (dockview / gridview / splitview / paneview) fall through to the host container in a real browser:
   - The dockview fixture sizes the layout **only** via the forwarded `style`, so a regression collapses the host to 0×0 and the test fails.
   - The grid/split/pane views statically size their host, so those cases assert the class landed on the real container (it owns the view's inner element: `.dv-grid-view` / `.dv-split-view-container` / `.dv-pane-container`) and the style outline applied.

## Type of change

- [x] Bug fix
- [x] I have added or updated tests where applicable

## Affected packages

- [x] `dockview-vue`

## How to test

- `yarn test` in `packages/dockview-vue` — 129 unit tests pass, including the new `provides`-mutation regression.
- `yarn test:e2e` (after building the bundles) — 8 Vue e2e tests pass (4 attribute-forwarding + 4 keep-alive). The 3 view tests and the dockview test were each confirmed to fail when the `$attrs` binding is removed and pass once restored.

## Checklist

- [x] `yarn test` passes
- [x] I have added or updated tests where applicable


---
_Generated by [Claude Code](https://claude.ai/code/session_018RyJLwbU1PcXvD9cRbxmyL)_