### PR TITLE
fix: three defects surfaced by the v8 coverage pass

### DIFF
--- a/packages/dockview-core/src/__tests__/events.spec.ts
+++ b/packages/dockview-core/src/__tests__/events.spec.ts
@@ -568,6 +568,43 @@ describe('events', () => {
             expect(Emitter.MEMORY_LEAK_WATCHER.size).toBe(0);
         });
 
+        it('warns about a leaked listener, deferred to a microtask', async () => {
+            Emitter.setLeakageMonitorEnabled(true);
+
+            const emitter = new Emitter<number>();
+            emitter.event(() => {
+                // leaked: never disposed
+            });
+
+            emitter.dispose();
+            // the leak check is deferred, so nothing is logged synchronously
+            expect(warnSpy).not.toHaveBeenCalled();
+
+            await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+            // the deferred check now reports the leaked listener
+            expect(warnSpy).toHaveBeenCalled();
+            expect(warnSpy.mock.calls[0][0]).toBe('dockview: stacktrace');
+        });
+
+        it('does not warn when the listener is disposed out-of-order in the same block', async () => {
+            Emitter.setLeakageMonitorEnabled(true);
+
+            const emitter = new Emitter<number>();
+            const stream = emitter.event(() => {
+                // noop
+            });
+
+            // dispose the emitter, then the listener, in the same execution
+            // block: the deferred check must see the listener already removed.
+            emitter.dispose();
+            stream.dispose();
+
+            await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
         it('warns when disposing a listener that was already removed while tracking', () => {
             Emitter.setLeakageMonitorEnabled(true);
 

--- a/packages/dockview-core/src/__tests__/gridview/baseComponentGridview.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/baseComponentGridview.spec.ts
@@ -631,14 +631,29 @@ describe('baseComponentGridview', () => {
             cut.dispose();
         });
 
-        test('updates disableResizing when the key is present', () => {
+        test('updates disableResizing when disableAutoResizing is provided', () => {
             const cut = createCut();
             expect(cut.disableResizing).toBe(false);
 
-            cut.updateOptions({
-                disableResizing: true,
-                disableAutoResizing: true,
-            } as Partial<BaseGridOptions>);
+            // The real option key is `disableAutoResizing`; providing it must
+            // update `disableResizing` (regression guard: the guard previously
+            // checked a non-existent `disableResizing` key and never fired).
+            cut.updateOptions({ disableAutoResizing: true });
+            expect(cut.disableResizing).toBe(true);
+
+            cut.updateOptions({ disableAutoResizing: false });
+            expect(cut.disableResizing).toBe(false);
+
+            cut.dispose();
+        });
+
+        test('leaves disableResizing unchanged when the option is omitted', () => {
+            const cut = createCut();
+            cut.updateOptions({ disableAutoResizing: true });
+            expect(cut.disableResizing).toBe(true);
+
+            // An unrelated update must not reset it.
+            cut.updateOptions({ orientation: cut.orientation });
             expect(cut.disableResizing).toBe(true);
 
             cut.dispose();

--- a/packages/dockview-core/src/__tests__/gridview/gridviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridviewComponent.spec.ts
@@ -3216,6 +3216,11 @@ describe('gridview', () => {
                 reference: 'does_not_exist',
             })
         ).toThrow('reference group does_not_exist does not exist');
+
+        // The panel must NOT have been removed by the failed move: validation
+        // runs before the panel is taken out of the grid.
+        expect(gridview.size).toBe(1);
+        expect(gridview.getPanel('panel1')).toBeTruthy();
     });
 
     test('movePanel throws when the direction resolves to center', () => {
@@ -3235,6 +3240,11 @@ describe('gridview', () => {
                 reference: 'panel1',
             })
         ).toThrow('center not supported as an option');
+
+        // Both panels survive the rejected move.
+        expect(gridview.size).toBe(2);
+        expect(gridview.getPanel('panel1')).toBeTruthy();
+        expect(gridview.getPanel('panel2')).toBeTruthy();
     });
 
     test('addPanel throws when the reference panel does not exist', () => {

--- a/packages/dockview-core/src/events.ts
+++ b/packages/dockview-core/src/events.ts
@@ -190,18 +190,24 @@ export class Emitter<T> implements IDisposable {
 
             if (this._listeners.length > 0) {
                 if (Emitter.ENABLE_TRACKING) {
+                    // Defer the leak check AND the clear to a microtask: this
+                    // lets listeners disposed out-of-order later in the same
+                    // execution block remove themselves from `_listeners` first,
+                    // so they aren't falsely reported. Clearing synchronously
+                    // here (as before) left the microtask iterating an empty
+                    // array, so the leak warning never fired.
                     queueMicrotask(() => {
-                        // don't check until stack of execution is completed to allow for out-of-order disposals within the same execution block
                         for (const listener of this._listeners) {
                             console.warn(
                                 'dockview: stacktrace',
                                 listener.stacktrace?.print()
                             );
                         }
+                        this._listeners = [];
                     });
+                } else {
+                    this._listeners = [];
                 }
-
-                this._listeners = [];
             }
 
             if (Emitter.ENABLE_TRACKING && this._event) {

--- a/packages/dockview-core/src/gridview/baseComponentGridview.ts
+++ b/packages/dockview-core/src/gridview/baseComponentGridview.ts
@@ -240,7 +240,7 @@ export abstract class BaseGrid<T extends IGridPanelView>
         if ('styles' in options) {
             // this.gridview.styles = options.styles; // not supported
         }
-        if ('disableResizing' in options) {
+        if ('disableAutoResizing' in options) {
             this.disableResizing = options.disableAutoResizing ?? false;
         }
         if ('locked' in options) {

--- a/packages/dockview-core/src/gridview/gridviewComponent.ts
+++ b/packages/dockview-core/src/gridview/gridviewComponent.ts
@@ -293,10 +293,9 @@ export class GridviewComponent
         panel: GridviewPanel,
         options: { direction: Direction; reference: string; size?: number }
     ): void {
-        let relativeLocation: number[];
-
-        const removedPanel = this.gridview.remove(panel) as GridviewPanel;
-
+        // Validate before mutating: resolve the reference group and target
+        // first, so an invalid reference/direction throws while `panel` is
+        // still in the grid rather than leaving it removed and dangling.
         const referenceGroup = this._groups.get(options.reference)?.value;
 
         if (!referenceGroup) {
@@ -308,14 +307,16 @@ export class GridviewComponent
         const target = toTarget(options.direction);
         if (target === 'center') {
             throw new Error(`${target} not supported as an option`);
-        } else {
-            const location = getGridLocation(referenceGroup.element);
-            relativeLocation = getRelativeLocation(
-                this.gridview.orientation,
-                location,
-                target
-            );
         }
+
+        const location = getGridLocation(referenceGroup.element);
+        const relativeLocation = getRelativeLocation(
+            this.gridview.orientation,
+            location,
+            target
+        );
+
+        const removedPanel = this.gridview.remove(panel) as GridviewPanel;
 
         this.doAddGroup(removedPanel, relativeLocation, options.size);
     }


### PR DESCRIPTION
## Description

Fixes the three pre-existing bugs surfaced while writing the coverage tests in #1523 (now merged). Rebased onto `v8-branch`, so the diff is just the three source fixes and their regression tests. Full suites pass: **1668 core + 460 enterprise**.

### 1. `gridviewComponent.movePanel` — remove-after-validate
`this.gridview.remove(panel)` ran **before** validating `options.reference`/direction. An invalid reference (or a `center` direction) threw *after* the panel was already removed, leaving it dangling in `_groups`. Now the reference group and relative location are resolved first; the panel is removed only once the move is guaranteed to succeed. (`addPanel` already validated first — this makes them consistent.)
_Test:_ `movePanel` with an invalid reference / center direction throws **and** the panel(s) remain in the grid.

### 2. `baseComponentGridview.updateOptions` — wrong option key
The guard was `if ('disableResizing' in options)`, but the option is named `disableAutoResizing` (and the body reads `options.disableAutoResizing`). So `updateOptions({ disableAutoResizing })` never entered the branch and the flag was never updated. Fixed the key to `'disableAutoResizing'`.
_Test:_ `updateOptions({ disableAutoResizing: true/false })` toggles `disableResizing`; an unrelated update leaves it unchanged.

### 3. `Emitter.dispose()` — dead leak warning
The dev-only leak check (`ENABLE_TRACKING`) queued a microtask iterating `this._listeners`, but `this._listeners = []` ran **synchronously** first, so the microtask always saw an empty array and the warning never fired. The clear is now deferred into the same microtask — preserving the original intent of letting listeners disposed out-of-order in the same execution block be excluded from the leak report.
_Test:_ a leaked listener is reported (after the microtask); a listener disposed out-of-order in the same block is **not** reported.

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [x] `yarn test` passes
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented (none — #3 is a dev-only diagnostic; #1/#2 only change behavior on invalid input / a previously-ignored option)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm8oMASAfaxk6KWEjwqUPY