### PR TITLE
Publish styles from dockview-enterprise, stop publishing from dockview-core

### DIFF
--- a/packages/dockview-core/package.json
+++ b/packages/dockview-core/package.json
@@ -52,7 +52,6 @@
             "import": "./dist/package/main.esm.mjs",
             "require": "./dist/package/main.cjs.js"
         },
-        "./dist/styles/*": "./dist/styles/*",
         "./dist/*": "./dist/*",
         "./package.json": "./package.json"
     },
@@ -63,7 +62,6 @@
     "files": [
         "dist/package",
         "dist/cjs/**/*.d.ts",
-        "dist/styles",
         "dist/*.js",
         "README.md",
         "LICENCE.md"

--- a/packages/dockview-enterprise/package.json
+++ b/packages/dockview-enterprise/package.json
@@ -29,6 +29,7 @@
             "import": "./dist/package/main.esm.mjs",
             "require": "./dist/package/main.cjs.js"
         },
+        "./dist/styles/*": "./dist/styles/*",
         "./dist/*": "./dist/*",
         "./package.json": "./package.json"
     },
@@ -36,6 +37,7 @@
     "files": [
         "dist/package",
         "dist/cjs/**/*.d.ts",
+        "dist/styles",
         "dist/*.js",
         "README.md",
         "LICENCE.md"
@@ -43,7 +45,8 @@
     "scripts": {
         "build:bundle": "rolldown -c rolldown.config.mjs",
         "build:cjs": "tsc --build ./tsconfig.json --verbose --extendedDiagnostics",
-        "build": "npm run build:cjs",
+        "build:css": "node scripts/copy-css.js",
+        "build": "npm run build:cjs && npm run build:css",
         "clean": "rimraf dist/ .build/ .rollup.cache/",
         "rebuild": "npm run clean && npm run build && npm run build:bundle",
         "types:check": "attw --pack . --ignore-rules false-cjs",

--- a/packages/dockview-enterprise/scripts/copy-css.js
+++ b/packages/dockview-enterprise/scripts/copy-css.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const fs = require('fs');
+
+const outDir = path.join(__dirname, '../dist/styles');
+
+if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir);
+}
+
+fs.copyFileSync(
+    path.join(__dirname, '../../dockview-core/dist/styles/dockview.css'),
+    path.join(outDir, 'dockview.css')
+);


### PR DESCRIPTION
## Description

`dockview-enterprise` is a public package but did not ship the dockview stylesheet, unlike the other public wrapper packages (`dockview`, `dockview-react`, `dockview-vue`, `dockview-angular`). This wires up style publishing for it using the exact same pattern as the other wrappers:

- Adds `packages/dockview-enterprise/scripts/copy-css.js` — copies core's compiled `dockview.css` into `dist/styles` (identical to `dockview`/`dockview-react`'s script).
- Adds a `build:css` step and runs it as part of `build` (`build:cjs && build:css`).
- Adds `dist/styles` to `files` and the `./dist/styles/*` entry to `exports`.

Enterprise features' styles (multi-row tabs, drop guides, edge groups, etc.) already live in core's compiled `dockview.css`, so re-exporting that single file is exactly what the other wrappers do — no separate enterprise stylesheet is required.

This PR also stops `dockview-core` from publishing styles. `dockview-core` is an internal package and consumers should not import its styles directly, so `dist/styles` is removed from its published `files` and the `./dist/styles/*` export is dropped. Core still runs `build:css` to compile the SCSS into its local `dist/`, which the wrapper packages copy from the filesystem during the monorepo build — so the build chain is unaffected. The only externally-visible effect is that `dockview-core/dist/styles/dockview.css` is no longer resolvable as a package import.

## Type of change

- [x] Breaking change (`dockview-core` no longer exposes its styles as a package import)
- [x] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [x] `dockview-enterprise`

## How to test

- Build the packages (nx `^build` ordering guarantees `dockview-core` builds before `dockview-enterprise`, so core's CSS exists when the enterprise copy step runs).
- Confirm `packages/dockview-enterprise/dist/styles/dockview.css` is produced and that `npm pack` for `dockview-enterprise` includes `dist/styles`.
- Confirm `npm pack` for `dockview-core` no longer includes `dist/styles`.
- All in-repo references to core's styles are either the internal filesystem-path copies (unaffected) or a historical v7 migration diff — no live consumer imports core styles via the package specifier.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [x] Breaking changes are documented

> Note: dependencies were not installed in the authoring environment, so the full nx build / lint / test suite was not run locally. The package.json wiring is a byte-for-byte match of the working wrapper packages, and the copy script's path resolution + behavior were verified directly against a simulated core `dockview.css`. CI is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016jrj5S9cxdwoSgUPHEZzja)_