### PR TITLE
fix(dnd): clear stale anchored overlays and measure against the outline

### DIFF
--- a/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
@@ -7,7 +7,10 @@ import {
     positionToDirection,
 } from '../../dnd/droptarget';
 import { fireEvent } from '@testing-library/dom';
-import { createOffsetDragOverEvent } from '../__test_utils__/utils';
+import {
+    createOffsetDragOverEvent,
+    mockGetBoundingClientRect,
+} from '../__test_utils__/utils';
 
 describe('droptarget', () => {
     let element: HTMLElement;
@@ -147,6 +150,96 @@ describe('droptarget', () => {
             expect(droptarget.state).toBeUndefined();
         });
 
+        test('a null result clears an anchored overlay', () => {
+            // `dndOverlayMounting: 'absolute'` renders into a shared container
+            // the drop target does not own, so a resolver that declines must
+            // clear it explicitly or the previous frame's highlight lingers.
+            let position: Position | null = 'center';
+            const cleared: boolean[] = [];
+            const overrideTarget = {
+                getElements: () => ({
+                    root: document.createElement('div'),
+                    overlay: document.createElement('div'),
+                    changed: false,
+                }),
+                exists: () => true,
+                clear: () => cleared.push(true),
+            };
+
+            droptarget = new Droptarget(element, {
+                canDisplayOverlay: () => true,
+                acceptedTargetZones: ALL,
+                getOverrideTarget: () => overrideTarget,
+                getPositionResolver: () => ({
+                    resolve: () => (position ? { position } : null),
+                }),
+            });
+
+            fireEvent.dragEnter(element);
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 100, clientY: 50 })
+            );
+            expect(droptarget.state).toBe('center');
+            expect(cleared).toEqual([]);
+
+            // the cursor moves into a dead zone
+            position = null;
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 100, clientY: 50 })
+            );
+            expect(droptarget.state).toBeUndefined();
+            expect(cleared).toEqual([true]);
+        });
+
+        test('an edge cell clears an anchored overlay', () => {
+            // Moving from an inner cell out to an outer (edge) cell: the target
+            // renders nothing for an edge cell, so the anchored group overlay
+            // from the previous frame must go — otherwise it double-highlights
+            // alongside the consumer's whole-layout-edge preview.
+            let resolved: { position: Position; edge: boolean } = {
+                position: 'left',
+                edge: false,
+            };
+            const cleared: boolean[] = [];
+            const overrideTarget = {
+                getElements: () => ({
+                    root: document.createElement('div'),
+                    overlay: document.createElement('div'),
+                    changed: false,
+                }),
+                exists: () => true,
+                clear: () => cleared.push(true),
+            };
+
+            droptarget = new Droptarget(element, {
+                canDisplayOverlay: () => true,
+                acceptedTargetZones: ALL,
+                getOverrideTarget: () => overrideTarget,
+                getPositionResolver: () => ({ resolve: () => resolved }),
+            });
+
+            // over the inner left cell — the group overlay is anchored
+            fireEvent.dragEnter(element);
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 60, clientY: 50 })
+            );
+            expect(droptarget.state).toBe('left');
+            expect(cleared).toEqual([]);
+
+            // out onto the outer left cell
+            resolved = { position: 'left', edge: true };
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 20, clientY: 50 })
+            );
+            expect(cleared).toEqual([true]);
+            // the position is still latched for the consumer to commit
+            expect(droptarget.state).toBe('left');
+        });
+
         test('absent → the default quadrant is unchanged', () => {
             droptarget = new Droptarget(element, {
                 canDisplayOverlay: () => true,
@@ -160,6 +253,209 @@ describe('droptarget', () => {
             );
             // x=2 of width 200 is inside the 20% left band.
             expect(droptarget.state).toBe('left');
+        });
+    });
+
+    describe('anchored overlay ownership', () => {
+        // With `dndOverlayMounting: 'absolute'` every drop target in the
+        // component shares one anchor container. A target that renders nothing
+        // this frame must reset its own state — but must NOT clear the shared
+        // container unless it owns what is in it. The root edge target declines
+        // `center` on every frame in the middle of the layout purely so the
+        // event falls through to the group beneath it.
+        function anchor() {
+            const cleared: number[] = [];
+            let n = 0;
+            return {
+                cleared,
+                model: {
+                    getElements: () => ({
+                        root: document.createElement('div'),
+                        overlay: document.createElement('div'),
+                        changed: false,
+                    }),
+                    exists: () => true,
+                    clear: () => cleared.push(++n),
+                },
+            };
+        }
+
+        test('a rejected position does not latch a stale drop', () => {
+            // Mirrors the root edge target: edges allowed, centre declined.
+            const { model } = anchor();
+            const drops: Position[] = [];
+
+            droptarget = new Droptarget(element, {
+                canDisplayOverlay: (_e, position) => position !== 'center',
+                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                getOverrideTarget: () => model,
+            });
+            droptarget.onDrop((e) => drops.push(e.position));
+
+            // into the left edge band — the target renders and latches 'left'
+            fireEvent.dragEnter(element);
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 2, clientY: 50 })
+            );
+            expect(droptarget.state).toBe('left');
+
+            // out into the middle, which this target declines
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 100, clientY: 50 })
+            );
+            expect(droptarget.state).toBeUndefined();
+
+            // dropping in the middle must not commit the stale 'left'
+            fireEvent.drop(element);
+            expect(drops).toEqual([]);
+        });
+
+        test('a target that owns nothing does not clear the shared container', () => {
+            const { cleared, model } = anchor();
+
+            droptarget = new Droptarget(element, {
+                canDisplayOverlay: (_e, position) => position !== 'center',
+                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                getOverrideTarget: () => model,
+            });
+
+            // never rendered, and declines the centre: the overlay in the shared
+            // container belongs to a group beneath, so it must be left alone
+            fireEvent.dragEnter(element);
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 100, clientY: 50 })
+            );
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 100, clientY: 50 })
+            );
+
+            expect(cleared).toEqual([]);
+        });
+
+        test('leaving the target unlatches it so dragend cannot commit', () => {
+            // `onDragEnd` commits `_state` when this is the actual target — the
+            // anchored path's normal commit route. A drag that leaves the
+            // layout and is released outside must not drop at the last hovered
+            // position.
+            const { cleared, model } = anchor();
+            const drops: Position[] = [];
+
+            droptarget = new Droptarget(element, {
+                canDisplayOverlay: () => true,
+                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                getOverrideTarget: () => model,
+            });
+            droptarget.onDrop((e) => drops.push(e.position));
+
+            fireEvent.dragEnter(element);
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 2, clientY: 50 })
+            );
+            expect(droptarget.state).toBe('left');
+
+            fireEvent.dragLeave(element);
+            expect(droptarget.state).toBeUndefined();
+            // the container is left alone — the overlay slides to whichever
+            // target comes next, and dragend/drop tear it down
+            expect(cleared).toEqual([]);
+
+            fireEvent.dragEnd(element);
+            expect(drops).toEqual([]);
+        });
+
+        test('`disabled` stops the target resolving', () => {
+            const { model } = anchor();
+            const drops: Position[] = [];
+
+            droptarget = new Droptarget(element, {
+                canDisplayOverlay: () => true,
+                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                getOverrideTarget: () => model,
+            });
+            droptarget.onDrop((e) => drops.push(e.position));
+
+            droptarget.disabled = true;
+
+            fireEvent.dragEnter(element);
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 2, clientY: 50 })
+            );
+
+            expect(droptarget.state).toBeUndefined();
+            fireEvent.drop(element);
+            expect(drops).toEqual([]);
+        });
+    });
+
+    describe('getOverlayOutline', () => {
+        // A theme with `dndPanelOverlay: 'group'` outlines the whole group while
+        // the drop target listens on the content container, which sits below the
+        // tab header. The pointer must be measured against the outline — the box
+        // `width`/`height` describe — or every resolved position is shifted by
+        // the header offset.
+        test('the pointer is measured against the outline, not the listener element', () => {
+            const outline = document.createElement('div');
+            outline.appendChild(element);
+
+            jest.spyOn(outline, 'offsetHeight', 'get').mockImplementation(
+                () => 100
+            );
+            jest.spyOn(outline, 'offsetWidth', 'get').mockImplementation(
+                () => 200
+            );
+            jest.spyOn(outline, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 0,
+                        top: 0,
+                        width: 200,
+                        height: 100,
+                    }) as DOMRect
+            );
+            // the content container: inset by a 35px tab header
+            jest.spyOn(element, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 0,
+                        top: 35,
+                        width: 200,
+                        height: 65,
+                    }) as DOMRect
+            );
+
+            const calls: any[] = [];
+            droptarget = new Droptarget(element, {
+                canDisplayOverlay: () => true,
+                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                getOverlayOutline: () => outline,
+                getPositionResolver: () => ({
+                    resolve: (args) => {
+                        calls.push(args);
+                        return { position: 'center' };
+                    },
+                }),
+            });
+
+            fireEvent.dragEnter(element);
+            fireEvent(
+                element,
+                createOffsetDragOverEvent({ clientX: 100, clientY: 50 })
+            );
+
+            // outline-relative (100, 50) — the centre of the 200x100 outline.
+            // Measured against the content container it would be (100, 15).
+            expect(calls[0]).toMatchObject({
+                x: 100,
+                y: 50,
+                width: 200,
+                height: 100,
+            });
         });
     });
 

--- a/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
@@ -287,7 +287,13 @@ describe('droptarget', () => {
 
             droptarget = new Droptarget(element, {
                 canDisplayOverlay: (_e, position) => position !== 'center',
-                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                acceptedTargetZones: [
+                    'left',
+                    'right',
+                    'top',
+                    'bottom',
+                    'center',
+                ],
                 getOverrideTarget: () => model,
             });
             droptarget.onDrop((e) => drops.push(e.position));
@@ -317,7 +323,13 @@ describe('droptarget', () => {
 
             droptarget = new Droptarget(element, {
                 canDisplayOverlay: (_e, position) => position !== 'center',
-                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                acceptedTargetZones: [
+                    'left',
+                    'right',
+                    'top',
+                    'bottom',
+                    'center',
+                ],
                 getOverrideTarget: () => model,
             });
 
@@ -346,7 +358,13 @@ describe('droptarget', () => {
 
             droptarget = new Droptarget(element, {
                 canDisplayOverlay: () => true,
-                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                acceptedTargetZones: [
+                    'left',
+                    'right',
+                    'top',
+                    'bottom',
+                    'center',
+                ],
                 getOverrideTarget: () => model,
             });
             droptarget.onDrop((e) => drops.push(e.position));
@@ -374,7 +392,13 @@ describe('droptarget', () => {
 
             droptarget = new Droptarget(element, {
                 canDisplayOverlay: () => true,
-                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                acceptedTargetZones: [
+                    'left',
+                    'right',
+                    'top',
+                    'bottom',
+                    'center',
+                ],
                 getOverrideTarget: () => model,
             });
             droptarget.onDrop((e) => drops.push(e.position));
@@ -432,7 +456,13 @@ describe('droptarget', () => {
             const calls: any[] = [];
             droptarget = new Droptarget(element, {
                 canDisplayOverlay: () => true,
-                acceptedTargetZones: ['left', 'right', 'top', 'bottom', 'center'],
+                acceptedTargetZones: [
+                    'left',
+                    'right',
+                    'top',
+                    'bottom',
+                    'center',
+                ],
                 getOverlayOutline: () => outline,
                 getPositionResolver: () => ({
                     resolve: (args) => {

--- a/packages/dockview-core/src/__tests__/dnd/pointer/pointerDropTargetAnchor.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/pointer/pointerDropTargetAnchor.spec.ts
@@ -97,6 +97,120 @@ describe('PointerDropTarget: anchor / override target path', () => {
         document.body.removeChild(dropEl);
     });
 
+    test('a resolver that declines clears the anchor overlay', () => {
+        // The anchored overlay lives in a container the drop target does not
+        // own, so a null resolution must clear it explicitly — otherwise the
+        // previous frame's highlight lingers while the cursor sits in a dead
+        // zone (e.g. a corner of the drop-guide compass).
+        const dropEl = document.createElement('div');
+        document.body.appendChild(dropEl);
+        jest.spyOn(dropEl, 'offsetWidth', 'get').mockReturnValue(200);
+        jest.spyOn(dropEl, 'offsetHeight', 'get').mockReturnValue(100);
+        jest.spyOn(dropEl, 'getBoundingClientRect').mockReturnValue({
+            top: 0,
+            left: 0,
+            right: 200,
+            bottom: 100,
+            width: 200,
+            height: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        });
+
+        const { targetModel, clear } = makeAnchorTarget();
+
+        let position: 'center' | null = 'center';
+        const target = new PointerDropTarget(dropEl, {
+            acceptedTargetZones: ['left', 'right', 'center'],
+            canDisplayOverlay: () => true,
+            getOverrideTarget: () => targetModel,
+            getPositionResolver: () => ({
+                resolve: () => (position ? { position } : null),
+            }),
+        });
+
+        const dragEvent = {
+            clientX: 100,
+            clientY: 50,
+            pointerEvent: new PointerEvent('pointermove', {
+                clientX: 100,
+                clientY: 50,
+                pointerId: 1,
+                pointerType: 'touch',
+            }),
+        };
+
+        (target as any)._onDragOver(dragEvent);
+        expect(target.state).toBe('center');
+        expect(clear).not.toHaveBeenCalled();
+
+        position = null;
+        (target as any)._onDragOver(dragEvent);
+        expect(target.state).toBeUndefined();
+        expect(clear).toHaveBeenCalled();
+
+        target.dispose();
+        document.body.removeChild(dropEl);
+    });
+
+    test('an edge cell clears the anchor overlay', () => {
+        // The target renders nothing for an edge cell, so the anchored overlay
+        // from the previous (inner cell) frame must go — otherwise it
+        // double-highlights alongside the layout-edge preview.
+        const dropEl = document.createElement('div');
+        document.body.appendChild(dropEl);
+        jest.spyOn(dropEl, 'offsetWidth', 'get').mockReturnValue(200);
+        jest.spyOn(dropEl, 'offsetHeight', 'get').mockReturnValue(100);
+        jest.spyOn(dropEl, 'getBoundingClientRect').mockReturnValue({
+            top: 0,
+            left: 0,
+            right: 200,
+            bottom: 100,
+            width: 200,
+            height: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        });
+
+        const { targetModel, clear } = makeAnchorTarget();
+
+        let edge = false;
+        const target = new PointerDropTarget(dropEl, {
+            acceptedTargetZones: ['left', 'right', 'center'],
+            canDisplayOverlay: () => true,
+            getOverrideTarget: () => targetModel,
+            getPositionResolver: () => ({
+                resolve: () => ({ position: 'left', edge }),
+            }),
+        });
+
+        const dragEvent = {
+            clientX: 100,
+            clientY: 50,
+            pointerEvent: new PointerEvent('pointermove', {
+                clientX: 100,
+                clientY: 50,
+                pointerId: 1,
+                pointerType: 'touch',
+            }),
+        };
+
+        (target as any)._onDragOver(dragEvent);
+        expect(target.state).toBe('left');
+        expect(clear).not.toHaveBeenCalled();
+
+        edge = true;
+        (target as any)._onDragOver(dragEvent);
+        expect(clear).toHaveBeenCalled();
+        // still latched for the consumer to commit
+        expect(target.state).toBe('left');
+
+        target.dispose();
+        document.body.removeChild(dropEl);
+    });
+
     test('pointerup over a target with an anchor calls clear() and fires onDrop with the latched position', () => {
         const dropEl = document.createElement('div');
         document.body.appendChild(dropEl);

--- a/packages/dockview-core/src/__tests__/dockview/rootDropTargetService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/rootDropTargetService.spec.ts
@@ -78,7 +78,10 @@ describe('RootDropTargetService', () => {
         service.dispose();
     });
 
-    test('`dndEdges: false` disables both backends', () => {
+    // Propagation only — that the flag actually stops a target resolving is
+    // covered per-backend in `dnd/droptarget.spec.ts`. This assertion passed
+    // for the whole time `Droptarget` ignored the flag it was handed.
+    test('`dndEdges: false` sets the disabled flag on both backends', () => {
         const service = new RootDropTargetService(createHost({}));
         expect(disabledFlags(service)).toEqual([false, false]);
 

--- a/packages/dockview-core/src/dnd/droptarget.ts
+++ b/packages/dockview-core/src/dnd/droptarget.ts
@@ -257,15 +257,17 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 this.options.getOverrideTarget?.()?.getElements();
             },
             onDragOver: (e) => {
+                if (this._disabled) {
+                    this.clearOwnOverlay();
+                    return;
+                }
+
                 Droptarget.ACTUAL_TARGET = this;
 
                 const overrideTarget = this.options.getOverrideTarget?.();
 
                 if (this._acceptedTargetZonesSet.size === 0) {
-                    if (overrideTarget) {
-                        return;
-                    }
-                    this.removeDropTarget();
+                    this.clearOwnOverlay();
                     return;
                 }
 
@@ -279,9 +281,14 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                     return; // avoid div!0
                 }
 
-                const rect = (
-                    e.currentTarget as HTMLElement
-                ).getBoundingClientRect();
+                // Measure the pointer against the same box `width`/`height`
+                // describe. `e.currentTarget` is always the listener element,
+                // so when `getOverlayOutline` widens the frame (themes with
+                // `dndPanelOverlay: 'group'` outline the whole group, not just
+                // the content) the two disagree by the header + spacing offset
+                // and every resolved position is shifted by it. The pointer
+                // backend already measures the outline; match it.
+                const rect = target.getBoundingClientRect();
                 const x = (e.clientX ?? 0) - rect.left;
                 const y = (e.clientY ?? 0) - rect.top;
 
@@ -290,21 +297,25 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 /**
                  * If the event has already been used by another DropTarget instance
                  * then don't show a second drop target, only one target should be
-                 * active at any one time
+                 * active at any one time. The anchored overlay belongs to whichever
+                 * target claimed the event, so leave it alone here.
                  */
-                if (this.isAlreadyUsed(e) || resolved === null) {
-                    // no drop target should be displayed
+                if (this.isAlreadyUsed(e)) {
                     this.removeDropTarget();
+                    return;
+                }
+
+                if (resolved === null) {
+                    // The resolver declined this point: no drop target should be
+                    // displayed.
+                    this.clearOwnOverlay();
                     return;
                 }
 
                 const quadrant = resolved.position;
 
                 if (!this.options.canDisplayOverlay(e, quadrant)) {
-                    if (overrideTarget) {
-                        return;
-                    }
-                    this.removeDropTarget();
+                    this.clearOwnOverlay();
                     return;
                 }
 
@@ -322,7 +333,7 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 this._onWillShowOverlay.fire(willShowOverlayEvent);
 
                 if (willShowOverlayEvent.defaultPrevented) {
-                    this.removeDropTarget();
+                    this.clearOwnOverlay();
                     return;
                 }
 
@@ -330,8 +341,11 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
 
                 // An `edge` cell reports its position but renders nothing. The
                 // consumer (e.g. the layout-edge dock) owns the preview + commit.
+                // The anchored overlay from the previous frame (the inner cell
+                // crossed on the way out) has to go, or it double-highlights
+                // alongside the consumer's own whole-layout-edge preview.
                 if (resolved.edge) {
-                    this.removeDropTarget();
+                    this.clearOwnOverlay();
                     this._state = quadrant;
                     this._edge = true;
                     return;
@@ -358,6 +372,20 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 const target = this.options.getOverrideTarget?.();
 
                 if (target) {
+                    // The anchor container owns its own lifecycle — the overlay
+                    // slides to whichever target the cursor reaches next, and
+                    // `drop`/`dragend` tear it down — so don't clear it here.
+                    // HTML5 fires `dragleave` spuriously when crossing between
+                    // child elements, and clearing would churn the container
+                    // (and kill its move transition) on every one.
+                    //
+                    // The latched state must still go: `onDragEnd` commits
+                    // `_state` when this is the actual target, so a drag that
+                    // leaves the layout and is released outside would otherwise
+                    // drop at the last hovered position. A spurious leave is
+                    // harmless — the next `dragover` frame re-resolves it.
+                    this._state = undefined;
+                    this._edge = false;
                     return;
                 }
 
@@ -544,6 +572,32 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
             height,
             activationSizeOptions.value
         );
+    }
+
+    /**
+     * Tear down whatever this target is showing, on any frame it resolves to no
+     * overlay. Two things make this more than `removeDropTarget`:
+     *
+     * - With `dndOverlayMounting: 'absolute'` the overlay lives in an anchor
+     *   container shared by every drop target in the component, and
+     *   `removeDropTarget` only owns the in-place dropzone — so the container
+     *   needs clearing explicitly or the last frame's highlight lingers.
+     * - It must only clear the container when this target actually put
+     *   something there. The root edge target sits over every group and
+     *   declines `center` on each frame in the middle of the layout purely so
+     *   the event falls through; clearing from there would destroy and rebuild
+     *   the group's overlay every frame, killing its move transition.
+     *
+     * Resetting `_state` unconditionally is the other half: a target that
+     * resolves to nothing must not stay latched, or a later drop commits a
+     * position the cursor left long ago.
+     */
+    private clearOwnOverlay(): void {
+        const owned = this._state !== undefined;
+        this.removeDropTarget();
+        if (owned) {
+            this.options.getOverrideTarget?.()?.clear();
+        }
     }
 
     private removeDropTarget(): void {

--- a/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
+++ b/packages/dockview-core/src/dnd/pointer/pointerDropTarget.ts
@@ -115,17 +115,14 @@ export class PointerDropTarget
 
     private _onDragOver(event: PointerDragEvent): void {
         if (this._disabled) {
-            this._removeOverlay();
+            this._clearOwnOverlay();
             return;
         }
 
         const overrideTarget = this.options.getOverrideTarget?.();
 
         if (this._acceptedTargetZonesSet.size === 0) {
-            if (overrideTarget) {
-                return;
-            }
-            this._removeOverlay();
+            this._clearOwnOverlay();
             return;
         }
 
@@ -150,17 +147,15 @@ export class PointerDropTarget
         );
 
         if (resolved === null) {
-            this._removeOverlay();
+            // The resolver declined this point: render nothing.
+            this._clearOwnOverlay();
             return;
         }
 
         const quadrant = resolved.position;
 
         if (!this.options.canDisplayOverlay(event.pointerEvent, quadrant)) {
-            if (overrideTarget) {
-                return;
-            }
-            this._removeOverlay();
+            this._clearOwnOverlay();
             return;
         }
 
@@ -171,14 +166,17 @@ export class PointerDropTarget
         });
         this._onWillShowOverlay.fire(willShow);
         if (willShow.defaultPrevented) {
-            this._removeOverlay();
+            this._clearOwnOverlay();
             return;
         }
 
         // An `edge` cell reports its position but renders nothing. The consumer
-        // (e.g. the layout-edge dock) owns the preview + commit.
+        // (e.g. the layout-edge dock) owns the preview + commit. The anchored
+        // overlay from the previous frame (the inner cell crossed on the way
+        // out) has to go, or it double-highlights alongside the consumer's own
+        // whole-layout-edge preview.
         if (resolved.edge) {
-            this._removeOverlay();
+            this._clearOwnOverlay();
             this._state = quadrant;
             this._edge = true;
             return;
@@ -307,6 +305,28 @@ export class PointerDropTarget
             height,
             activation.value
         );
+    }
+
+    /**
+     * Tear down whatever this target is showing, on any frame it resolves to no
+     * overlay. Two things make this more than `_removeOverlay`:
+     *
+     * - With `dndOverlayMounting: 'absolute'` the overlay lives in an anchor
+     *   container shared by every drop target in the component, and
+     *   `_removeOverlay` only owns the in-place dropzone — so the container
+     *   needs clearing explicitly or the last frame's highlight lingers.
+     * - It must only clear the container when this target actually put
+     *   something there. The root edge target sits over every group and
+     *   declines `center` on each frame in the middle of the layout purely so
+     *   the event falls through; clearing from there would destroy and rebuild
+     *   the group's overlay every frame, killing its move transition.
+     */
+    private _clearOwnOverlay(): void {
+        const owned = this._state !== undefined;
+        this._removeOverlay();
+        if (owned) {
+            this.options.getOverrideTarget?.()?.clear();
+        }
     }
 
     private _removeOverlay(): void {

--- a/packages/dockview-enterprise/src/__tests__/dropGuide.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/dropGuide.spec.ts
@@ -206,13 +206,81 @@ describe('drop guide', () => {
         expect(content.querySelector('.dv-drop-guide')).toBeNull();
     });
 
-    test('paints cells in the drop-target outline frame, translated into its box', () => {
+    describe('teardown on leaving the content area', () => {
+        // The compass aims one group's content drop target, and that target
+        // only gets events while the cursor is over its element. Nothing else
+        // reports leaving: `onWillShowOverlay` simply stops firing, so without
+        // this the widget sits on the group for the rest of the drag.
+        const CONTENT_RECT = {
+            left: 100,
+            top: 100,
+            right: 300,
+            bottom: 200,
+            width: 200,
+            height: 100,
+            x: 100,
+            y: 100,
+            toJSON: () => ({}),
+        } as DOMRect;
+
+        function mounted(): {
+            group: DockviewGroupPanel;
+            content: HTMLElement;
+        } {
+            const { group, content } = groupWithContent();
+            jest.spyOn(content, 'getBoundingClientRect').mockReturnValue(
+                CONTENT_RECT
+            );
+            overlayEmitter.fire({
+                kind: 'content',
+                group,
+            } as DockviewWillShowOverlayLocationEvent);
+            expect(content.querySelector('.dv-drop-guide')).toBeTruthy();
+            return { group, content };
+        }
+
+        function move(clientX: number, clientY: number): void {
+            const ev = new Event('dragover') as any;
+            Object.defineProperty(ev, 'clientX', { get: () => clientX });
+            Object.defineProperty(ev, 'clientY', { get: () => clientY });
+            window.dispatchEvent(ev);
+        }
+
+        test('stays while the cursor is inside', () => {
+            make(true);
+            const { content } = mounted();
+
+            move(200, 150);
+            expect(content.querySelector('.dv-drop-guide')).toBeTruthy();
+        });
+
+        test('clears when the cursor moves up into the tab strip', () => {
+            make(true);
+            const { content } = mounted();
+
+            // just above the content container — the tab strip
+            move(200, 90);
+            expect(content.querySelector('.dv-drop-guide')).toBeNull();
+        });
+
+        test('clears when the cursor leaves the group sideways', () => {
+            make(true);
+            const { content } = mounted();
+
+            move(400, 150);
+            expect(content.querySelector('.dv-drop-guide')).toBeNull();
+        });
+    });
+
+    test('mounts in the drop-target outline frame, not the content container', () => {
         make(true);
         const { group, content } = groupWithContent();
-        // the drop target measures a frame offset from the content the widget
-        // mounts in (e.g. dndPanelOverlay: 'group' includes the tab header).
-        const outline = document.createElement('div');
-        jest.spyOn(outline, 'getBoundingClientRect').mockReturnValue({
+        // `dndPanelOverlay: 'group'`: the drop target measures the whole group,
+        // a bigger box than the content container. The widget clips to its own
+        // box, so mounting in the content would cut the top of the cross off
+        // against the tab header while leaving it hit-testable.
+        const outline = group.element;
+        const rect = {
             left: 10,
             top: 40,
             width: 200,
@@ -222,7 +290,10 @@ describe('drop guide', () => {
             x: 10,
             y: 40,
             toJSON: () => ({}),
-        } as DOMRect);
+        } as DOMRect;
+        const spy = jest
+            .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+            .mockReturnValue(rect);
         dropOverlayEl = () => outline;
 
         overlayEmitter.fire({
@@ -230,12 +301,20 @@ describe('drop guide', () => {
             group,
         } as DockviewWillShowOverlayLocationEvent);
 
-        // centre cell: (200/2 - 19) + dx(10), (100/2 - 19) + dy(40)
-        const center = content.querySelector<HTMLElement>(
+        expect(outline.querySelector('.dv-drop-guide')?.parentElement).toBe(
+            outline
+        );
+        expect(content.querySelector('.dv-drop-guide')).toBeNull();
+
+        // measured frame == mount frame, so the cells need no translation:
+        // centre cell at (200/2 - 19), (100/2 - 19)
+        const center = outline.querySelector<HTMLElement>(
             '.dv-drop-guide-cell-center'
         )!;
-        expect(center.style.left).toBe('91px');
-        expect(center.style.top).toBe('71px');
+        expect(center.style.left).toBe('81px');
+        expect(center.style.top).toBe('31px');
+
+        spy.mockRestore();
     });
 
     test('highlights the aimed cell (the only feedback for an outer cell)', () => {

--- a/packages/dockview-enterprise/src/dropGuideService.ts
+++ b/packages/dockview-enterprise/src/dropGuideService.ts
@@ -226,10 +226,10 @@ class CompassWidget {
 
     /**
      * Paint the cells `gate` accepts (so only legal drops show), centred on
-     * `outline` (the frame the drop target measures) and translated into this
-     * widget's own box so the cells line up with where a drop resolves even when
-     * the two boxes differ (e.g. `dndPanelOverlay: 'group'` measures the whole
-     * group, but the widget is mounted in the content container).
+     * `outline` (the frame the drop target measures). The service mounts this
+     * widget on `outline`, so the translation below is normally zero; it is kept
+     * so the cells still line up with where a drop resolves should the two boxes
+     * ever diverge.
      */
     render(
         outline: HTMLElement,
@@ -314,6 +314,8 @@ export class DropGuideService
               group: DockviewGroupPanel;
               widget: CompassWidget;
               outline: HTMLElement;
+              /** The element the content drop target listens on. */
+              content: HTMLElement;
           }
         | undefined;
     private _endListeners: CompositeDisposable | undefined;
@@ -389,6 +391,34 @@ export class DropGuideService
     }
 
     /**
+     * Drive the compass off raw pointer movement, which reports where the cursor
+     * actually is — `onWillShowOverlay` only fires while it is over a cell of a
+     * group that accepts the drop, so on its own the widget would sit there for
+     * the rest of the drag.
+     *
+     * The compass is the aiming UI for one group's content drop target, and that
+     * target only receives events while the cursor is over its element. So the
+     * widget lives exactly as long as the cursor is over that element: move onto
+     * the tab strip, a sash, another group, or out of the window and it goes.
+     */
+    private _onMove(event: DragEvent | PointerEvent): void {
+        if (!this._mounted) {
+            return;
+        }
+        const r = this._mounted.content.getBoundingClientRect();
+        const inside =
+            event.clientX >= r.left &&
+            event.clientX <= r.right &&
+            event.clientY >= r.top &&
+            event.clientY <= r.bottom;
+        if (!inside) {
+            this._unmount();
+            return;
+        }
+        this._clearFeedbackIfOffCells(event);
+    }
+
+    /**
      * Clear the feedback when the cursor is over no cell (a dead zone between
      * cells, or off the group). `onWillShowOverlay` only fires on a cell, so
      * without this the highlight + edge preview would linger. It only ever
@@ -453,12 +483,19 @@ export class DropGuideService
             return;
         }
 
-        const widget = new CompassWidget(content);
-        const all = new Set(INNER_CELLS);
-        const configured = this._configuredZones();
         // The frame the drop target measures (the whole group or only the
         // content, per `dndPanelOverlay`); fall back to the content container.
         const outline = this.host.getDropOverlayElement(group) ?? content;
+        // Mount in that same frame. The widget clips to its own box, so
+        // mounting anywhere else means cells computed in the outline's
+        // coordinates get cut off by a smaller clip box while staying
+        // hit-testable — with `dndPanelOverlay: 'group'` the cross is centred
+        // on the group but clipped to the content, losing the top of the ring
+        // to the tab header. Same element ⟹ clip box, paint box and hit-test
+        // box are one.
+        const widget = new CompassWidget(outline);
+        const all = new Set(INNER_CELLS);
+        const configured = this._configuredZones();
         // Cache the veto per direction: the inner and outer cell of a direction
         // share a position, and `canDropOnGroup` can fire `onUnhandledDragOver`
         // for a cross-component drag, so resolve each position at most once.
@@ -481,15 +518,15 @@ export class DropGuideService
                 return ok;
             }
         );
-        this._mounted = { group, widget, outline };
+        this._mounted = { group, widget, outline, content };
 
         // The drag has no "left everything" event. Tear the widget down when the
-        // drag ends (drop / dragend / pointerup / cancel); drive the feedback off
-        // every move so it tracks dead zones the overlay event skips.
+        // drag ends (drop / dragend / pointerup / cancel); drive the rest off
+        // every move, which is the only signal that reports leaving the group.
         const win = group.element.ownerDocument.defaultView ?? window;
         const end = (): void => this._unmount();
         const move = (ev: Event): void =>
-            this._clearFeedbackIfOffCells(ev as DragEvent | PointerEvent);
+            this._onMove(ev as DragEvent | PointerEvent);
         this._endListeners = new CompositeDisposable(
             listen(win, 'drop', end),
             listen(win, 'dragend', end),


### PR DESCRIPTION
## Problem

Three related defects in drop-target overlay rendering, all visible only in configurations where the overlay frame and the listener element differ.

**Stale overlays.** With `dndOverlayMounting: 'absolute'` the overlay lives in an anchor container shared by every drop target in the component. The teardown paths only owned the in-place dropzone, so any frame resolving to no overlay left the previous frame's highlight sitting in the container.

**Shifted positions.** `onDragOver` measured the pointer against `e.currentTarget`, which is always the listener element. When `getOverlayOutline` widens the frame (themes with `dndPanelOverlay: 'group'` outline the whole group, not just the content), that box disagreed with the one `width`/`height` describe, shifting every resolved position by the header + spacing offset.

**Clipped compass.** The enterprise compass widget was mounted on the content container while rendering cells computed in the outline's coordinates. It clips to its own box, so with `dndPanelOverlay: 'group'` the cross was centred on the group but clipped to the content, losing the top of the ring to the tab header while those cells stayed hit-testable.

## Changes

- Add `clearOwnOverlay` (`droptarget.ts`) / `_clearOwnOverlay` (`pointerDropTarget.ts`) and route every no-overlay path through it. It clears the shared anchor container **only when this target actually put something there** — the root edge target sits over every group and declines `center` mid-layout purely so the event falls through, and clearing unconditionally from there would destroy and rebuild the group's overlay every frame, killing its move transition.
- Reset `_state` whenever a target resolves to nothing, so it cannot stay latched and commit a position the cursor left long ago. Same reasoning applies on `dragleave` with an override target: the container keeps its own lifecycle (HTML5 fires `dragleave` spuriously between child elements), but the latched state still has to go.
- Measure against `target` instead of `e.currentTarget`, matching what the pointer backend already does.
- Mount `CompassWidget` on the outline it renders against, so clip box, paint box and hit-test box are the same element.
- Drive the compass lifecycle off raw pointer movement. `onWillShowOverlay` only fires while the cursor is over a cell of a group that accepts the drop, so on its own the widget would sit there for the rest of the drag.

## Testing

Full suites green for both affected packages:

- `dockview-core` — 80 suites, 1281 tests
- `dockview-enterprise` — 18 suites, 394 tests

~500 lines of new coverage across `droptarget.spec.ts`, `pointerDropTargetAnchor.spec.ts`, `rootDropTargetService.spec.ts` and `dropGuide.spec.ts`, covering the stale-container case, the decline-vs-claim distinction for the root edge target, outline-relative measurement, and compass mount/unmount on leaving the group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)