### PR TITLE
test: raise unit-test coverage across the v8 branch

### DIFF
--- a/packages/dockview-core/src/__tests__/api/component.api.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/component.api.spec.ts
@@ -211,7 +211,7 @@ describe('component.api', () => {
             expect(cut.maximumSize).toBe(500);
             expect(cut.width).toBe(100);
             expect(cut.height).toBe(200);
-            expect(cut.length).toBe(3);
+            expect(cut).toHaveLength(3);
             expect(cut.orientation).toBe(Orientation.HORIZONTAL);
             expect(cut.panels).toEqual(['a', 'b']);
             expect(cut.onDidLayoutFromJSON).toBe(onDidLayoutFromJSON);

--- a/packages/dockview-core/src/__tests__/api/component.api.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/component.api.spec.ts
@@ -8,6 +8,7 @@ import { GridviewComponent } from '../../gridview/gridviewComponent';
 import { PaneviewComponent } from '../../paneview/paneviewComponent';
 import { SplitviewComponent } from '../../splitview/splitviewComponent';
 import { DockviewComponent } from '../../dockview/dockviewComponent';
+import { Orientation } from '../../splitview/splitview';
 
 describe('component.api', () => {
     describe('splitview', () => {
@@ -184,6 +185,744 @@ describe('component.api', () => {
             expect(activatePrevious).toHaveBeenCalledWith({
                 includePanel: false,
             });
+        });
+    });
+
+    describe('splitview method delegation', () => {
+        test('getters return the underlying component values', () => {
+            const onDidLayoutFromJSON = jest.fn();
+            const onDidAddView = jest.fn();
+            const onDidRemoveView = jest.fn();
+            const component: Partial<SplitviewComponent> = {
+                minimumSize: 5,
+                maximumSize: 500,
+                width: 100,
+                height: 200,
+                length: 3,
+                orientation: Orientation.HORIZONTAL,
+                panels: ['a', 'b'] as any,
+                onDidLayoutFromJSON: onDidLayoutFromJSON as any,
+                onDidAddView: onDidAddView as any,
+                onDidRemoveView: onDidRemoveView as any,
+            };
+            const cut = new SplitviewApi(<SplitviewComponent>component);
+
+            expect(cut.minimumSize).toBe(5);
+            expect(cut.maximumSize).toBe(500);
+            expect(cut.width).toBe(100);
+            expect(cut.height).toBe(200);
+            expect(cut.length).toBe(3);
+            expect(cut.orientation).toBe(Orientation.HORIZONTAL);
+            expect(cut.panels).toEqual(['a', 'b']);
+            expect(cut.onDidLayoutFromJSON).toBe(onDidLayoutFromJSON);
+            expect(cut.onDidAddView).toBe(onDidAddView);
+            expect(cut.onDidRemoveView).toBe(onDidRemoveView);
+        });
+
+        test('methods delegate to the component', () => {
+            const panel = { id: 'x' } as any;
+            const getPanel = jest.fn().mockReturnValue(panel);
+            const addPanel = jest.fn().mockReturnValue(panel);
+            const toJSON = jest.fn().mockReturnValue({ some: 'data' });
+            const component: Partial<SplitviewComponent> = {
+                removePanel: jest.fn(),
+                focus: jest.fn(),
+                getPanel,
+                layout: jest.fn(),
+                addPanel,
+                movePanel: jest.fn(),
+                fromJSON: jest.fn(),
+                toJSON,
+                clear: jest.fn(),
+                updateOptions: jest.fn(),
+                dispose: jest.fn(),
+            };
+            const cut = new SplitviewApi(<SplitviewComponent>component);
+
+            cut.removePanel(panel, 'auto' as any);
+            expect(component.removePanel).toHaveBeenCalledWith(panel, 'auto');
+
+            cut.focus();
+            expect(component.focus).toHaveBeenCalledTimes(1);
+
+            expect(cut.getPanel('x')).toBe(panel);
+            expect(getPanel).toHaveBeenCalledWith('x');
+
+            cut.layout(10, 20);
+            expect(component.layout).toHaveBeenCalledWith(10, 20);
+
+            const addOptions = { id: 'x', component: 'c' } as any;
+            expect(cut.addPanel(addOptions)).toBe(panel);
+            expect(addPanel).toHaveBeenCalledWith(addOptions);
+
+            cut.movePanel(0, 1);
+            expect(component.movePanel).toHaveBeenCalledWith(0, 1);
+
+            const data = { foo: 1 } as any;
+            cut.fromJSON(data);
+            expect(component.fromJSON).toHaveBeenCalledWith(data);
+
+            expect(cut.toJSON()).toEqual({ some: 'data' });
+
+            cut.clear();
+            expect(component.clear).toHaveBeenCalledTimes(1);
+
+            const opts = { orientation: Orientation.VERTICAL } as any;
+            cut.updateOptions(opts);
+            expect(component.updateOptions).toHaveBeenCalledWith(opts);
+
+            cut.dispose();
+            expect(component.dispose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('paneview method delegation', () => {
+        test('getters return the underlying component values', () => {
+            const onDidLayoutFromJSON = jest.fn();
+            const onDidAddView = jest.fn();
+            const onDidRemoveView = jest.fn();
+            const onDidDrop = jest.fn();
+            const onUnhandledDragOver = jest.fn();
+            const component: Partial<PaneviewComponent> = {
+                minimumSize: 1,
+                maximumSize: 2,
+                width: 3,
+                height: 4,
+                panels: ['p'] as any,
+                onDidLayoutFromJSON: onDidLayoutFromJSON as any,
+                onDidAddView: onDidAddView as any,
+                onDidRemoveView: onDidRemoveView as any,
+                onDidDrop: onDidDrop as any,
+                onUnhandledDragOver: onUnhandledDragOver as any,
+            };
+            const cut = new PaneviewApi(<PaneviewComponent>component);
+
+            expect(cut.minimumSize).toBe(1);
+            expect(cut.maximumSize).toBe(2);
+            expect(cut.width).toBe(3);
+            expect(cut.height).toBe(4);
+            expect(cut.panels).toEqual(['p']);
+            expect(cut.onDidLayoutFromJSON).toBe(onDidLayoutFromJSON);
+            expect(cut.onDidAddView).toBe(onDidAddView);
+            expect(cut.onDidRemoveView).toBe(onDidRemoveView);
+            expect(cut.onDidDrop).toBe(onDidDrop);
+            expect(cut.onUnhandledDragOver).toBe(onUnhandledDragOver);
+        });
+
+        test('methods delegate to the component', () => {
+            const panel = { id: 'p' } as any;
+            const getPanel = jest.fn().mockReturnValue(panel);
+            const addPanel = jest.fn().mockReturnValue(panel);
+            const toJSON = jest.fn().mockReturnValue({ v: 1 });
+            const component: Partial<PaneviewComponent> = {
+                removePanel: jest.fn(),
+                getPanel,
+                movePanel: jest.fn(),
+                focus: jest.fn(),
+                layout: jest.fn(),
+                addPanel,
+                fromJSON: jest.fn(),
+                toJSON,
+                clear: jest.fn(),
+                updateOptions: jest.fn(),
+                dispose: jest.fn(),
+            };
+            const cut = new PaneviewApi(<PaneviewComponent>component);
+
+            cut.removePanel(panel);
+            expect(component.removePanel).toHaveBeenCalledWith(panel);
+
+            expect(cut.getPanel('p')).toBe(panel);
+            expect(getPanel).toHaveBeenCalledWith('p');
+
+            cut.movePanel(2, 0);
+            expect(component.movePanel).toHaveBeenCalledWith(2, 0);
+
+            cut.focus();
+            expect(component.focus).toHaveBeenCalledTimes(1);
+
+            cut.layout(50, 60);
+            expect(component.layout).toHaveBeenCalledWith(50, 60);
+
+            const addOptions = { id: 'p', component: 'c' } as any;
+            expect(cut.addPanel(addOptions)).toBe(panel);
+            expect(addPanel).toHaveBeenCalledWith(addOptions);
+
+            const data = { bar: 2 } as any;
+            cut.fromJSON(data);
+            expect(component.fromJSON).toHaveBeenCalledWith(data);
+
+            expect(cut.toJSON()).toEqual({ v: 1 });
+
+            cut.clear();
+            expect(component.clear).toHaveBeenCalledTimes(1);
+
+            const opts = { disableAutoResizing: true } as any;
+            cut.updateOptions(opts);
+            expect(component.updateOptions).toHaveBeenCalledWith(opts);
+
+            cut.dispose();
+            expect(component.dispose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('gridview method delegation', () => {
+        test('remapped event getters delegate to the group-oriented component events', () => {
+            const onDidAddGroup = jest.fn();
+            const onDidRemoveGroup = jest.fn();
+            const onDidActiveGroupChange = jest.fn();
+            const component: Partial<GridviewComponent> = {
+                onDidAddGroup: onDidAddGroup as any,
+                onDidRemoveGroup: onDidRemoveGroup as any,
+                onDidActiveGroupChange: onDidActiveGroupChange as any,
+                groups: ['g1', 'g2'] as any,
+            };
+            const cut = new GridviewApi(<GridviewComponent>component);
+
+            expect(cut.onDidAddPanel).toBe(onDidAddGroup);
+            expect(cut.onDidRemovePanel).toBe(onDidRemoveGroup);
+            expect(cut.onDidActivePanelChange).toBe(onDidActiveGroupChange);
+            expect(cut.panels).toEqual(['g1', 'g2']);
+        });
+
+        test('orientation setter routes through updateOptions', () => {
+            const updateOptions = jest.fn();
+            const component: Partial<GridviewComponent> = {
+                orientation: Orientation.HORIZONTAL,
+                updateOptions,
+            };
+            const cut = new GridviewApi(<GridviewComponent>component);
+
+            cut.orientation = Orientation.VERTICAL;
+            expect(updateOptions).toHaveBeenCalledWith({
+                orientation: Orientation.VERTICAL,
+            });
+        });
+
+        test('methods delegate to the component', () => {
+            const panel = { id: 'g' } as any;
+            const getPanel = jest.fn().mockReturnValue(panel);
+            const addPanel = jest.fn().mockReturnValue(panel);
+            const toJSON = jest.fn().mockReturnValue({ grid: true });
+            const component: Partial<GridviewComponent> = {
+                focus: jest.fn(),
+                layout: jest.fn(),
+                addPanel,
+                removePanel: jest.fn(),
+                movePanel: jest.fn(),
+                getPanel,
+                fromJSON: jest.fn(),
+                toJSON,
+                clear: jest.fn(),
+                updateOptions: jest.fn(),
+                dispose: jest.fn(),
+            };
+            const cut = new GridviewApi(<GridviewComponent>component);
+
+            cut.focus();
+            expect(component.focus).toHaveBeenCalledTimes(1);
+
+            cut.layout(10, 20);
+            expect(component.layout).toHaveBeenCalledWith(10, 20, false);
+
+            cut.layout(10, 20, true);
+            expect(component.layout).toHaveBeenLastCalledWith(10, 20, true);
+
+            const addOptions = { id: 'g', component: 'c' } as any;
+            expect(cut.addPanel(addOptions)).toBe(panel);
+            expect(addPanel).toHaveBeenCalledWith(addOptions);
+
+            cut.removePanel(panel, 'auto' as any);
+            expect(component.removePanel).toHaveBeenCalledWith(panel, 'auto');
+
+            const moveOptions = { direction: 'left', reference: 'ref' } as any;
+            cut.movePanel(panel, moveOptions);
+            expect(component.movePanel).toHaveBeenCalledWith(
+                panel,
+                moveOptions
+            );
+
+            expect(cut.getPanel('g')).toBe(panel);
+            expect(getPanel).toHaveBeenCalledWith('g');
+
+            const data = { baz: 3 } as any;
+            cut.fromJSON(data);
+            expect(component.fromJSON).toHaveBeenCalledWith(data);
+
+            expect(cut.toJSON()).toEqual({ grid: true });
+
+            cut.clear();
+            expect(component.clear).toHaveBeenCalledTimes(1);
+
+            const opts = { orientation: Orientation.VERTICAL } as any;
+            cut.updateOptions(opts);
+            expect(component.updateOptions).toHaveBeenCalledWith(opts);
+
+            cut.dispose();
+            expect(component.dispose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('dockview method delegation', () => {
+        function createComponent(
+            overrides: Partial<DockviewComponent> = {}
+        ): Partial<DockviewComponent> {
+            return {
+                withOrigin: jest.fn((_origin: any, func: any) => func()),
+                ...overrides,
+            };
+        }
+
+        test('id, tabGroupColors and messages getters', () => {
+            const entries = jest.fn().mockReturnValue([{ label: 'red' }]);
+            const component = createComponent({
+                id: 'dock-1',
+                tabGroupColorPalette: { entries } as any,
+                options: { messages: undefined } as any,
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            expect(cut.id).toBe('dock-1');
+            expect(cut.tabGroupColors).toEqual([{ label: 'red' }]);
+            expect(entries).toHaveBeenCalledTimes(1);
+            // resolveMessages merges over English defaults; result is an object.
+            expect(typeof cut.messages).toBe('object');
+        });
+
+        test('simple event getters delegate to the component', () => {
+            const events: (keyof DockviewApi)[] = [
+                'onDidPanelPinnedChange',
+                'onDidMovePanel',
+                'onDidDrop',
+                'onWillDrop',
+                'onWillMutateLayout',
+                'onDidMutateLayout',
+                'onWillShowOverlay',
+                'onWillDragGroup',
+                'onWillDragPanel',
+                'onUnhandledDragOver',
+                'onDidPopoutGroupSizeChange',
+                'onDidPopoutGroupPositionChange',
+                'onDidAddPopoutGroup',
+                'onDidRemovePopoutGroup',
+                'onDidOpenPopoutWindowFail',
+                'onDidCreateTabGroup',
+                'onDidDestroyTabGroup',
+                'onDidAddPanelToTabGroup',
+                'onDidRemovePanelFromTabGroup',
+                'onDidTabGroupChange',
+                'onDidTabGroupCollapsedChange',
+                'onWillDrop',
+                'onDidChangeHistory',
+                'onDidSnapFloat',
+                'onDidSnapTogether',
+                'onDidMaximizedGroupChange',
+            ];
+
+            for (const name of events) {
+                const sentinel = jest.fn();
+                const component = createComponent({
+                    [name]: sentinel as any,
+                });
+                const cut = new DockviewApi(<DockviewComponent>component);
+                expect((cut as any)[name]).toBe(sentinel);
+            }
+        });
+
+        test('scalar getters delegate to the component', () => {
+            const promise = Promise.resolve();
+            const component = createComponent({
+                canUndo: true,
+                canRedo: false,
+                smartGuidesEnabled: true,
+                popoutRestorationPromise: promise,
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            expect(cut.canUndo).toBe(true);
+            expect(cut.canRedo).toBe(false);
+            expect(cut.smartGuidesEnabled).toBe(true);
+            expect(cut.popoutRestorationPromise).toBe(promise);
+        });
+
+        test('getPanel delegates to getGroupPanel and getGroup to getPanel', () => {
+            const panel = { id: 'p' } as any;
+            const group = { id: 'g' } as any;
+            const getGroupPanel = jest.fn().mockReturnValue(panel);
+            const getPanel = jest.fn().mockReturnValue(group);
+            const component = createComponent({ getGroupPanel, getPanel });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            expect(cut.getPanel('p')).toBe(panel);
+            expect(getGroupPanel).toHaveBeenCalledWith('p');
+
+            expect(cut.getGroup('g')).toBe(group);
+            expect(getPanel).toHaveBeenCalledWith('g');
+        });
+
+        test('focus and layout delegate to the component', () => {
+            const component = createComponent({
+                focus: jest.fn(),
+                layout: jest.fn(),
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            cut.focus();
+            expect(component.focus).toHaveBeenCalledTimes(1);
+
+            cut.layout(10, 20);
+            expect(component.layout).toHaveBeenCalledWith(10, 20, false);
+
+            cut.layout(10, 20, true);
+            expect(component.layout).toHaveBeenLastCalledWith(10, 20, true);
+        });
+
+        test('mutating methods run inside withOrigin("api")', () => {
+            const panel = { id: 'p' } as any;
+            const group = { id: 'g' } as any;
+            const addPanel = jest.fn().mockReturnValue(panel);
+            const addPopoutGroup = jest.fn().mockResolvedValue(true);
+            const component = createComponent({
+                addPanel,
+                removePanel: jest.fn(),
+                closeAllGroups: jest.fn(),
+                removeGroup: jest.fn(),
+                addFloatingGroup: jest.fn(),
+                fromJSON: jest.fn(),
+                clear: jest.fn(),
+                addPopoutGroup,
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            const addOptions = { id: 'p', component: 'c' } as any;
+            expect(cut.addPanel(addOptions)).toBe(panel);
+            expect(addPanel).toHaveBeenCalledWith(addOptions);
+
+            cut.removePanel(panel);
+            expect(component.removePanel).toHaveBeenCalledWith(panel);
+
+            cut.closeAllGroups();
+            expect(component.closeAllGroups).toHaveBeenCalledTimes(1);
+
+            cut.removeGroup(group);
+            expect(component.removeGroup).toHaveBeenCalledWith(group);
+
+            const floatOptions = { position: {} } as any;
+            cut.addFloatingGroup(panel, floatOptions);
+            expect(component.addFloatingGroup).toHaveBeenCalledWith(
+                panel,
+                floatOptions
+            );
+
+            const data = { grid: {} } as any;
+            cut.fromJSON(data, { reuseExistingPanels: true });
+            expect(component.fromJSON).toHaveBeenCalledWith(data, {
+                reuseExistingPanels: true,
+            });
+
+            cut.clear();
+            expect(component.clear).toHaveBeenCalledTimes(1);
+
+            const popoutOptions = { position: {} } as any;
+            void cut.addPopoutGroup(panel, popoutOptions);
+            expect(addPopoutGroup).toHaveBeenCalledWith(panel, popoutOptions);
+
+            // Every mutating call went through withOrigin('api', ...)
+            expect(component.withOrigin).toHaveBeenCalled();
+            for (const call of (component.withOrigin as jest.Mock).mock.calls) {
+                expect(call[0]).toBe('api');
+            }
+        });
+
+        test('addGroup delegates directly (no origin wrapping)', () => {
+            const group = { id: 'g' } as any;
+            const addGroup = jest.fn().mockReturnValue(group);
+            const component = createComponent({ addGroup });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            const options = { id: 'g' } as any;
+            expect(cut.addGroup(options)).toBe(group);
+            expect(addGroup).toHaveBeenCalledWith(options);
+        });
+
+        test('toJSON delegates to the component', () => {
+            const toJSON = jest.fn().mockReturnValue({ dock: true });
+            const component = createComponent({ toJSON });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            expect(cut.toJSON()).toEqual({ dock: true });
+        });
+
+        test('history methods delegate to the component', () => {
+            const component = createComponent({
+                undo: jest.fn(),
+                redo: jest.fn(),
+                clearHistory: jest.fn(),
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            cut.undo();
+            expect(component.undo).toHaveBeenCalledTimes(1);
+
+            cut.redo();
+            expect(component.redo).toHaveBeenCalledTimes(1);
+
+            cut.clearHistory();
+            expect(component.clearHistory).toHaveBeenCalledTimes(1);
+        });
+
+        test('smart guides methods delegate to the component', () => {
+            const component = createComponent({
+                setSmartGuidesEnabled: jest.fn(),
+                updateSmartGuidesOptions: jest.fn(),
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            cut.setSmartGuidesEnabled(true);
+            expect(component.setSmartGuidesEnabled).toHaveBeenCalledWith(true);
+
+            const opts = { snapThreshold: 10 } as any;
+            cut.updateSmartGuidesOptions(opts);
+            expect(component.updateSmartGuidesOptions).toHaveBeenCalledWith(
+                opts
+            );
+        });
+
+        test('adjacentGroupInDirection delegates to the component', () => {
+            const group = { id: 'g' } as any;
+            const result = { id: 'other' } as any;
+            const adjacentGroupInDirection = jest.fn().mockReturnValue(result);
+            const component = createComponent({ adjacentGroupInDirection });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            expect(cut.adjacentGroupInDirection(group, 'left')).toBe(result);
+            expect(adjacentGroupInDirection).toHaveBeenCalledWith(
+                group,
+                'left'
+            );
+        });
+
+        test('maximize group methods delegate to the component', () => {
+            const group = { id: 'g' } as any;
+            const panel = { group } as any;
+            const hasMaximizedGroup = jest.fn().mockReturnValue(true);
+            const component = createComponent({
+                maximizeGroup: jest.fn(),
+                hasMaximizedGroup,
+                exitMaximizedGroup: jest.fn(),
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            cut.maximizeGroup(panel);
+            expect(component.maximizeGroup).toHaveBeenCalledWith(group);
+
+            expect(cut.hasMaximizedGroup()).toBe(true);
+
+            cut.exitMaximizedGroup();
+            expect(component.exitMaximizedGroup).toHaveBeenCalledTimes(1);
+        });
+
+        test('getPopouts and updateOptions delegate to the component', () => {
+            const popouts = [{ id: 'po' }] as any;
+            const getPopouts = jest.fn().mockReturnValue(popouts);
+            const component = createComponent({
+                getPopouts,
+                updateOptions: jest.fn(),
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            expect(cut.getPopouts()).toBe(popouts);
+
+            const opts = { disableFloatingGroups: true } as any;
+            cut.updateOptions(opts);
+            expect(component.updateOptions).toHaveBeenCalledWith(opts);
+        });
+
+        test('edge group methods delegate to the component', () => {
+            const api = { id: 'edge' } as any;
+            const addEdgeGroup = jest.fn().mockReturnValue(api);
+            const getEdgeGroup = jest.fn().mockReturnValue(api);
+            const isEdgeGroupVisible = jest.fn().mockReturnValue(true);
+            const component = createComponent({
+                addEdgeGroup,
+                revealEdgeGroupWithData: jest.fn(),
+                getEdgeGroup,
+                setEdgeGroupVisible: jest.fn(),
+                isEdgeGroupVisible,
+                removeEdgeGroup: jest.fn(),
+                pinEdgeGroup: jest.fn(),
+                autoHideEdgeGroup: jest.fn(),
+                peekEdgeGroup: jest.fn(),
+            });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            const addOptions = { component: 'c' } as any;
+            expect(cut.addEdgeGroup('left', addOptions)).toBe(api);
+            expect(addEdgeGroup).toHaveBeenCalledWith('left', addOptions);
+
+            const data = { groupId: 'g', panelId: 'p' };
+            cut.revealEdgeGroupWithData('right', data, { autoHide: true });
+            expect(component.revealEdgeGroupWithData).toHaveBeenCalledWith(
+                'right',
+                data,
+                { autoHide: true }
+            );
+
+            expect(cut.getEdgeGroup('top')).toBe(api);
+            expect(getEdgeGroup).toHaveBeenCalledWith('top');
+
+            cut.setEdgeGroupVisible('bottom', false);
+            expect(component.setEdgeGroupVisible).toHaveBeenCalledWith(
+                'bottom',
+                false
+            );
+
+            expect(cut.isEdgeGroupVisible('left')).toBe(true);
+            expect(isEdgeGroupVisible).toHaveBeenCalledWith('left');
+
+            cut.removeEdgeGroup('left');
+            expect(component.removeEdgeGroup).toHaveBeenCalledWith('left');
+
+            cut.pinEdgeGroup('left');
+            expect(component.pinEdgeGroup).toHaveBeenCalledWith('left');
+
+            cut.autoHideEdgeGroup('left');
+            expect(component.autoHideEdgeGroup).toHaveBeenCalledWith('left');
+
+            cut.peekEdgeGroup('left', true);
+            expect(component.peekEdgeGroup).toHaveBeenCalledWith('left', true);
+        });
+
+        test('dispose delegates to the component', () => {
+            const component = createComponent({ dispose: jest.fn() });
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            cut.dispose();
+            expect(component.dispose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('dockview tab group API', () => {
+        function createModel(): any {
+            return {
+                createTabGroup: jest.fn().mockReturnValue({ id: 'tg' }),
+                dissolveTabGroup: jest.fn(),
+                addPanelToTabGroup: jest.fn(),
+                removePanelFromTabGroup: jest.fn(),
+                getTabGroups: jest.fn().mockReturnValue([{ id: 'tg' }]),
+                getTabGroupForPanel: jest.fn().mockReturnValue({ id: 'tg' }),
+                moveTabGroup: jest.fn(),
+            };
+        }
+
+        function createComponent(model: any): Partial<DockviewComponent> {
+            return {
+                withOrigin: jest.fn((_origin: any, func: any) => func()),
+                getPanel: jest.fn().mockReturnValue({ model }),
+            };
+        }
+
+        test('createTabGroup resolves the group model and delegates', () => {
+            const model = createModel();
+            const component = createComponent(model);
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            const result = cut.createTabGroup({
+                groupId: 'g1',
+                label: 'L',
+                color: 'blue',
+                componentParams: { a: 1 },
+            });
+            expect(component.getPanel).toHaveBeenCalledWith('g1');
+            expect(model.createTabGroup).toHaveBeenCalledWith({
+                label: 'L',
+                color: 'blue',
+                componentParams: { a: 1 },
+            });
+            expect(result).toEqual({ id: 'tg' });
+        });
+
+        test('dissolveTabGroup delegates to the model', () => {
+            const model = createModel();
+            const cut = new DockviewApi(
+                <DockviewComponent>createComponent(model)
+            );
+
+            cut.dissolveTabGroup({ groupId: 'g1', tabGroupId: 'tg1' });
+            expect(model.dissolveTabGroup).toHaveBeenCalledWith('tg1');
+        });
+
+        test('addPanelToTabGroup delegates to the model', () => {
+            const model = createModel();
+            const cut = new DockviewApi(
+                <DockviewComponent>createComponent(model)
+            );
+
+            cut.addPanelToTabGroup({
+                groupId: 'g1',
+                tabGroupId: 'tg1',
+                panelId: 'p1',
+                index: 2,
+            });
+            expect(model.addPanelToTabGroup).toHaveBeenCalledWith(
+                'tg1',
+                'p1',
+                2
+            );
+        });
+
+        test('removePanelFromTabGroup delegates to the model', () => {
+            const model = createModel();
+            const cut = new DockviewApi(
+                <DockviewComponent>createComponent(model)
+            );
+
+            cut.removePanelFromTabGroup({ groupId: 'g1', panelId: 'p1' });
+            expect(model.removePanelFromTabGroup).toHaveBeenCalledWith('p1');
+        });
+
+        test('getTabGroups delegates to the model', () => {
+            const model = createModel();
+            const cut = new DockviewApi(
+                <DockviewComponent>createComponent(model)
+            );
+
+            expect(cut.getTabGroups({ groupId: 'g1' })).toEqual([{ id: 'tg' }]);
+            expect(model.getTabGroups).toHaveBeenCalledTimes(1);
+        });
+
+        test('getTabGroupForPanel delegates to the model', () => {
+            const model = createModel();
+            const cut = new DockviewApi(
+                <DockviewComponent>createComponent(model)
+            );
+
+            expect(
+                cut.getTabGroupForPanel({ groupId: 'g1', panelId: 'p1' })
+            ).toEqual({ id: 'tg' });
+            expect(model.getTabGroupForPanel).toHaveBeenCalledWith('p1');
+        });
+
+        test('moveTabGroup delegates to the model', () => {
+            const model = createModel();
+            const cut = new DockviewApi(
+                <DockviewComponent>createComponent(model)
+            );
+
+            cut.moveTabGroup({ groupId: 'g1', tabGroupId: 'tg1', index: 3 });
+            expect(model.moveTabGroup).toHaveBeenCalledWith('tg1', 3);
+        });
+
+        test('tab group methods throw when the group is not found', () => {
+            const component: Partial<DockviewComponent> = {
+                withOrigin: jest.fn((_origin: any, func: any) => func()),
+                getPanel: jest.fn().mockReturnValue(undefined),
+            };
+            const cut = new DockviewApi(<DockviewComponent>component);
+
+            expect(() => cut.getTabGroups({ groupId: 'missing' })).toThrow(
+                "dockview: group 'missing' not found"
+            );
         });
     });
 });

--- a/packages/dockview-core/src/__tests__/api/dockviewGroupPanelApi.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/dockviewGroupPanelApi.spec.ts
@@ -111,6 +111,690 @@ describe('DockviewGroupPanelApiImpl', () => {
         });
     });
 
+    describe('location getter', () => {
+        test('throws when group is not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => cut.location).toThrow(
+                'dockview: DockviewGroupPanelApiImpl not initialized'
+            );
+        });
+
+        test('returns the group model location', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+            const group = fromPartial<DockviewGroupPanel>({
+                model: { location: { type: 'grid' } },
+            });
+            cut.initialize(group);
+
+            expect(cut.location).toEqual({ type: 'grid' });
+        });
+    });
+
+    describe('boundingBox getter', () => {
+        test('returns undefined when group is not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(cut.boundingBox).toBeUndefined();
+        });
+
+        test('returns undefined for a popout group', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+            const group = fromPartial<DockviewGroupPanel>({
+                model: { location: { type: 'popout', getWindow: jest.fn() } },
+            });
+            cut.initialize(group);
+
+            expect(cut.boundingBox).toBeUndefined();
+        });
+
+        test('computes the box relative to the accessor root', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                element: {
+                    getBoundingClientRect: () =>
+                        ({ left: 10, top: 20 }) as DOMRect,
+                },
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({
+                model: { location: { type: 'grid' } },
+                element: {
+                    getBoundingClientRect: () =>
+                        ({
+                            left: 50,
+                            top: 70,
+                            width: 100,
+                            height: 200,
+                        }) as DOMRect,
+                },
+            });
+            cut.initialize(group);
+
+            expect(cut.boundingBox).toEqual({
+                left: 40,
+                top: 50,
+                width: 100,
+                height: 200,
+            });
+        });
+    });
+
+    describe('locked getter/setter', () => {
+        test('getter throws when group is not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => cut.locked).toThrow(
+                'dockview: DockviewGroupPanelApiImpl not initialized'
+            );
+        });
+
+        test('setter throws when group is not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => {
+                cut.locked = true;
+            }).toThrow('dockview: DockviewGroupPanelApiImpl not initialized');
+        });
+
+        test('getter returns the group locked value', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+            const group = fromPartial<DockviewGroupPanel>({ locked: true });
+            cut.initialize(group);
+
+            expect(cut.locked).toBe(true);
+        });
+
+        test('setter assigns the group locked value', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+            const group = fromPartial<DockviewGroupPanel>({ locked: false });
+            cut.initialize(group);
+
+            cut.locked = 'no-drop-target';
+
+            expect(group.locked).toBe('no-drop-target');
+        });
+    });
+
+    describe('setSize / pending size', () => {
+        test('setSize fires onDidSizeChange immediately', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            const events: { width?: number; height?: number }[] = [];
+            cut.onDidSizeChange((e) => events.push(e));
+
+            cut.setSize({ width: 123, height: 456 });
+
+            expect(events).toEqual([{ width: 123, height: 456 }]);
+        });
+
+        test('pending size is re-applied when the group becomes visible', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            cut.setSize({ width: 100, height: 200 });
+
+            const events: { width?: number; height?: number }[] = [];
+            cut.onDidSizeChange((e) => events.push(e));
+
+            // becoming visible re-applies the pending size once
+            cut._onDidVisibilityChange.fire({ isVisible: true });
+            expect(events).toEqual([{ width: 100, height: 200 }]);
+
+            // pending is cleared, so a second visibility event does nothing
+            cut._onDidVisibilityChange.fire({ isVisible: true });
+            expect(events).toHaveLength(1);
+        });
+
+        test('pending size is not applied when becoming invisible', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            cut.setSize({ width: 100, height: 200 });
+
+            const events: { width?: number; height?: number }[] = [];
+            cut.onDidSizeChange((e) => events.push(e));
+
+            cut._onDidVisibilityChange.fire({ isVisible: false });
+
+            expect(events).toHaveLength(0);
+        });
+    });
+
+    describe('close', () => {
+        test('is a no-op when group is not initialized', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                removeGroup: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+
+            expect(() => cut.close()).not.toThrow();
+            expect(accessor.removeGroup).not.toHaveBeenCalled();
+        });
+
+        test('delegates to accessor.removeGroup(group)', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                removeGroup: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({});
+            cut.initialize(group);
+
+            cut.close();
+
+            expect(accessor.removeGroup).toHaveBeenCalledWith(group);
+        });
+    });
+
+    describe('getWindow', () => {
+        test('returns globalThis.window for a non-popout group', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+            const group = fromPartial<DockviewGroupPanel>({
+                model: { location: { type: 'grid' } },
+            });
+            cut.initialize(group);
+
+            expect(cut.getWindow()).toBe(globalThis.window);
+        });
+
+        test('returns the popout window for a popout group', () => {
+            const popoutWindow = {} as Window;
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+            const group = fromPartial<DockviewGroupPanel>({
+                model: {
+                    location: {
+                        type: 'popout',
+                        getWindow: () => popoutWindow,
+                    },
+                },
+            });
+            cut.initialize(group);
+
+            expect(cut.getWindow()).toBe(popoutWindow);
+        });
+    });
+
+    describe('header position', () => {
+        test('setHeaderPosition throws when not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => cut.setHeaderPosition('left')).toThrow(
+                'dockview: DockviewGroupPanelApiImpl not initialized'
+            );
+        });
+
+        test('getHeaderPosition throws when not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => cut.getHeaderPosition()).toThrow(
+                'dockview: DockviewGroupPanelApiImpl not initialized'
+            );
+        });
+
+        test('setHeaderPosition assigns the model header position', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+            const model: { headerPosition: string } = {
+                headerPosition: 'top',
+            };
+            const group = fromPartial<DockviewGroupPanel>({ model });
+            cut.initialize(group);
+
+            cut.setHeaderPosition('left');
+
+            expect(model.headerPosition).toBe('left');
+        });
+
+        test('getHeaderPosition returns the model header position', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+            const group = fromPartial<DockviewGroupPanel>({
+                model: { headerPosition: 'right' },
+            });
+            cut.initialize(group);
+
+            expect(cut.getHeaderPosition()).toBe('right');
+        });
+    });
+
+    describe('moveTo', () => {
+        test('throws when group is not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => cut.moveTo({})).toThrow(
+                'dockview: DockviewGroupPanelApiImpl not initialized'
+            );
+        });
+
+        test('moves into an explicitly provided target group', () => {
+            const targetGroup = fromPartial<DockviewGroupPanel>({
+                id: 'target',
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                addGroup: jest.fn(),
+                moveGroupOrPanel: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({ id: 'source' });
+            cut.initialize(group);
+
+            cut.moveTo({
+                group: targetGroup,
+                position: 'right',
+                index: 2,
+            });
+
+            expect(accessor.addGroup).not.toHaveBeenCalled();
+            expect(accessor.moveGroupOrPanel).toHaveBeenCalledWith({
+                from: { groupId: 'source' },
+                to: {
+                    group: targetGroup,
+                    position: 'right',
+                    index: 2,
+                },
+                skipSetActive: undefined,
+            });
+        });
+
+        test('uses position "center" as default when a group is provided without a position', () => {
+            const targetGroup = fromPartial<DockviewGroupPanel>({
+                id: 'target',
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                addGroup: jest.fn(),
+                moveGroupOrPanel: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({ id: 'source' });
+            cut.initialize(group);
+
+            cut.moveTo({ group: targetGroup });
+
+            expect(accessor.moveGroupOrPanel).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    to: expect.objectContaining({
+                        group: targetGroup,
+                        position: 'center',
+                    }),
+                })
+            );
+        });
+
+        test('creates a new group when none is provided, using the given position', () => {
+            const createdGroup = fromPartial<DockviewGroupPanel>({
+                id: 'created',
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                addGroup: jest.fn().mockReturnValue(createdGroup),
+                moveGroupOrPanel: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({ id: 'source' });
+            cut.initialize(group);
+
+            cut.moveTo({ position: 'left', skipSetActive: true });
+
+            expect(accessor.addGroup).toHaveBeenCalledWith({
+                direction: 'left',
+                skipSetActive: true,
+            });
+            expect(accessor.moveGroupOrPanel).toHaveBeenCalledWith({
+                from: { groupId: 'source' },
+                to: {
+                    group: createdGroup,
+                    position: 'center',
+                    index: undefined,
+                },
+                skipSetActive: true,
+            });
+        });
+
+        test('defaults to the "right" direction and skipSetActive false when creating a group without options', () => {
+            const createdGroup = fromPartial<DockviewGroupPanel>({
+                id: 'created',
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                addGroup: jest.fn().mockReturnValue(createdGroup),
+                moveGroupOrPanel: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({ id: 'source' });
+            cut.initialize(group);
+
+            cut.moveTo({});
+
+            expect(accessor.addGroup).toHaveBeenCalledWith({
+                direction: 'right',
+                skipSetActive: false,
+            });
+        });
+    });
+
+    describe('maximize / isMaximized / exitMaximized', () => {
+        test('maximize throws when not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => cut.maximize()).toThrow(
+                'dockview: DockviewGroupPanelApiImpl not initialized'
+            );
+        });
+
+        test('maximize is a no-op for non-grid groups', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                maximizeGroup: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({
+                model: { location: { type: 'floating' } },
+            });
+            cut.initialize(group);
+
+            cut.maximize();
+
+            expect(accessor.maximizeGroup).not.toHaveBeenCalled();
+        });
+
+        test('maximize delegates to accessor.maximizeGroup for grid groups', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                maximizeGroup: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({
+                model: { location: { type: 'grid' } },
+            });
+            cut.initialize(group);
+
+            cut.maximize();
+
+            expect(accessor.maximizeGroup).toHaveBeenCalledWith(group);
+        });
+
+        test('isMaximized throws when not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => cut.isMaximized()).toThrow(
+                'dockview: DockviewGroupPanelApiImpl not initialized'
+            );
+        });
+
+        test('isMaximized delegates to accessor.isMaximizedGroup', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                isMaximizedGroup: jest.fn().mockReturnValue(true),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({});
+            cut.initialize(group);
+
+            expect(cut.isMaximized()).toBe(true);
+            expect(accessor.isMaximizedGroup).toHaveBeenCalledWith(group);
+        });
+
+        test('exitMaximized throws when not initialized', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            expect(() => cut.exitMaximized()).toThrow(
+                'dockview: DockviewGroupPanelApiImpl not initialized'
+            );
+        });
+
+        test('exitMaximized exits when the group is maximized', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                isMaximizedGroup: jest.fn().mockReturnValue(true),
+                exitMaximizedGroup: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({});
+            cut.initialize(group);
+
+            cut.exitMaximized();
+
+            expect(accessor.exitMaximizedGroup).toHaveBeenCalledTimes(1);
+        });
+
+        test('exitMaximized does nothing when the group is not maximized', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                isMaximizedGroup: jest.fn().mockReturnValue(false),
+                exitMaximizedGroup: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({});
+            cut.initialize(group);
+
+            cut.exitMaximized();
+
+            expect(accessor.exitMaximizedGroup).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('isPeeking / setAutoHide', () => {
+        test('isPeeking returns false when not initialized', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                isEdgeGroupPeeking: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+
+            expect(cut.isPeeking()).toBe(false);
+            expect(accessor.isEdgeGroupPeeking).not.toHaveBeenCalled();
+        });
+
+        test('isPeeking delegates to accessor.isEdgeGroupPeeking', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                isEdgeGroupPeeking: jest.fn().mockReturnValue(true),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({});
+            cut.initialize(group);
+
+            expect(cut.isPeeking()).toBe(true);
+            expect(accessor.isEdgeGroupPeeking).toHaveBeenCalledWith(group);
+        });
+
+        test('setAutoHide is a no-op when not initialized', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                setEdgeGroupAutoHide: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+
+            cut.setAutoHide(true);
+
+            expect(accessor.setEdgeGroupAutoHide).not.toHaveBeenCalled();
+        });
+
+        test('setAutoHide delegates to accessor.setEdgeGroupAutoHide', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                setEdgeGroupAutoHide: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({});
+            cut.initialize(group);
+
+            cut.setAutoHide(undefined);
+
+            expect(accessor.setEdgeGroupAutoHide).toHaveBeenCalledWith(
+                group,
+                undefined
+            );
+        });
+    });
+
+    describe('event passthrough', () => {
+        test('onDidLocationChange forwards fired events', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            const events: { location: { type: string } }[] = [];
+            cut.onDidLocationChange((e) =>
+                events.push(e as { location: { type: string } })
+            );
+
+            cut._onDidLocationChange.fire({ location: { type: 'floating' } });
+
+            expect(events).toEqual([{ location: { type: 'floating' } }]);
+        });
+
+        test('onDidActivePanelChange forwards fired events', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            const events: unknown[] = [];
+            cut.onDidActivePanelChange((e) => events.push(e));
+
+            const payload = fromPartial({ panel: undefined });
+            cut._onDidActivePanelChange.fire(payload);
+
+            expect(events).toHaveLength(1);
+            expect(events[0]).toBe(payload);
+        });
+
+        test('onDidPeekChange forwards fired events', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            const events: { isPeeking: boolean }[] = [];
+            cut.onDidPeekChange((e) => events.push(e));
+
+            cut._onDidPeekChange.fire({ isPeeking: true });
+
+            expect(events).toEqual([{ isPeeking: true }]);
+        });
+
+        test('onDidHeaderDirectionChange forwards fired events', () => {
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                fromPartial<DockviewComponent>({})
+            );
+
+            const events: {
+                direction: string;
+                position: string;
+            }[] = [];
+            cut.onDidHeaderDirectionChange((e) =>
+                events.push(e as { direction: string; position: string })
+            );
+
+            cut._onDidHeaderDirectionChange.fire({
+                direction: 'vertical',
+                position: 'left',
+            });
+
+            expect(events).toEqual([
+                { direction: 'vertical', position: 'left' },
+            ]);
+        });
+    });
+
     describe('onDidCollapsedChange', () => {
         function makeAccessor() {
             return fromPartial<DockviewComponent>({

--- a/packages/dockview-core/src/__tests__/api/dockviewPanelApi.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/dockviewPanelApi.spec.ts
@@ -3,6 +3,7 @@ import { DockviewComponent } from '../../dockview/dockviewComponent';
 import { DockviewPanel } from '../../dockview/dockviewPanel';
 import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
 import { fromPartial } from '@total-typescript/shoehorn';
+import { Emitter } from '../../events';
 
 describe('groupPanelApi', () => {
     test('title', () => {
@@ -117,6 +118,455 @@ describe('groupPanelApi', () => {
         cut.group = groupViewPanel2;
         expect(events).toBe(1);
         expect(cut.group).toBe(groupViewPanel2);
+
+        disposable.dispose();
+    });
+
+    /**
+     * Builds a `DockviewPanelApiImpl` backed by controllable mocks. The group's
+     * event surface is wired to real `Emitter`s so tests can drive the internal
+     * group-event listeners deterministically.
+     */
+    function createFixture(options?: {
+        panel?: Partial<DockviewPanel>;
+        group?: Partial<DockviewGroupPanel>;
+        groupApi?: Record<string, unknown>;
+        accessor?: Partial<DockviewComponent>;
+        tabComponent?: string;
+    }) {
+        const onDidVisibilityChange = new Emitter<{ isVisible: boolean }>();
+        const onDidLocationChange = new Emitter<any>();
+        const onDidActiveChange = new Emitter<any>();
+
+        const panel = fromPartial<DockviewPanel>({
+            id: 'panel_id',
+            update: jest.fn(),
+            setTitle: jest.fn(),
+            setRenderer: jest.fn(),
+            ...options?.panel,
+        });
+
+        const groupApi = {
+            location: { type: 'grid' },
+            getWindow: jest.fn(),
+            maximize: jest.fn(),
+            isMaximized: jest.fn(),
+            exitMaximized: jest.fn(),
+            onDidVisibilityChange: onDidVisibilityChange.event,
+            onDidLocationChange: onDidLocationChange.event,
+            onDidActiveChange: onDidActiveChange.event,
+            ...options?.groupApi,
+        };
+
+        const group = fromPartial<DockviewGroupPanel>({
+            id: 'group_id',
+            isActive: false,
+            api: groupApi,
+            model: {
+                closePanel: jest.fn(),
+                isPanelActive: jest.fn(),
+            },
+            ...options?.group,
+        });
+
+        // by default the panel reports it belongs to the group under test
+        if ((panel as any).group === undefined) {
+            (panel as any).group = group;
+        }
+
+        const accessor = fromPartial<DockviewComponent>({
+            onDidAddPanel: jest.fn(),
+            onDidRemovePanel: jest.fn(),
+            options: {},
+            onDidOptionsChange: jest.fn(),
+            moveGroupOrPanel: jest.fn(),
+            setPanelPinned: jest.fn(),
+            withOrigin: jest.fn((_origin: string, cb: () => void) => cb()),
+            ...options?.accessor,
+        });
+
+        const cut = new DockviewPanelApiImpl(
+            panel,
+            group,
+            accessor,
+            'fake-component',
+            options?.tabComponent
+        );
+
+        return {
+            cut,
+            panel,
+            group,
+            groupApi,
+            accessor,
+            emitters: {
+                onDidVisibilityChange,
+                onDidLocationChange,
+                onDidActiveChange,
+            },
+        };
+    }
+
+    test('location delegates to group.api.location', () => {
+        const { cut, groupApi } = createFixture({
+            groupApi: { location: { type: 'floating' } },
+        });
+        expect(cut.location).toBe(groupApi.location);
+    });
+
+    test('title delegates to panel.title', () => {
+        const { cut } = createFixture({ panel: { title: 'a_title' } });
+        expect(cut.title).toBe('a_title');
+    });
+
+    test('isPinned delegates to panel.isPinned', () => {
+        const { cut } = createFixture({ panel: { isPinned: true } as any });
+        expect(cut.isPinned).toBe(true);
+    });
+
+    test('isGroupActive delegates to group.isActive', () => {
+        const { cut } = createFixture({ group: { isActive: true } });
+        expect(cut.isGroupActive).toBe(true);
+    });
+
+    test('renderer delegates to panel.renderer', () => {
+        const { cut } = createFixture({
+            panel: { renderer: 'onlyWhenVisible' } as any,
+        });
+        expect(cut.renderer).toBe('onlyWhenVisible');
+    });
+
+    test('tabComponent returns the value provided in the constructor', () => {
+        const { cut } = createFixture({ tabComponent: 'my-tab' });
+        expect(cut.tabComponent).toBe('my-tab');
+    });
+
+    test('tabComponent is undefined when not provided', () => {
+        const { cut } = createFixture();
+        expect(cut.tabComponent).toBeUndefined();
+    });
+
+    test('getWindow delegates to group.api.getWindow', () => {
+        const theWindow = {} as Window;
+        const getWindow = jest.fn(() => theWindow);
+        const { cut } = createFixture({ groupApi: { getWindow } });
+        expect(cut.getWindow()).toBe(theWindow);
+        expect(getWindow).toHaveBeenCalledTimes(1);
+    });
+
+    test('setActive tags the activation with the "api" origin', () => {
+        const { cut, accessor } = createFixture();
+
+        let activeEvents = 0;
+        const disposable = cut.onActiveChange(() => {
+            activeEvents++;
+        });
+
+        cut.setActive();
+
+        expect(accessor.withOrigin).toHaveBeenCalledTimes(1);
+        expect((accessor.withOrigin as jest.Mock).mock.calls[0][0]).toBe('api');
+        // the wrapped super.setActive() should still have run
+        expect(activeEvents).toBe(1);
+
+        disposable.dispose();
+    });
+
+    test('setPinned delegates to accessor.setPanelPinned', () => {
+        const { cut, accessor, panel } = createFixture();
+        cut.setPinned(true);
+        expect(accessor.setPanelPinned).toHaveBeenCalledTimes(1);
+        expect(accessor.setPanelPinned).toHaveBeenCalledWith(panel, true);
+    });
+
+    test('setRenderer delegates to panel.setRenderer', () => {
+        const { cut, panel } = createFixture();
+        cut.setRenderer('always');
+        expect(panel.setRenderer).toHaveBeenCalledTimes(1);
+        expect(panel.setRenderer).toHaveBeenCalledWith('always');
+    });
+
+    test('close delegates to group.model.closePanel', () => {
+        const { cut, group, panel } = createFixture();
+        cut.close();
+        expect(group.model.closePanel).toHaveBeenCalledTimes(1);
+        expect(group.model.closePanel).toHaveBeenCalledWith(panel);
+    });
+
+    test('maximize delegates to group.api.maximize', () => {
+        const { cut, groupApi } = createFixture();
+        cut.maximize();
+        expect(groupApi.maximize).toHaveBeenCalledTimes(1);
+    });
+
+    test('isMaximized returns group.api.isMaximized result', () => {
+        const isMaximized = jest.fn(() => true);
+        const { cut } = createFixture({ groupApi: { isMaximized } });
+        expect(cut.isMaximized()).toBe(true);
+        expect(isMaximized).toHaveBeenCalledTimes(1);
+    });
+
+    test('exitMaximized delegates to group.api.exitMaximized', () => {
+        const { cut, groupApi } = createFixture();
+        cut.exitMaximized();
+        expect(groupApi.exitMaximized).toHaveBeenCalledTimes(1);
+    });
+
+    test('moveTo with no target group stays in current group at center', () => {
+        const { cut, accessor, group, panel } = createFixture();
+        cut.moveTo({});
+        expect(accessor.moveGroupOrPanel).toHaveBeenCalledTimes(1);
+        expect(accessor.moveGroupOrPanel).toHaveBeenCalledWith({
+            from: { groupId: group.id, panelId: panel.id },
+            to: {
+                group,
+                position: 'center',
+                index: undefined,
+            },
+            skipSetActive: undefined,
+        });
+    });
+
+    test('moveTo with a target group forwards position, index and skipSetActive', () => {
+        const { cut, accessor, group, panel } = createFixture();
+        const targetGroup = fromPartial<DockviewGroupPanel>({
+            id: 'target_group',
+        });
+
+        cut.moveTo({
+            group: targetGroup,
+            position: 'right',
+            index: 3,
+            skipSetActive: true,
+        });
+
+        expect(accessor.moveGroupOrPanel).toHaveBeenCalledWith({
+            from: { groupId: group.id, panelId: panel.id },
+            to: {
+                group: targetGroup,
+                position: 'right',
+                index: 3,
+            },
+            skipSetActive: true,
+        });
+    });
+
+    test('moveTo with a target group defaults position to center', () => {
+        const { cut, accessor } = createFixture();
+        const targetGroup = fromPartial<DockviewGroupPanel>({
+            id: 'target_group',
+        });
+
+        cut.moveTo({ group: targetGroup });
+
+        const call = (accessor.moveGroupOrPanel as jest.Mock).mock.calls[0][0];
+        expect(call.to.group).toBe(targetGroup);
+        expect(call.to.position).toBe('center');
+    });
+
+    test('group visibility change fires onDidVisibilityChange when panel becomes hidden', () => {
+        const { cut, emitters } = createFixture();
+
+        const events: boolean[] = [];
+        const disposable = cut.onDidVisibilityChange((e) => {
+            events.push(e.isVisible);
+        });
+
+        // panel starts visible; the group becoming hidden should propagate
+        emitters.onDidVisibilityChange.fire({ isVisible: false });
+
+        expect(events).toEqual([false]);
+
+        disposable.dispose();
+    });
+
+    test('group visibility change fires when becoming visible and panel is the active panel', () => {
+        const isPanelActive = jest.fn(() => true);
+        const { cut, emitters } = createFixture({
+            group: { model: { isPanelActive } as any },
+        });
+
+        // first drive it hidden so the panel is not visible
+        emitters.onDidVisibilityChange.fire({ isVisible: false });
+
+        const events: boolean[] = [];
+        const disposable = cut.onDidVisibilityChange((e) => {
+            events.push(e.isVisible);
+        });
+
+        emitters.onDidVisibilityChange.fire({ isVisible: true });
+
+        expect(events).toEqual([true]);
+        expect(isPanelActive).toHaveBeenCalled();
+
+        disposable.dispose();
+    });
+
+    test('group visibility change does not fire when becoming visible but panel is not active', () => {
+        const isPanelActive = jest.fn(() => false);
+        const { cut, emitters } = createFixture({
+            group: { model: { isPanelActive } as any },
+        });
+
+        emitters.onDidVisibilityChange.fire({ isVisible: false });
+
+        let events = 0;
+        const disposable = cut.onDidVisibilityChange(() => {
+            events++;
+        });
+
+        emitters.onDidVisibilityChange.fire({ isVisible: true });
+
+        expect(events).toBe(0);
+
+        disposable.dispose();
+    });
+
+    test('group location change fires onDidLocationChange when group is the panel group', () => {
+        const { cut, emitters } = createFixture();
+
+        const events: any[] = [];
+        const disposable = cut.onDidLocationChange((e) => {
+            events.push(e);
+        });
+
+        const event = { location: { type: 'floating' } };
+        emitters.onDidLocationChange.fire(event);
+
+        expect(events).toEqual([event]);
+
+        disposable.dispose();
+    });
+
+    test('group location change is ignored when group is not the panel group', () => {
+        const { cut, emitters, panel } = createFixture();
+        // make the panel report a different group than the one under test
+        (panel as any).group = fromPartial<DockviewGroupPanel>({
+            id: 'other_group',
+        });
+
+        let events = 0;
+        const disposable = cut.onDidLocationChange(() => {
+            events++;
+        });
+
+        emitters.onDidLocationChange.fire({ location: { type: 'grid' } });
+
+        expect(events).toBe(0);
+
+        disposable.dispose();
+    });
+
+    test('group active change fires onDidActiveGroupChange when the active state changes', () => {
+        const { cut, group, emitters } = createFixture();
+
+        const events: boolean[] = [];
+        const disposable = cut.onDidActiveGroupChange((e) => {
+            events.push(e.isActive);
+        });
+
+        (group as any).isActive = true;
+        emitters.onDidActiveChange.fire({});
+
+        expect(events).toEqual([true]);
+
+        disposable.dispose();
+    });
+
+    test('group active change does not fire when the active state is unchanged', () => {
+        const { cut, emitters } = createFixture({
+            group: { isActive: false },
+        });
+
+        let events = 0;
+        const disposable = cut.onDidActiveGroupChange(() => {
+            events++;
+        });
+
+        // isActive stays false, matching the initial tracked state
+        emitters.onDidActiveChange.fire({});
+
+        expect(events).toBe(0);
+
+        disposable.dispose();
+    });
+
+    test('group active change is ignored when group is not the panel group', () => {
+        const { cut, group, emitters, panel } = createFixture();
+        (panel as any).group = fromPartial<DockviewGroupPanel>({
+            id: 'other_group',
+        });
+
+        let events = 0;
+        const disposable = cut.onDidActiveGroupChange(() => {
+            events++;
+        });
+
+        (group as any).isActive = true;
+        emitters.onDidActiveChange.fire({});
+
+        expect(events).toBe(0);
+
+        disposable.dispose();
+    });
+
+    test('setting group to the same value is a no-op', () => {
+        const { cut, group } = createFixture();
+
+        let events = 0;
+        const disposable = cut.onDidGroupChange(() => {
+            events++;
+        });
+
+        cut.group = group;
+
+        expect(events).toBe(0);
+        expect(cut.group).toBe(group);
+
+        disposable.dispose();
+    });
+
+    test('onDidTitleChange fires when the internal title emitter fires', () => {
+        const { cut } = createFixture();
+
+        const events: string[] = [];
+        const disposable = cut.onDidTitleChange((e) => {
+            events.push(e.title);
+        });
+
+        cut._onDidTitleChange.fire({ title: 'next' });
+
+        expect(events).toEqual(['next']);
+
+        disposable.dispose();
+    });
+
+    test('onDidChangePinned fires when the internal pinned emitter fires', () => {
+        const { cut } = createFixture();
+
+        const events: boolean[] = [];
+        const disposable = cut.onDidChangePinned((e) => {
+            events.push(e.isPinned);
+        });
+
+        cut._onDidChangePinned.fire({ isPinned: true });
+
+        expect(events).toEqual([true]);
+
+        disposable.dispose();
+    });
+
+    test('onDidRendererChange fires when the internal renderer emitter fires', () => {
+        const { cut } = createFixture();
+
+        const events: string[] = [];
+        const disposable = cut.onDidRendererChange((e) => {
+            events.push(e.renderer);
+        });
+
+        cut._onDidRendererChange.fire({ renderer: 'always' });
+
+        expect(events).toEqual(['always']);
 
         disposable.dispose();
     });

--- a/packages/dockview-core/src/__tests__/dockview/accessibilityMessages.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/accessibilityMessages.spec.ts
@@ -1,0 +1,82 @@
+import {
+    DEFAULT_MESSAGES,
+    resolveMessages,
+} from '../../dockview/accessibilityMessages';
+
+describe('accessibilityMessages', () => {
+    describe('DEFAULT_MESSAGES', () => {
+        test('panel + group lifecycle announcements', () => {
+            expect(DEFAULT_MESSAGES.panelOpened('Logs')).toBe('Logs opened');
+            expect(DEFAULT_MESSAGES.panelClosed('Logs')).toBe('Logs closed');
+            expect(DEFAULT_MESSAGES.groupMaximized('A')).toBe('A maximized');
+            expect(DEFAULT_MESSAGES.groupRestored('A')).toBe('A restored');
+            expect(DEFAULT_MESSAGES.groupFloated('A')).toBe('A floated');
+            expect(DEFAULT_MESSAGES.groupDocked('A')).toBe('A docked');
+            expect(DEFAULT_MESSAGES.groupPoppedOut('A')).toBe(
+                'A opened in a new window'
+            );
+        });
+
+        test('tab close labels', () => {
+            expect(DEFAULT_MESSAGES.closeTab('Editor')).toBe('Close Editor');
+            expect(DEFAULT_MESSAGES.closeTabPlain()).toBe('Close');
+        });
+
+        test('move: target-phase prompt includes position and progress', () => {
+            expect(DEFAULT_MESSAGES.movePickTarget('Src', 'Dst', 2, 5)).toBe(
+                'Moving Src. Target Dst, 2 of 5. Enter to choose where, Escape to cancel.'
+            );
+        });
+
+        test('move: edge-phase prompt reads "Tab into" for center', () => {
+            expect(DEFAULT_MESSAGES.movePickEdge('center', 'Dst')).toBe(
+                'Tab into Dst. Arrows to change, Enter to confirm, Escape to go back.'
+            );
+        });
+
+        test('move: edge-phase prompt reads "Split <side>" for an edge', () => {
+            expect(DEFAULT_MESSAGES.movePickEdge('left', 'Dst')).toBe(
+                'Split left of Dst. Arrows to change, Enter to confirm, Escape to go back.'
+            );
+        });
+
+        test('move: commit sentence reads "docked into" for center', () => {
+            expect(DEFAULT_MESSAGES.moveCommitted('Src', 'Dst', 'center')).toBe(
+                'Src docked into Dst.'
+            );
+        });
+
+        test('move: commit sentence reads "split <side>" for an edge', () => {
+            expect(DEFAULT_MESSAGES.moveCommitted('Src', 'Dst', 'bottom')).toBe(
+                'Src split bottom of Dst.'
+            );
+        });
+
+        test('move: terminal announcements', () => {
+            expect(DEFAULT_MESSAGES.moveCancelled()).toBe('Move cancelled.');
+            expect(DEFAULT_MESSAGES.moveNotAllowed()).toBe(
+                'That move is not allowed.'
+            );
+            expect(DEFAULT_MESSAGES.moveFloated('Src')).toBe('Src floated.');
+        });
+    });
+
+    describe('resolveMessages', () => {
+        test('returns the defaults verbatim when no overrides are given', () => {
+            expect(resolveMessages()).toBe(DEFAULT_MESSAGES);
+            expect(resolveMessages(undefined)).toBe(DEFAULT_MESSAGES);
+        });
+
+        test('layers a partial override over the defaults', () => {
+            const resolved = resolveMessages({
+                panelOpened: (title) => `opened ${title}`,
+            });
+            // overridden entry wins...
+            expect(resolved.panelOpened('X')).toBe('opened X');
+            // ...untouched entries keep the English defaults.
+            expect(resolved.panelClosed('X')).toBe('X closed');
+            // and the defaults object itself is not mutated.
+            expect(DEFAULT_MESSAGES.panelOpened('X')).toBe('X opened');
+        });
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/floatingTitleBar.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/floatingTitleBar.spec.ts
@@ -1,0 +1,272 @@
+import { FloatingTitleBar } from '../../../../dockview/components/titlebar/floatingTitleBar';
+import { fromPartial } from '@total-typescript/shoehorn';
+import type { DockviewComponent } from '../../../../dockview/dockviewComponent';
+import type { DockviewGroupPanel } from '../../../../dockview/dockviewGroupPanel';
+import { fireEvent } from '@testing-library/dom';
+import { quasiDefaultPrevented } from '../../../../dom';
+import {
+    LocalSelectionTransfer,
+    PanelTransfer,
+} from '../../../../dnd/dataTransfer';
+
+describe('floatingTitleBar', () => {
+    afterEach(() => {
+        LocalSelectionTransfer.getInstance().clearData(PanelTransfer.prototype);
+    });
+
+    function createGroup(overrides: Partial<DockviewGroupPanel> = {}) {
+        return fromPartial<DockviewGroupPanel>({
+            id: 'groupId',
+            size: 1,
+            api: fromPartial<DockviewGroupPanel['api']>({
+                location: { type: 'grid' },
+            }),
+            ...overrides,
+        });
+    }
+
+    describe('element construction', () => {
+        test('that the element is a div with the dv-floating-titlebar class', () => {
+            const accessor = fromPartial<DockviewComponent>({ options: {} });
+            const group = createGroup();
+
+            const cut = new FloatingTitleBar(accessor, group);
+
+            expect(cut.element.tagName).toBe('DIV');
+            expect(cut.element.className).toContain('dv-floating-titlebar');
+
+            cut.dispose();
+        });
+
+        test('that the handle is draggable by default (dnd enabled)', () => {
+            const accessor = fromPartial<DockviewComponent>({ options: {} });
+            const cut = new FloatingTitleBar(accessor, createGroup());
+
+            expect(cut.element.draggable).toBe(true);
+            expect(cut.element.classList.contains('dv-draggable')).toBe(true);
+
+            cut.dispose();
+        });
+
+        test('that the handle is not draggable when disableDnd is true', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                options: { disableDnd: true },
+            });
+            const cut = new FloatingTitleBar(accessor, createGroup());
+
+            expect(cut.element.draggable).toBe(false);
+            expect(cut.element.classList.contains('dv-draggable')).toBe(false);
+
+            cut.dispose();
+        });
+    });
+
+    describe('anchor group', () => {
+        test('that the group getter returns the constructor group', () => {
+            const accessor = fromPartial<DockviewComponent>({ options: {} });
+            const group = createGroup();
+            const cut = new FloatingTitleBar(accessor, group);
+
+            expect(cut.group).toBe(group);
+
+            cut.dispose();
+        });
+
+        test('that setGroup retargets the anchor group', () => {
+            const accessor = fromPartial<DockviewComponent>({ options: {} });
+            const group = createGroup({ id: 'groupA' });
+            const nextGroup = createGroup({ id: 'groupB' });
+            const cut = new FloatingTitleBar(accessor, group);
+
+            cut.setGroup(nextGroup);
+
+            expect(cut.group).toBe(nextGroup);
+
+            cut.dispose();
+        });
+    });
+
+    describe('pointerdown activation', () => {
+        test('that pointerdown activates the anchor group', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+            const group = createGroup();
+            const cut = new FloatingTitleBar(accessor, group);
+
+            expect(accessor.doSetGroupActive).not.toHaveBeenCalled();
+
+            fireEvent.pointerDown(cut.element);
+
+            expect(accessor.doSetGroupActive).toHaveBeenCalledWith(group);
+
+            cut.dispose();
+        });
+
+        test('that pointerdown activates the *current* anchor group after setGroup', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+            const group = createGroup({ id: 'groupA' });
+            const nextGroup = createGroup({ id: 'groupB' });
+            const cut = new FloatingTitleBar(accessor, group);
+
+            cut.setGroup(nextGroup);
+            fireEvent.pointerDown(cut.element);
+
+            expect(accessor.doSetGroupActive).toHaveBeenCalledWith(nextGroup);
+            expect(accessor.doSetGroupActive).not.toHaveBeenCalledWith(group);
+
+            cut.dispose();
+        });
+
+        test('that pointerdown no longer activates once disposed', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+            const cut = new FloatingTitleBar(accessor, createGroup());
+
+            cut.dispose();
+            fireEvent.pointerDown(cut.element);
+
+            expect(accessor.doSetGroupActive).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('shift+pointerdown disambiguation', () => {
+        test('that a shift+pointerdown is quasi-prevented (blocks the overlay move drag)', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+            const cut = new FloatingTitleBar(accessor, createGroup());
+
+            const event = new Event('pointerdown');
+            (event as any).shiftKey = true;
+            fireEvent(cut.element, event);
+
+            expect(quasiDefaultPrevented(event)).toBe(true);
+
+            cut.dispose();
+        });
+
+        test('that a plain pointerdown is NOT quasi-prevented', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+            const cut = new FloatingTitleBar(accessor, createGroup());
+
+            const event = new Event('pointerdown');
+            (event as any).shiftKey = false;
+            fireEvent(cut.element, event);
+
+            expect(quasiDefaultPrevented(event)).toBeFalsy();
+
+            cut.dispose();
+        });
+    });
+
+    describe('onDragStart wiring', () => {
+        test('that the drag source drag-start is re-emitted through onDragStart', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                id: 'accessorId',
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+            const group = createGroup();
+            const cut = new FloatingTitleBar(accessor, group);
+
+            const onDragStart = jest.fn();
+            cut.onDragStart(onDragStart);
+
+            const event = new Event('dragstart');
+            Object.defineProperty(event, 'dataTransfer', {
+                value: {
+                    setDragImage: jest.fn(),
+                    setData: jest.fn(),
+                    items: [],
+                } as unknown as DataTransfer,
+            });
+            fireEvent(cut.element, event);
+
+            expect(onDragStart).toHaveBeenCalledTimes(1);
+
+            cut.dispose();
+        });
+
+        test('that the html5 drag publishes a whole-group PanelTransfer for the current anchor', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                id: 'accessorId',
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+            const group = createGroup({ id: 'groupA' });
+            const nextGroup = createGroup({ id: 'groupB' });
+            const cut = new FloatingTitleBar(accessor, group);
+
+            // retarget before dragging: the drag source resolves the group
+            // lazily, so the transfer must reference the new anchor.
+            cut.setGroup(nextGroup);
+
+            const event = new Event('dragstart');
+            Object.defineProperty(event, 'dataTransfer', {
+                value: {
+                    setDragImage: jest.fn(),
+                    setData: jest.fn(),
+                    items: [],
+                } as unknown as DataTransfer,
+            });
+            fireEvent(cut.element, event);
+
+            const transfer =
+                LocalSelectionTransfer.getInstance<PanelTransfer>();
+            expect(transfer.hasData(PanelTransfer.prototype)).toBe(true);
+            const data = transfer.getData(PanelTransfer.prototype)!;
+            expect(data[0].viewId).toBe('accessorId');
+            expect(data[0].groupId).toBe('groupB');
+            // null panelId marks a whole-group drag
+            expect(data[0].panelId).toBeNull();
+
+            cut.dispose();
+        });
+    });
+
+    describe('updateDragAndDropState', () => {
+        test('that it re-reads dnd capabilities and toggles draggable state', () => {
+            const options = { disableDnd: false };
+            const accessor = fromPartial<DockviewComponent>({ options });
+            const cut = new FloatingTitleBar(accessor, createGroup());
+
+            expect(cut.element.draggable).toBe(true);
+            expect(cut.element.classList.contains('dv-draggable')).toBe(true);
+
+            options.disableDnd = true;
+            cut.updateDragAndDropState();
+            expect(cut.element.draggable).toBe(false);
+            expect(cut.element.classList.contains('dv-draggable')).toBe(false);
+
+            options.disableDnd = false;
+            cut.updateDragAndDropState();
+            expect(cut.element.draggable).toBe(true);
+            expect(cut.element.classList.contains('dv-draggable')).toBe(true);
+
+            cut.dispose();
+        });
+    });
+
+    describe('disposal', () => {
+        test('that dispose does not throw and can be called safely', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                options: {},
+                doSetGroupActive: jest.fn(),
+            });
+            const cut = new FloatingTitleBar(accessor, createGroup());
+
+            expect(() => cut.dispose()).not.toThrow();
+        });
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
@@ -1,0 +1,864 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import {
+    TabGroupManager,
+    TabGroupManagerCallbacks,
+    TabGroupManagerContext,
+} from '../../../../dockview/components/titlebar/tabGroups';
+import { TabGroup } from '../../../../dockview/tabGroup';
+import { DockviewComponent } from '../../../../dockview/dockviewComponent';
+import { DockviewGroupPanel } from '../../../../dockview/dockviewGroupPanel';
+import { DockviewGroupPanelModel } from '../../../../dockview/dockviewGroupPanelModel';
+import { Tab } from '../../../../dockview/components/tab/tab';
+import { IDockviewPanel } from '../../../../dockview/dockviewPanel';
+import { IValueDisposable } from '../../../../lifecycle';
+import {
+    DEFAULT_TAB_GROUP_COLORS,
+    TabGroupColorPalette,
+} from '../../../../dockview/tabGroupAccent';
+import { ITabGroupChipRenderer } from '../../../../dockview/framework';
+import { DockviewHeaderDirection } from '../../../../dockview/options';
+
+function createTab(id: string): IValueDisposable<Tab> {
+    const element = document.createElement('div');
+    element.className = 'dv-tab';
+    const value = fromPartial<Tab>({
+        element,
+        panel: fromPartial<IDockviewPanel>({ id }),
+    });
+    return { value, disposable: { dispose: jest.fn() } };
+}
+
+interface Harness {
+    manager: TabGroupManager;
+    ctx: TabGroupManagerContext;
+    callbacks: {
+        onChipContextMenu: jest.Mock;
+        onChipDragStart: jest.Mock;
+        onChipDragEnd: jest.Mock;
+        onChipDrop: jest.Mock;
+    };
+    tabsList: HTMLElement;
+    tabMap: Map<string, IValueDisposable<Tab>>;
+    group: DockviewGroupPanel;
+    accessor: DockviewComponent;
+    options: Record<string, any>;
+    state: { direction: DockviewHeaderDirection };
+    tabGroups: TabGroup[];
+}
+
+const managersToDispose: TabGroupManager[] = [];
+
+function createManager(
+    opts: {
+        tabs?: IValueDisposable<Tab>[];
+        tabGroups?: TabGroup[];
+        options?: Record<string, any>;
+        direction?: DockviewHeaderDirection;
+        activePanelId?: string;
+        createChip?: (tabGroup: any) => ITabGroupChipRenderer;
+    } = {}
+): Harness {
+    const tabs = opts.tabs ?? [];
+    const tabsList = document.createElement('div');
+    const tabMap = new Map<string, IValueDisposable<Tab>>();
+    for (const t of tabs) {
+        tabMap.set(t.value.panel.id, t);
+        tabsList.appendChild(t.value.element);
+    }
+
+    const tabGroups = opts.tabGroups ?? [];
+    const options: Record<string, any> = opts.options ?? {};
+    if (opts.createChip) {
+        options.createTabGroupChipComponent = opts.createChip;
+    }
+    const state = { direction: opts.direction ?? 'horizontal' };
+
+    const model = fromPartial<DockviewGroupPanelModel>({
+        getTabGroups: () => tabGroups,
+        canDisplayOverlay: jest.fn().mockReturnValue(false),
+        headerPosition: 'top',
+    });
+
+    const group = fromPartial<DockviewGroupPanel>({
+        id: 'group-1',
+        model,
+        locked: false,
+        activePanel: opts.activePanelId
+            ? fromPartial<IDockviewPanel>({ id: opts.activePanelId })
+            : undefined,
+    });
+
+    const accessor = fromPartial<DockviewComponent>({
+        id: 'accessor-1',
+        options,
+        api: fromPartial<DockviewComponent['api']>({}),
+        element: document.createElement('div'),
+        tabGroupColorPalette: new TabGroupColorPalette(
+            DEFAULT_TAB_GROUP_COLORS,
+            true
+        ),
+    });
+
+    const callbacks = {
+        onChipContextMenu: jest.fn(),
+        onChipDragStart: jest.fn(),
+        onChipDragEnd: jest.fn(),
+        onChipDrop: jest.fn(),
+    };
+
+    const ctx: TabGroupManagerContext = {
+        group,
+        accessor,
+        tabsList,
+        getTabs: () => tabs,
+        getTabMap: () => tabMap,
+        getDirection: () => state.direction,
+    };
+
+    const manager = new TabGroupManager(
+        ctx,
+        callbacks as unknown as TabGroupManagerCallbacks
+    );
+    managersToDispose.push(manager);
+
+    return {
+        manager,
+        ctx,
+        callbacks,
+        tabsList,
+        tabMap,
+        group,
+        accessor,
+        options,
+        state,
+        tabGroups,
+    };
+}
+
+function makeGroup(id: string, panelIds: string[], opts?: any): TabGroup {
+    const tg = new TabGroup(id, opts);
+    for (const pid of panelIds) {
+        tg.addPanel(pid);
+    }
+    return tg;
+}
+
+function mockChipRenderer(): ITabGroupChipRenderer & {
+    init: jest.Mock;
+    update: jest.Mock;
+    dispose: jest.Mock;
+} {
+    const element = document.createElement('div');
+    element.className = 'dv-tab-group-chip';
+    return {
+        element,
+        init: jest.fn(),
+        update: jest.fn(),
+        dispose: jest.fn(),
+    };
+}
+
+describe('TabGroupManager', () => {
+    afterEach(() => {
+        while (managersToDispose.length > 0) {
+            managersToDispose.pop()?.disposeAll();
+        }
+    });
+
+    describe('chip creation & group membership', () => {
+        test('update creates a chip per tab group and positions it before the first tab', () => {
+            const tabs = [createTab('p1'), createTab('p2'), createTab('p3')];
+            const tg = makeGroup('g1', ['p1', 'p2'], { color: 'blue' });
+            const { manager, tabsList } = createManager({
+                tabs,
+                tabGroups: [tg],
+            });
+
+            manager.update();
+
+            expect(manager.chipRenderers.has('g1')).toBe(true);
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+            // chip inserted immediately before p1's tab element
+            expect(chipEl.nextSibling).toBe(tabs[0].value.element);
+            expect(tabsList.firstChild).toBe(chipEl);
+        });
+
+        test('update applies membership CSS classes (grouped/first/last) and accent', () => {
+            const tabs = [createTab('p1'), createTab('p2'), createTab('p3')];
+            const tg = makeGroup('g1', ['p1', 'p2'], { color: 'blue' });
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+
+            expect(
+                tabs[0].value.element.classList.contains('dv-tab--grouped')
+            ).toBe(true);
+            expect(
+                tabs[0].value.element.classList.contains('dv-tab--group-first')
+            ).toBe(true);
+            expect(
+                tabs[0].value.element.classList.contains('dv-tab--group-last')
+            ).toBe(false);
+
+            expect(
+                tabs[1].value.element.classList.contains('dv-tab--group-last')
+            ).toBe(true);
+            expect(
+                tabs[1].value.element.classList.contains('dv-tab--group-first')
+            ).toBe(false);
+
+            // ungrouped tab
+            expect(
+                tabs[2].value.element.classList.contains('dv-tab--grouped')
+            ).toBe(false);
+
+            // accent custom property resolved from palette
+            expect(
+                tabs[0].value.element.style.getPropertyValue(
+                    '--dv-tab-group-color'
+                )
+            ).toBe('var(--dv-tab-group-color-blue)');
+            // ungrouped tab has no accent property
+            expect(
+                tabs[2].value.element.style.getPropertyValue(
+                    '--dv-tab-group-color'
+                )
+            ).toBe('');
+        });
+
+        test('membership classes are cleared when a tab leaves its group', () => {
+            const tabs = [createTab('p1'), createTab('p2')];
+            const tg = makeGroup('g1', ['p1', 'p2'], { color: 'red' });
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            expect(
+                tabs[1].value.element.classList.contains('dv-tab--grouped')
+            ).toBe(true);
+
+            tg.removePanel('p2');
+            manager.update();
+
+            expect(
+                tabs[1].value.element.classList.contains('dv-tab--grouped')
+            ).toBe(false);
+            expect(
+                tabs[1].value.element.style.getPropertyValue(
+                    '--dv-tab-group-color'
+                )
+            ).toBe('');
+        });
+
+        test('a dissolved group has its chip removed and disposed', () => {
+            const tabs = [createTab('p1'), createTab('p2')];
+            const tg = makeGroup('g1', ['p1', 'p2']);
+            const harness = createManager({ tabs, tabGroups: [tg] });
+
+            harness.manager.update();
+            const chipEl =
+                harness.manager.chipRenderers.get('g1')!.chip.element;
+            expect(harness.tabsList.contains(chipEl)).toBe(true);
+
+            // dissolve the group
+            harness.tabGroups.length = 0;
+            harness.manager.update();
+
+            expect(harness.manager.chipRenderers.has('g1')).toBe(false);
+            expect(harness.tabsList.contains(chipEl)).toBe(false);
+        });
+
+        test('chip is removed from the DOM when the group has no panels', () => {
+            const tg = makeGroup('g1', []);
+            const { manager, tabsList } = createManager({
+                tabs: [],
+                tabGroups: [tg],
+            });
+
+            manager.update();
+
+            expect(manager.chipRenderers.has('g1')).toBe(true);
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+            expect(tabsList.contains(chipEl)).toBe(false);
+        });
+
+        test('chip is removed when the first panel has no rendered tab', () => {
+            const tg = makeGroup('g1', ['ghost']);
+            const { manager, tabsList } = createManager({
+                tabs: [],
+                tabGroups: [tg],
+            });
+
+            manager.update();
+
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+            expect(tabsList.contains(chipEl)).toBe(false);
+        });
+    });
+
+    describe('custom chip renderer', () => {
+        test('uses createTabGroupChipComponent and calls init', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const chip = mockChipRenderer();
+            const createChip = jest.fn().mockReturnValue(chip);
+
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                createChip,
+            });
+
+            manager.update();
+
+            expect(createChip).toHaveBeenCalledWith(tg);
+            expect(chip.init).toHaveBeenCalledTimes(1);
+            expect(manager.chipRenderers.get('g1')!.chip).toBe(chip);
+        });
+
+        test('refreshAccents calls chip.update for each group', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const chip = mockChipRenderer();
+
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                createChip: () => chip,
+            });
+
+            manager.update();
+            chip.update.mockClear();
+
+            manager.refreshAccents();
+
+            expect(chip.update).toHaveBeenCalledWith({ tabGroup: tg });
+        });
+
+        test('a tab group onDidChange refreshes the chip', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const chip = mockChipRenderer();
+
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                createChip: () => chip,
+            });
+
+            manager.update();
+            chip.update.mockClear();
+
+            tg.setLabel('renamed');
+
+            expect(chip.update).toHaveBeenCalledWith({ tabGroup: tg });
+        });
+
+        test('a custom chip forwards contextmenu events to the callback', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const chip = mockChipRenderer();
+
+            const { manager, callbacks } = createManager({
+                tabs,
+                tabGroups: [tg],
+                createChip: () => chip,
+            });
+
+            manager.update();
+
+            const event = new MouseEvent('contextmenu');
+            chip.element.dispatchEvent(event);
+
+            expect(callbacks.onChipContextMenu).toHaveBeenCalledWith(tg, event);
+        });
+    });
+
+    describe('built-in chip interactions', () => {
+        test('right-clicking the built-in chip forwards to onChipContextMenu', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager, callbacks } = createManager({
+                tabs,
+                tabGroups: [tg],
+            });
+
+            manager.update();
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+
+            const event = new MouseEvent('contextmenu');
+            chipEl.dispatchEvent(event);
+
+            expect(callbacks.onChipContextMenu).toHaveBeenCalledTimes(1);
+            expect(callbacks.onChipContextMenu.mock.calls[0][0]).toBe(tg);
+        });
+    });
+
+    describe('collapse / expand', () => {
+        test('a group born collapsed applies the collapsed class instantly', () => {
+            const tabs = [createTab('p1'), createTab('p2')];
+            const tg = makeGroup('g1', ['p1', 'p2'], { collapsed: true });
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+
+            expect(
+                tabs[0].value.element.classList.contains(
+                    'dv-tab--group-collapsed'
+                )
+            ).toBe(true);
+            expect(
+                tabs[1].value.element.classList.contains(
+                    'dv-tab--group-collapsed'
+                )
+            ).toBe(true);
+            // the one-shot skip flag is reset after the update
+            expect(manager.skipNextCollapseAnimation).toBe(false);
+        });
+
+        test('collapse animation in vertical orientation adds the collapsed class', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                direction: 'vertical',
+            });
+
+            manager.update();
+            tg.collapse();
+            manager.update();
+
+            expect(
+                tabs[0].value.element.classList.contains(
+                    'dv-tab--group-collapsed'
+                )
+            ).toBe(true);
+        });
+
+        test('collapsing an existing group animates the collapsed class on', () => {
+            const tabs = [createTab('p1'), createTab('p2')];
+            const tg = makeGroup('g1', ['p1', 'p2']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            expect(
+                tabs[0].value.element.classList.contains(
+                    'dv-tab--group-collapsed'
+                )
+            ).toBe(false);
+
+            tg.collapse();
+            manager.update();
+
+            expect(
+                tabs[0].value.element.classList.contains(
+                    'dv-tab--group-collapsed'
+                )
+            ).toBe(true);
+        });
+
+        test('expanding a collapsed tab adds the expanding class and cleanupTransition clears it', () => {
+            const tabs = [createTab('p1')];
+            tabs[0].value.element.classList.add('dv-tab--group-collapsed');
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+
+            expect(
+                tabs[0].value.element.classList.contains(
+                    'dv-tab--group-expanding'
+                )
+            ).toBe(true);
+            expect(
+                tabs[0].value.element.classList.contains(
+                    'dv-tab--group-collapsed'
+                )
+            ).toBe(false);
+
+            manager.cleanupTransition('p1');
+
+            expect(
+                tabs[0].value.element.classList.contains(
+                    'dv-tab--group-expanding'
+                )
+            ).toBe(false);
+        });
+
+        test('cleanupTransition is a no-op for an unknown panel', () => {
+            const { manager } = createManager();
+            expect(() => manager.cleanupTransition('nope')).not.toThrow();
+        });
+
+        test('skipNextCollapseAnimation getter/setter round-trips', () => {
+            const { manager } = createManager();
+            expect(manager.skipNextCollapseAnimation).toBe(false);
+            manager.skipNextCollapseAnimation = true;
+            expect(manager.skipNextCollapseAnimation).toBe(true);
+        });
+    });
+
+    describe('underline / indicator', () => {
+        test('groupUnderlines is empty before any update', () => {
+            const { manager } = createManager();
+            expect(manager.groupUnderlines.size).toBe(0);
+        });
+
+        test('update creates an underline element per active group', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1'], { color: 'blue' });
+            const { manager, tabsList } = createManager({
+                tabs,
+                tabGroups: [tg],
+            });
+
+            manager.update();
+
+            expect(manager.groupUnderlines.has('g1')).toBe(true);
+            const underline = manager.groupUnderlines.get('g1')!;
+            expect(underline.classList.contains('dv-tab-group-underline')).toBe(
+                true
+            );
+            expect(tabsList.contains(underline)).toBe(true);
+        });
+
+        test('the "none" indicator strategy still tracks underlines', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1'], { color: 'blue' });
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                options: { theme: { tabGroupIndicator: 'none' } },
+            });
+
+            manager.update();
+
+            expect(manager.groupUnderlines.has('g1')).toBe(true);
+        });
+
+        test('positionUnderlines / trackUnderlines do not throw', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1'], { color: 'blue' });
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+
+            expect(() => manager.positionUnderlines()).not.toThrow();
+            expect(() => manager.trackUnderlines()).not.toThrow();
+        });
+
+        test('positionUnderlines synchronously reads the indicator context', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1'], { color: 'blue' });
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                activePanelId: 'p1',
+            });
+
+            manager.update();
+
+            const raf = jest
+                .spyOn(global, 'requestAnimationFrame')
+                .mockImplementation((cb: FrameRequestCallback) => {
+                    cb(0);
+                    return 0;
+                });
+            try {
+                expect(() => manager.positionUnderlines()).not.toThrow();
+            } finally {
+                raf.mockRestore();
+            }
+        });
+
+        test('switching the indicator strategy at runtime recreates the indicator', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1'], { color: 'blue' });
+            const { manager, options } = createManager({
+                tabs,
+                tabGroups: [tg],
+                options: { theme: { tabGroupIndicator: 'wrap' } },
+            });
+
+            manager.update();
+            expect(manager.groupUnderlines.has('g1')).toBe(true);
+
+            options.theme.tabGroupIndicator = 'none';
+            expect(() => manager.update()).not.toThrow();
+            expect(manager.groupUnderlines.has('g1')).toBe(true);
+        });
+    });
+
+    describe('chip positioning helpers', () => {
+        test('positionAllChips returns early when there are no chips', () => {
+            const { manager } = createManager();
+            expect(() => manager.positionAllChips()).not.toThrow();
+        });
+
+        test('positionAllChips re-inserts chips before their first tab', () => {
+            const tabs = [createTab('p1'), createTab('p2')];
+            const tg = makeGroup('g1', ['p1', 'p2']);
+            const { manager, tabsList } = createManager({
+                tabs,
+                tabGroups: [tg],
+            });
+
+            manager.update();
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+
+            // move the chip elsewhere then re-position
+            tabsList.appendChild(chipEl);
+            expect(tabsList.firstChild).not.toBe(chipEl);
+
+            manager.positionAllChips();
+            expect(tabsList.firstChild).toBe(chipEl);
+        });
+
+        test('snapshotChipWidths returns a width per chip', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            const widths = manager.snapshotChipWidths();
+
+            expect(widths.has('g1')).toBe(true);
+            expect(typeof widths.get('g1')).toBe('number');
+        });
+    });
+
+    describe('direction & drag-and-drop state', () => {
+        test('updateDirection sets drop-target zones per orientation', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager, state } = createManager({
+                tabs,
+                tabGroups: [tg],
+            });
+
+            manager.update();
+            const dropTarget = manager.chipRenderers.get('g1')!.dropTarget;
+            const spy = jest.spyOn(dropTarget, 'setTargetZones');
+
+            manager.updateDirection();
+            expect(spy).toHaveBeenLastCalledWith(['left']);
+
+            state.direction = 'vertical';
+            manager.updateDirection();
+            expect(spy).toHaveBeenLastCalledWith(['top']);
+        });
+
+        test('updateDragAndDropState reflects disableDnd on the chip element', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager, options } = createManager({
+                tabs,
+                tabGroups: [tg],
+                options: { dndStrategy: 'html5' },
+            });
+
+            manager.update();
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+            expect(chipEl.draggable).toBe(true);
+
+            options.disableDnd = true;
+            manager.updateDragAndDropState();
+            expect(chipEl.draggable).toBe(false);
+        });
+    });
+
+    describe('native html5 drag wiring', () => {
+        test('a native dragstart/dragend on the chip drives the callbacks', () => {
+            const tabs = [createTab('p1'), createTab('p2')];
+            const tg = makeGroup('g1', ['p1', 'p2']);
+            const { manager, callbacks } = createManager({
+                tabs,
+                tabGroups: [tg],
+                options: { dndStrategy: 'html5' },
+            });
+
+            manager.update();
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+
+            const startEvent = new Event('dragstart', { bubbles: true });
+            Object.defineProperty(startEvent, 'dataTransfer', {
+                value: {
+                    setData: jest.fn(),
+                    setDragImage: jest.fn(),
+                    items: { length: 0 },
+                    effectAllowed: '',
+                },
+            });
+            chipEl.dispatchEvent(startEvent);
+
+            expect(callbacks.onChipDragStart).toHaveBeenCalledTimes(1);
+            expect(callbacks.onChipDragStart.mock.calls[0][0]).toBe(tg);
+
+            const endEvent = new Event('dragend', { bubbles: true });
+            chipEl.dispatchEvent(endEvent);
+
+            expect(callbacks.onChipDragEnd).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('chip drag source lifecycle (#1410)', () => {
+        test('disposeChipDrag clears the drag sources and update re-arms them', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            const entry = manager.chipRenderers.get('g1')!;
+            expect(entry.html5DragSource).toBeDefined();
+            expect(entry.pointerDragSource).toBeDefined();
+
+            manager.disposeChipDrag('g1');
+            expect(entry.html5DragSource).toBeUndefined();
+            expect(entry.pointerDragSource).toBeUndefined();
+
+            // a subsequent update re-arms the sources on the same chip element
+            manager.update();
+            expect(entry.html5DragSource).toBeDefined();
+            expect(entry.pointerDragSource).toBeDefined();
+        });
+
+        test('disposeChipDrag is a no-op for an unknown group', () => {
+            const { manager } = createManager();
+            expect(() => manager.disposeChipDrag('nope')).not.toThrow();
+        });
+    });
+
+    describe('setGroupDragImage', () => {
+        test('returns early without a dataTransfer', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+            manager.update();
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+
+            expect(() =>
+                manager.setGroupDragImage(
+                    { dataTransfer: null } as any,
+                    tg,
+                    chipEl
+                )
+            ).not.toThrow();
+        });
+
+        test('sets the drag image using the cloned chip (horizontal)', () => {
+            const tabs = [createTab('p1'), createTab('p2')];
+            const tg = makeGroup('g1', ['p1', 'p2']);
+            const { manager, accessor } = createManager({
+                tabs,
+                tabGroups: [tg],
+            });
+            manager.update();
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+
+            const setDragImage = jest.fn();
+            const event = {
+                dataTransfer: { setDragImage },
+                clientX: 5,
+                clientY: 7,
+            } as any;
+
+            manager.setGroupDragImage(event, tg, chipEl);
+
+            expect(setDragImage).toHaveBeenCalledTimes(1);
+            // the wrapper is appended to the dockview root during the call
+            expect(setDragImage.mock.calls[0][0]).toBeInstanceOf(HTMLElement);
+            // wrapper is mounted inside the accessor element
+            expect(
+                accessor.element.querySelector('.dv-groupview')
+            ).toBeTruthy();
+        });
+
+        test('falls back to the cursor offset when the clone has no chip', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            // custom chip WITHOUT the .dv-tab-group-chip class, so the cloned
+            // tabs list contains no `.dv-tab-group-chip` to anchor against.
+            const chip = mockChipRenderer();
+            chip.element.className = 'custom-chip';
+
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                createChip: () => chip,
+            });
+            manager.update();
+
+            const setDragImage = jest.fn();
+            const event = {
+                dataTransfer: { setDragImage },
+                clientX: 3,
+                clientY: 4,
+            } as any;
+
+            manager.setGroupDragImage(event, tg, chip.element);
+            expect(setDragImage).toHaveBeenCalledTimes(1);
+        });
+
+        test('sets the drag image in vertical orientation', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                direction: 'vertical',
+            });
+            manager.update();
+            const chipEl = manager.chipRenderers.get('g1')!.chip.element;
+
+            const setDragImage = jest.fn();
+            const event = {
+                dataTransfer: { setDragImage },
+                clientX: 1,
+                clientY: 2,
+            } as any;
+
+            manager.setGroupDragImage(event, tg, chipEl);
+            expect(setDragImage).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('disposeAll', () => {
+        test('disposes chips, indicator and clears the chip map', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const chip = mockChipRenderer();
+            const { manager } = createManager({
+                tabs,
+                tabGroups: [tg],
+                createChip: () => chip,
+            });
+
+            manager.update();
+            expect(manager.chipRenderers.size).toBe(1);
+
+            manager.disposeAll();
+
+            expect(chip.dispose).toHaveBeenCalledTimes(1);
+            expect(manager.chipRenderers.size).toBe(0);
+            expect(manager.groupUnderlines.size).toBe(0);
+        });
+
+        test('disposeAll flushes a pending expand transition cleanup', () => {
+            const tabs = [createTab('p1')];
+            tabs[0].value.element.classList.add('dv-tab--group-collapsed');
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            // an expand animation is now pending
+            expect(
+                tabs[0].value.element.classList.contains(
+                    'dv-tab--group-expanding'
+                )
+            ).toBe(true);
+
+            expect(() => manager.disposeAll()).not.toThrow();
+            expect(manager.chipRenderers.size).toBe(0);
+        });
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
@@ -11,6 +11,7 @@ import { TestPanel } from '../../dockviewGroupPanelModel.spec';
 import { IDockviewPanel } from '../../../../dockview/dockviewPanel';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { DockviewPanelApi } from '../../../../api/dockviewPanelApi';
+import { Emitter } from '../../../../events';
 
 describe('tabsContainer', () => {
     test('that an external event does not render a drop target and calls through to the group mode', () => {
@@ -1542,5 +1543,648 @@ describe('tabsContainer', () => {
                 'dv-right-actions-container-vertical'
             )
         ).toBeFalsy();
+    });
+
+    describe('additional coverage', () => {
+        const makeAccessor = (
+            overrides: Partial<DockviewComponent> = {}
+        ): DockviewComponent =>
+            fromPartial<DockviewComponent>({
+                withOrigin: (_origin: any, fn: () => any) => fn(),
+                onDidAddPanel: jest.fn(),
+                onDidRemovePanel: jest.fn(),
+                doSetGroupActive: jest.fn(),
+                options: {},
+                onDidOptionsChange: jest
+                    .fn()
+                    .mockReturnValue({ dispose: jest.fn() }),
+                ...overrides,
+            });
+
+        const makeGroup = (
+            overrides: Partial<DockviewGroupPanel> = {}
+        ): DockviewGroupPanel =>
+            fromPartial<DockviewGroupPanel>({
+                id: 'testgroupid',
+                model: fromPartial<DockviewGroupPanelModel>({
+                    getTabGroups: () => [],
+                }),
+                api: fromPartial<DockviewGroupPanel['api']>({
+                    locked: false,
+                }),
+                ...overrides,
+            });
+
+        const makeOverflowMockTabs = (tabs: any[]): any => ({
+            tabs,
+            onDrop: jest.fn(),
+            onTabDragStart: jest.fn(),
+            onWillShowOverlay: jest.fn(),
+            onOverflowTabsChange: jest.fn(),
+            size: tabs.length,
+            panels: tabs.map((t) => t.panel.id),
+            isActive: jest.fn(),
+            indexOf: jest.fn(),
+            delete: jest.fn(),
+            setActivePanel: jest.fn(),
+            openPanel: jest.fn(),
+            showTabsOverflowControl: true,
+            updateDragAndDropState: jest.fn(),
+            element: document.createElement('div'),
+            dispose: jest.fn(),
+        });
+
+        const makeOverflowPanel = (
+            id: string,
+            isActive = false
+        ): IDockviewPanel =>
+            fromPartial<IDockviewPanel>({
+                id,
+                api: {
+                    isActive,
+                    setActive: jest.fn(),
+                },
+                view: {
+                    createTabRenderer: jest.fn().mockReturnValue({
+                        element: document.createElement('div'),
+                    }),
+                },
+            });
+
+        test('delegates simple methods and getters to the underlying tabs', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+
+            const listEl = document.createElement('div');
+            const sentinelPanel = fromPartial<IDockviewPanel>({ id: 'sp' });
+
+            const mockTabs = {
+                ...makeOverflowMockTabs([]),
+                isActive: jest.fn().mockReturnValue(true),
+                indexOf: jest.fn().mockReturnValue(3),
+                getTabId: jest.fn().mockReturnValue('the-tab-id'),
+                getPanelForTab: jest.fn().mockReturnValue(sentinelPanel),
+                focusActiveTab: jest.fn(),
+                setActivePanel: jest.fn(),
+                setOverflowExclude: jest.fn(),
+                setForcedOverflow: jest.fn(),
+                setPinnedSticky: jest.fn(),
+                refreshOverflow: jest.fn(),
+                updateTabGroups: jest.fn(),
+                refreshTabGroupAccent: jest.fn(),
+                delete: jest.fn(),
+                size: 2,
+                panels: ['a', 'b'],
+                tabsListElement: listEl,
+            };
+            (cut as any).tabs = mockTabs;
+
+            const tab = {} as any;
+            expect(cut.isActive(tab)).toBe(true);
+            expect(mockTabs.isActive).toHaveBeenCalledWith(tab);
+
+            expect(cut.indexOf('panel')).toBe(3);
+            expect(mockTabs.indexOf).toHaveBeenCalledWith('panel');
+
+            expect(cut.getTabId('panel')).toBe('the-tab-id');
+            expect(mockTabs.getTabId).toHaveBeenCalledWith('panel');
+
+            const el = document.createElement('div');
+            expect(cut.getPanelForTab(el)).toBe(sentinelPanel);
+            expect(mockTabs.getPanelForTab).toHaveBeenCalledWith(el);
+
+            cut.focusActiveTab();
+            expect(mockTabs.focusActiveTab).toHaveBeenCalledTimes(1);
+
+            const activePanel = fromPartial<IDockviewPanel>({ id: 'x' });
+            cut.setActivePanel(activePanel);
+            expect(mockTabs.setActivePanel).toHaveBeenCalledWith(activePanel);
+
+            const excludeFn = (_: string) => true;
+            cut.setOverflowExclude(excludeFn);
+            expect(mockTabs.setOverflowExclude).toHaveBeenCalledWith(excludeFn);
+
+            const forcedFn = (_: string) => true;
+            cut.setForcedOverflow(forcedFn);
+            expect(mockTabs.setForcedOverflow).toHaveBeenCalledWith(forcedFn);
+
+            cut.setPinnedSticky(true);
+            expect(mockTabs.setPinnedSticky).toHaveBeenCalledWith(true);
+
+            cut.refreshOverflow();
+            expect(mockTabs.refreshOverflow).toHaveBeenCalledTimes(1);
+
+            cut.updateTabGroups();
+            expect(mockTabs.updateTabGroups).toHaveBeenCalledTimes(1);
+
+            cut.refreshTabGroupAccent();
+            expect(mockTabs.refreshTabGroupAccent).toHaveBeenCalledTimes(1);
+
+            cut.delete('panel');
+            expect(mockTabs.delete).toHaveBeenCalledWith('panel');
+
+            expect(cut.size).toBe(2);
+            expect(cut.panels).toEqual(['a', 'b']);
+            expect(cut.tabsListElement).toBe(listEl);
+
+            // setActive is a documented noop
+            expect(() => cut.setActive(true)).not.toThrow();
+        });
+
+        test('show/hide/hidden control the element display style', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+
+            cut.hide();
+            expect(cut.element.style.display).toBe('none');
+
+            // show() only clears display when not hidden
+            cut.show();
+            expect(cut.element.style.display).toBe('');
+
+            cut.hidden = true;
+            expect(cut.hidden).toBe(true);
+            expect(cut.element.style.display).toBe('none');
+
+            // show() is a noop while hidden
+            cut.show();
+            expect(cut.element.style.display).toBe('none');
+
+            cut.hidden = false;
+            expect(cut.hidden).toBe(false);
+            expect(cut.element.style.display).toBe('');
+        });
+
+        test('drop index resolver defaults to identity and can be overridden', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+
+            // identity by default
+            expect(cut.resolveDropIndex('panel', 4)).toBe(4);
+
+            const resolver = jest.fn().mockReturnValue(9);
+            cut.setDropIndexResolver(resolver);
+            expect(cut.resolveDropIndex('panel', 4)).toBe(9);
+            expect(resolver).toHaveBeenCalledWith('panel', 4);
+        });
+
+        test('setPinnedRow mounts, replaces and removes the pinned row', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+
+            const row = document.createElement('div');
+            cut.setPinnedRow(row);
+            expect(cut.element.firstChild).toBe(row);
+            expect(row.classList.contains('dv-pinned-row')).toBe(true);
+            expect(
+                cut.element.classList.contains(
+                    'dv-tabs-and-actions-container--pinned-row'
+                )
+            ).toBe(true);
+
+            // setting the same row again is a noop
+            cut.setPinnedRow(row);
+            expect(cut.element.firstChild).toBe(row);
+
+            const row2 = document.createElement('div');
+            cut.setPinnedRow(row2);
+            expect(cut.element.contains(row)).toBe(false);
+            expect(cut.element.firstChild).toBe(row2);
+
+            cut.setPinnedRow(undefined);
+            expect(cut.element.contains(row2)).toBe(false);
+            expect(
+                cut.element.classList.contains(
+                    'dv-tabs-and-actions-container--pinned-row'
+                )
+            ).toBe(false);
+        });
+
+        test('re-emits drop, overlay, tab-drag and group-drag events', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+            const group = (cut as any).group as DockviewGroupPanel;
+
+            const dropEvents: any[] = [];
+            cut.onDrop((e) => dropEvents.push(e));
+            (cut as any).tabs._onDrop.fire({ event: {} as any, index: 5 });
+            expect(dropEvents).toHaveLength(1);
+            expect(dropEvents[0].index).toBe(5);
+
+            const overlayEvents: any[] = [];
+            cut.onWillShowOverlay((e) => overlayEvents.push(e));
+            (cut as any).tabs._onWillShowOverlay.fire({} as any);
+            expect(overlayEvents).toHaveLength(1);
+
+            const tabDragEvents: any[] = [];
+            cut.onTabDragStart((e) => tabDragEvents.push(e));
+            (cut as any).tabs._onTabDragStart.fire({
+                nativeEvent: {} as any,
+                panel: {} as any,
+            });
+            expect(tabDragEvents).toHaveLength(1);
+
+            const groupDragEvents: any[] = [];
+            cut.onGroupDragStart((e) => groupDragEvents.push(e));
+            const dragEvent = {} as any;
+            (cut as any).voidContainer._onDragStart.fire(dragEvent);
+            expect(groupDragEvents).toHaveLength(1);
+            expect(groupDragEvents[0].group).toBe(group);
+            expect(groupDragEvents[0].nativeEvent).toBe(dragEvent);
+
+            const voidDropEvents: any[] = [];
+            cut.onDrop((e) => voidDropEvents.push(e));
+            (cut as any).voidContainer._onDrop.fire({
+                nativeEvent: {} as any,
+            });
+            // no active group drag -> re-emits with the tabs size as index
+            expect(voidDropEvents).toHaveLength(1);
+            expect(voidDropEvents[0].index).toBe((cut as any).tabs.size);
+        });
+
+        test('overflow-tabs change from tabs builds the dropdown', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+
+            (cut as any).tabs._onOverflowTabsChange.fire({
+                tabs: ['a', 'b'],
+                tabGroups: [],
+                pinnedTabs: [],
+                reset: false,
+            });
+
+            const root = cut.element.querySelector(
+                '.dv-tabs-overflow-dropdown-root'
+            );
+            expect(root).toBeTruthy();
+        });
+
+        test('option changes toggle the overflow control on the tabs', () => {
+            const optionsChange = new Emitter<void>();
+            const options: any = { disableTabsOverflowList: false };
+            const accessor = fromPartial<DockviewComponent>({
+                withOrigin: (_origin: any, fn: () => any) => fn(),
+                onDidAddPanel: jest.fn(),
+                onDidRemovePanel: jest.fn(),
+                doSetGroupActive: jest.fn(),
+                options,
+                onDidOptionsChange: optionsChange.event,
+            });
+
+            const cut = new TabsContainer(accessor, makeGroup());
+            const mockTabs = { showTabsOverflowControl: true };
+            (cut as any).tabs = mockTabs;
+
+            options.disableTabsOverflowList = true;
+            optionsChange.fire();
+            expect(mockTabs.showTabsOverflowControl).toBe(false);
+
+            options.disableTabsOverflowList = false;
+            optionsChange.fire();
+            expect(mockTabs.showTabsOverflowControl).toBe(true);
+
+            optionsChange.dispose();
+        });
+
+        test('dragleave on left actions/void container updates tab drag state', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+
+            const mockTabs = {
+                clearExternalAnimState: jest.fn(),
+                setExternalInsertionIndex: jest.fn(),
+            };
+            (cut as any).tabs = mockTabs;
+
+            const leftActions = cut.element.querySelector(
+                '.dv-left-actions-container'
+            ) as HTMLElement;
+            const voidEl = cut.element.querySelector(
+                '.dv-void-container'
+            ) as HTMLElement;
+
+            const dragLeaveWith = (
+                target: HTMLElement,
+                relatedTarget: EventTarget | null
+            ): void => {
+                const evt = new Event('dragleave', { bubbles: true });
+                Object.defineProperty(evt, 'relatedTarget', {
+                    value: relatedTarget,
+                    configurable: true,
+                });
+                fireEvent(target, evt);
+            };
+
+            // Leaving the header entirely from the left actions clears state.
+            dragLeaveWith(leftActions, null);
+            expect(mockTabs.clearExternalAnimState).toHaveBeenCalledTimes(1);
+
+            // Leaving into the left actions container itself does nothing.
+            mockTabs.clearExternalAnimState.mockClear();
+            dragLeaveWith(leftActions, leftActions);
+            expect(mockTabs.clearExternalAnimState).not.toHaveBeenCalled();
+
+            // Leaving the void container for the header entirely clears state.
+            dragLeaveWith(voidEl, document.createElement('div'));
+            expect(mockTabs.clearExternalAnimState).toHaveBeenCalledTimes(1);
+
+            // Leaving the void container for another header part keeps state.
+            dragLeaveWith(voidEl, leftActions);
+            expect(mockTabs.setExternalInsertionIndex).toHaveBeenCalledWith(
+                null
+            );
+        });
+
+        test('void container pointerdown is ignored when default is prevented', () => {
+            const accessor = makeAccessor({
+                element: document.createElement('div'),
+                addFloatingGroup: jest.fn(),
+                options: { disableFloatingGroups: false },
+            });
+            const cut = new TabsContainer(
+                accessor,
+                makeGroup({
+                    api: fromPartial<DockviewGroupPanel['api']>({
+                        location: { type: 'grid' } as any,
+                    }),
+                })
+            );
+
+            const voidEl = cut.element.querySelector(
+                '.dv-void-container'
+            ) as HTMLElement;
+
+            const evt = new KeyboardEvent('pointerdown', {
+                shiftKey: true,
+                cancelable: true,
+                bubbles: true,
+            });
+            evt.preventDefault();
+            fireEvent(voidEl, evt);
+
+            expect(accessor.addFloatingGroup).not.toHaveBeenCalled();
+        });
+
+        test('toggleDropdown updates count in place and disposes on reset', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+
+            (cut as any).toggleDropdown({
+                tabs: ['a', 'b'],
+                tabGroups: [],
+                pinnedTabs: [],
+                reset: false,
+            });
+            const root = cut.element.querySelector(
+                '.dv-tabs-overflow-dropdown-root'
+            ) as HTMLElement;
+            expect(root).toBeTruthy();
+            expect(root.querySelector('span')?.textContent).toBe('2');
+
+            // second call reuses the same root and updates the count
+            (cut as any).toggleDropdown({
+                tabs: ['a', 'b', 'c'],
+                tabGroups: [],
+                pinnedTabs: [],
+                reset: false,
+            });
+            expect(
+                cut.element.querySelector('.dv-tabs-overflow-dropdown-root')
+            ).toBe(root);
+            expect(root.querySelector('span')?.textContent).toBe('3');
+
+            // reset tears the dropdown down
+            (cut as any).toggleDropdown({
+                tabs: [],
+                tabGroups: [],
+                pinnedTabs: [],
+                reset: true,
+            });
+            expect(
+                cut.element.querySelector('.dv-tabs-overflow-dropdown-root')
+            ).toBeNull();
+        });
+
+        test('dropdown root swallows pointerdown', () => {
+            const cut = new TabsContainer(makeAccessor(), makeGroup());
+            (cut as any).toggleDropdown({
+                tabs: ['a'],
+                tabGroups: [],
+                pinnedTabs: [],
+                reset: false,
+            });
+            const root = cut.element.querySelector(
+                '.dv-tabs-overflow-dropdown-root'
+            ) as HTMLElement;
+
+            const evt = new KeyboardEvent('pointerdown', {
+                cancelable: true,
+                bubbles: true,
+            });
+            const spy = jest.spyOn(evt, 'preventDefault');
+            fireEvent(root, evt);
+            expect(spy).toHaveBeenCalled();
+        });
+
+        test('overflow render context builders (advanced overflow path)', () => {
+            const mockPopupService = {
+                openPopover: jest.fn(),
+                close: jest.fn(),
+            };
+
+            let capturedContext: any;
+            const accessor = makeAccessor({
+                getPopupServiceForGroup: () => mockPopupService as any,
+                advancedOverflowService: {
+                    renderOverflow: (args: any) => {
+                        capturedContext = args.context;
+                    },
+                } as any,
+            });
+
+            const expand = jest.fn();
+            const tabGroup = {
+                id: 'tg1',
+                label: 'Group One',
+                color: 'blue',
+                collapsed: true,
+                panelIds: ['panel-a'],
+                expand,
+            };
+
+            const mockSetActive = jest.fn();
+            const mockPanel = fromPartial<IDockviewPanel>({
+                id: 'panel-a',
+                api: {
+                    isActive: false,
+                    setActive: mockSetActive,
+                },
+                view: {
+                    createTabRenderer: jest.fn().mockReturnValue({
+                        element: document.createElement('div'),
+                    }),
+                },
+            });
+
+            const mockTab = {
+                panel: mockPanel,
+                element: { scrollIntoView: jest.fn() },
+            };
+
+            const group = makeGroup({
+                panels: [mockPanel],
+                model: fromPartial<DockviewGroupPanelModel>({
+                    getTabGroups: () => [tabGroup] as any,
+                }),
+            });
+
+            const cut = new TabsContainer(accessor, group);
+            (cut as any).tabs = makeOverflowMockTabs([mockTab]);
+
+            (cut as any).toggleDropdown({
+                tabs: ['panel-a'],
+                tabGroups: ['tg1'],
+                pinnedTabs: [],
+                reset: false,
+            });
+
+            const trigger = cut.element.querySelector(
+                '.dv-tabs-overflow-dropdown-root'
+            );
+            fireEvent.click(trigger!);
+
+            expect(capturedContext).toBeTruthy();
+
+            // overflowGroupIdForPanel resolves overflow-group membership
+            expect(capturedContext.overflowGroupIdForPanel('panel-a')).toBe(
+                'tg1'
+            );
+            expect(
+                capturedContext.overflowGroupIdForPanel('unknown')
+            ).toBeUndefined();
+
+            // buildGroupHeader for an overflow group
+            const header = capturedContext.buildGroupHeader('tg1');
+            expect(header).toBeTruthy();
+            expect(
+                header.querySelector('.dv-tabs-overflow-group-label')
+                    ?.textContent
+            ).toBe('Group One');
+            // collapsed group renders a count badge
+            expect(
+                header.querySelector('.dv-tabs-overflow-group-collapsed-badge')
+                    ?.textContent
+            ).toBe('1');
+            // a non-overflow group returns undefined
+            expect(
+                capturedContext.buildGroupHeader('does-not-exist')
+            ).toBeUndefined();
+
+            // clicking a group header closes the popup, expands and activates
+            fireEvent.click(header);
+            expect(mockPopupService.close).toHaveBeenCalled();
+            expect(expand).toHaveBeenCalled();
+            expect(mockSetActive).toHaveBeenCalled();
+
+            // pinned header
+            const pinnedHeader = capturedContext.buildPinnedHeader();
+            expect(
+                pinnedHeader.querySelector('.dv-tabs-overflow-group-label')
+                    ?.textContent
+            ).toBe('Pinned');
+
+            // buildRow for a grouped panel
+            const row = capturedContext.buildRow('panel-a');
+            expect(row).toBeTruthy();
+            expect(row.element.classList.contains('dv-tab')).toBe(true);
+            expect(row.element.classList.contains('dv-tab--grouped')).toBe(
+                true
+            );
+            expect(row.panel).toBe(mockPanel);
+            // an unknown panel has no row
+            expect(capturedContext.buildRow('missing')).toBeUndefined();
+
+            // activating via the row handle
+            expand.mockClear();
+            mockSetActive.mockClear();
+            row.activate();
+            expect(mockPopupService.close).toHaveBeenCalled();
+            expect(expand).toHaveBeenCalled();
+            expect(mockSetActive).toHaveBeenCalled();
+
+            // clicking the row wrapper activates the tab too
+            mockSetActive.mockClear();
+            fireEvent.click(row.element);
+            expect(mockSetActive).toHaveBeenCalled();
+
+            // open/close/focusTrigger route through the popup service
+            const body = document.createElement('div');
+            capturedContext.open(body);
+            expect(mockPopupService.openPopover).toHaveBeenCalledWith(
+                body,
+                expect.anything()
+            );
+            mockPopupService.close.mockClear();
+            capturedContext.close();
+            expect(mockPopupService.close).toHaveBeenCalled();
+            expect(() => capturedContext.focusTrigger()).not.toThrow();
+        });
+
+        test('free overflow list renders pinned section and group headers', () => {
+            const mockPopupService = {
+                openPopover: jest.fn(),
+                close: jest.fn(),
+            };
+
+            const accessor = makeAccessor({
+                getPopupServiceForGroup: () => mockPopupService as any,
+                // no advancedOverflowService -> free render path
+            });
+
+            const pinnedPanel = makeOverflowPanel('pinned-a');
+            const groupedPanel = makeOverflowPanel('grouped-b');
+
+            const tabGroup = {
+                id: 'tg1',
+                label: 'Group One',
+                color: undefined,
+                collapsed: false,
+                panelIds: ['grouped-b'],
+                expand: jest.fn(),
+            };
+
+            const group = makeGroup({
+                panels: [pinnedPanel, groupedPanel],
+                model: fromPartial<DockviewGroupPanelModel>({
+                    getTabGroups: () => [tabGroup] as any,
+                }),
+            });
+
+            const cut = new TabsContainer(accessor, group);
+            (cut as any).tabs = makeOverflowMockTabs([
+                { panel: pinnedPanel, element: { scrollIntoView: jest.fn() } },
+                { panel: groupedPanel, element: { scrollIntoView: jest.fn() } },
+            ]);
+
+            (cut as any).toggleDropdown({
+                tabs: ['grouped-b'],
+                tabGroups: ['tg1'],
+                pinnedTabs: ['pinned-a'],
+                reset: false,
+            });
+
+            const trigger = cut.element.querySelector(
+                '.dv-tabs-overflow-dropdown-root'
+            );
+            fireEvent.click(trigger!);
+
+            expect(mockPopupService.openPopover).toHaveBeenCalled();
+            const body = mockPopupService.openPopover.mock.calls[0][0];
+
+            // a pinned section header precedes the pinned rows
+            expect(
+                body.querySelector('.dv-tabs-overflow-pinned-header')
+            ).toBeTruthy();
+            // an overflow group header precedes its member tab
+            expect(
+                body.querySelector(
+                    '.dv-tabs-overflow-group-header:not(.dv-tabs-overflow-pinned-header)'
+                )
+            ).toBeTruthy();
+            // pinned row + grouped row
+            expect(body.querySelectorAll('.dv-tab')).toHaveLength(2);
+        });
     });
 });

--- a/packages/dockview-core/src/__tests__/dockview/events.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/events.spec.ts
@@ -1,0 +1,72 @@
+import { DockviewWillShowOverlayLocationEvent } from '../../dockview/events';
+
+describe('DockviewWillShowOverlayLocationEvent', () => {
+    test('delegates every getter to the underlying event / options', () => {
+        const nativeEvent = {} as any;
+        const preventDefault = jest.fn();
+        const event = {
+            nativeEvent,
+            position: 'left',
+            edge: true,
+            edgeGroup: false,
+            defaultPrevented: false,
+            preventDefault,
+        } as any;
+
+        const panel = { id: 'p1' } as any;
+        const api = { id: 'api' } as any;
+        const group = { id: 'g1' } as any;
+        const transfer = { panelId: 'p1' } as any;
+        const getData = jest.fn().mockReturnValue(transfer);
+        const options = {
+            kind: 'content' as const,
+            panel,
+            api,
+            group,
+            getData,
+        };
+
+        const sut = new DockviewWillShowOverlayLocationEvent(event, options);
+
+        // options-derived
+        expect(sut.kind).toBe('content');
+        expect(sut.panel).toBe(panel);
+        expect(sut.api).toBe(api);
+        expect(sut.group).toBe(group);
+
+        // event-derived
+        expect(sut.nativeEvent).toBe(nativeEvent);
+        expect(sut.position).toBe('left');
+        expect(sut.edge).toBe(true);
+        expect(sut.edgeGroup).toBe(false);
+        expect(sut.defaultPrevented).toBe(false);
+
+        // methods delegate through
+        expect(sut.getData()).toBe(transfer);
+        expect(getData).toHaveBeenCalledTimes(1);
+
+        sut.preventDefault();
+        expect(preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    test('reflects a prevented event and undefined panel / group', () => {
+        const event = {
+            defaultPrevented: true,
+            preventDefault: jest.fn(),
+        } as any;
+        const options = {
+            kind: 'edge' as const,
+            panel: undefined,
+            api: {} as any,
+            group: undefined,
+            getData: () => undefined,
+        };
+
+        const sut = new DockviewWillShowOverlayLocationEvent(event, options);
+
+        expect(sut.defaultPrevented).toBe(true);
+        expect(sut.panel).toBeUndefined();
+        expect(sut.group).toBeUndefined();
+        expect(sut.getData()).toBeUndefined();
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/floatingGroupService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/floatingGroupService.spec.ts
@@ -1,0 +1,558 @@
+import {
+    FloatingGroupModule,
+    FloatingGroupService,
+} from '../../dockview/floatingGroupService';
+import { Emitter } from '../../events';
+import { DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE } from '../../constants';
+
+/**
+ * These tests exercise the FloatingGroupService in isolation. The service is
+ * intentionally decoupled from DockviewComponent (it only depends on the
+ * narrow `IFloatingGroupHost` surface), so it is driven here with lightweight
+ * mock host / overlay / gridview / group objects wired up with real Emitters.
+ *
+ * The `add` method constructs a real `DockviewFloatingGroupPanel`, so the mock
+ * overlay / gridview must satisfy the `IDisposable` contract it relies on.
+ */
+
+interface MockEmitters {
+    activeChange: Emitter<{ isActive: boolean }>;
+    activePanelChange: Emitter<void>;
+    groupChange: Emitter<{ height?: number; width?: number } | undefined>;
+    overlayChange: Emitter<void>;
+    overlayChangeEnd: Emitter<void>;
+}
+
+function createMocks(options?: {
+    activePanelTitle?: string | undefined;
+    headerHeight?: number;
+    serializeRoot?: any;
+    gridWidth?: number;
+    gridHeight?: number;
+    toJSON?: any;
+}) {
+    const emitters: MockEmitters = {
+        activeChange: new Emitter(),
+        activePanelChange: new Emitter(),
+        groupChange: new Emitter(),
+        overlayChange: new Emitter(),
+        overlayChangeEnd: new Emitter(),
+    };
+
+    const overlayElement = document.createElement('div');
+    const gridviewElement = document.createElement('div');
+    const groupElement = document.createElement('div');
+
+    const overlay: any = {
+        element: overlayElement,
+        headerHeight: options?.headerHeight ?? 0,
+        onDidChange: emitters.overlayChange.event,
+        onDidChangeEnd: emitters.overlayChangeEnd.event,
+        bringToFront: jest.fn(),
+        setBounds: jest.fn(),
+        toJSON: jest.fn(
+            () => options?.toJSON ?? { left: 0, top: 0, width: 0, height: 0 }
+        ),
+        minimumInViewportWidth: -1,
+        minimumInViewportHeight: -1,
+        dispose: jest.fn(),
+    };
+
+    const gridview: any = {
+        element: gridviewElement,
+        width: options?.gridWidth ?? 200,
+        height: options?.gridHeight ?? 100,
+        layout: jest.fn(),
+        serialize: jest.fn(() => ({
+            root: options?.serializeRoot ?? {
+                type: 'branch',
+                data: [{ type: 'leaf', data: { id: 'leaf-1' } }],
+            },
+            width: 200,
+            height: 100,
+            orientation: 'HORIZONTAL',
+        })),
+        dispose: jest.fn(),
+    };
+
+    const group: any = {
+        element: groupElement,
+        activePanel:
+            options && 'activePanelTitle' in options
+                ? { title: options.activePanelTitle }
+                : { title: 'panel-title' },
+        api: {
+            onDidActiveChange: emitters.activeChange.event,
+            onDidActivePanelChange: emitters.activePanelChange.event,
+        },
+        onDidChange: emitters.groupChange.event,
+        model: { location: { type: 'floating' } },
+    };
+
+    const host = { fireLayoutChange: jest.fn() };
+
+    return { emitters, overlay, gridview, group, host };
+}
+
+describe('FloatingGroupService', () => {
+    test('FloatingGroupModule wires the service to its host', () => {
+        const host = { fireLayoutChange: jest.fn() };
+        expect(FloatingGroupModule.moduleName).toBe('FloatingGroup');
+
+        const factory = (FloatingGroupModule.services as any)
+            .floatingGroupService as (h: typeof host) => FloatingGroupService;
+        const service = factory(host);
+
+        expect(service).toBeInstanceOf(FloatingGroupService);
+        expect(service.floatingGroups).toEqual([]);
+    });
+
+    test('starts with no floating groups', () => {
+        const { host } = createMocks();
+        const service = new FloatingGroupService(host);
+        expect(service.floatingGroups).toEqual([]);
+    });
+
+    test('add registers a floating group and returns the panel', () => {
+        const { host, overlay, gridview, group } = createMocks();
+        const service = new FloatingGroupService(host);
+
+        const panel = service.add(group, overlay, gridview);
+
+        expect(service.floatingGroups).toHaveLength(1);
+        expect(service.floatingGroups[0]).toBe(panel);
+        expect(panel.group).toBe(group);
+        expect(panel.overlay).toBe(overlay);
+        expect(panel.gridview).toBe(gridview);
+    });
+
+    test('add sets an aria-label from the active panel title', () => {
+        const { host, overlay, gridview, group } = createMocks({
+            activePanelTitle: 'My Panel',
+        });
+        const service = new FloatingGroupService(host);
+
+        service.add(group, overlay, gridview);
+
+        expect(overlay.element.getAttribute('aria-label')).toBe('My Panel');
+    });
+
+    test('add leaves the dialog unnamed when the active panel has no title', () => {
+        const { host, overlay, gridview, group } = createMocks({
+            activePanelTitle: undefined,
+        });
+        const service = new FloatingGroupService(host);
+
+        service.add(group, overlay, gridview);
+
+        expect(overlay.element.hasAttribute('aria-label')).toBe(false);
+    });
+
+    test('the aria-label refreshes when the active panel changes', () => {
+        const { host, overlay, gridview, group, emitters } = createMocks({
+            activePanelTitle: 'first',
+        });
+        const service = new FloatingGroupService(host);
+        service.add(group, overlay, gridview);
+        expect(overlay.element.getAttribute('aria-label')).toBe('first');
+
+        group.activePanel = { title: 'second' };
+        emitters.activePanelChange.fire();
+        expect(overlay.element.getAttribute('aria-label')).toBe('second');
+
+        // an untitled active panel removes the label again
+        group.activePanel = { title: undefined };
+        emitters.activePanelChange.fire();
+        expect(overlay.element.hasAttribute('aria-label')).toBe(false);
+    });
+
+    test('activating the group brings its overlay to front', () => {
+        const { host, overlay, gridview, group, emitters } = createMocks();
+        const service = new FloatingGroupService(host);
+        service.add(group, overlay, gridview);
+
+        emitters.activeChange.fire({ isActive: false });
+        expect(overlay.bringToFront).not.toHaveBeenCalled();
+
+        emitters.activeChange.fire({ isActive: true });
+        expect(overlay.bringToFront).toHaveBeenCalledTimes(1);
+    });
+
+    test('overlay onDidChange re-layouts the nested gridview at its current size', () => {
+        const { host, overlay, gridview, group, emitters } = createMocks({
+            gridWidth: 321,
+            gridHeight: 234,
+        });
+        const service = new FloatingGroupService(host);
+        service.add(group, overlay, gridview);
+
+        emitters.overlayChange.fire();
+        expect(gridview.layout).toHaveBeenLastCalledWith(321, 234);
+    });
+
+    test('overlay onDidChangeEnd notifies the host of a layout change', () => {
+        const { host, overlay, gridview, group, emitters } = createMocks();
+        const service = new FloatingGroupService(host);
+        service.add(group, overlay, gridview);
+
+        expect(host.fireLayoutChange).not.toHaveBeenCalled();
+        emitters.overlayChangeEnd.fire();
+        expect(host.fireLayoutChange).toHaveBeenCalledTimes(1);
+    });
+
+    test('group onDidChange with a numeric height adds the header height back to the overlay bounds', () => {
+        const { host, overlay, gridview, group, emitters } = createMocks({
+            headerHeight: 30,
+        });
+        const service = new FloatingGroupService(host);
+        service.add(group, overlay, gridview);
+
+        emitters.groupChange.fire({ height: 100, width: 250 });
+        expect(overlay.setBounds).toHaveBeenLastCalledWith({
+            height: 130,
+            width: 250,
+        });
+    });
+
+    test('group onDidChange without a numeric height passes the value through unchanged', () => {
+        const { host, overlay, gridview, group, emitters } = createMocks({
+            headerHeight: 30,
+        });
+        const service = new FloatingGroupService(host);
+        service.add(group, overlay, gridview);
+
+        emitters.groupChange.fire({ width: 250 });
+        expect(overlay.setBounds).toHaveBeenLastCalledWith({
+            height: undefined,
+            width: 250,
+        });
+    });
+
+    test('group onDidChange tolerates an undefined event', () => {
+        const { host, overlay, gridview, group, emitters } = createMocks();
+        const service = new FloatingGroupService(host);
+        service.add(group, overlay, gridview);
+
+        expect(() => emitters.groupChange.fire(undefined)).not.toThrow();
+        expect(overlay.setBounds).toHaveBeenLastCalledWith({
+            height: undefined,
+            width: undefined,
+        });
+    });
+
+    describe('findByGroup', () => {
+        test('finds a floating group by its anchor group', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            const panel = service.add(group, overlay, gridview);
+
+            expect(service.findByGroup(group)).toBe(panel);
+        });
+
+        test('finds a floating group when the queried group lives inside its gridview', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            const panel = service.add(group, overlay, gridview);
+
+            const nested: any = { element: document.createElement('div') };
+            gridview.element.appendChild(nested.element);
+
+            expect(service.findByGroup(nested)).toBe(panel);
+        });
+
+        test('returns undefined for an unrelated group', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+
+            const other: any = { element: document.createElement('div') };
+            expect(service.findByGroup(other)).toBeUndefined();
+        });
+    });
+
+    describe('serialize', () => {
+        test('emits the legacy single-group `data` shape for a single-leaf window', () => {
+            const { host, overlay, gridview, group } = createMocks({
+                serializeRoot: {
+                    type: 'branch',
+                    data: [{ type: 'leaf', data: { id: 'the-leaf' } }],
+                },
+                toJSON: { left: 5, top: 6, width: 7, height: 8 },
+            });
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+
+            const result = service.serialize();
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual({
+                data: { id: 'the-leaf' },
+                position: { left: 5, top: 6, width: 7, height: 8 },
+            });
+            expect((result[0] as any).grid).toBeUndefined();
+        });
+
+        test('emits the nested `grid` shape for a multi-group window', () => {
+            const root = {
+                type: 'branch',
+                data: [
+                    { type: 'leaf', data: { id: 'a' } },
+                    { type: 'leaf', data: { id: 'b' } },
+                ],
+            };
+            const { host, overlay, gridview, group } = createMocks({
+                serializeRoot: root,
+                toJSON: { left: 1, top: 2, width: 3, height: 4 },
+            });
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+
+            const result = service.serialize();
+            expect(result).toHaveLength(1);
+            expect((result[0] as any).data).toBeUndefined();
+            expect((result[0] as any).grid.root).toBe(root);
+            expect(result[0].position).toEqual({
+                left: 1,
+                top: 2,
+                width: 3,
+                height: 4,
+            });
+        });
+
+        test('emits the nested `grid` shape when the single child is not a leaf', () => {
+            const root = {
+                type: 'branch',
+                data: [{ type: 'branch', data: [] }],
+            };
+            const { host, overlay, gridview, group } = createMocks({
+                serializeRoot: root,
+            });
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+
+            const result = service.serialize();
+            expect((result[0] as any).data).toBeUndefined();
+            expect((result[0] as any).grid.root).toBe(root);
+        });
+    });
+
+    describe('constrainBounds', () => {
+        test('re-applies bounds on every floating overlay', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const second = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+            service.add(second.group, second.overlay, second.gridview);
+
+            overlay.setBounds.mockClear();
+            second.overlay.setBounds.mockClear();
+
+            service.constrainBounds();
+
+            expect(overlay.setBounds).toHaveBeenCalledTimes(1);
+            expect(overlay.setBounds).toHaveBeenCalledWith();
+            expect(second.overlay.setBounds).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('updateBounds', () => {
+        test('is a no-op when the options do not mention floatingGroupBounds', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+            overlay.setBounds.mockClear();
+
+            service.updateBounds({});
+
+            expect(overlay.setBounds).not.toHaveBeenCalled();
+        });
+
+        test('boundedWithinViewport clears the minimum in-viewport sizes', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+            overlay.setBounds.mockClear();
+
+            service.updateBounds({
+                floatingGroupBounds: 'boundedWithinViewport',
+            });
+
+            expect(overlay.minimumInViewportHeight).toBeUndefined();
+            expect(overlay.minimumInViewportWidth).toBeUndefined();
+            expect(overlay.setBounds).toHaveBeenCalledTimes(1);
+        });
+
+        test('an undefined bound restores the default overflow size', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+            overlay.setBounds.mockClear();
+
+            service.updateBounds({ floatingGroupBounds: undefined });
+
+            expect(overlay.minimumInViewportHeight).toBe(
+                DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE
+            );
+            expect(overlay.minimumInViewportWidth).toBe(
+                DEFAULT_FLOATING_GROUP_OVERFLOW_SIZE
+            );
+            expect(overlay.setBounds).toHaveBeenCalledTimes(1);
+        });
+
+        test('an explicit bound object applies the requested minimum sizes', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+            overlay.setBounds.mockClear();
+
+            service.updateBounds({
+                floatingGroupBounds: {
+                    minimumHeightWithinViewport: 42,
+                    minimumWidthWithinViewport: 84,
+                },
+            });
+
+            expect(overlay.minimumInViewportHeight).toBe(42);
+            expect(overlay.minimumInViewportWidth).toBe(84);
+            expect(overlay.setBounds).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('disposal', () => {
+        test('disposing a floating panel removes it and resets the group to the grid', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            const panel = service.add(group, overlay, gridview);
+
+            panel.dispose();
+
+            expect(service.floatingGroups).toHaveLength(0);
+            expect(group.model.location).toEqual({ type: 'grid' });
+            expect(overlay.dispose).toHaveBeenCalled();
+            expect(gridview.dispose).toHaveBeenCalled();
+        });
+
+        test('disposeAll tears down every floating group', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const second = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+            service.add(second.group, second.overlay, second.gridview);
+            expect(service.floatingGroups).toHaveLength(2);
+
+            service.disposeAll();
+
+            expect(service.floatingGroups).toHaveLength(0);
+            expect(overlay.dispose).toHaveBeenCalled();
+            expect(second.overlay.dispose).toHaveBeenCalled();
+        });
+
+        test('dispose() delegates to disposeAll', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+
+            service.dispose();
+
+            expect(service.floatingGroups).toHaveLength(0);
+            expect(overlay.dispose).toHaveBeenCalled();
+        });
+
+        test('after disposal, group events no longer drive the overlay', () => {
+            const { host, overlay, gridview, group, emitters } = createMocks();
+            const service = new FloatingGroupService(host);
+            const panel = service.add(group, overlay, gridview);
+
+            panel.dispose();
+            overlay.bringToFront.mockClear();
+            host.fireLayoutChange.mockClear();
+
+            emitters.activeChange.fire({ isActive: true });
+            emitters.overlayChangeEnd.fire();
+
+            expect(overlay.bringToFront).not.toHaveBeenCalled();
+            expect(host.fireLayoutChange).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('nested gridview resize wiring', () => {
+        let OriginalResizeObserver: typeof window.ResizeObserver;
+        let capturedCallback:
+            | ((entries: Array<{ contentRect: DOMRectReadOnly }>) => void)
+            | undefined;
+
+        let rafSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            // watchElementResize defers the callback to requestAnimationFrame;
+            // run it synchronously so the resize handling is deterministic.
+            rafSpy = jest
+                .spyOn(window, 'requestAnimationFrame')
+                .mockImplementation((cb: FrameRequestCallback): number => {
+                    cb(0);
+                    return 0;
+                });
+            OriginalResizeObserver = window.ResizeObserver;
+            capturedCallback = undefined;
+            (window as any).ResizeObserver = class {
+                constructor(
+                    cb: (
+                        entries: Array<{ contentRect: DOMRectReadOnly }>
+                    ) => void
+                ) {
+                    capturedCallback = cb;
+                }
+                observe(): void {
+                    /* noop */
+                }
+                unobserve(): void {
+                    /* noop */
+                }
+                disconnect(): void {
+                    /* noop */
+                }
+            };
+        });
+
+        afterEach(() => {
+            window.ResizeObserver = OriginalResizeObserver;
+            rafSpy.mockRestore();
+        });
+
+        test('a resize lays out the gridview at the measured content box, skipping unchanged sizes', () => {
+            const { host, overlay, gridview, group } = createMocks();
+            const service = new FloatingGroupService(host);
+            service.add(group, overlay, gridview);
+
+            expect(capturedCallback).toBeDefined();
+
+            capturedCallback!([
+                {
+                    contentRect: {
+                        width: 150.4,
+                        height: 80.6,
+                    } as DOMRectReadOnly,
+                },
+            ]);
+            expect(gridview.layout).toHaveBeenLastCalledWith(150, 81);
+
+            const callsAfterFirst = gridview.layout.mock.calls.length;
+
+            // firing again with the same rounded size is ignored
+            capturedCallback!([
+                {
+                    contentRect: {
+                        width: 150.1,
+                        height: 81.2,
+                    } as DOMRectReadOnly,
+                },
+            ]);
+            expect(gridview.layout.mock.calls.length).toBe(callsAfterFirst);
+
+            // a genuinely different size lays out again
+            capturedCallback!([
+                { contentRect: { width: 200, height: 120 } as DOMRectReadOnly },
+            ]);
+            expect(gridview.layout).toHaveBeenLastCalledWith(200, 120);
+        });
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/floatingGroupService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/floatingGroupService.spec.ts
@@ -546,7 +546,7 @@ describe('FloatingGroupService', () => {
                     } as DOMRectReadOnly,
                 },
             ]);
-            expect(gridview.layout.mock.calls.length).toBe(callsAfterFirst);
+            expect(gridview.layout.mock.calls).toHaveLength(callsAfterFirst);
 
             // a genuinely different size lays out again
             capturedCallback!([

--- a/packages/dockview-core/src/__tests__/dockview/popoutWindowService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/popoutWindowService.spec.ts
@@ -1,0 +1,724 @@
+import {
+    PopoutWindowService,
+    PopoutWindowModule,
+    PopoutGroupEntry,
+    IPopoutWindowHost,
+} from '../../dockview/popoutWindowService';
+import { PopoutWindow } from '../../popoutWindow';
+import { DockviewGroupPanel } from '../../dockview/dockviewGroupPanel';
+import { Gridview } from '../../gridview/gridview';
+import { OverlayRenderContainer } from '../../overlay/overlayRenderContainer';
+
+/**
+ * The PopoutWindowService is a bookkeeping/coordination service. It never
+ * creates a real popout window itself (that is `PopoutWindow`'s job), so every
+ * collaborator here can be a lightweight fake. jsdom cannot emulate the real
+ * cross-realm popout window (geometry, ResizeObserver in another realm), but
+ * the service's own logic is deterministic and fully testable with fakes.
+ */
+
+function makeHost(isDisposed = false): IPopoutWindowHost & {
+    isDisposed: boolean;
+} {
+    return { isDisposed };
+}
+
+/**
+ * Build a gridview element whose clientWidth/clientHeight can be controlled,
+ * because jsdom always reports 0 for layout metrics.
+ */
+function makeGridElement(width = 0, height = 0): HTMLElement {
+    const element = document.createElement('div');
+    Object.defineProperty(element, 'clientWidth', {
+        configurable: true,
+        get: () => width,
+    });
+    Object.defineProperty(element, 'clientHeight', {
+        configurable: true,
+        get: () => height,
+    });
+    return element;
+}
+
+interface FakeEntryOptions {
+    popoutGroup?: any;
+    referenceGroup?: string;
+    gridElement?: HTMLElement;
+    serializeResult?: any;
+    dimensions?: any;
+    locationType?: 'popout' | 'grid';
+    popoutUrl?: string;
+}
+
+function makeEntry(options: FakeEntryOptions = {}): PopoutGroupEntry & {
+    disposable: { dispose: jest.Mock };
+} {
+    const gridElement = options.gridElement ?? makeGridElement();
+
+    const popoutGroup =
+        options.popoutGroup ??
+        ({
+            element: document.createElement('div'),
+            api: {
+                location: {
+                    type: options.locationType ?? 'popout',
+                    popoutUrl: options.popoutUrl,
+                },
+            },
+        } as unknown as DockviewGroupPanel);
+
+    const gridview = {
+        element: gridElement,
+        serialize: jest.fn(
+            () =>
+                options.serializeResult ?? {
+                    root: {
+                        type: 'branch',
+                        data: [{ type: 'leaf', data: { id: 'leaf-data' } }],
+                    },
+                    width: 100,
+                    height: 100,
+                    orientation: 'HORIZONTAL',
+                }
+        ),
+        layout: jest.fn(),
+    } as unknown as Gridview;
+
+    const overlayRenderContainer = {
+        updateAllPositions: jest.fn(),
+    } as unknown as OverlayRenderContainer;
+
+    const window_ = {
+        dimensions: jest.fn(
+            () => options.dimensions ?? { left: 1, top: 2, width: 3, height: 4 }
+        ),
+    } as unknown as PopoutWindow;
+
+    const disposable = { dispose: jest.fn() };
+
+    return {
+        window: window_,
+        popoutGroup,
+        referenceGroup: options.referenceGroup,
+        gridview,
+        overlayRenderContainer,
+        dropTargetContainer: {} as any,
+        getWindow: () => ({}) as Window,
+        popoutUrl: options.popoutUrl,
+        popupService: {} as any,
+        setAnchorGroup: jest.fn(),
+        disposable,
+    } as unknown as PopoutGroupEntry & {
+        disposable: { dispose: jest.Mock };
+    };
+}
+
+describe('PopoutWindowService', () => {
+    describe('add / entries', () => {
+        test('add appends entries and entries exposes them in order', () => {
+            const service = new PopoutWindowService(makeHost());
+            const a = makeEntry();
+            const b = makeEntry();
+
+            expect(service.entries).toEqual([]);
+
+            service.add(a);
+            service.add(b);
+
+            expect(service.entries).toEqual([a, b]);
+        });
+    });
+
+    describe('remove', () => {
+        test('fires onDidRemove on a genuine removal when host is not disposed', () => {
+            const service = new PopoutWindowService(makeHost(false));
+            const entry = makeEntry();
+            service.add(entry);
+
+            const listener = jest.fn();
+            service.onDidRemove(listener);
+
+            service.remove(entry);
+
+            expect(service.entries).toEqual([]);
+            expect(listener).toHaveBeenCalledTimes(1);
+            expect(listener).toHaveBeenCalledWith(entry);
+        });
+
+        test('does not fire onDidRemove when the entry was not present', () => {
+            const service = new PopoutWindowService(makeHost(false));
+            const listener = jest.fn();
+            service.onDidRemove(listener);
+
+            service.remove(makeEntry());
+
+            expect(listener).not.toHaveBeenCalled();
+        });
+
+        test('does not fire onDidRemove while the host is disposed', () => {
+            const host = makeHost(false);
+            const service = new PopoutWindowService(host);
+            const entry = makeEntry();
+            service.add(entry);
+
+            const listener = jest.fn();
+            service.onDidRemove(listener);
+
+            host.isDisposed = true;
+            service.remove(entry);
+
+            // The entry is still removed from bookkeeping...
+            expect(service.entries).toEqual([]);
+            // ...but no event is emitted during teardown.
+            expect(listener).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('findByGroup', () => {
+        test('matches the anchor popoutGroup by identity', () => {
+            const service = new PopoutWindowService(makeHost());
+            const entry = makeEntry();
+            service.add(entry);
+
+            expect(service.findByGroup(entry.popoutGroup)).toBe(entry);
+        });
+
+        test('matches a non-anchor group by DOM containment in the gridview', () => {
+            const service = new PopoutWindowService(makeHost());
+            const gridElement = makeGridElement();
+            const child = document.createElement('div');
+            gridElement.appendChild(child);
+
+            const entry = makeEntry({ gridElement });
+            service.add(entry);
+
+            const member = { element: child } as unknown as DockviewGroupPanel;
+            expect(service.findByGroup(member)).toBe(entry);
+        });
+
+        test('returns undefined when no entry owns the group', () => {
+            const service = new PopoutWindowService(makeHost());
+            service.add(makeEntry());
+
+            const stranger = {
+                element: document.createElement('div'),
+            } as unknown as DockviewGroupPanel;
+
+            expect(service.findByGroup(stranger)).toBeUndefined();
+        });
+    });
+
+    describe('findReferenceGroupId', () => {
+        test('returns the referenceGroup of the matching anchor group', () => {
+            const service = new PopoutWindowService(makeHost());
+            const entry = makeEntry({ referenceGroup: 'ref-1' });
+            service.add(entry);
+
+            expect(service.findReferenceGroupId(entry.popoutGroup)).toBe(
+                'ref-1'
+            );
+        });
+
+        test('returns undefined when the anchor group has no reference group', () => {
+            const service = new PopoutWindowService(makeHost());
+            const entry = makeEntry();
+            service.add(entry);
+
+            expect(
+                service.findReferenceGroupId(entry.popoutGroup)
+            ).toBeUndefined();
+        });
+
+        test('returns undefined for a group that is not an anchor', () => {
+            const service = new PopoutWindowService(makeHost());
+            service.add(makeEntry({ referenceGroup: 'ref-1' }));
+
+            const stranger = {
+                element: document.createElement('div'),
+            } as unknown as DockviewGroupPanel;
+
+            expect(service.findReferenceGroupId(stranger)).toBeUndefined();
+        });
+    });
+
+    describe('serialize', () => {
+        test('emits the legacy single-group `data` shape for a single leaf', () => {
+            const service = new PopoutWindowService(makeHost());
+            const entry = makeEntry({
+                referenceGroup: 'ref-1',
+                locationType: 'popout',
+                popoutUrl: '/popout.html',
+                dimensions: { left: 10, top: 20, width: 30, height: 40 },
+                serializeResult: {
+                    root: {
+                        type: 'branch',
+                        data: [
+                            { type: 'leaf', data: { id: 'the-leaf-state' } },
+                        ],
+                    },
+                },
+            });
+            service.add(entry);
+
+            const result = service.serialize();
+
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual({
+                gridReferenceGroup: 'ref-1',
+                position: { left: 10, top: 20, width: 30, height: 40 },
+                url: '/popout.html',
+                data: { id: 'the-leaf-state' },
+            });
+            expect((result[0] as any).grid).toBeUndefined();
+        });
+
+        test('emits the nested `grid` shape when the window hosts multiple groups', () => {
+            const service = new PopoutWindowService(makeHost());
+            const grid = {
+                root: {
+                    type: 'branch',
+                    data: [
+                        { type: 'leaf', data: { id: 'a' } },
+                        { type: 'leaf', data: { id: 'b' } },
+                    ],
+                },
+            };
+            const entry = makeEntry({ serializeResult: grid });
+            service.add(entry);
+
+            const result = service.serialize();
+
+            expect((result[0] as any).grid).toBe(grid);
+            expect((result[0] as any).data).toBeUndefined();
+        });
+
+        test('emits the nested `grid` shape when the single child is not a leaf', () => {
+            const service = new PopoutWindowService(makeHost());
+            const grid = {
+                root: {
+                    type: 'branch',
+                    data: [{ type: 'branch', data: [] }],
+                },
+            };
+            const entry = makeEntry({ serializeResult: grid });
+            service.add(entry);
+
+            const result = service.serialize();
+
+            expect((result[0] as any).grid).toBe(grid);
+            expect((result[0] as any).data).toBeUndefined();
+        });
+
+        test('leaves url undefined when the anchor is not in a popout location', () => {
+            const service = new PopoutWindowService(makeHost());
+            const entry = makeEntry({
+                locationType: 'grid',
+                popoutUrl: '/should-be-ignored.html',
+            });
+            service.add(entry);
+
+            const result = service.serialize();
+
+            expect(result[0].url).toBeUndefined();
+        });
+    });
+
+    describe('observeGridviewSize', () => {
+        function makeResizeObserverFactory() {
+            const instances: Array<{
+                callback: ResizeObserverCallback;
+                observe: jest.Mock;
+                disconnect: jest.Mock;
+            }> = [];
+
+            class FakeResizeObserver {
+                observe = jest.fn();
+                disconnect = jest.fn();
+                unobserve = jest.fn();
+                constructor(public callback: ResizeObserverCallback) {
+                    instances.push(this as any);
+                }
+            }
+
+            return { FakeResizeObserver, instances };
+        }
+
+        function makePopoutWindow(
+            win: Partial<Window> | undefined
+        ): PopoutWindow {
+            return { window: win } as unknown as PopoutWindow;
+        }
+
+        test('returns undefined when the popout realm has no ResizeObserver', () => {
+            const service = new PopoutWindowService(makeHost());
+            const entry = makeEntry();
+
+            const result = service.observeGridviewSize(
+                makePopoutWindow({ ResizeObserver: undefined } as any),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            expect(result).toBeUndefined();
+        });
+
+        test('returns undefined when the popout window itself is undefined', () => {
+            const service = new PopoutWindowService(makeHost());
+            const entry = makeEntry();
+
+            const result = service.observeGridviewSize(
+                makePopoutWindow(undefined),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            expect(result).toBeUndefined();
+        });
+
+        test('observes the gridview element and dispose disconnects the observer', () => {
+            const service = new PopoutWindowService(makeHost());
+            const { FakeResizeObserver, instances } =
+                makeResizeObserverFactory();
+            const entry = makeEntry({ gridElement: makeGridElement(100, 200) });
+
+            const result = service.observeGridviewSize(
+                makePopoutWindow({
+                    ResizeObserver: FakeResizeObserver as any,
+                }),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            expect(instances).toHaveLength(1);
+            expect(instances[0].observe).toHaveBeenCalledWith(
+                entry.gridview.element
+            );
+
+            result!.dispose();
+            expect(instances[0].disconnect).toHaveBeenCalledTimes(1);
+        });
+
+        test('lays out the gridview and updates positions on a resize with a positive size', () => {
+            const service = new PopoutWindowService(makeHost());
+            const { FakeResizeObserver, instances } =
+                makeResizeObserverFactory();
+            const gridElement = makeGridElement(100, 200);
+            const entry = makeEntry({ gridElement });
+
+            // No requestAnimationFrame -> relayout runs synchronously.
+            service.observeGridviewSize(
+                makePopoutWindow({
+                    ResizeObserver: FakeResizeObserver as any,
+                    closed: false,
+                } as any),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            instances[0].callback([], instances[0] as any);
+
+            expect(entry.gridview.layout).toHaveBeenCalledWith(100, 200);
+            expect(
+                entry.overlayRenderContainer.updateAllPositions
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        test('does not call layout for a zero-sized box but still updates positions', () => {
+            const service = new PopoutWindowService(makeHost());
+            const { FakeResizeObserver, instances } =
+                makeResizeObserverFactory();
+            const entry = makeEntry({ gridElement: makeGridElement(0, 0) });
+
+            service.observeGridviewSize(
+                makePopoutWindow({
+                    ResizeObserver: FakeResizeObserver as any,
+                    closed: false,
+                } as any),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            instances[0].callback([], instances[0] as any);
+
+            expect(entry.gridview.layout).not.toHaveBeenCalled();
+            expect(
+                entry.overlayRenderContainer.updateAllPositions
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        test('deduplicates consecutive resizes of the same measured size', () => {
+            const service = new PopoutWindowService(makeHost());
+            const { FakeResizeObserver, instances } =
+                makeResizeObserverFactory();
+            const entry = makeEntry({ gridElement: makeGridElement(100, 200) });
+
+            service.observeGridviewSize(
+                makePopoutWindow({
+                    ResizeObserver: FakeResizeObserver as any,
+                    closed: false,
+                } as any),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            instances[0].callback([], instances[0] as any);
+            instances[0].callback([], instances[0] as any);
+
+            expect(entry.gridview.layout).toHaveBeenCalledTimes(1);
+            expect(
+                entry.overlayRenderContainer.updateAllPositions
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        test('skips relayout when the host component has been disposed', () => {
+            const host = makeHost(false);
+            const service = new PopoutWindowService(host);
+            const { FakeResizeObserver, instances } =
+                makeResizeObserverFactory();
+            const entry = makeEntry({ gridElement: makeGridElement(100, 200) });
+
+            service.observeGridviewSize(
+                makePopoutWindow({
+                    ResizeObserver: FakeResizeObserver as any,
+                    closed: false,
+                } as any),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            host.isDisposed = true;
+            instances[0].callback([], instances[0] as any);
+
+            expect(entry.gridview.layout).not.toHaveBeenCalled();
+            expect(
+                entry.overlayRenderContainer.updateAllPositions
+            ).not.toHaveBeenCalled();
+        });
+
+        test('skips relayout when the popout window has been closed', () => {
+            const service = new PopoutWindowService(makeHost());
+            const { FakeResizeObserver, instances } =
+                makeResizeObserverFactory();
+            const entry = makeEntry({ gridElement: makeGridElement(100, 200) });
+
+            service.observeGridviewSize(
+                makePopoutWindow({
+                    ResizeObserver: FakeResizeObserver as any,
+                    closed: true,
+                } as any),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            instances[0].callback([], instances[0] as any);
+
+            expect(entry.gridview.layout).not.toHaveBeenCalled();
+            expect(
+                entry.overlayRenderContainer.updateAllPositions
+            ).not.toHaveBeenCalled();
+        });
+
+        test('defers relayout through the popout realm requestAnimationFrame when available', () => {
+            const service = new PopoutWindowService(makeHost());
+            const { FakeResizeObserver, instances } =
+                makeResizeObserverFactory();
+            const entry = makeEntry({ gridElement: makeGridElement(100, 200) });
+
+            let deferred: FrameRequestCallback | undefined;
+            const raf = jest.fn((cb: FrameRequestCallback) => {
+                deferred = cb;
+                return 1;
+            });
+
+            service.observeGridviewSize(
+                makePopoutWindow({
+                    ResizeObserver: FakeResizeObserver as any,
+                    requestAnimationFrame: raf as any,
+                    closed: false,
+                } as any),
+                entry.gridview,
+                entry.overlayRenderContainer
+            );
+
+            instances[0].callback([], instances[0] as any);
+
+            // Nothing runs until the frame callback is invoked.
+            expect(raf).toHaveBeenCalledTimes(1);
+            expect(entry.gridview.layout).not.toHaveBeenCalled();
+
+            deferred!(0);
+            expect(entry.gridview.layout).toHaveBeenCalledWith(100, 200);
+        });
+    });
+
+    describe('scheduleRestoration', () => {
+        beforeEach(() => jest.useFakeTimers());
+        afterEach(() => {
+            jest.runOnlyPendingTimers();
+            jest.useRealTimers();
+        });
+
+        test('runs the work and resolves after the delay elapses', async () => {
+            const service = new PopoutWindowService(makeHost(false));
+            const work = jest.fn();
+            const onCancel = jest.fn();
+
+            const promise = service.scheduleRestoration(50, work, onCancel);
+
+            expect(work).not.toHaveBeenCalled();
+            jest.advanceTimersByTime(50);
+            await promise;
+
+            expect(work).toHaveBeenCalledTimes(1);
+            expect(onCancel).not.toHaveBeenCalled();
+        });
+
+        test('does not run the work when the host was disposed before the timer fired', async () => {
+            const host = makeHost(false);
+            const service = new PopoutWindowService(host);
+            const work = jest.fn();
+
+            const promise = service.scheduleRestoration(50, work);
+
+            host.isDisposed = true;
+            jest.advanceTimersByTime(50);
+            await promise;
+
+            expect(work).not.toHaveBeenCalled();
+        });
+
+        test('cancelPendingRestorations cancels the timer, runs onCancel and resolves without work', async () => {
+            const service = new PopoutWindowService(makeHost(false));
+            const work = jest.fn();
+            const onCancel = jest.fn();
+
+            const promise = service.scheduleRestoration(50, work, onCancel);
+
+            service.cancelPendingRestorations();
+            await promise;
+
+            expect(onCancel).toHaveBeenCalledTimes(1);
+            expect(work).not.toHaveBeenCalled();
+
+            // The timer was cleared: advancing does not run work afterwards.
+            jest.advanceTimersByTime(100);
+            expect(work).not.toHaveBeenCalled();
+        });
+
+        test('cancelPendingRestorations with no onCancel resolves cleanly', async () => {
+            const service = new PopoutWindowService(makeHost(false));
+            const work = jest.fn();
+
+            const promise = service.scheduleRestoration(50, work);
+            service.cancelPendingRestorations();
+            await promise;
+
+            expect(work).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('finishRestoration / restorationPromise', () => {
+        test('defaults to an already-resolved promise', async () => {
+            const service = new PopoutWindowService(makeHost());
+            await expect(service.restorationPromise).resolves.toBeUndefined();
+        });
+
+        test('restorationPromise resolves once all supplied promises resolve', async () => {
+            const service = new PopoutWindowService(makeHost());
+
+            let resolveA: () => void = () => undefined;
+            let resolveB: () => void = () => undefined;
+            const a = new Promise<void>((r) => (resolveA = r));
+            const b = new Promise<void>((r) => (resolveB = r));
+
+            service.finishRestoration([a, b]);
+
+            let settled = false;
+            const tracked = service.restorationPromise.then(() => {
+                settled = true;
+            });
+
+            resolveA();
+            await Promise.resolve();
+            expect(settled).toBe(false);
+
+            resolveB();
+            await tracked;
+            expect(settled).toBe(true);
+        });
+    });
+
+    describe('disposeAll', () => {
+        test('disposes each entry disposable', () => {
+            const service = new PopoutWindowService(makeHost());
+            const a = makeEntry();
+            const b = makeEntry();
+            service.add(a);
+            service.add(b);
+
+            service.disposeAll();
+
+            expect(a.disposable.dispose).toHaveBeenCalledTimes(1);
+            expect(b.disposable.dispose).toHaveBeenCalledTimes(1);
+        });
+
+        test('is safe when an entry disposal mutates the entries list', () => {
+            const service = new PopoutWindowService(makeHost());
+            const a = makeEntry();
+            const b = makeEntry();
+            service.add(a);
+            service.add(b);
+
+            // Disposing `a` removes it from the service mid-iteration; the
+            // implementation iterates a copy so `b` is still disposed.
+            (a.disposable.dispose as jest.Mock).mockImplementation(() =>
+                service.remove(a)
+            );
+
+            service.disposeAll();
+
+            expect(a.disposable.dispose).toHaveBeenCalledTimes(1);
+            expect(b.disposable.dispose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('dispose', () => {
+        test('cancels pending restorations, disposes entries and the emitter', async () => {
+            jest.useFakeTimers();
+            try {
+                const service = new PopoutWindowService(makeHost(false));
+                const entry = makeEntry();
+                service.add(entry);
+
+                const onCancel = jest.fn();
+                const pending = service.scheduleRestoration(
+                    1000,
+                    jest.fn(),
+                    onCancel
+                );
+
+                service.dispose();
+                await pending;
+
+                expect(onCancel).toHaveBeenCalledTimes(1);
+                expect(entry.disposable.dispose).toHaveBeenCalledTimes(1);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+    });
+
+    describe('PopoutWindowModule', () => {
+        test('describes the popoutWindowService and creates instances', () => {
+            expect(PopoutWindowModule.moduleName).toBe('PopoutWindow');
+
+            const create = (PopoutWindowModule.services as any)[
+                'popoutWindowService'
+            ];
+            expect(typeof create).toBe('function');
+
+            const instance = create(makeHost());
+            expect(instance).toBeInstanceOf(PopoutWindowService);
+        });
+    });
+});

--- a/packages/dockview-core/src/__tests__/dockview/theme.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/theme.spec.ts
@@ -1,0 +1,242 @@
+import {
+    type DockviewTheme,
+    themeAbyss,
+    themeAbyssSpaced,
+    themeCatppuccinMocha,
+    themeCatppuccinMochaSpaced,
+    themeDark,
+    themeDracula,
+    themeGithubDark,
+    themeGithubDarkSpaced,
+    themeGithubLight,
+    themeGithubLightSpaced,
+    themeLight,
+    themeLightSpaced,
+    themeMonokai,
+    themeNord,
+    themeNordSpaced,
+    themeSolarizedLight,
+    themeSolarizedLightSpaced,
+    themeVisualStudio,
+} from '../../dockview/theme';
+
+describe('theme', () => {
+    const allThemes: {
+        theme: DockviewTheme;
+        name: string;
+        className: string;
+    }[] = [
+        { theme: themeDark, name: 'dark', className: 'dockview-theme-dark' },
+        {
+            theme: themeLight,
+            name: 'light',
+            className: 'dockview-theme-light',
+        },
+        {
+            theme: themeVisualStudio,
+            name: 'visualStudio',
+            className: 'dockview-theme-vs',
+        },
+        {
+            theme: themeAbyss,
+            name: 'abyss',
+            className: 'dockview-theme-abyss',
+        },
+        {
+            theme: themeDracula,
+            name: 'dracula',
+            className: 'dockview-theme-dracula',
+        },
+        {
+            theme: themeAbyssSpaced,
+            name: 'abyssSpaced',
+            className: 'dockview-theme-abyss-spaced',
+        },
+        {
+            theme: themeLightSpaced,
+            name: 'lightSpaced',
+            className: 'dockview-theme-light-spaced',
+        },
+        {
+            theme: themeNord,
+            name: 'nord',
+            className: 'dockview-theme-nord',
+        },
+        {
+            theme: themeNordSpaced,
+            name: 'nordSpaced',
+            className: 'dockview-theme-nord-spaced',
+        },
+        {
+            theme: themeCatppuccinMocha,
+            name: 'catppuccinMocha',
+            className: 'dockview-theme-catppuccin-mocha',
+        },
+        {
+            theme: themeCatppuccinMochaSpaced,
+            name: 'catppuccinMochaSpaced',
+            className: 'dockview-theme-catppuccin-mocha-spaced',
+        },
+        {
+            theme: themeMonokai,
+            name: 'monokai',
+            className: 'dockview-theme-monokai',
+        },
+        {
+            theme: themeSolarizedLight,
+            name: 'solarizedLight',
+            className: 'dockview-theme-solarized-light',
+        },
+        {
+            theme: themeSolarizedLightSpaced,
+            name: 'solarizedLightSpaced',
+            className: 'dockview-theme-solarized-light-spaced',
+        },
+        {
+            theme: themeGithubDark,
+            name: 'githubDark',
+            className: 'dockview-theme-github-dark',
+        },
+        {
+            theme: themeGithubDarkSpaced,
+            name: 'githubDarkSpaced',
+            className: 'dockview-theme-github-dark-spaced',
+        },
+        {
+            theme: themeGithubLight,
+            name: 'githubLight',
+            className: 'dockview-theme-github-light',
+        },
+        {
+            theme: themeGithubLightSpaced,
+            name: 'githubLightSpaced',
+            className: 'dockview-theme-github-light-spaced',
+        },
+    ];
+
+    test.each(allThemes)('theme $name has the expected name and className', ({
+        theme,
+        name,
+        className,
+    }) => {
+        expect(theme.name).toBe(name);
+        expect(theme.className).toBe(className);
+    });
+
+    test('every theme declares a colorScheme of light or dark', () => {
+        for (const { theme } of allThemes) {
+            expect(['light', 'dark']).toContain(theme.colorScheme);
+        }
+    });
+
+    test('theme names are unique', () => {
+        const names = allThemes.map(({ theme }) => theme.name);
+        expect(new Set(names).size).toBe(names.length);
+    });
+
+    test('theme classNames are unique', () => {
+        const classNames = allThemes.map(({ theme }) => theme.className);
+        expect(new Set(classNames).size).toBe(classNames.length);
+    });
+
+    describe('colorScheme', () => {
+        test('dark themes are marked dark', () => {
+            const darkThemes = [
+                themeDark,
+                themeVisualStudio,
+                themeAbyss,
+                themeDracula,
+                themeAbyssSpaced,
+                themeNord,
+                themeNordSpaced,
+                themeCatppuccinMocha,
+                themeCatppuccinMochaSpaced,
+                themeMonokai,
+                themeGithubDark,
+                themeGithubDarkSpaced,
+            ];
+            for (const theme of darkThemes) {
+                expect(theme.colorScheme).toBe('dark');
+            }
+        });
+
+        test('light themes are marked light', () => {
+            const lightThemes = [
+                themeLight,
+                themeLightSpaced,
+                themeSolarizedLight,
+                themeSolarizedLightSpaced,
+                themeGithubLight,
+                themeGithubLightSpaced,
+            ];
+            for (const theme of lightThemes) {
+                expect(theme.colorScheme).toBe('light');
+            }
+        });
+    });
+
+    describe('non-spaced themes', () => {
+        test('do not declare spacing / gap related overrides', () => {
+            const nonSpaced = [
+                themeDark,
+                themeLight,
+                themeAbyss,
+                themeDracula,
+                themeNord,
+                themeCatppuccinMocha,
+                themeMonokai,
+                themeSolarizedLight,
+                themeGithubDark,
+                themeGithubLight,
+            ];
+            for (const theme of nonSpaced) {
+                expect(theme.gap).toBeUndefined();
+                expect(theme.dndOverlayMounting).toBeUndefined();
+                expect(theme.dndPanelOverlay).toBeUndefined();
+                expect(theme.dndTabIndicator).toBeUndefined();
+                expect(theme.dndOverlayBorder).toBeUndefined();
+            }
+        });
+    });
+
+    describe('spaced themes', () => {
+        const spacedThemes = [
+            themeAbyssSpaced,
+            themeLightSpaced,
+            themeNordSpaced,
+            themeCatppuccinMochaSpaced,
+            themeSolarizedLightSpaced,
+            themeGithubDarkSpaced,
+            themeGithubLightSpaced,
+        ];
+
+        test('share the common spaced configuration', () => {
+            for (const theme of spacedThemes) {
+                expect(theme.gap).toBe(10);
+                expect(theme.edgeGroupCollapsedSize).toBe(44);
+                expect(theme.dndOverlayMounting).toBe('absolute');
+                expect(theme.dndPanelOverlay).toBe('group');
+                expect(theme.dndTabIndicator).toBe('line');
+                expect(theme.dndOverlayBorder).toBe(
+                    '2px solid var(--dv-active-sash-color)'
+                );
+            }
+        });
+    });
+
+    describe('specific overrides', () => {
+        test('visualStudio overrides the edge group collapsed size to 22', () => {
+            expect(themeVisualStudio.edgeGroupCollapsedSize).toBe(22);
+        });
+
+        test('abyss disables the tab group indicator', () => {
+            expect(themeAbyss.tabGroupIndicator).toBe('none');
+        });
+
+        test('themes without an explicit tabGroupIndicator leave it undefined', () => {
+            expect(themeDark.tabGroupIndicator).toBeUndefined();
+            expect(themeLight.tabGroupIndicator).toBeUndefined();
+            expect(themeAbyssSpaced.tabGroupIndicator).toBeUndefined();
+        });
+    });
+});

--- a/packages/dockview-core/src/__tests__/dom.spec.ts
+++ b/packages/dockview-core/src/__tests__/dom.spec.ts
@@ -1,10 +1,33 @@
 import {
+    Classnames,
     addStyles,
     disableIframePointEvents,
+    findRelativeZIndexParent,
+    isChildEntirelyVisibleWithinParent,
     isInDocument,
+    prefersReducedMotion,
     quasiDefaultPrevented,
     quasiPreventDefault,
+    resolveOpaqueBackground,
 } from '../dom';
+
+function stubRect(
+    el: HTMLElement,
+    r: { left: number; top: number; width: number; height: number }
+): void {
+    el.getBoundingClientRect = () =>
+        ({
+            left: r.left,
+            top: r.top,
+            width: r.width,
+            height: r.height,
+            right: r.left + r.width,
+            bottom: r.top + r.height,
+            x: r.left,
+            y: r.top,
+            toJSON: () => ({}),
+        }) as DOMRect;
+}
 
 describe('dom', () => {
     test('quasiPreventDefault', () => {
@@ -257,5 +280,134 @@ describe('dom', () => {
             const style = targetDoc.head.querySelector('style')!;
             expect(style.getAttribute('nonce')).toBe('from-popout');
         });
+    });
+});
+
+describe('Classnames', () => {
+    test('applies, trims, and swaps class names against the element', () => {
+        const el = document.createElement('div');
+        const cn = new Classnames(el);
+
+        cn.setClassNames('a b c');
+        expect(el.classList.contains('a')).toBe(true);
+        expect(el.classList.contains('b')).toBe(true);
+        expect(el.classList.contains('c')).toBe(true);
+
+        // A second call clears the previous set, keeps overlaps, adds new.
+        cn.setClassNames('c d');
+        expect(el.classList.contains('a')).toBe(false);
+        expect(el.classList.contains('b')).toBe(false);
+        expect(el.classList.contains('c')).toBe(true);
+        expect(el.classList.contains('d')).toBe(true);
+
+        // Extra whitespace / empty tokens are filtered out.
+        cn.setClassNames('   x    y   ');
+        expect(el.classList.contains('c')).toBe(false);
+        expect(el.classList.contains('d')).toBe(false);
+        expect([...el.classList].sort()).toEqual(['x', 'y']);
+    });
+});
+
+describe('isChildEntirelyVisibleWithinParent', () => {
+    const parent = document.createElement('div');
+    stubRect(parent, { left: 0, top: 0, width: 100, height: 100 });
+
+    test('true when the child sits fully inside the parent box', () => {
+        const child = document.createElement('div');
+        stubRect(child, { left: 10, top: 10, width: 20, height: 20 });
+        expect(isChildEntirelyVisibleWithinParent(child, parent)).toBe(true);
+    });
+
+    test.each([
+        ['left', { left: -1, top: 10, width: 20, height: 20 }],
+        ['right', { left: 90, top: 10, width: 20, height: 20 }],
+        ['top', { left: 10, top: -1, width: 20, height: 20 }],
+        ['bottom', { left: 10, top: 90, width: 20, height: 20 }],
+    ])('false when the child overflows the %s edge', (_side, rect) => {
+        const child = document.createElement('div');
+        stubRect(child, rect);
+        expect(isChildEntirelyVisibleWithinParent(child, parent)).toBe(false);
+    });
+});
+
+describe('findRelativeZIndexParent', () => {
+    test('walks up past auto / empty z-index to the first positioned ancestor', () => {
+        const grandparent = document.createElement('div');
+        const parent = document.createElement('div');
+        const child = document.createElement('div');
+        grandparent.appendChild(parent);
+        parent.appendChild(child);
+        grandparent.style.zIndex = '5';
+        parent.style.zIndex = 'auto';
+
+        expect(findRelativeZIndexParent(child)).toBe(grandparent);
+    });
+
+    test('returns the element itself when it already sets a z-index', () => {
+        const el = document.createElement('div');
+        el.style.zIndex = '3';
+        expect(findRelativeZIndexParent(el)).toBe(el);
+    });
+
+    test('returns null when no ancestor sets a z-index', () => {
+        const el = document.createElement('div');
+        el.style.zIndex = 'auto';
+        expect(findRelativeZIndexParent(el)).toBeNull();
+    });
+});
+
+describe('prefersReducedMotion', () => {
+    const win = document.defaultView as Window & {
+        matchMedia?: (q: string) => MediaQueryList;
+    };
+    const original = win.matchMedia;
+
+    afterEach(() => {
+        win.matchMedia = original;
+    });
+
+    test('reflects the media query match result', () => {
+        win.matchMedia = ((query: string) =>
+            ({ matches: true, media: query }) as MediaQueryList) as any;
+        expect(prefersReducedMotion(document)).toBe(true);
+
+        win.matchMedia = ((query: string) =>
+            ({ matches: false, media: query }) as MediaQueryList) as any;
+        expect(prefersReducedMotion(document)).toBe(false);
+    });
+
+    test('false when matchMedia is unavailable', () => {
+        delete (win as { matchMedia?: unknown }).matchMedia;
+        expect(prefersReducedMotion(document)).toBe(false);
+    });
+});
+
+describe('resolveOpaqueBackground', () => {
+    test('returns the first opaque background walking up the ancestors', () => {
+        const parent = document.createElement('div');
+        const child = document.createElement('div');
+        parent.appendChild(child);
+        document.body.appendChild(parent);
+        parent.style.backgroundColor = 'rgb(1, 2, 3)';
+
+        const expected =
+            document.defaultView!.getComputedStyle(parent).backgroundColor;
+        expect(expected).toBeTruthy();
+        // child has no background of its own, so it inherits the parent's.
+        expect(resolveOpaqueBackground(child)).toBe(expected);
+
+        // an opaque background on the element itself wins.
+        child.style.backgroundColor = 'rgb(9, 9, 9)';
+        expect(resolveOpaqueBackground(child)).toBe(
+            document.defaultView!.getComputedStyle(child).backgroundColor
+        );
+
+        document.body.removeChild(parent);
+    });
+
+    test('skips fully-transparent colours and returns "" when none is opaque', () => {
+        const el = document.createElement('div');
+        el.style.backgroundColor = 'rgba(255, 255, 255, 0)';
+        expect(resolveOpaqueBackground(el)).toBe('');
     });
 });

--- a/packages/dockview-core/src/__tests__/events.spec.ts
+++ b/packages/dockview-core/src/__tests__/events.spec.ts
@@ -1,4 +1,11 @@
-import { AsapEvent, Emitter, Event, addDisposableListener } from '../events';
+import {
+    AcceptableEvent,
+    AsapEvent,
+    DockviewEvent,
+    Emitter,
+    Event,
+    addDisposableListener,
+} from '../events';
 
 describe('events', () => {
     describe('emitter', () => {
@@ -367,6 +374,342 @@ describe('events', () => {
             expect(value).toBe(2);
 
             stream.dispose();
+        });
+    });
+
+    describe('emitter additional behaviours', () => {
+        it('should fire to multiple listeners', () => {
+            const emitter = new Emitter<number>();
+
+            let a: number | undefined = undefined;
+            let b: number | undefined = undefined;
+            let c: number | undefined = undefined;
+
+            const d1 = emitter.event((x) => {
+                a = x;
+            });
+            const d2 = emitter.event((x) => {
+                b = x;
+            });
+            const d3 = emitter.event((x) => {
+                c = x;
+            });
+
+            emitter.fire(5);
+
+            expect(a).toBe(5);
+            expect(b).toBe(5);
+            expect(c).toBe(5);
+
+            d1.dispose();
+            d2.dispose();
+            d3.dispose();
+        });
+
+        it('should only unsubscribe the disposed listener', () => {
+            const emitter = new Emitter<number>();
+
+            let a: number | undefined = undefined;
+            let b: number | undefined = undefined;
+
+            const d1 = emitter.event((x) => {
+                a = x;
+            });
+            const d2 = emitter.event((x) => {
+                b = x;
+            });
+
+            d1.dispose();
+
+            emitter.fire(7);
+
+            expect(a).toBeUndefined();
+            expect(b).toBe(7);
+
+            d2.dispose();
+        });
+
+        it('should return the same event function on repeated access', () => {
+            const emitter = new Emitter<number>();
+            expect(emitter.event).toBe(emitter.event);
+        });
+
+        it('should expose the last fired value via the value getter in replay mode', () => {
+            const emitter = new Emitter<number>({ replay: true });
+
+            expect(emitter.value).toBeUndefined();
+
+            emitter.fire(1);
+            expect(emitter.value).toBe(1);
+
+            emitter.fire(2);
+            expect(emitter.value).toBe(2);
+        });
+
+        it('should not track a last value when not in replay mode', () => {
+            const emitter = new Emitter<number>();
+
+            emitter.fire(1);
+            expect(emitter.value).toBeUndefined();
+        });
+
+        it('disposing a listener twice is a no-op', () => {
+            const emitter = new Emitter<number>();
+
+            let value: number | undefined = undefined;
+            const stream = emitter.event((x) => {
+                value = x;
+            });
+
+            stream.dispose();
+            expect(() => stream.dispose()).not.toThrow();
+
+            emitter.fire(1);
+            expect(value).toBeUndefined();
+        });
+
+        it('should stop firing to any listener after the emitter is disposed', () => {
+            const emitter = new Emitter<number>();
+
+            let value: number | undefined = undefined;
+            emitter.event((x) => {
+                value = x;
+            });
+
+            emitter.dispose();
+
+            emitter.fire(1);
+            expect(value).toBeUndefined();
+        });
+
+        it('disposing the emitter twice is a no-op', () => {
+            const emitter = new Emitter<number>();
+            emitter.event(() => {
+                // noop
+            });
+
+            emitter.dispose();
+            expect(() => emitter.dispose()).not.toThrow();
+        });
+    });
+
+    describe('leakage tracking', () => {
+        let warnSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            jest.useRealTimers();
+            warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
+                // suppress
+            });
+        });
+
+        afterEach(() => {
+            Emitter.setLeakageMonitorEnabled(false);
+            Emitter.MEMORY_LEAK_WATCHER.clear();
+            warnSpy.mockRestore();
+        });
+
+        it('toggling tracking clears the watcher and updates the flag', () => {
+            expect(Emitter.ENABLE_TRACKING).toBeFalsy();
+
+            Emitter.setLeakageMonitorEnabled(true);
+            expect(Emitter.ENABLE_TRACKING).toBe(true);
+
+            Emitter.setLeakageMonitorEnabled(false);
+            expect(Emitter.ENABLE_TRACKING).toBe(false);
+        });
+
+        it('setting the same value does not clear the watcher', () => {
+            const clearSpy = jest.spyOn(Emitter.MEMORY_LEAK_WATCHER, 'clear');
+
+            // already false, set to false again
+            Emitter.setLeakageMonitorEnabled(false);
+            expect(clearSpy).not.toHaveBeenCalled();
+
+            clearSpy.mockRestore();
+        });
+
+        it('registers the event in the watcher when tracking is enabled', () => {
+            Emitter.setLeakageMonitorEnabled(true);
+
+            const emitter = new Emitter<number>();
+            expect(Emitter.MEMORY_LEAK_WATCHER.size).toBe(0);
+
+            // accessing `event` registers the emitter with the watcher
+            const stream = emitter.event(() => {
+                // noop
+            });
+            expect(Emitter.MEMORY_LEAK_WATCHER.size).toBe(1);
+
+            emitter.dispose();
+            expect(Emitter.MEMORY_LEAK_WATCHER.size).toBe(0);
+
+            stream.dispose();
+        });
+
+        it('disposing with a live listener while tracking queues cleanup without throwing', async () => {
+            Emitter.setLeakageMonitorEnabled(true);
+
+            const emitter = new Emitter<number>();
+            emitter.event(() => {
+                // never explicitly disposed -> leaked
+            });
+
+            emitter.fire(1);
+
+            // disposing with a live listener enters the tracking branch that
+            // queues a microtask; it must clear listeners and not throw
+            expect(() => emitter.dispose()).not.toThrow();
+
+            // flush any queued microtask
+            await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+            // the watcher entry for this emitter has been removed
+            expect(Emitter.MEMORY_LEAK_WATCHER.size).toBe(0);
+        });
+
+        it('warns when disposing a listener that was already removed while tracking', () => {
+            Emitter.setLeakageMonitorEnabled(true);
+
+            const emitter = new Emitter<number>();
+            const stream = emitter.event(() => {
+                // noop
+            });
+
+            // first dispose removes the listener, second dispose hits the
+            // tracking branch for an already-removed listener
+            stream.dispose();
+            expect(() => stream.dispose()).not.toThrow();
+
+            emitter.dispose();
+        });
+    });
+
+    describe('Event.any', () => {
+        it('unsubscribes from all children when disposed', () => {
+            const emitter1 = new Emitter<number>();
+            const emitter2 = new Emitter<number>();
+
+            let value: number | undefined = undefined;
+
+            const stream = Event.any(
+                emitter1.event,
+                emitter2.event
+            )((x) => {
+                value = x;
+            });
+
+            emitter1.fire(1);
+            expect(value).toBe(1);
+
+            stream.dispose();
+
+            value = undefined;
+            emitter1.fire(2);
+            emitter2.fire(3);
+            expect(value).toBeUndefined();
+        });
+    });
+
+    describe('DockviewEvent', () => {
+        it('defaults to not prevented and can be prevented', () => {
+            const event = new DockviewEvent();
+            expect(event.defaultPrevented).toBe(false);
+
+            event.preventDefault();
+            expect(event.defaultPrevented).toBe(true);
+        });
+    });
+
+    describe('AcceptableEvent', () => {
+        it('defaults to not accepted and can be accepted', () => {
+            const event = new AcceptableEvent();
+            expect(event.isAccepted).toBe(false);
+
+            event.accept();
+            expect(event.isAccepted).toBe(true);
+        });
+    });
+
+    describe('AsapEvent additional', () => {
+        beforeEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('batches multiple fires into a single microtask dispatch', async () => {
+            const event = new AsapEvent();
+
+            let count = 0;
+            const disposable = event.onEvent(() => {
+                count++;
+            });
+
+            event.fire();
+            event.fire();
+            event.fire();
+
+            expect(count).toBe(0);
+
+            await Promise.resolve();
+
+            expect(count).toBe(1);
+
+            disposable.dispose();
+            event.dispose();
+        });
+
+        it('fires again on a subsequent event-loop cycle', async () => {
+            const event = new AsapEvent();
+
+            let count = 0;
+            const disposable = event.onEvent(() => {
+                count++;
+            });
+
+            event.fire();
+            await Promise.resolve();
+            expect(count).toBe(1);
+
+            event.fire();
+            await Promise.resolve();
+            expect(count).toBe(2);
+
+            disposable.dispose();
+            event.dispose();
+        });
+
+        it('does not fire to a listener disposed before the microtask runs', async () => {
+            const event = new AsapEvent();
+
+            let count = 0;
+            const disposable = event.onEvent(() => {
+                count++;
+            });
+
+            event.fire();
+            disposable.dispose();
+
+            await Promise.resolve();
+
+            expect(count).toBe(0);
+
+            event.dispose();
+        });
+
+        it('dispose tears down the underlying emitter', async () => {
+            const event = new AsapEvent();
+
+            let count = 0;
+            event.onEvent(() => {
+                count++;
+            });
+
+            event.dispose();
+
+            event.fire();
+            await Promise.resolve();
+
+            expect(count).toBe(0);
         });
     });
 });

--- a/packages/dockview-core/src/__tests__/gridview/baseComponentGridview.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/baseComponentGridview.spec.ts
@@ -3,6 +3,7 @@ import {
     BaseGrid,
     IGridPanelView,
     BaseGridOptions,
+    toTarget,
 } from '../../gridview/baseComponentGridview';
 import { IViewSize } from '../../gridview/gridview';
 import { CompositeDisposable } from '../../lifecycle';
@@ -202,5 +203,475 @@ describe('baseComponentGridview', () => {
 
         disposable.dispose();
         cut.dispose();
+    });
+
+    function createPanel(id: string): TestPanel {
+        return new TestPanel(
+            id,
+            document.createElement('div'),
+            0,
+            100,
+            0,
+            100,
+            LayoutPriority.Normal,
+            false
+        );
+    }
+
+    function createCut(options?: Partial<BaseGridOptions>): ClassUnderTest {
+        return new ClassUnderTest(document.createElement('div'), {
+            orientation: Orientation.HORIZONTAL,
+            proportionalLayout: true,
+            ...options,
+        });
+    }
+
+    describe('toTarget', () => {
+        test('maps directions to positions', () => {
+            expect(toTarget('left')).toBe('left');
+            expect(toTarget('right')).toBe('right');
+            expect(toTarget('above')).toBe('top');
+            expect(toTarget('below')).toBe('bottom');
+            expect(toTarget('within')).toBe('center');
+        });
+    });
+
+    test('id is a non-empty string and stable', () => {
+        const cut = createCut();
+        expect(typeof cut.id).toBe('string');
+        expect(cut.id.length).toBeGreaterThan(0);
+        expect(cut.id).toBe(cut.id);
+        cut.dispose();
+    });
+
+    test('size and groups reflect added groups', () => {
+        const cut = createCut();
+
+        expect(cut.size).toBe(0);
+        expect(cut.groups).toEqual([]);
+
+        const panel1 = createPanel('id1');
+        const panel2 = createPanel('id2');
+
+        cut.doAddGroup(panel1);
+        cut.doAddGroup(panel2, [1]);
+
+        expect(cut.size).toBe(2);
+        expect(cut.groups).toEqual([panel1, panel2]);
+
+        cut.dispose();
+    });
+
+    test('getPanel returns the group by id or undefined', () => {
+        const cut = createCut();
+
+        const panel1 = createPanel('id1');
+        cut.doAddGroup(panel1);
+
+        expect(cut.getPanel('id1')).toBe(panel1);
+        expect(cut.getPanel('does-not-exist')).toBeUndefined();
+
+        cut.dispose();
+    });
+
+    test('dimension getters delegate to the gridview', () => {
+        const cut = createCut();
+
+        expect(cut.width).toBe(cut.gridview.width);
+        expect(cut.height).toBe(cut.gridview.height);
+        expect(cut.minimumHeight).toBe(cut.gridview.minimumHeight);
+        expect(cut.maximumHeight).toBe(cut.gridview.maximumHeight);
+        expect(cut.minimumWidth).toBe(cut.gridview.minimumWidth);
+        expect(cut.maximumWidth).toBe(cut.gridview.maximumWidth);
+
+        cut.dispose();
+    });
+
+    test('locked getter/setter delegate to the gridview', () => {
+        const cut = createCut();
+
+        expect(cut.locked).toBe(false);
+
+        cut.locked = true;
+        expect(cut.locked).toBe(true);
+        expect(cut.gridview.locked).toBe(true);
+
+        cut.locked = false;
+        expect(cut.locked).toBe(false);
+        expect(cut.gridview.locked).toBe(false);
+
+        cut.dispose();
+    });
+
+    test('locked option is applied in the constructor', () => {
+        const cut = createCut({ locked: true });
+        expect(cut.locked).toBe(true);
+        expect(cut.gridview.locked).toBe(true);
+        cut.dispose();
+    });
+
+    test('className option is applied in the constructor', () => {
+        const cut = createCut({ className: 'foo bar' });
+        expect(cut.element.classList.contains('foo')).toBe(true);
+        expect(cut.element.classList.contains('bar')).toBe(true);
+        cut.dispose();
+    });
+
+    describe('doSetGroupActive', () => {
+        test('activates a group, deactivates the previous and fires event', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            const panel2 = createPanel('id2');
+            cut.doAddGroup(panel1);
+            cut.doAddGroup(panel2, [1]);
+
+            const spy1 = jest.spyOn(panel1, 'setActive');
+            const spy2 = jest.spyOn(panel2, 'setActive');
+
+            const activeEvents: (TestPanel | undefined)[] = [];
+            const disposable = cut.onDidActiveChange((event) => {
+                activeEvents.push(event);
+            });
+
+            cut.doSetGroupActive(panel1);
+            expect(cut.activeGroup).toBe(panel1);
+            expect(spy1).toHaveBeenLastCalledWith(true);
+            expect(activeEvents).toEqual([panel1]);
+
+            cut.doSetGroupActive(panel2);
+            expect(cut.activeGroup).toBe(panel2);
+            expect(spy1).toHaveBeenLastCalledWith(false);
+            expect(spy2).toHaveBeenLastCalledWith(true);
+            expect(activeEvents).toEqual([panel1, panel2]);
+
+            disposable.dispose();
+            cut.dispose();
+        });
+
+        test('is a no-op when the group is already active', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            cut.doAddGroup(panel1);
+
+            cut.doSetGroupActive(panel1);
+
+            const spy = jest.spyOn(panel1, 'setActive');
+            let fired = false;
+            const disposable = cut.onDidActiveChange(() => {
+                fired = true;
+            });
+
+            cut.doSetGroupActive(panel1);
+
+            expect(spy).not.toHaveBeenCalled();
+            expect(fired).toBe(false);
+
+            disposable.dispose();
+            cut.dispose();
+        });
+
+        test('can clear the active group with undefined', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            cut.doAddGroup(panel1);
+            cut.doSetGroupActive(panel1);
+            expect(cut.activeGroup).toBe(panel1);
+
+            const spy = jest.spyOn(panel1, 'setActive');
+            cut.doSetGroupActive(undefined);
+
+            expect(cut.activeGroup).toBeUndefined();
+            expect(spy).toHaveBeenLastCalledWith(false);
+
+            cut.dispose();
+        });
+    });
+
+    describe('doRemoveGroup', () => {
+        test('reassigns active group to the first remaining group', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            const panel2 = createPanel('id2');
+            cut.doAddGroup(panel1);
+            cut.doAddGroup(panel2, [1]);
+
+            cut.doSetGroupActive(panel2);
+            expect(cut.activeGroup).toBe(panel2);
+
+            cut.doRemoveGroup(panel2);
+
+            expect(cut.activeGroup).toBe(panel1);
+
+            cut.dispose();
+        });
+
+        test('active group becomes undefined when the last group is removed', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            cut.doAddGroup(panel1);
+            cut.doSetGroupActive(panel1);
+
+            cut.doRemoveGroup(panel1);
+
+            expect(cut.activeGroup).toBeUndefined();
+
+            cut.dispose();
+        });
+
+        test('throws for a group that is not part of the grid', () => {
+            const cut = createCut();
+            const stranger = createPanel('stranger');
+
+            expect(() => cut.doRemoveGroup(stranger)).toThrow(
+                'invalid operation'
+            );
+
+            cut.dispose();
+        });
+
+        test('removeGroup delegates to doRemoveGroup', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            cut.doAddGroup(panel1);
+
+            const removeEvents: TestPanel[] = [];
+            const disposable = cut.onDidRemove((event) => {
+                removeEvents.push(event);
+            });
+
+            cut.removeGroup(panel1);
+
+            expect(removeEvents).toEqual([panel1]);
+            expect(cut.size).toBe(0);
+
+            disposable.dispose();
+            cut.dispose();
+        });
+    });
+
+    describe('activateNext / activatePrevious', () => {
+        test('return early when there is no group to move from', () => {
+            const cut = createCut();
+
+            expect(cut.activeGroup).toBeUndefined();
+            cut.activateNext();
+            cut.activatePrevious();
+            expect(cut.activeGroup).toBeUndefined();
+
+            cut.dispose();
+        });
+
+        test('move the active group forwards and backwards', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            const panel2 = createPanel('id2');
+            cut.doAddGroup(panel1);
+            cut.doAddGroup(panel2, [1]);
+
+            cut.doSetGroupActive(panel1);
+
+            cut.activateNext();
+            expect(cut.activeGroup).toBe(panel2);
+
+            cut.activatePrevious();
+            expect(cut.activeGroup).toBe(panel1);
+
+            cut.dispose();
+        });
+
+        test('accept an explicit group via options', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            const panel2 = createPanel('id2');
+            cut.doAddGroup(panel1);
+            cut.doAddGroup(panel2, [1]);
+
+            cut.activateNext({ group: panel1 });
+            expect(cut.activeGroup).toBe(panel2);
+
+            cut.activatePrevious({ group: panel2 });
+            expect(cut.activeGroup).toBe(panel1);
+
+            cut.dispose();
+        });
+    });
+
+    describe('maximized group', () => {
+        test('maximize/exit updates state, activates and fires events', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            const panel2 = createPanel('id2');
+            cut.doAddGroup(panel1);
+            cut.doAddGroup(panel2, [1]);
+
+            const events: boolean[] = [];
+            const disposable = cut.onDidMaximizedChange((event) => {
+                expect(event.panel).toBe(panel1);
+                events.push(event.isMaximized);
+            });
+
+            expect(cut.hasMaximizedGroup()).toBe(false);
+            expect(cut.isMaximizedGroup(panel1)).toBe(false);
+
+            cut.maximizeGroup(panel1);
+
+            expect(cut.hasMaximizedGroup()).toBe(true);
+            expect(cut.isMaximizedGroup(panel1)).toBe(true);
+            expect(cut.isMaximizedGroup(panel2)).toBe(false);
+            expect(cut.activeGroup).toBe(panel1);
+            expect(events).toEqual([true]);
+
+            cut.exitMaximizedGroup();
+
+            expect(cut.hasMaximizedGroup()).toBe(false);
+            expect(cut.isMaximizedGroup(panel1)).toBe(false);
+            expect(events).toEqual([true, false]);
+
+            disposable.dispose();
+            cut.dispose();
+        });
+    });
+
+    describe('setVisible / isVisible', () => {
+        test('toggle visibility of a group', () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            const panel2 = createPanel('id2');
+            cut.doAddGroup(panel1);
+            cut.doAddGroup(panel2, [1]);
+
+            expect(cut.isVisible(panel1)).toBe(true);
+
+            cut.setVisible(panel1, false);
+            expect(cut.isVisible(panel1)).toBe(false);
+
+            cut.setVisible(panel1, true);
+            expect(cut.isVisible(panel1)).toBe(true);
+
+            cut.dispose();
+        });
+
+        test('visibility change triggers a relayout via the microtask queue', async () => {
+            const cut = createCut();
+
+            const panel1 = createPanel('id1');
+            const panel2 = createPanel('id2');
+            cut.doAddGroup(panel1);
+            cut.doAddGroup(panel2, [1]);
+
+            cut.layout(100, 100, true);
+
+            const spy = jest.spyOn(cut, 'layout');
+            cut.gridview.setViewVisible([0], false);
+
+            await new Promise<void>((resolve) => queueMicrotask(resolve));
+            await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+            expect(spy).toHaveBeenCalled();
+
+            cut.dispose();
+        });
+    });
+
+    describe('updateOptions', () => {
+        test('updates orientation', () => {
+            const cut = createCut();
+
+            cut.updateOptions({ orientation: Orientation.VERTICAL });
+            expect(cut.gridview.orientation).toBe(Orientation.VERTICAL);
+
+            cut.dispose();
+        });
+
+        test('updates margin', () => {
+            const cut = createCut();
+
+            cut.updateOptions({ margin: 12 });
+            expect(cut.gridview.margin).toBe(12);
+
+            cut.updateOptions({ margin: undefined });
+            expect(cut.gridview.margin).toBe(0);
+
+            cut.dispose();
+        });
+
+        test('updates locked', () => {
+            const cut = createCut();
+
+            cut.updateOptions({ locked: true });
+            expect(cut.locked).toBe(true);
+
+            cut.updateOptions({ locked: undefined });
+            expect(cut.locked).toBe(false);
+
+            cut.dispose();
+        });
+
+        test('updates className', () => {
+            const cut = createCut({ className: 'initial' });
+            expect(cut.element.classList.contains('initial')).toBe(true);
+
+            cut.updateOptions({ className: 'updated' });
+            expect(cut.element.classList.contains('initial')).toBe(false);
+            expect(cut.element.classList.contains('updated')).toBe(true);
+
+            cut.updateOptions({ className: undefined });
+            expect(cut.element.classList.contains('updated')).toBe(false);
+
+            cut.dispose();
+        });
+
+        test('updates disableResizing when the key is present', () => {
+            const cut = createCut();
+            expect(cut.disableResizing).toBe(false);
+
+            cut.updateOptions({
+                disableResizing: true,
+                disableAutoResizing: true,
+            } as Partial<BaseGridOptions>);
+            expect(cut.disableResizing).toBe(true);
+
+            cut.dispose();
+        });
+
+        test('ignores the unsupported proportionalLayout and styles options', () => {
+            const cut = createCut();
+
+            expect(() =>
+                cut.updateOptions({
+                    proportionalLayout: false,
+                    styles: undefined,
+                })
+            ).not.toThrow();
+
+            cut.dispose();
+        });
+    });
+
+    test('dispose disposes all remaining groups', () => {
+        const cut = createCut();
+
+        const panel1 = createPanel('id1');
+        const panel2 = createPanel('id2');
+        cut.doAddGroup(panel1);
+        cut.doAddGroup(panel2, [1]);
+
+        const spy1 = jest.spyOn(panel1, 'dispose');
+        const spy2 = jest.spyOn(panel2, 'dispose');
+
+        cut.dispose();
+
+        expect(spy1).toHaveBeenCalled();
+        expect(spy2).toHaveBeenCalled();
     });
 });

--- a/packages/dockview-core/src/__tests__/gridview/gridviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridviewComponent.spec.ts
@@ -3001,4 +3001,357 @@ describe('gridview', () => {
         // The main test is that we got this far without errors
         expect(true).toBeTruthy();
     });
+
+    function createGridview(
+        orientation: Orientation = Orientation.VERTICAL,
+        proportionalLayout = false
+    ): GridviewComponent {
+        return new GridviewComponent(container, {
+            proportionalLayout,
+            orientation,
+            createComponent: (options) => {
+                switch (options.name) {
+                    case 'default':
+                        return new TestGridview(options.id, options.name);
+                    default:
+                        throw new Error('unsupported');
+                }
+            },
+        });
+    }
+
+    test('orientation getter reflects the constructor value', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL);
+        expect(gridview.orientation).toBe(Orientation.HORIZONTAL);
+    });
+
+    test('orientation setter updates the underlying gridview', () => {
+        const gridview = createGridview(Orientation.VERTICAL);
+        gridview.layout(800, 400);
+
+        expect(gridview.orientation).toBe(Orientation.VERTICAL);
+
+        gridview.orientation = Orientation.HORIZONTAL;
+
+        expect(gridview.orientation).toBe(Orientation.HORIZONTAL);
+    });
+
+    test('deserializer getter/setter round-trips the value', () => {
+        const gridview = createGridview();
+
+        expect(gridview.deserializer).toBeUndefined();
+
+        const deserializer = {
+            fromJSON: jest.fn(),
+        };
+
+        gridview.deserializer = deserializer;
+
+        expect(gridview.deserializer).toBe(deserializer);
+
+        gridview.deserializer = undefined;
+
+        expect(gridview.deserializer).toBeUndefined();
+    });
+
+    test('options getter exposes the provided options', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+
+        expect(gridview.options.orientation).toBe(Orientation.HORIZONTAL);
+        expect(gridview.options.proportionalLayout).toBe(true);
+    });
+
+    test('updateOptions changes the orientation', () => {
+        const gridview = createGridview(Orientation.VERTICAL);
+        gridview.layout(800, 400);
+
+        expect(gridview.orientation).toBe(Orientation.VERTICAL);
+
+        gridview.updateOptions({ orientation: Orientation.HORIZONTAL });
+
+        expect(gridview.orientation).toBe(Orientation.HORIZONTAL);
+        expect(gridview.options.orientation).toBe(Orientation.HORIZONTAL);
+    });
+
+    test('updateOptions with an unchanged orientation is a no-op for orientation', () => {
+        const gridview = createGridview(Orientation.VERTICAL);
+        gridview.layout(800, 400);
+
+        gridview.updateOptions({ orientation: Orientation.VERTICAL });
+
+        expect(gridview.orientation).toBe(Orientation.VERTICAL);
+    });
+
+    test('setActive makes the requested panel active and deactivates the others', () => {
+        const gridview = createGridview();
+        gridview.layout(800, 400);
+
+        const panel1 = gridview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = gridview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        // panel2 was added last, so it is active
+        expect(panel2.api.isActive).toBeTruthy();
+
+        gridview.setActive(panel1 as GridviewPanel);
+
+        expect(panel1.api.isActive).toBeTruthy();
+        expect(panel2.api.isActive).toBeFalsy();
+    });
+
+    test('focus does not throw when a panel is active', () => {
+        const gridview = createGridview();
+        gridview.layout(800, 400);
+
+        const panel1 = gridview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+
+        const spy = jest.spyOn(panel1 as GridviewPanel, 'focus');
+
+        expect(() => gridview.focus()).not.toThrow();
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    test('focus does not throw when there is no active panel', () => {
+        const gridview = createGridview();
+        gridview.layout(800, 400);
+
+        expect(() => gridview.focus()).not.toThrow();
+    });
+
+    test('a panel becomes active when its api fires a focus event', () => {
+        const gridview = createGridview();
+        gridview.layout(800, 400);
+
+        const panel1 = gridview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = gridview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        // panel2 is active (added last)
+        expect(panel2.api.isActive).toBeTruthy();
+
+        // simulate panel1 gaining focus
+        panel1.api._onDidChangeFocus.fire({ isFocused: true });
+
+        expect(panel1.api.isActive).toBeTruthy();
+        expect(panel2.api.isActive).toBeFalsy();
+    });
+
+    test('a focus event with isFocused=false does not change the active panel', () => {
+        const gridview = createGridview();
+        gridview.layout(800, 400);
+
+        const panel1 = gridview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        const panel2 = gridview.addPanel({
+            id: 'panel2',
+            component: 'default',
+        });
+
+        expect(panel2.api.isActive).toBeTruthy();
+
+        panel1.api._onDidChangeFocus.fire({ isFocused: false });
+
+        // no change - panel2 remains active
+        expect(panel2.api.isActive).toBeTruthy();
+        expect(panel1.api.isActive).toBeFalsy();
+    });
+
+    test('movePanel repositions a panel relative to a reference', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        gridview.addPanel({ id: 'panel1', component: 'default' });
+        gridview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { referencePanel: 'panel1', direction: 'right' },
+        });
+        const panel3 = gridview.addPanel({
+            id: 'panel3',
+            component: 'default',
+            position: { referencePanel: 'panel2', direction: 'right' },
+        });
+
+        expect(gridview.size).toBe(3);
+
+        gridview.movePanel(panel3 as GridviewPanel, {
+            direction: 'left',
+            reference: 'panel1',
+        });
+
+        // all three panels still present after the move
+        expect(gridview.size).toBe(3);
+        expect(gridview.getPanel('panel1')).toBeTruthy();
+        expect(gridview.getPanel('panel2')).toBeTruthy();
+        expect(gridview.getPanel('panel3')).toBeTruthy();
+    });
+
+    test('movePanel throws when the reference group does not exist', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        const panel1 = gridview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+
+        expect(() =>
+            gridview.movePanel(panel1 as GridviewPanel, {
+                direction: 'right',
+                reference: 'does_not_exist',
+            })
+        ).toThrow('reference group does_not_exist does not exist');
+    });
+
+    test('movePanel throws when the direction resolves to center', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        gridview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = gridview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { referencePanel: 'panel1', direction: 'right' },
+        });
+
+        expect(() =>
+            gridview.movePanel(panel2 as GridviewPanel, {
+                direction: 'within',
+                reference: 'panel1',
+            })
+        ).toThrow('center not supported as an option');
+    });
+
+    test('addPanel throws when the reference panel does not exist', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        expect(() =>
+            gridview.addPanel({
+                id: 'panel1',
+                component: 'default',
+                position: {
+                    referencePanel: 'does_not_exist',
+                    direction: 'right',
+                },
+            })
+        ).toThrow('reference group does_not_exist does not exist');
+    });
+
+    test('addPanel throws when the position direction resolves to center', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        gridview.addPanel({ id: 'panel1', component: 'default' });
+
+        expect(() =>
+            gridview.addPanel({
+                id: 'panel2',
+                component: 'default',
+                position: { referencePanel: 'panel1', direction: 'within' },
+            })
+        ).toThrow('center not supported as an option');
+    });
+
+    test('addPanel honours an explicit location', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        gridview.addPanel({ id: 'panel1', component: 'default' });
+        const panel2 = gridview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            location: [0],
+        });
+
+        expect(gridview.size).toBe(2);
+        expect(panel2.api.isActive).toBeTruthy();
+    });
+
+    test('moveGroup swaps two siblings within the same parent', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        const panel1 = gridview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        gridview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { referencePanel: 'panel1', direction: 'right' },
+        });
+
+        // panel1 and panel2 are siblings under the root branch - moving
+        // panel2 to the right of panel1 is a swap within the same parent
+        expect(() =>
+            gridview.moveGroup(panel1 as GridviewPanel, 'panel2', 'right')
+        ).not.toThrow();
+
+        expect(gridview.size).toBe(2);
+        expect(gridview.getPanel('panel1')).toBeTruthy();
+        expect(gridview.getPanel('panel2')).toBeTruthy();
+    });
+
+    test('moveGroup relocates a group into a different parent', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        const panel1 = gridview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+        gridview.addPanel({
+            id: 'panel2',
+            component: 'default',
+            position: { referencePanel: 'panel1', direction: 'right' },
+        });
+        const panel3 = gridview.addPanel({
+            id: 'panel3',
+            component: 'default',
+            position: { referencePanel: 'panel2', direction: 'below' },
+        });
+
+        // panel3 lives in a nested branch alongside panel2; move it up
+        // against panel1 which lives in the root branch (different parent)
+        expect(() =>
+            gridview.moveGroup(panel1 as GridviewPanel, panel3.id, 'above')
+        ).not.toThrow();
+
+        expect(gridview.size).toBe(3);
+        expect(gridview.getPanel('panel3')).toBeTruthy();
+    });
+
+    test('moveGroup throws for an unknown source group', () => {
+        const gridview = createGridview(Orientation.HORIZONTAL, true);
+        gridview.layout(1000, 1000);
+
+        const panel1 = gridview.addPanel({
+            id: 'panel1',
+            component: 'default',
+        });
+
+        expect(() =>
+            gridview.moveGroup(
+                panel1 as GridviewPanel,
+                'does_not_exist',
+                'right'
+            )
+        ).toThrow('invalid operation');
+    });
 });

--- a/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
@@ -1563,49 +1563,15 @@ describe('overlay', () => {
             overlay.dispose();
         });
 
-        test('bottomright corner resizes both dimensions', () => {
+        test.each([
+            ['bottomright', { clientX: 250, clientY: 250 }],
+            ['topleft', { clientX: 80, clientY: 80 }],
+            ['topright', { clientX: 250, clientY: 80 }],
+            ['bottomleft', { clientX: 80, clientY: 250 }],
+        ] as const)('%s corner resizes both dimensions', (corner, point) => {
             const { overlay, container } = setup();
 
-            resizeVia(container, 'bottomright', {
-                clientX: 250,
-                clientY: 250,
-            });
-
-            const bounds = overlay.toJSON();
-            expect(bounds.width).toBeGreaterThan(0);
-            expect(bounds.height).toBeGreaterThan(0);
-
-            overlay.dispose();
-        });
-
-        test('topleft corner resizes both dimensions', () => {
-            const { overlay, container } = setup();
-
-            resizeVia(container, 'topleft', { clientX: 80, clientY: 80 });
-
-            const bounds = overlay.toJSON();
-            expect(bounds.width).toBeGreaterThan(0);
-            expect(bounds.height).toBeGreaterThan(0);
-
-            overlay.dispose();
-        });
-
-        test('topright corner resizes both dimensions', () => {
-            const { overlay, container } = setup();
-
-            resizeVia(container, 'topright', { clientX: 250, clientY: 80 });
-
-            const bounds = overlay.toJSON();
-            expect(bounds.width).toBeGreaterThan(0);
-            expect(bounds.height).toBeGreaterThan(0);
-
-            overlay.dispose();
-        });
-
-        test('bottomleft corner resizes both dimensions', () => {
-            const { overlay, container } = setup();
-
-            resizeVia(container, 'bottomleft', { clientX: 80, clientY: 250 });
+            resizeVia(container, corner, point);
 
             const bounds = overlay.toJSON();
             expect(bounds.width).toBeGreaterThan(0);

--- a/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
@@ -1007,4 +1007,611 @@ describe('overlay', () => {
             overlay.dispose();
         });
     });
+
+    describe('visibility', () => {
+        test('setVisible toggles the dv-hidden class and isVisible flag', () => {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            document.body.appendChild(container);
+
+            const overlay = new Overlay({
+                height: 100,
+                width: 100,
+                left: 10,
+                top: 10,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content,
+            });
+
+            expect(overlay.isVisible).toBe(true);
+            expect(overlay.element.classList.contains('dv-hidden')).toBe(false);
+
+            overlay.setVisible(false);
+            expect(overlay.isVisible).toBe(false);
+            expect(overlay.element.classList.contains('dv-hidden')).toBe(true);
+
+            overlay.setVisible(true);
+            expect(overlay.isVisible).toBe(true);
+            expect(overlay.element.classList.contains('dv-hidden')).toBe(false);
+
+            overlay.dispose();
+        });
+
+        test('setVisible is a no-op when the value is unchanged', () => {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            document.body.appendChild(container);
+
+            const overlay = new Overlay({
+                height: 100,
+                width: 100,
+                left: 10,
+                top: 10,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content,
+            });
+
+            // already visible → no class change
+            overlay.setVisible(true);
+            expect(overlay.isVisible).toBe(true);
+            expect(overlay.element.classList.contains('dv-hidden')).toBe(false);
+
+            overlay.dispose();
+        });
+    });
+
+    describe('minimum-in-viewport (no constraint configured)', () => {
+        test('omitting the minimum options leaves clamping unconstrained', () => {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            document.body.appendChild(container);
+            container.appendChild(content);
+
+            // No minimumInViewportWidth/Height → getMinimumWidth/Height return 0
+            const overlay = new Overlay({
+                height: 200,
+                width: 100,
+                left: 10,
+                top: 20,
+                container,
+                content,
+            });
+
+            jest.spyOn(
+                overlay.element,
+                'getBoundingClientRect'
+            ).mockImplementation(() =>
+                mockGetBoundingClientRect({
+                    left: 80,
+                    top: 100,
+                    width: 40,
+                    height: 50,
+                })
+            );
+            jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 20,
+                        top: 30,
+                        width: 100,
+                        height: 100,
+                    })
+            );
+
+            // top: clamp(overlay.top(100) - container.top(30), 0, max(0, 100-50)) = 50
+            // left: clamp(overlay.left(80) - container.left(20), 0, max(0, 100-40)) = 60
+            expect(() => overlay.setBounds()).not.toThrow();
+            expect(overlay.toJSON()).toEqual({
+                top: 50,
+                left: 60,
+                width: 40,
+                height: 50,
+            });
+
+            overlay.dispose();
+        });
+
+        test('the minimumInViewport setters feed the clamping offsets', () => {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            document.body.appendChild(container);
+            container.appendChild(content);
+
+            const overlay = new Overlay({
+                height: 100,
+                width: 100,
+                left: 10,
+                top: 10,
+                container,
+                content,
+            });
+
+            jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 0,
+                        top: 0,
+                        width: 100,
+                        height: 100,
+                    })
+            );
+            // overlay is wider/taller than the container and positioned well
+            // beyond it, so it will be clamped to the maximum allowed offset.
+            jest.spyOn(
+                overlay.element,
+                'getBoundingClientRect'
+            ).mockImplementation(() =>
+                mockGetBoundingClientRect({
+                    left: 500,
+                    top: 500,
+                    width: 200,
+                    height: 200,
+                })
+            );
+
+            // Without a configured minimum the max offset is
+            //   max(0, container(100) - overlay(200)) = 0.
+            // Setting a 20px in-viewport minimum widens it to
+            //   max(0, 100 - 200 + (200 - 20)) = 80,
+            // so the clamped edge lands at 80 instead of 0.
+            overlay.minimumInViewportWidth = 20;
+            overlay.minimumInViewportHeight = 20;
+
+            overlay.setBounds();
+
+            const bounds = overlay.toJSON() as Record<string, number>;
+            expect(bounds.top).toBe(80);
+            expect(bounds.left).toBe(80);
+
+            overlay.dispose();
+        });
+    });
+
+    describe('cancelPendingDrag', () => {
+        function setup() {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            document.body.appendChild(container);
+            container.appendChild(content);
+
+            const overlay = new Overlay({
+                height: 50,
+                width: 50,
+                left: 10,
+                top: 10,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content,
+            });
+
+            jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 0,
+                        top: 0,
+                        width: 200,
+                        height: 200,
+                    })
+            );
+            jest.spyOn(
+                overlay.element,
+                'getBoundingClientRect'
+            ).mockImplementation(() =>
+                mockGetBoundingClientRect({
+                    left: 10,
+                    top: 10,
+                    width: 50,
+                    height: 50,
+                })
+            );
+
+            const dragTarget = document.createElement('div');
+            container.appendChild(dragTarget);
+            overlay.setupDrag(dragTarget);
+
+            return { overlay, dragTarget };
+        }
+
+        test('does nothing when no drag is in flight', () => {
+            const { overlay } = setup();
+            expect(() => overlay.cancelPendingDrag()).not.toThrow();
+            expect(
+                overlay.element.classList.contains(
+                    'dv-resize-container-dragging'
+                )
+            ).toBe(false);
+            overlay.dispose();
+        });
+
+        test('aborts an in-flight drag and clears the dragging class', () => {
+            const { overlay, dragTarget } = setup();
+
+            const down = new MouseEvent('pointerdown', {
+                clientX: 20,
+                clientY: 20,
+                bubbles: true,
+            }) as any;
+            down.pointerId = 1;
+            dragTarget.dispatchEvent(down);
+
+            const move = new MouseEvent('pointermove', {
+                clientX: 40,
+                clientY: 40,
+                bubbles: true,
+            }) as any;
+            move.pointerId = 1;
+            window.dispatchEvent(move);
+
+            expect(
+                overlay.element.classList.contains(
+                    'dv-resize-container-dragging'
+                )
+            ).toBe(true);
+
+            overlay.cancelPendingDrag();
+
+            expect(
+                overlay.element.classList.contains(
+                    'dv-resize-container-dragging'
+                )
+            ).toBe(false);
+
+            overlay.dispose();
+        });
+    });
+
+    describe('setupDrag guards and pointer capture', () => {
+        function setup() {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            document.body.appendChild(container);
+            container.appendChild(content);
+
+            const overlay = new Overlay({
+                height: 50,
+                width: 50,
+                left: 10,
+                top: 10,
+                minimumInViewportWidth: 0,
+                minimumInViewportHeight: 0,
+                container,
+                content,
+            });
+
+            jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 0,
+                        top: 0,
+                        width: 200,
+                        height: 200,
+                    })
+            );
+            jest.spyOn(
+                overlay.element,
+                'getBoundingClientRect'
+            ).mockImplementation(() =>
+                mockGetBoundingClientRect({
+                    left: 10,
+                    top: 10,
+                    width: 50,
+                    height: 50,
+                })
+            );
+
+            return { overlay, container, content };
+        }
+
+        test('captures and releases the pointer over a full drag', () => {
+            const { overlay, container } = setup();
+
+            const dragTarget = document.createElement('div');
+            const setPointerCapture = jest.fn();
+            const releasePointerCapture = jest.fn();
+            (dragTarget as any).setPointerCapture = setPointerCapture;
+            (dragTarget as any).releasePointerCapture = releasePointerCapture;
+            container.appendChild(dragTarget);
+            overlay.setupDrag(dragTarget);
+
+            const down = new MouseEvent('pointerdown', {
+                clientX: 20,
+                clientY: 20,
+                bubbles: true,
+            }) as any;
+            down.pointerId = 7;
+            dragTarget.dispatchEvent(down);
+
+            expect(setPointerCapture).toHaveBeenCalledWith(7);
+
+            const move = new MouseEvent('pointermove', {
+                clientX: 40,
+                clientY: 40,
+                bubbles: true,
+            }) as any;
+            move.pointerId = 7;
+            window.dispatchEvent(move);
+
+            const up = new MouseEvent('pointerup', { bubbles: true }) as any;
+            up.pointerId = 7;
+            window.dispatchEvent(up);
+
+            expect(releasePointerCapture).toHaveBeenCalledWith(7);
+
+            overlay.dispose();
+        });
+
+        test('ignores pointerdown when defaultPrevented', () => {
+            const { overlay, container } = setup();
+            const dragTarget = document.createElement('div');
+            container.appendChild(dragTarget);
+            overlay.setupDrag(dragTarget);
+
+            const onDidStartMoving = jest.fn();
+            overlay.onDidStartMoving(onDidStartMoving);
+
+            const down = new MouseEvent('pointerdown', {
+                clientX: 20,
+                clientY: 20,
+                bubbles: true,
+                cancelable: true,
+            }) as any;
+            down.pointerId = 1;
+            down.preventDefault();
+            dragTarget.dispatchEvent(down);
+
+            const move = new MouseEvent('pointermove', {
+                clientX: 40,
+                clientY: 40,
+                bubbles: true,
+            }) as any;
+            move.pointerId = 1;
+            window.dispatchEvent(move);
+
+            // no drag was started
+            expect(onDidStartMoving).not.toHaveBeenCalled();
+
+            overlay.dispose();
+        });
+
+        test('shift+pointerdown on the content starts a drag', () => {
+            const { overlay, content } = setup();
+            overlay.setupDrag(document.createElement('div'));
+
+            const onDidStartMoving = jest.fn();
+            overlay.onDidStartMoving(onDidStartMoving);
+
+            const down = new MouseEvent('pointerdown', {
+                clientX: 20,
+                clientY: 20,
+                bubbles: true,
+                shiftKey: true,
+            }) as any;
+            down.pointerId = 1;
+            content.dispatchEvent(down);
+
+            const move = new MouseEvent('pointermove', {
+                clientX: 40,
+                clientY: 40,
+                bubbles: true,
+            }) as any;
+            move.pointerId = 1;
+            window.dispatchEvent(move);
+
+            expect(onDidStartMoving).toHaveBeenCalledTimes(1);
+
+            overlay.dispose();
+        });
+
+        test('pointerdown on the content without shift does not drag', () => {
+            const { overlay, content } = setup();
+            overlay.setupDrag(document.createElement('div'));
+
+            const onDidStartMoving = jest.fn();
+            overlay.onDidStartMoving(onDidStartMoving);
+
+            const down = new MouseEvent('pointerdown', {
+                clientX: 20,
+                clientY: 20,
+                bubbles: true,
+            }) as any;
+            down.pointerId = 1;
+            content.dispatchEvent(down);
+
+            const move = new MouseEvent('pointermove', {
+                clientX: 40,
+                clientY: 40,
+                bubbles: true,
+            }) as any;
+            move.pointerId = 1;
+            window.dispatchEvent(move);
+
+            expect(onDidStartMoving).not.toHaveBeenCalled();
+
+            overlay.dispose();
+        });
+
+        test('inDragMode begins tracking immediately', () => {
+            const { overlay } = setup();
+
+            const dragTarget = document.createElement('div');
+            overlay.setupDrag(dragTarget, { inDragMode: true });
+
+            const onDidStartMoving = jest.fn();
+            overlay.onDidStartMoving(onDidStartMoving);
+
+            const move = new MouseEvent('pointermove', {
+                clientX: 40,
+                clientY: 40,
+                bubbles: true,
+            }) as any;
+            move.pointerId = 1;
+            window.dispatchEvent(move);
+
+            expect(onDidStartMoving).toHaveBeenCalledTimes(1);
+            expect(
+                overlay.element.classList.contains(
+                    'dv-resize-container-dragging'
+                )
+            ).toBe(true);
+
+            overlay.dispose();
+        });
+    });
+
+    describe('resize handles (additional directions)', () => {
+        function setup() {
+            const container = document.createElement('div');
+            const content = document.createElement('div');
+            document.body.appendChild(container);
+            container.appendChild(content);
+
+            const overlay = new Overlay({
+                height: 100,
+                width: 100,
+                left: 50,
+                top: 50,
+                minimumInViewportWidth: 25,
+                minimumInViewportHeight: 25,
+                container,
+                content,
+            });
+
+            jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
+                () =>
+                    mockGetBoundingClientRect({
+                        left: 0,
+                        top: 0,
+                        width: 400,
+                        height: 400,
+                    })
+            );
+            jest.spyOn(
+                overlay.element,
+                'getBoundingClientRect'
+            ).mockImplementation(() =>
+                mockGetBoundingClientRect({
+                    left: 50,
+                    top: 50,
+                    width: 100,
+                    height: 100,
+                })
+            );
+
+            return { overlay, container };
+        }
+
+        function resizeVia(
+            container: HTMLElement,
+            direction: string,
+            move: { clientX: number; clientY: number }
+        ) {
+            const handle = container.querySelector(
+                `.dv-resize-handle-${direction}`
+            ) as HTMLElement;
+            expect(handle).toBeTruthy();
+
+            const setPointerCapture = jest.fn();
+            const releasePointerCapture = jest.fn();
+            (handle as any).setPointerCapture = setPointerCapture;
+            (handle as any).releasePointerCapture = releasePointerCapture;
+
+            const down = new MouseEvent('pointerdown', {
+                clientX: 150,
+                clientY: 150,
+                bubbles: true,
+                cancelable: true,
+            }) as any;
+            down.pointerId = 3;
+            handle.dispatchEvent(down);
+
+            const pmove = new MouseEvent('pointermove', {
+                clientX: move.clientX,
+                clientY: move.clientY,
+                bubbles: true,
+            }) as any;
+            pmove.pointerId = 3;
+            window.dispatchEvent(pmove);
+
+            const up = new MouseEvent('pointerup', { bubbles: true }) as any;
+            up.pointerId = 3;
+            window.dispatchEvent(up);
+
+            return { setPointerCapture, releasePointerCapture };
+        }
+
+        test('bottom handle resizes height and captures/releases the pointer', () => {
+            const { overlay, container } = setup();
+
+            const { setPointerCapture, releasePointerCapture } = resizeVia(
+                container,
+                'bottom',
+                { clientX: 150, clientY: 200 }
+            );
+
+            expect(setPointerCapture).toHaveBeenCalledWith(3);
+            expect(releasePointerCapture).toHaveBeenCalledWith(3);
+
+            const bounds = overlay.toJSON();
+            expect(bounds.height).toBeGreaterThan(0);
+            expect(bounds.height).toBeLessThanOrEqual(400);
+
+            overlay.dispose();
+        });
+
+        test('bottomright corner resizes both dimensions', () => {
+            const { overlay, container } = setup();
+
+            resizeVia(container, 'bottomright', {
+                clientX: 250,
+                clientY: 250,
+            });
+
+            const bounds = overlay.toJSON();
+            expect(bounds.width).toBeGreaterThan(0);
+            expect(bounds.height).toBeGreaterThan(0);
+
+            overlay.dispose();
+        });
+
+        test('topleft corner resizes both dimensions', () => {
+            const { overlay, container } = setup();
+
+            resizeVia(container, 'topleft', { clientX: 80, clientY: 80 });
+
+            const bounds = overlay.toJSON();
+            expect(bounds.width).toBeGreaterThan(0);
+            expect(bounds.height).toBeGreaterThan(0);
+
+            overlay.dispose();
+        });
+
+        test('topright corner resizes both dimensions', () => {
+            const { overlay, container } = setup();
+
+            resizeVia(container, 'topright', { clientX: 250, clientY: 80 });
+
+            const bounds = overlay.toJSON();
+            expect(bounds.width).toBeGreaterThan(0);
+            expect(bounds.height).toBeGreaterThan(0);
+
+            overlay.dispose();
+        });
+
+        test('bottomleft corner resizes both dimensions', () => {
+            const { overlay, container } = setup();
+
+            resizeVia(container, 'bottomleft', { clientX: 80, clientY: 250 });
+
+            const bounds = overlay.toJSON();
+            expect(bounds.width).toBeGreaterThan(0);
+            expect(bounds.height).toBeGreaterThan(0);
+
+            overlay.dispose();
+        });
+    });
 });

--- a/packages/dockview-core/src/__tests__/splitview/splitviewPanel.spec.ts
+++ b/packages/dockview-core/src/__tests__/splitview/splitviewPanel.spec.ts
@@ -1,0 +1,371 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import type { IFrameworkPart } from '../../panel/types';
+import { LayoutPriority, Orientation } from '../../splitview/splitview';
+import type { PanelViewInitParameters } from '../../splitview/options';
+import type { SplitviewComponent } from '../../splitview/splitviewComponent';
+import { SplitviewPanel } from '../../splitview/splitviewPanel';
+
+class TestPanel extends SplitviewPanel {
+    readonly partUpdate = jest.fn();
+    readonly partDispose = jest.fn();
+
+    getComponent(): IFrameworkPart {
+        return {
+            update: this.partUpdate,
+            dispose: this.partDispose,
+        };
+    }
+}
+
+function createInitParameters(
+    accessor: SplitviewComponent,
+    overrides: Partial<PanelViewInitParameters> = {}
+): PanelViewInitParameters {
+    return {
+        params: {},
+        accessor,
+        ...overrides,
+    };
+}
+
+describe('splitviewPanel', () => {
+    let accessor: SplitviewComponent;
+    let setVisibleSpy: jest.Mock;
+    let setActiveSpy: jest.Mock;
+
+    beforeEach(() => {
+        setVisibleSpy = jest.fn();
+        setActiveSpy = jest.fn();
+        accessor = fromPartial<SplitviewComponent>({
+            setVisible: setVisibleSpy,
+            setActive: setActiveSpy,
+        });
+    });
+
+    test('init stores priority and default constraints', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(
+            createInitParameters(accessor, {
+                priority: LayoutPriority.High,
+            })
+        );
+
+        expect(panel.priority).toBe(LayoutPriority.High);
+        expect(panel.minimumSize).toBe(0);
+        expect(panel.maximumSize).toBe(Number.POSITIVE_INFINITY);
+        expect(panel.snap).toBe(false);
+
+        panel.dispose();
+    });
+
+    test('init applies minimumSize, maximumSize and snap', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(
+            createInitParameters(accessor, {
+                minimumSize: 50,
+                maximumSize: 500,
+                snap: true,
+            })
+        );
+
+        expect(panel.minimumSize).toBe(50);
+        expect(panel.maximumSize).toBe(500);
+        expect(panel.snap).toBe(true);
+
+        panel.dispose();
+    });
+
+    test('orientation getter/setter', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.orientation = Orientation.VERTICAL;
+        expect(panel.orientation).toBe(Orientation.VERTICAL);
+
+        panel.orientation = Orientation.HORIZONTAL;
+        expect(panel.orientation).toBe(Orientation.HORIZONTAL);
+
+        panel.dispose();
+    });
+
+    test('layout maps size/orthogonalSize based on HORIZONTAL orientation', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+        panel.orientation = Orientation.HORIZONTAL;
+
+        panel.layout(100, 200);
+
+        // HORIZONTAL => [width, height] = [size, orthogonalSize]
+        expect(panel.width).toBe(100);
+        expect(panel.height).toBe(200);
+
+        panel.dispose();
+    });
+
+    test('layout maps size/orthogonalSize based on VERTICAL orientation', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+        panel.orientation = Orientation.VERTICAL;
+
+        panel.layout(100, 200);
+
+        // VERTICAL => [width, height] = [orthogonalSize, size]
+        expect(panel.width).toBe(200);
+        expect(panel.height).toBe(100);
+
+        panel.dispose();
+    });
+
+    test('minimumSize supports a function value', () => {
+        const panel = new TestPanel('id', 'component');
+        let value = 10;
+        panel.init(
+            createInitParameters(accessor, {
+                minimumSize: (() => value) as unknown as number,
+            })
+        );
+
+        expect(panel.minimumSize).toBe(10);
+        value = 42;
+        expect(panel.minimumSize).toBe(42);
+
+        panel.dispose();
+    });
+
+    test('maximumSize supports a function value', () => {
+        const panel = new TestPanel('id', 'component');
+        let value = 1000;
+        panel.init(
+            createInitParameters(accessor, {
+                maximumSize: (() => value) as unknown as number,
+            })
+        );
+
+        expect(panel.maximumSize).toBe(1000);
+        value = 750;
+        expect(panel.maximumSize).toBe(750);
+
+        panel.dispose();
+    });
+
+    test('reading minimumSize fires a constraints change when the evaluated value changes', () => {
+        const panel = new TestPanel('id', 'component');
+        let value = 10;
+        panel.init(
+            createInitParameters(accessor, {
+                minimumSize: (() => value) as unknown as number,
+            })
+        );
+
+        // prime the evaluated size so the first read below is a no-op
+        expect(panel.minimumSize).toBe(10);
+
+        const events: unknown[] = [];
+        panel.api.onDidConstraintsChange((e) => events.push(e));
+        events.length = 0;
+
+        // no change -> no fire
+        expect(panel.minimumSize).toBe(10);
+        expect(events).toHaveLength(0);
+
+        // change -> fire
+        value = 99;
+        expect(panel.minimumSize).toBe(99);
+        expect(events).toHaveLength(1);
+        expect(events[0]).toEqual({
+            minimumSize: 99,
+            maximumSize: Number.POSITIVE_INFINITY,
+        });
+
+        panel.dispose();
+    });
+
+    test('setConstraints via api updates minimum and maximum size', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        panel.api.setConstraints({ minimumSize: 20, maximumSize: 80 });
+
+        expect(panel.minimumSize).toBe(20);
+        expect(panel.maximumSize).toBe(80);
+
+        panel.dispose();
+    });
+
+    test('setConstraints updates only the provided dimension', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(
+            createInitParameters(accessor, {
+                minimumSize: 10,
+                maximumSize: 90,
+            })
+        );
+
+        panel.api.setConstraints({ maximumSize: 200 });
+        expect(panel.minimumSize).toBe(10);
+        expect(panel.maximumSize).toBe(200);
+
+        panel.api.setConstraints({ minimumSize: 40 });
+        expect(panel.minimumSize).toBe(40);
+        expect(panel.maximumSize).toBe(200);
+
+        panel.dispose();
+    });
+
+    test('setConstraints accepts function-valued constraints', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        panel.api.setConstraints({
+            minimumSize: () => 15,
+            maximumSize: () => 150,
+        });
+
+        expect(panel.minimumSize).toBe(15);
+        expect(panel.maximumSize).toBe(150);
+
+        panel.dispose();
+    });
+
+    test('setSize via api fires onDidChange with the new size', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        const events: { size?: number; orthogonalSize?: number }[] = [];
+        panel.onDidChange((e) => events.push(e));
+
+        panel.api.setSize({ size: 123 });
+
+        expect(events).toEqual([{ size: 123 }]);
+
+        panel.dispose();
+    });
+
+    test('api.setVisible delegates to accessor.setVisible', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        // api.setVisible fires onWillVisibilityChange, which the panel wires
+        // through to accessor.setVisible
+        panel.api.setVisible(false);
+
+        expect(setVisibleSpy).toHaveBeenCalledWith(panel, false);
+
+        panel.dispose();
+    });
+
+    test('api.setActive delegates to accessor.setActive', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        // api.setActive fires onActiveChange, which the panel wires through to
+        // accessor.setActive
+        panel.api.setActive();
+
+        expect(setActiveSpy).toHaveBeenCalledWith(panel);
+
+        panel.dispose();
+    });
+
+    test('setVisible fires the api onDidVisibilityChange event', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        const events: boolean[] = [];
+        panel.api.onDidVisibilityChange((e) => events.push(e.isVisible));
+
+        panel.setVisible(false);
+        panel.setVisible(true);
+
+        expect(events).toEqual([false, true]);
+        expect(panel.api.isVisible).toBe(true);
+
+        panel.dispose();
+    });
+
+    test('setActive fires the api onDidActiveChange event', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        const events: boolean[] = [];
+        panel.api.onDidActiveChange((e) => events.push(e.isActive));
+
+        panel.setActive(true);
+
+        expect(events).toEqual([true]);
+        expect(panel.api.isActive).toBe(true);
+
+        panel.dispose();
+    });
+
+    test('update forwards merged params to the framework part', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor, { params: { a: 1 } }));
+
+        panel.update({ params: { b: 2 } });
+
+        expect(panel.params).toEqual({ a: 1, b: 2 });
+        expect(panel.partUpdate).toHaveBeenLastCalledWith({
+            params: { a: 1, b: 2 },
+        });
+
+        panel.dispose();
+    });
+
+    test('toJSON omits default (unbounded) constraints', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        expect(panel.toJSON()).toEqual({
+            id: 'id',
+            component: 'component',
+            params: undefined,
+            minimumSize: undefined,
+            maximumSize: undefined,
+        });
+
+        panel.dispose();
+    });
+
+    test('toJSON serializes explicit constraints', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(
+            createInitParameters(accessor, {
+                minimumSize: 30,
+                maximumSize: 300,
+            })
+        );
+
+        expect(panel.toJSON()).toEqual({
+            id: 'id',
+            component: 'component',
+            params: undefined,
+            minimumSize: 30,
+            maximumSize: 300,
+        });
+
+        panel.dispose();
+    });
+
+    test('toJSON treats MAX_SAFE_INTEGER maximum as unbounded', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(
+            createInitParameters(accessor, {
+                maximumSize: Number.MAX_SAFE_INTEGER,
+            })
+        );
+
+        expect((panel.toJSON() as { maximumSize?: number }).maximumSize).toBe(
+            undefined
+        );
+
+        panel.dispose();
+    });
+
+    test('dispose disposes the framework part', () => {
+        const panel = new TestPanel('id', 'component');
+        panel.init(createInitParameters(accessor));
+
+        panel.dispose();
+
+        expect(panel.partDispose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/dockview-core/src/__tests__/splitview/splitviewPanel.spec.ts
+++ b/packages/dockview-core/src/__tests__/splitview/splitviewPanel.spec.ts
@@ -353,9 +353,9 @@ describe('splitviewPanel', () => {
             })
         );
 
-        expect((panel.toJSON() as { maximumSize?: number }).maximumSize).toBe(
-            undefined
-        );
+        expect(
+            (panel.toJSON() as { maximumSize?: number }).maximumSize
+        ).toBeUndefined();
 
         panel.dispose();
     });

--- a/packages/dockview-enterprise/src/__tests__/autoEdgeGroupService.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/autoEdgeGroupService.spec.ts
@@ -1,0 +1,464 @@
+import { DockviewEmitter as Emitter } from 'dockview';
+import type {
+    DockviewWillDropEvent,
+    DockviewWillShowOverlayLocationEvent,
+    Position,
+    PositionResolverArgs,
+} from 'dockview';
+import { AutoEdgeGroupService } from '../autoEdgeGroupService';
+
+/**
+ * AutoEdgeGroupService: the two-band drag-reveal affordance. Driven at the
+ * service boundary with a mock host + synthetic overlay/drop events. The edge
+ * band detection is pure geometry (depth from the drop-zone rect) and the
+ * quadrant fallback is pure percentage math, so neither needs a real browser
+ * layout.
+ *
+ * `autoEdgeGroups.spec.ts` already exercises the left-edge happy paths; this
+ * suite fills the remaining branches: the right/top/bottom/center quadrant
+ * fallback, the right/top/bottom highlight geometry, the disabled `resolveEdge`
+ * guard, and the no-data drop guard.
+ */
+describe('auto edge group service (branch coverage)', () => {
+    const ALL_ZONES: Position[] = ['left', 'right', 'top', 'bottom', 'center'];
+
+    // A 1000x1000 content area anchored at the origin, so drop-zone px and the
+    // synthetic clientX/clientY share one coordinate system.
+    const rect = {
+        left: 0,
+        top: 0,
+        right: 1000,
+        bottom: 1000,
+        width: 1000,
+        height: 1000,
+    } as DOMRect;
+
+    function createHost(dockToEdgeGroups: unknown = true) {
+        const overlayRoot = document.createElement('div');
+        document.body.appendChild(overlayRoot);
+        const willShow = new Emitter<DockviewWillShowOverlayLocationEvent>();
+        const willDrop = new Emitter<DockviewWillDropEvent>();
+        const reveal = jest.fn();
+        const host = {
+            options: { dockToEdgeGroups },
+            overlayRoot,
+            getDropZoneRect: () => rect,
+            onWillShowOverlay: willShow.event,
+            onWillDrop: willDrop.event,
+            revealEdgeGroupWithData: reveal,
+        };
+        const service = new AutoEdgeGroupService(host as any);
+        return { service, overlayRoot, willShow, willDrop, reveal };
+    }
+
+    const band = (root: HTMLElement): HTMLElement | null =>
+        root.querySelector('.dv-auto-edge-band');
+
+    // resolver args whose edge-detection pointer sits dead-centre (far from every
+    // edge band) so `resolveEdge` returns null and the quadrant fallback runs.
+    // The quadrant is chosen purely by args.x / args.y against args.width/height.
+    const quadrantArgs = (
+        x: number,
+        y: number,
+        zones: Position[] = ALL_ZONES
+    ): PositionResolverArgs => ({
+        x,
+        y,
+        width: 1000,
+        height: 1000,
+        zones: new Set<Position>(zones),
+        event: { clientX: 500, clientY: 500 } as any,
+    });
+
+    let created: AutoEdgeGroupService[];
+    beforeEach(() => {
+        created = [];
+    });
+    afterEach(() => {
+        for (const s of created.splice(0)) {
+            s.dispose();
+        }
+        document.body.innerHTML = '';
+    });
+
+    function host(dockToEdgeGroups: unknown = true) {
+        const h = createHost(dockToEdgeGroups);
+        created.push(h.service);
+        return h;
+    }
+
+    // --- quadrant fallback (defaultQuadrant): right / top / bottom / center ---
+
+    test('resolver falls back to each inner quadrant outside the edge band', () => {
+        const { service } = host();
+        const resolver = service.resolver!;
+
+        // xp = 90 (> 80) → right split, not an edge (pointer is centred)
+        expect(resolver.resolve(quadrantArgs(900, 500))).toEqual({
+            position: 'right',
+            edge: false,
+        });
+        // yp = 10 (< 20) → top split
+        expect(resolver.resolve(quadrantArgs(500, 100))).toEqual({
+            position: 'top',
+            edge: false,
+        });
+        // yp = 90 (> 80) → bottom split
+        expect(resolver.resolve(quadrantArgs(500, 900))).toEqual({
+            position: 'bottom',
+            edge: false,
+        });
+        // dead centre → center split
+        expect(resolver.resolve(quadrantArgs(500, 500))).toEqual({
+            position: 'center',
+            edge: false,
+        });
+    });
+
+    test('resolver yields null in the centre when the group rejects a tab-into (no center zone)', () => {
+        const { service } = host();
+        // centre pointer, but `center` is not an accepted zone → no split at all
+        expect(
+            service.resolver!.resolve(
+                quadrantArgs(500, 500, ['left', 'right', 'top', 'bottom'])
+            )
+        ).toBeNull();
+    });
+
+    test('quadrant is gated by the accepted zones', () => {
+        const { service } = host();
+        // pointer is in the right quadrant, but `right` is not offered → falls
+        // through to center (which is offered)
+        expect(
+            service.resolver!.resolve(quadrantArgs(900, 500, ['center']))
+        ).toEqual({ position: 'center', edge: false });
+    });
+
+    // --- resolveEdge guard + edge detection on every edge ---
+
+    test('resolveEdge returns null when the feature is disabled', () => {
+        const { service } = host(false);
+        // exercises the `!this._enabled` guard directly (resolver getter is
+        // undefined when disabled, but resolveEdge is public for composition)
+        expect(service.resolveEdge(quadrantArgs(5, 500))).toBeNull();
+    });
+
+    test('resolveEdge detects the outer band on right, top and bottom edges', () => {
+        const { service } = host();
+        const at = (
+            clientX: number,
+            clientY: number,
+            zones: Position[] = ALL_ZONES
+        ): PositionResolverArgs => ({
+            x: clientX,
+            y: clientY,
+            width: 1000,
+            height: 1000,
+            zones: new Set<Position>(zones),
+            event: { clientX, clientY } as any,
+        });
+
+        // 4px from the right edge (1000) → within the 16px band
+        expect(service.resolveEdge(at(996, 500))).toEqual({
+            position: 'right',
+            edge: true,
+            edgeGroup: true,
+        });
+        // 4px from the top edge
+        expect(service.resolveEdge(at(500, 4))).toEqual({
+            position: 'top',
+            edge: true,
+            edgeGroup: true,
+        });
+        // 4px from the bottom edge (1000)
+        expect(service.resolveEdge(at(500, 996))).toEqual({
+            position: 'bottom',
+            edge: true,
+            edgeGroup: true,
+        });
+        // exactly 16px in is still inside the band (<=)
+        expect(service.resolveEdge(at(16, 500))).toEqual({
+            position: 'left',
+            edge: true,
+            edgeGroup: true,
+        });
+        // 17px in is past the band
+        expect(service.resolveEdge(at(17, 500))).toBeNull();
+    });
+
+    test('an event with no clientX/clientY treats the pointer as the origin', () => {
+        const { service } = host();
+        // clientX/clientY absent → edgeDepth falls back to 0, i.e. hard against
+        // the top-left corner, so both the left and top bands register.
+        const result = service.resolveEdge({
+            x: 0,
+            y: 0,
+            width: 1000,
+            height: 1000,
+            zones: new Set<Position>(ALL_ZONES),
+            event: {} as any,
+        });
+        expect(result).toEqual({
+            position: 'left',
+            edge: true,
+            edgeGroup: true,
+        });
+    });
+
+    test('resolveEdge only fires for edges present in the accepted zones', () => {
+        const { service } = host();
+        // pointer sits in the left band but `left` is not an accepted zone
+        expect(
+            service.resolveEdge({
+                x: 4,
+                y: 500,
+                width: 1000,
+                height: 1000,
+                zones: new Set<Position>(['right', 'top', 'bottom', 'center']),
+                event: { clientX: 4, clientY: 500 } as any,
+            })
+        ).toBeNull();
+    });
+
+    test('per-edge dockToEdgeGroups gates which edges become edge groups', () => {
+        // only the left edge is enabled for edge-docking
+        const { service } = host({ left: true });
+        const at = (clientX: number): PositionResolverArgs => ({
+            x: clientX,
+            y: 500,
+            width: 1000,
+            height: 1000,
+            zones: new Set<Position>(ALL_ZONES),
+            event: { clientX, clientY: 500 } as any,
+        });
+        expect(service.resolveEdge(at(4))).toEqual({
+            position: 'left',
+            edge: true,
+            edgeGroup: true,
+        });
+        // right band pointer: the edge is disabled per-edge → no edge cell
+        expect(service.resolveEdge(at(996))).toBeNull();
+    });
+
+    // --- highlight geometry (_show) for right / top / bottom ---
+
+    test('the highlight hugs the right edge with the right geometry', () => {
+        const { service, overlayRoot, willShow } = host();
+        willShow.fire({
+            kind: 'edge',
+            position: 'right',
+            nativeEvent: { clientX: 996, clientY: 500 },
+        } as any);
+        const el = band(overlayRoot)!;
+        expect(el).toBeTruthy();
+        // left = dz.width - LINE(3); a full-height vertical line
+        expect(el.style.left).toBe('997px');
+        expect(el.style.top).toBe('0px');
+        expect(el.style.width).toBe('3px');
+        expect(el.style.height).toBe('1000px');
+        service.dispose();
+    });
+
+    test('the highlight hugs the top edge with the right geometry', () => {
+        const { service, overlayRoot, willShow } = host();
+        willShow.fire({
+            kind: 'edge',
+            position: 'top',
+            nativeEvent: { clientX: 500, clientY: 4 },
+        } as any);
+        const el = band(overlayRoot)!;
+        // a full-width horizontal line at the top
+        expect(el.style.left).toBe('0px');
+        expect(el.style.top).toBe('0px');
+        expect(el.style.width).toBe('1000px');
+        expect(el.style.height).toBe('3px');
+        service.dispose();
+    });
+
+    test('the highlight hugs the bottom edge with the right geometry', () => {
+        const { service, overlayRoot, willShow } = host();
+        willShow.fire({
+            kind: 'edge',
+            position: 'bottom',
+            nativeEvent: { clientX: 500, clientY: 996 },
+        } as any);
+        const el = band(overlayRoot)!;
+        // a full-width horizontal line at the bottom (top = height - LINE)
+        expect(el.style.left).toBe('0px');
+        expect(el.style.top).toBe('997px');
+        expect(el.style.width).toBe('1000px');
+        expect(el.style.height).toBe('3px');
+        service.dispose();
+    });
+
+    test('the highlight element is reused across shows, not recreated', () => {
+        const { service, overlayRoot, willShow } = host();
+        willShow.fire({
+            kind: 'edge',
+            position: 'left',
+            nativeEvent: { clientX: 4, clientY: 500 },
+        } as any);
+        const first = band(overlayRoot)!;
+        // move to the right band without an intervening hide (both are edges)
+        willShow.fire({
+            kind: 'edge',
+            position: 'right',
+            nativeEvent: { clientX: 996, clientY: 500 },
+        } as any);
+        expect(band(overlayRoot)).toBe(first);
+        expect(overlayRoot.querySelectorAll('.dv-auto-edge-band')).toHaveLength(
+            1
+        );
+        // it re-geometried to the right edge
+        expect(first.style.left).toBe('997px');
+        service.dispose();
+    });
+
+    // --- onWillShowOverlay gating ---
+
+    test('a center overlay hides the highlight (never an edge band)', () => {
+        const { service, overlayRoot, willShow } = host();
+        // show something first
+        willShow.fire({
+            kind: 'edge',
+            position: 'left',
+            nativeEvent: { clientX: 4, clientY: 500 },
+        } as any);
+        expect(band(overlayRoot)).toBeTruthy();
+        // a center position is never an edge band → hidden
+        willShow.fire({
+            kind: 'content',
+            position: 'center',
+            nativeEvent: { clientX: 500, clientY: 500 },
+        } as any);
+        expect(band(overlayRoot)).toBeNull();
+        service.dispose();
+    });
+
+    // --- onWillDrop guards ---
+
+    test('a drop with no drag data is a no-op (no reveal, no preventDefault)', () => {
+        const { willDrop, reveal } = host();
+        const preventDefault = jest.fn();
+        willDrop.fire({
+            kind: 'edge',
+            position: 'left',
+            nativeEvent: { clientX: 4, clientY: 500 },
+            getData: () => undefined,
+            preventDefault,
+        } as any);
+        expect(reveal).not.toHaveBeenCalled();
+        expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    test('a non-edge drop kind is left to core', () => {
+        const { willDrop, reveal } = host();
+        const preventDefault = jest.fn();
+        willDrop.fire({
+            kind: 'content',
+            position: 'left',
+            nativeEvent: { clientX: 4, clientY: 500 },
+            getData: () => ({ groupId: 'g1', panelId: 'p1' }),
+            preventDefault,
+        } as any);
+        expect(reveal).not.toHaveBeenCalled();
+        expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    test('a center drop is left to core (center is never an edge group)', () => {
+        const { willDrop, reveal } = host();
+        const preventDefault = jest.fn();
+        willDrop.fire({
+            kind: 'edge',
+            position: 'center',
+            nativeEvent: { clientX: 500, clientY: 500 },
+            getData: () => ({ groupId: 'g1', panelId: 'p1' }),
+            preventDefault,
+        } as any);
+        expect(reveal).not.toHaveBeenCalled();
+        expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    test('an outer-band drop reveals a right edge group and omits an absent panelId', () => {
+        const { willDrop, reveal } = host();
+        const preventDefault = jest.fn();
+        willDrop.fire({
+            kind: 'edge',
+            position: 'right',
+            nativeEvent: { clientX: 996, clientY: 500 },
+            getData: () => ({ groupId: 'g1' }), // no panelId
+            preventDefault,
+        } as any);
+        expect(preventDefault).toHaveBeenCalledTimes(1);
+        expect(reveal).toHaveBeenCalledWith(
+            'right',
+            { groupId: 'g1', panelId: undefined },
+            { autoHide: true }
+        );
+    });
+
+    // --- lifecycle / document-level cleanup ---
+
+    test('a document drop event tears the highlight down', () => {
+        const { overlayRoot, willShow } = host();
+        willShow.fire({
+            kind: 'edge',
+            position: 'left',
+            nativeEvent: { clientX: 4, clientY: 500 },
+        } as any);
+        expect(band(overlayRoot)).toBeTruthy();
+
+        document.dispatchEvent(new Event('drop', { bubbles: true }));
+        expect(band(overlayRoot)).toBeNull();
+    });
+
+    test('a document dragend event tears the highlight down', () => {
+        const { overlayRoot, willShow } = host();
+        willShow.fire({
+            kind: 'edge',
+            position: 'top',
+            nativeEvent: { clientX: 500, clientY: 4 },
+        } as any);
+        expect(band(overlayRoot)).toBeTruthy();
+
+        document.dispatchEvent(new Event('dragend', { bubbles: true }));
+        expect(band(overlayRoot)).toBeNull();
+    });
+
+    test('a document pointerup event tears the highlight down', () => {
+        const { overlayRoot, willShow } = host();
+        willShow.fire({
+            kind: 'edge',
+            position: 'bottom',
+            nativeEvent: { clientX: 500, clientY: 996 },
+        } as any);
+        expect(band(overlayRoot)).toBeTruthy();
+
+        document.dispatchEvent(new Event('pointerup', { bubbles: true }));
+        expect(band(overlayRoot)).toBeNull();
+    });
+
+    test('dispose removes the highlight and detaches the document listeners', () => {
+        const { service, overlayRoot, willShow } = host();
+        willShow.fire({
+            kind: 'edge',
+            position: 'left',
+            nativeEvent: { clientX: 4, clientY: 500 },
+        } as any);
+        expect(band(overlayRoot)).toBeTruthy();
+
+        service.dispose();
+        expect(band(overlayRoot)).toBeNull();
+
+        // after dispose the document listeners are gone: a later show still
+        // works (emitter is detached too), and stray events do not throw
+        expect(() =>
+            document.dispatchEvent(new Event('pointerup', { bubbles: true }))
+        ).not.toThrow();
+    });
+
+    test('the resolver getter is undefined when disabled and present when enabled', () => {
+        expect(host(false).service.resolver).toBeUndefined();
+        expect(host(true).service.resolver).toBeDefined();
+    });
+});

--- a/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
@@ -1,6 +1,6 @@
 import { fireEvent } from '@testing-library/dom';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { ContextMenuController } from '../contextMenu';
+import { ContextMenuController, ContextMenuModule } from '../contextMenu';
 import { DockviewComponent } from 'dockview-core';
 import { DockviewGroupPanel } from 'dockview-core';
 import { IDockviewPanel } from 'dockview-core';
@@ -1439,6 +1439,497 @@ describe('ContextMenuController', () => {
 
             const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
             expect(labels(menuEl)).toEqual(['Close']);
+        });
+    });
+
+    describe('custom element item in show()', () => {
+        test('appends the provided element directly', () => {
+            const customEl = document.createElement('section');
+            customEl.className = 'my-custom-element';
+
+            const { accessor, openPopover } = makeAccessor({
+                getTabContextMenuItems: jest
+                    .fn()
+                    .mockReturnValue([{ element: customEl }]),
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.show(
+                makePanel(),
+                makeGroup(),
+                new MouseEvent('contextmenu')
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(menuEl.contains(customEl)).toBe(true);
+            expect(menuEl.querySelector('.my-custom-element')).toBe(customEl);
+        });
+    });
+
+    describe('color swatch click', () => {
+        function makeChipAccessor(palette: TabGroupColorPalette) {
+            const openPopover = jest.fn();
+            const close = jest.fn();
+            const popupService = fromPartial<PopupService>({
+                openPopover,
+                close,
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                options: {
+                    getTabGroupChipContextMenuItems: jest
+                        .fn()
+                        .mockReturnValue(['colorPicker']),
+                },
+                api: {} as any,
+                popupService,
+                getPopupServiceForGroup: () => popupService,
+                tabGroupColorPalette: palette,
+            });
+            return { accessor, openPopover };
+        }
+
+        test('calls tabGroup.setColor() with the entry id on click', () => {
+            const palette = new TabGroupColorPalette([
+                { id: 'brand', value: '#123456', label: 'Brand' },
+                { id: 'accent', value: '#abcdef', label: 'Accent' },
+            ]);
+            const { accessor, openPopover } = makeChipAccessor(palette);
+            const controller = new ContextMenuController(accessor);
+
+            const setColor = jest.fn();
+            const tabGroup = fromPartial<ITabGroup>({
+                color: 'brand',
+                setColor,
+            });
+            controller.showForChip(
+                tabGroup,
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            const swatches = menuEl.querySelectorAll(
+                '.dv-context-menu-color-swatch'
+            );
+            fireEvent.click(swatches[1]);
+
+            expect(setColor).toHaveBeenCalledWith('accent');
+        });
+
+        test('omits the title attribute for palette entries without a label', () => {
+            const palette = new TabGroupColorPalette([
+                { id: 'nolabel', value: '#010203' },
+            ]);
+            const { accessor, openPopover } = makeChipAccessor(palette);
+            const controller = new ContextMenuController(accessor);
+
+            controller.showForChip(
+                fromPartial<ITabGroup>({ color: 'other', setColor: jest.fn() }),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            const swatch = menuEl.querySelector(
+                '.dv-context-menu-color-swatch'
+            ) as HTMLElement;
+            expect(swatch.title).toBe('');
+            expect(
+                swatch.classList.contains(
+                    'dv-context-menu-color-swatch--selected'
+                )
+            ).toBe(false);
+        });
+    });
+
+    describe('config items with no renderable field', () => {
+        test('show() renders nothing for a config with no element/component/label', () => {
+            const { accessor, openPopover } = makeAccessor({
+                getTabContextMenuItems: jest
+                    .fn()
+                    .mockReturnValue([{ componentProps: { foo: 'bar' } }]),
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.show(
+                makePanel(),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(menuEl.children).toHaveLength(0);
+        });
+
+        test('showForChip() renders nothing for a config with no element/label', () => {
+            const openPopover = jest.fn();
+            const popupService = fromPartial<PopupService>({
+                openPopover,
+                close: jest.fn(),
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                options: {
+                    getTabGroupChipContextMenuItems: jest
+                        .fn()
+                        .mockReturnValue([{ componentProps: { foo: 'bar' } }]),
+                },
+                api: {} as any,
+                popupService,
+                getPopupServiceForGroup: () => popupService,
+            });
+            const controller = new ContextMenuController(accessor);
+
+            controller.showForChip(
+                fromPartial({}),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(menuEl.children).toHaveLength(0);
+        });
+    });
+
+    describe('showForChip() early returns', () => {
+        test('does nothing when getTabGroupChipContextMenuItems is not provided', () => {
+            const { accessor, openPopover } = makeAccessor();
+            const controller = new ContextMenuController(accessor);
+            const event = new MouseEvent('contextmenu', { cancelable: true });
+            const spy = jest.spyOn(event, 'preventDefault');
+
+            controller.showForChip(fromPartial({}), makeGroup(), event);
+
+            expect(openPopover).not.toHaveBeenCalled();
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        test('does nothing when the callback returns an empty array', () => {
+            const { accessor, openPopover } = makeAccessor({
+                getTabGroupChipContextMenuItems: jest.fn().mockReturnValue([]),
+            });
+            const controller = new ContextMenuController(accessor);
+            const event = new MouseEvent('contextmenu', { cancelable: true });
+            const spy = jest.spyOn(event, 'preventDefault');
+
+            controller.showForChip(fromPartial({}), makeGroup(), event);
+
+            expect(openPopover).not.toHaveBeenCalled();
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        test('calls preventDefault() and opens the popover when items exist', () => {
+            const { accessor, openPopover } = makeAccessor({
+                getTabGroupChipContextMenuItems: jest
+                    .fn()
+                    .mockReturnValue(['collapse']),
+            });
+            const controller = new ContextMenuController(accessor);
+            const event = new MouseEvent('contextmenu', { cancelable: true });
+            const spy = jest.spyOn(event, 'preventDefault');
+
+            controller.showForChip(
+                fromPartial<ITabGroup>({ collapsed: false, toggle: jest.fn() }),
+                makeGroup(),
+                event
+            );
+
+            expect(spy).toHaveBeenCalled();
+            expect(openPopover).toHaveBeenCalled();
+        });
+    });
+
+    describe('showForChip() item types', () => {
+        function makeChipAccessor(items: unknown[]) {
+            const openPopover = jest.fn();
+            const close = jest.fn();
+            const popupService = fromPartial<PopupService>({
+                openPopover,
+                close,
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                options: {
+                    getTabGroupChipContextMenuItems: jest
+                        .fn()
+                        .mockReturnValue(items),
+                },
+                api: {} as any,
+                popupService,
+                getPopupServiceForGroup: () => popupService,
+            });
+            return { accessor, openPopover, close };
+        }
+
+        test('renders a separator', () => {
+            const { accessor, openPopover } = makeChipAccessor(['separator']);
+            const controller = new ContextMenuController(accessor);
+
+            controller.showForChip(
+                fromPartial({}),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(
+                menuEl.querySelectorAll('.dv-context-menu-separator')
+            ).toHaveLength(1);
+        });
+
+        test('appends a custom element item directly', () => {
+            const customEl = document.createElement('span');
+            customEl.className = 'chip-custom-element';
+            const { accessor, openPopover } = makeChipAccessor([
+                { element: customEl },
+            ]);
+            const controller = new ContextMenuController(accessor);
+
+            controller.showForChip(
+                fromPartial({}),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            expect(menuEl.contains(customEl)).toBe(true);
+        });
+
+        test('renders a custom label item and runs its action on click', () => {
+            const action = jest.fn();
+            const { accessor, openPopover, close } = makeChipAccessor([
+                { label: 'Chip Action', action },
+            ]);
+            const controller = new ContextMenuController(accessor);
+
+            controller.showForChip(
+                fromPartial({}),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            const item = menuEl.querySelector(
+                '.dv-context-menu-item'
+            ) as HTMLElement;
+            expect(item.textContent).toBe('Chip Action');
+
+            fireEvent.click(item);
+            expect(action).toHaveBeenCalled();
+            expect(close).toHaveBeenCalled();
+        });
+
+        test('label item with no action does not throw on click', () => {
+            const { accessor, openPopover, close } = makeChipAccessor([
+                { label: 'No Action' },
+            ]);
+            const controller = new ContextMenuController(accessor);
+
+            controller.showForChip(
+                fromPartial({}),
+                makeGroup(),
+                new MouseEvent('contextmenu', { cancelable: true })
+            );
+
+            const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+            const item = menuEl.querySelector(
+                '.dv-context-menu-item'
+            ) as HTMLElement;
+            expect(() => fireEvent.click(item)).not.toThrow();
+            expect(close).toHaveBeenCalled();
+        });
+    });
+
+    describe("chip 'rename' input", () => {
+        function makeChipAccessor(items: unknown[]) {
+            const openPopover = jest.fn();
+            const popupService = fromPartial<PopupService>({
+                openPopover,
+                close: jest.fn(),
+            });
+            const accessor = fromPartial<DockviewComponent>({
+                options: {
+                    getTabGroupChipContextMenuItems: jest
+                        .fn()
+                        .mockReturnValue(items),
+                },
+                api: {} as any,
+                popupService,
+                getPopupServiceForGroup: () => popupService,
+            });
+            return { accessor, openPopover };
+        }
+
+        function renderRename(
+            tabGroup: ITabGroup,
+            rafImpl?: (cb: FrameRequestCallback) => number
+        ): HTMLInputElement {
+            const raf = jest
+                .spyOn(globalThis, 'requestAnimationFrame')
+                .mockImplementation(
+                    rafImpl ??
+                        ((cb: FrameRequestCallback) => {
+                            cb(0);
+                            return 0;
+                        })
+                );
+            try {
+                const { accessor, openPopover } = makeChipAccessor(['rename']);
+                const controller = new ContextMenuController(accessor);
+                controller.showForChip(
+                    tabGroup,
+                    makeGroup(),
+                    new MouseEvent('contextmenu', { cancelable: true })
+                );
+                const menuEl = openPopover.mock.calls[0][0] as HTMLElement;
+                return menuEl.querySelector(
+                    '.dv-context-menu-rename-input'
+                ) as HTMLInputElement;
+            } finally {
+                raf.mockRestore();
+            }
+        }
+
+        afterEach(() => {
+            // matchMedia may be assigned by individual tests; clean up.
+            // @ts-expect-error jsdom does not define matchMedia by default.
+            delete globalThis.matchMedia;
+        });
+
+        test('seeds the input with the current group label', () => {
+            const tabGroup = fromPartial<ITabGroup>({
+                label: 'My Group',
+                setLabel: jest.fn(),
+            });
+            const input = renderRename(tabGroup);
+            expect(input.value).toBe('My Group');
+            expect(input.placeholder).toBe('Name This Group');
+        });
+
+        test('calls setLabel() as the user types', () => {
+            const setLabel = jest.fn();
+            const tabGroup = fromPartial<ITabGroup>({
+                label: 'Old',
+                setLabel,
+            });
+            const input = renderRename(tabGroup);
+
+            fireEvent.input(input, { target: { value: 'New Name' } });
+            expect(setLabel).toHaveBeenCalledWith('New Name');
+        });
+
+        test('stops propagation of non Escape/Enter keydowns', () => {
+            const tabGroup = fromPartial<ITabGroup>({
+                label: 'Group',
+                setLabel: jest.fn(),
+            });
+            const input = renderRename(tabGroup);
+
+            const letter = new KeyboardEvent('keydown', {
+                key: 'a',
+                bubbles: true,
+                cancelable: true,
+            });
+            const letterSpy = jest.spyOn(letter, 'stopPropagation');
+            input.dispatchEvent(letter);
+            expect(letterSpy).toHaveBeenCalled();
+        });
+
+        test('lets Escape and Enter propagate (does not stop them)', () => {
+            const tabGroup = fromPartial<ITabGroup>({
+                label: 'Group',
+                setLabel: jest.fn(),
+            });
+            const input = renderRename(tabGroup);
+
+            for (const key of ['Escape', 'Enter']) {
+                const event = new KeyboardEvent('keydown', {
+                    key,
+                    bubbles: true,
+                    cancelable: true,
+                });
+                const spy = jest.spyOn(event, 'stopPropagation');
+                input.dispatchEvent(event);
+                expect(spy).not.toHaveBeenCalled();
+            }
+        });
+
+        test('stops propagation of clicks on the input', () => {
+            const tabGroup = fromPartial<ITabGroup>({
+                label: 'Group',
+                setLabel: jest.fn(),
+            });
+            const input = renderRename(tabGroup);
+
+            const click = new MouseEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            });
+            const spy = jest.spyOn(click, 'stopPropagation');
+            input.dispatchEvent(click);
+            expect(spy).toHaveBeenCalled();
+        });
+
+        test('auto-focuses and selects on a fine-pointer device', () => {
+            const tabGroup = fromPartial<ITabGroup>({
+                label: 'Group',
+                setLabel: jest.fn(),
+            });
+            // jsdom has no matchMedia by default => treated as non-coarse, so
+            // the auto-focus path runs.
+            const focus = jest.spyOn(HTMLInputElement.prototype, 'focus');
+            const select = jest.spyOn(HTMLInputElement.prototype, 'select');
+            try {
+                renderRename(tabGroup);
+                expect(focus).toHaveBeenCalled();
+                expect(select).toHaveBeenCalled();
+            } finally {
+                focus.mockRestore();
+                select.mockRestore();
+            }
+        });
+
+        test('skips auto-focus on a coarse (touch) primary device', () => {
+            // @ts-expect-error assigning a test double for matchMedia.
+            globalThis.matchMedia = (query: string) =>
+                ({
+                    matches: query.includes('coarse'),
+                }) as MediaQueryList;
+
+            const tabGroup = fromPartial<ITabGroup>({
+                label: 'Group',
+                setLabel: jest.fn(),
+            });
+            const raf = jest.spyOn(globalThis, 'requestAnimationFrame');
+            try {
+                renderRename(tabGroup);
+                // The auto-focus is scheduled via requestAnimationFrame; on a
+                // coarse device that scheduling is skipped entirely.
+                expect(raf).not.toHaveBeenCalled();
+            } finally {
+                raf.mockRestore();
+            }
+        });
+    });
+
+    describe('ContextMenuModule', () => {
+        test('the service factory builds a ContextMenuController for the host', () => {
+            const { accessor } = makeAccessor();
+            const factory = ContextMenuModule.services!.contextMenuService;
+            const service = factory(accessor);
+            expect(service).toBeInstanceOf(ContextMenuController);
+        });
+
+        test('module metadata is wired to the context menu service slot', () => {
+            expect(ContextMenuModule.moduleName).toBe('ContextMenu');
+            expect(Object.keys(ContextMenuModule.services ?? {})).toContain(
+                'contextMenuService'
+            );
+            expect(ContextMenuModule.options).toEqual(
+                expect.arrayContaining([
+                    'getTabContextMenuItems',
+                    'getTabGroupChipContextMenuItems',
+                    'createContextMenuItemComponent',
+                ])
+            );
         });
     });
 });

--- a/packages/dockview-enterprise/src/__tests__/keyboardShared.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/keyboardShared.spec.ts
@@ -1,0 +1,320 @@
+import type {
+    DockviewIDisposable as IDisposable,
+    KeyboardNavigationOptions,
+} from 'dockview';
+import {
+    type DocumentListenerSpec,
+    KEYBOARD_MOVE_ATTRIBUTE,
+    bindDocumentListeners,
+    matchesBinding,
+    readKeyboardNavigation,
+} from '../keyboardShared';
+
+/**
+ * Minimal stand-in for the accessibility host that `bindDocumentListeners`
+ * needs: a `rootElement` (whose `ownerDocument` is the main document),
+ * `getPopoutWindows()` and `onDidChangePopouts()`. Emitting a change re-runs
+ * every subscribed sync callback, mirroring popouts opening/closing.
+ */
+class FakeHost {
+    readonly rootElement: HTMLElement;
+    popouts: Window[] = [];
+    private readonly listeners = new Set<() => void>();
+
+    constructor(rootElement: HTMLElement = document.createElement('div')) {
+        this.rootElement = rootElement;
+    }
+
+    getPopoutWindows(): Window[] {
+        return this.popouts;
+    }
+
+    onDidChangePopouts(listener: () => void): IDisposable {
+        this.listeners.add(listener);
+        return { dispose: () => this.listeners.delete(listener) };
+    }
+
+    /** Number of live popout subscriptions (0 once disposed). */
+    get subscriptionCount(): number {
+        return this.listeners.size;
+    }
+
+    emitChange(): void {
+        for (const l of Array.from(this.listeners)) {
+            l();
+        }
+    }
+}
+
+/** Create a fresh jsdom `Document` and wrap it as a fake popout `Window`. */
+function makePopoutWindow(): { win: Window; doc: Document } {
+    const doc = document.implementation.createHTMLDocument('popout');
+    const win = { document: doc } as unknown as Window;
+    return { win, doc };
+}
+
+function makeSpecs(): DocumentListenerSpec[] {
+    return [
+        { type: 'keydown', handler: jest.fn(), capture: true },
+        { type: 'keyup', handler: jest.fn(), capture: false },
+    ];
+}
+
+describe('keyboardShared', () => {
+    describe('KEYBOARD_MOVE_ATTRIBUTE', () => {
+        test('is the shared DOM coordination attribute', () => {
+            expect(KEYBOARD_MOVE_ATTRIBUTE).toBe('data-dv-kbd-moving');
+        });
+    });
+
+    describe('matchesBinding', () => {
+        function evt(init: Partial<KeyboardEventInit> & { key: string }) {
+            return new KeyboardEvent('keydown', init);
+        }
+
+        test('matches a plain key with no modifiers', () => {
+            expect(matchesBinding(evt({ key: 'F6' }), 'f6')).toBe(true);
+        });
+
+        test('is case-insensitive on the final key part', () => {
+            expect(matchesBinding(evt({ key: 'A' }), 'a')).toBe(true);
+            expect(matchesBinding(evt({ key: 'a' }), 'A')).toBe(true);
+        });
+
+        test('matches ctrl modifier exactly', () => {
+            expect(
+                matchesBinding(evt({ key: ']', ctrlKey: true }), 'ctrl+]')
+            ).toBe(true);
+            // ctrl required but not held -> no match
+            expect(matchesBinding(evt({ key: ']' }), 'ctrl+]')).toBe(false);
+            // ctrl held but binding does not ask for it -> no match
+            expect(matchesBinding(evt({ key: ']', ctrlKey: true }), ']')).toBe(
+                false
+            );
+        });
+
+        test('matches shift modifier exactly', () => {
+            expect(
+                matchesBinding(evt({ key: 'F6', shiftKey: true }), 'shift+f6')
+            ).toBe(true);
+            expect(
+                matchesBinding(evt({ key: 'F6', shiftKey: true }), 'f6')
+            ).toBe(false);
+        });
+
+        test('matches alt modifier exactly', () => {
+            expect(
+                matchesBinding(evt({ key: 'x', altKey: true }), 'alt+x')
+            ).toBe(true);
+            expect(matchesBinding(evt({ key: 'x' }), 'alt+x')).toBe(false);
+        });
+
+        test('treats both "meta" and "cmd" as the meta modifier', () => {
+            expect(
+                matchesBinding(evt({ key: 'k', metaKey: true }), 'meta+k')
+            ).toBe(true);
+            expect(
+                matchesBinding(evt({ key: 'k', metaKey: true }), 'cmd+k')
+            ).toBe(true);
+            expect(matchesBinding(evt({ key: 'k' }), 'cmd+k')).toBe(false);
+        });
+
+        test('matches multiple modifiers together', () => {
+            expect(
+                matchesBinding(
+                    evt({ key: 'F6', ctrlKey: true, shiftKey: true }),
+                    'ctrl+shift+f6'
+                )
+            ).toBe(true);
+            // one extra modifier held that the binding did not request
+            expect(
+                matchesBinding(
+                    evt({
+                        key: 'F6',
+                        ctrlKey: true,
+                        shiftKey: true,
+                        altKey: true,
+                    }),
+                    'ctrl+shift+f6'
+                )
+            ).toBe(false);
+        });
+    });
+
+    describe('readKeyboardNavigation', () => {
+        test('returns undefined when the opt-in is falsy', () => {
+            expect(
+                readKeyboardNavigation({ keyboardNavigation: false } as any)
+            ).toBeUndefined();
+            expect(readKeyboardNavigation({} as any)).toBeUndefined();
+        });
+
+        test('returns an empty options object when the opt-in is `true`', () => {
+            expect(
+                readKeyboardNavigation({ keyboardNavigation: true } as any)
+            ).toEqual({});
+        });
+
+        test('passes through an explicit options object', () => {
+            const opts: KeyboardNavigationOptions =
+                {} as KeyboardNavigationOptions;
+            expect(
+                readKeyboardNavigation({ keyboardNavigation: opts } as any)
+            ).toBe(opts);
+        });
+    });
+
+    describe('bindDocumentListeners', () => {
+        let mainDoc: Document;
+
+        beforeEach(() => {
+            mainDoc = document.body.ownerDocument;
+        });
+
+        test('attaches every spec to the main document on bind', () => {
+            const host = new FakeHost(document.body);
+            const specs = makeSpecs();
+            const add = jest.spyOn(mainDoc, 'addEventListener');
+
+            const disposable = bindDocumentListeners(host, specs);
+
+            expect(add).toHaveBeenCalledWith('keydown', specs[0].handler, true);
+            expect(add).toHaveBeenCalledWith('keyup', specs[1].handler, false);
+
+            add.mockRestore();
+            disposable.dispose();
+        });
+
+        test('attaches listeners to a popout document added via sync', () => {
+            const host = new FakeHost(document.body);
+            const specs = makeSpecs();
+            const disposable = bindDocumentListeners(host, specs);
+
+            const { win, doc } = makePopoutWindow();
+            const add = jest.spyOn(doc, 'addEventListener');
+
+            host.popouts = [win];
+            host.emitChange();
+
+            expect(add).toHaveBeenCalledTimes(specs.length);
+            expect(add).toHaveBeenCalledWith('keydown', specs[0].handler, true);
+            expect(add).toHaveBeenCalledWith('keyup', specs[1].handler, false);
+
+            disposable.dispose();
+        });
+
+        test('detaches listeners when a popout document is removed', () => {
+            const host = new FakeHost(document.body);
+            const specs = makeSpecs();
+            const disposable = bindDocumentListeners(host, specs);
+
+            const { win, doc } = makePopoutWindow();
+            host.popouts = [win];
+            host.emitChange();
+
+            const remove = jest.spyOn(doc, 'removeEventListener');
+
+            // popout closed
+            host.popouts = [];
+            host.emitChange();
+
+            expect(remove).toHaveBeenCalledTimes(specs.length);
+            expect(remove).toHaveBeenCalledWith(
+                'keydown',
+                specs[0].handler,
+                true
+            );
+            expect(remove).toHaveBeenCalledWith(
+                'keyup',
+                specs[1].handler,
+                false
+            );
+
+            disposable.dispose();
+        });
+
+        test('is idempotent: an unchanged popout set does not re-add listeners', () => {
+            const host = new FakeHost(document.body);
+            const specs = makeSpecs();
+            const disposable = bindDocumentListeners(host, specs);
+
+            const { win, doc } = makePopoutWindow();
+            host.popouts = [win];
+            host.emitChange();
+
+            const add = jest.spyOn(doc, 'addEventListener');
+            // fire more sync events without changing the popout set
+            host.emitChange();
+            host.emitChange();
+
+            expect(add).not.toHaveBeenCalled();
+
+            disposable.dispose();
+        });
+
+        test('skips a popout that shares the main document (no double listeners)', () => {
+            const host = new FakeHost(document.body);
+            const specs = makeSpecs();
+            const disposable = bindDocumentListeners(host, specs);
+
+            const add = jest.spyOn(mainDoc, 'addEventListener');
+            // a popout window that reuses the jsdom main document
+            const sharedWin = { document: mainDoc } as unknown as Window;
+            host.popouts = [sharedWin];
+            host.emitChange();
+
+            expect(add).not.toHaveBeenCalled();
+
+            add.mockRestore();
+            disposable.dispose();
+        });
+
+        test('dispose removes every listener and unsubscribes from popout changes', () => {
+            const host = new FakeHost(document.body);
+            const specs = makeSpecs();
+            const disposable = bindDocumentListeners(host, specs);
+
+            const { win: winA, doc: docA } = makePopoutWindow();
+            const { win: winB, doc: docB } = makePopoutWindow();
+            host.popouts = [winA, winB];
+            host.emitChange();
+
+            const removeMain = jest.spyOn(mainDoc, 'removeEventListener');
+            const removeA = jest.spyOn(docA, 'removeEventListener');
+            const removeB = jest.spyOn(docB, 'removeEventListener');
+
+            expect(host.subscriptionCount).toBe(1);
+            disposable.dispose();
+
+            expect(host.subscriptionCount).toBe(0);
+            expect(removeMain).toHaveBeenCalledTimes(specs.length);
+            expect(removeA).toHaveBeenCalledTimes(specs.length);
+            expect(removeB).toHaveBeenCalledTimes(specs.length);
+
+            removeMain.mockRestore();
+        });
+
+        test('keeps unchanged popouts attached while adding a new one', () => {
+            const host = new FakeHost(document.body);
+            const specs = makeSpecs();
+            const disposable = bindDocumentListeners(host, specs);
+
+            const { win: winA, doc: docA } = makePopoutWindow();
+            host.popouts = [winA];
+            host.emitChange();
+
+            const addA = jest.spyOn(docA, 'addEventListener');
+            const { win: winB, doc: docB } = makePopoutWindow();
+            const addB = jest.spyOn(docB, 'addEventListener');
+
+            host.popouts = [winA, winB];
+            host.emitChange();
+
+            // existing popout untouched, new popout attached
+            expect(addA).not.toHaveBeenCalled();
+            expect(addB).toHaveBeenCalledTimes(specs.length);
+
+            disposable.dispose();
+        });
+    });
+});

--- a/packages/dockview-enterprise/src/__tests__/licenseValidator.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/licenseValidator.spec.ts
@@ -15,6 +15,19 @@ const GOLDEN_KEY =
 
 const GOLDEN_BODY = GOLDEN_KEY.slice(0, GOLDEN_KEY.lastIndexOf('__'));
 
+// Independent oracle: FNV-1a 64-bit computed over Node's own canonical UTF-8
+// encoding, using BigInt (a different arithmetic path than the verifier's
+// two-32-bit-halves impl). Lets us assert `fnv1a` — and therefore `utf8Bytes` —
+// is byte-identical to a standard encoder across the 1/2/3/4-byte ranges,
+// including surrogate pairs, without needing an issuer-minted fixture.
+function fnv1aReference(input: string): string {
+    let h = 0xcbf29ce484222325n;
+    for (const b of Buffer.from(input, 'utf8')) {
+        h = ((h ^ BigInt(b)) * 0x100000001b3n) & 0xffffffffffffffffn;
+    }
+    return h.toString(16).padStart(16, '0');
+}
+
 describe('fnv1a', () => {
     test('empty input is the FNV-1a 64-bit offset basis', () => {
         expect(fnv1a('')).toBe('cbf29ce484222325');
@@ -32,6 +45,23 @@ describe('fnv1a', () => {
 
     test('a single-byte change flips the digest', () => {
         expect(fnv1a(GOLDEN_BODY)).not.toBe(fnv1a(GOLDEN_BODY + ' '));
+    });
+
+    test('utf8 encoding matches a standard encoder across byte-lengths', () => {
+        // 1-byte (ASCII), 2-byte (Latin-1 supplement), 3-byte (CJK), and
+        // 4-byte (astral / surrogate-pair emoji) code points, plus a mix.
+        for (const s of [
+            'A',
+            'é',
+            'ñ',
+            '£',
+            '日本語',
+            '😀',
+            '𐀀',
+            'Acmé_Trådîng_🚀',
+        ]) {
+            expect(fnv1a(s)).toBe(fnv1aReference(s));
+        }
     });
 });
 
@@ -71,6 +101,39 @@ describe('parseLicenseKey', () => {
             10
         )}\r\n`;
         expect(parseLicenseKey(noisy)).not.toBeNull();
+    });
+
+    // Build a valid-checksum key with an arbitrary ValidUntil so the date
+    // parser's branches can be exercised through the public API.
+    const keyWithValidUntil = (validUntil: string): string => {
+        const body =
+            `[KeyId:K]_[Company:C]_[Plan:team]_[AppName:A]_[Email:e@x.com]` +
+            `_[ValidFrom:01_Jul_2026]_[ValidUntil:${validUntil}]`;
+        return `${body}__${fnv1a(body)}`;
+    };
+
+    test('date field with an unknown month name parses to null', () => {
+        expect(
+            parseLicenseKey(keyWithValidUntil('01_Zzz_2027'))!.validUntil
+        ).toBeNull();
+    });
+
+    test('date field with an impossible calendar day parses to null', () => {
+        // 31 Feb overflows into March, so it is rejected.
+        expect(
+            parseLicenseKey(keyWithValidUntil('31_Feb_2027'))!.validUntil
+        ).toBeNull();
+    });
+
+    test('date field with a malformed shape parses to null', () => {
+        expect(
+            parseLicenseKey(keyWithValidUntil('2027-07-01'))!.validUntil
+        ).toBeNull();
+    });
+
+    test('a well-formed date parses to the matching UTC calendar day', () => {
+        const d = parseLicenseKey(keyWithValidUntil('29_Feb_2028'))!.validUntil;
+        expect(d).toEqual(new Date(Date.UTC(2028, 1, 29))); // leap day
     });
 });
 


### PR DESCRIPTION
## Description

A sustained pass raising unit-test coverage across under-covered areas of the v8 branch. **Test-only — no source changes.** Full suites pass (**1665 core + 460 enterprise**).

### Coverage deltas (statements)

**`dockview-core`**
| File | Before → After |
|---|---|
| `dockview/theme.ts` | 0% → **100%** |
| `dockview/events.ts` | 21% → **100%** |
| `api/dockviewGroupPanelApi.ts` | 25% → **100%** |
| `api/component.api.ts` | 30% → **100%** |
| `api/dockviewPanelApi.ts` | 41% → **100%** |
| `dockview/components/titlebar/tabsContainer.ts` | 60% → **99.6%** |
| `dockview/accessibilityMessages.ts` | 62% → **100%** |
| `events.ts` (Emitter/AsapEvent) | 65% → **98%** |
| `gridview/gridviewComponent.ts` | 66% → **99%** |
| `dockview/popoutWindowService.ts` | 68% → **100%** |
| `dockview/components/titlebar/tabGroups.ts` | ~70% → **93%** |
| `dockview/floatingGroupService.ts` | 72% → **100%** |
| `splitview/splitviewPanel.ts` | 74% → **100%** |
| `gridview/baseComponentGridview.ts` | 76% → **99%** |
| `dockview/components/titlebar/floatingTitleBar.ts` | 76% → **100%** |
| `overlay/overlay.ts` | 79% → **98%** |
| `dom.ts` | 79% → **85%** |

**`dockview-enterprise`**
| File | Before → After |
|---|---|
| `licenseValidator.ts` | 87% → **100%** |
| `autoEdgeGroupService.ts` | 77% → **100%** |
| `contextMenu.ts` | 81% → **100%** |
| `keyboardShared.ts` | 82% → **98%** |

Tests driven through each component's existing harness conventions; real pointer-drag / window-geometry paths that jsdom can't simulate are noted as skipped, not faked.

### Findings (separate from this test-only change)
Three pre-existing source issues surfaced while writing tests. **None fixed here** (tests assert intended behavior, not the defect); flagged for a maintainer decision:
1. **`gridviewComponent.movePanel` (gridviewComponent.ts:298)** — `this.gridview.remove(panel)` runs *before* validating `options.reference`; an invalid reference throws after the panel is already removed, leaving it dangling in `_groups`. `addPanel` validates first.
2. **`baseComponentGridview.updateOptions` (baseComponentGridview.ts:243)** — guard is `if ('disableResizing' in options)` but the option field is `disableAutoResizing` (and the body reads `options.disableAutoResizing`). `updateOptions({ disableAutoResizing })` never enters the branch, so the value is never updated.
3. **`Emitter.dispose()` leak warning (events.ts:196)** — unreachable: `this._listeners` is cleared synchronously before the deferred `queueMicrotask` runs. Dev-only (`ENABLE_TRACKING`, off by default), no runtime impact.

## Type of change

- [x] Build / CI / tooling (tests)

## Affected packages

- [x] `dockview-core`
- [x] `dockview-enterprise`

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm8oMASAfaxk6KWEjwqUPY