### PR TITLE
refactor: optional chaining in applyDragOverTransforms (S6582)

### DIFF
--- a/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabReorderController.ts
@@ -1080,10 +1080,7 @@ export class TabReorderController extends CompositeDisposable {
         if (this._wrapMode) {
             return;
         }
-        if (
-            !this._animState ||
-            this._animState.currentInsertionIndex === null
-        ) {
+        if (this._animState?.currentInsertionIndex == null) {
             this.resetTabTransforms();
             return;
         }

--- a/packages/dockview-enterprise/src/licenseValidator.ts
+++ b/packages/dockview-enterprise/src/licenseValidator.ts
@@ -107,11 +107,12 @@ export function fnv1a(input: string): string {
  */
 function cleanKey(key: string): string {
     // CR, LF, zero-width space/non-joiner/joiner (U+200B–200D), BOM (U+FEFF).
-    // The class holds literal zero-width characters to strip, not an emoji
-    // zero-width-joiner sequence, so the misleading-character-class rule is a
-    // false positive here.
-    // biome-ignore lint/suspicious/noMisleadingCharacterClass: literal zero-width chars, not an emoji ZWJ sequence
-    return key.replace(/[\r\n\u200B\u200C\u200D\uFEFF]/g, '').trim();
+    // Deliberately an alternation, not a character class. A class containing the
+    // zero-width joiner is both a SonarQube bug (S5868) and a Biome error
+    // (noMisleadingCharacterClass). S6035 suggests collapsing this to a class,
+    // but that fix introduces the S5868 bug, so the alternation is the correct
+    // form and S6035 is left unresolved here.
+    return key.replace(/\r|\n|\u200B|\u200C|\u200D|\uFEFF/g, '').trim();
 }
 
 /** Parse `DD_MMM_YYYY` (UTC) → Date, rejecting impossible dates (e.g. 31_Feb). */

--- a/packages/dockview-enterprise/src/licenseValidator.ts
+++ b/packages/dockview-enterprise/src/licenseValidator.ts
@@ -107,9 +107,11 @@ export function fnv1a(input: string): string {
  */
 function cleanKey(key: string): string {
     // CR, LF, zero-width space/non-joiner/joiner (U+200B–200D), BOM (U+FEFF).
-    // Kept as an alternation (not a character class): a class containing the
-    // zero-width joiner trips the linter's misleading-character-class rule.
-    return key.replace(/\r|\n|\u200B|\u200C|\u200D|\uFEFF/g, '').trim();
+    // The class holds literal zero-width characters to strip, not an emoji
+    // zero-width-joiner sequence, so the misleading-character-class rule is a
+    // false positive here.
+    // biome-ignore lint/suspicious/noMisleadingCharacterClass: literal zero-width chars, not an emoji ZWJ sequence
+    return key.replace(/[\r\n\u200B\u200C\u200D\uFEFF]/g, '').trim();
 }
 
 /** Parse `DD_MMM_YYYY` (UTC) → Date, rejecting impossible dates (e.g. 31_Feb). */


### PR DESCRIPTION
## Description

Follow-up to #1521, addressing what remained of PR #1520's SonarCloud issues.

**Fixed — S6582** (`tabReorderController.ts`): use optional chaining in `applyDragOverTransforms` — `this._animState?.currentInsertionIndex == null` instead of `!this._animState || this._animState.currentInsertionIndex === null`.

**Not fixed — S6035** (`licenseValidator.ts`, left intentionally): S6035 asks to collapse the `\r|\n|…` alternation in `cleanKey` into a character class. But doing so makes SonarQube itself raise **S5868** — a MAJOR reliability **bug** ("Unicode joined character sequence in a character class") — because the set includes the zero-width joiner (U+200D). Biome's `noMisleadingCharacterClass` rejects it for the same reason. The alternation is therefore the correct form; S6035 is a false lead whose own fix introduces a bug. This is documented inline in `cleanKey` so it isn't re-attempted.

(An earlier commit on this branch tried the character-class + suppression route; it failed the quality gate on S5868 and has been reverted.)

## Type of change

- [x] Refactor / cleanup

## Affected packages

- [x] `dockview-core`
- [x] `dockview-enterprise` (comment-only)

## How to test

`yarn test` for both packages — all suites pass (1281 core + 394 enterprise). `yarn lint` and `yarn format:check` pass for both.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable (behavior-preserving; existing suites cover both files)
- [x] Breaking changes are documented (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm8oMASAfaxk6KWEjwqUPY