### PR TITLE
docs: document receiving custom params in panels across all frameworks

### DIFF
--- a/packages/docs/docs/core/panels/register.mdx
+++ b/packages/docs/docs/core/panels/register.mdx
@@ -32,12 +32,15 @@ You can register panels through the Dockview [option](/docs/api/dockview/options
 <FrameworkSpecific framework='React'>
 ```tsx
 const components = {
-  component_1: (props: IDockviewPanelProps) => {
+  component_1: (props: IDockviewPanelProps<{ foo: string }>) => {
     const api: DockviewPanelApi  = props.api;
     const groupApi: DockviewGroupPanelApi  = props.group.api;
     const containerApi: DockviewApi  = props.containerApi;
 
-    return <div>{/** logic */}</div>
+    // custom values passed via addPanel({ params: ... }) are read from props.params
+    const foo: string = props.params.foo;
+
+    return <div>{foo}</div>
 
 },
 component_2: (props: IDockviewPanelProps) => {
@@ -65,7 +68,9 @@ class Panel implements IContentRenderer {
     }
 
     init(parameters: GroupPanelPartInitParameters): void {
-        //
+        // custom values passed via addPanel({ params: ... }) are read from parameters.params
+        const foo = parameters.params.foo;
+        this._element.textContent = foo;
     }
 }
 

--- a/packages/docs/docs/core/panels/register.mdx
+++ b/packages/docs/docs/core/panels/register.mdx
@@ -112,6 +112,45 @@ Legacy Options-API style is still supported; components registered on any
 ancestor via `components: { ... }` (or globally via `app.component(...)`) are
 resolved by name as before.
 
+#### Receiving params inside a panel
+
+A panel component receives a single `params` prop of type
+`IDockviewPanelProps`. This is where Dockview passes the panel `api`, the
+`containerApi`, and any custom values you supplied. Your own values live one
+level down, under `params.params`, so a value passed as
+`addPanel({ params: { foo } })` is read as `params.params.foo`.
+
+```vue
+<script setup lang="ts">
+import type { IDockviewPanelProps } from 'dockview-vue';
+
+const { params } = defineProps<{
+    params: IDockviewPanelProps<{ foo: string }>;
+}>();
+</script>
+
+<template>
+    <div>{{ params.params.foo }}</div>
+</template>
+```
+
+Supply the value when you add the panel:
+
+```ts
+event.api.addPanel<{ foo: string }>({
+    id: 'panel_1',
+    component: 'component_1',
+    params: { foo: 'bar' },
+});
+```
+
+Anything you put in `params` is also serialised when the layout is saved to
+JSON, so keep it to simple, static values. For anything richer (store
+instances, callbacks, non-serialisable objects) use Vue's `provide`/`inject`
+instead, or read it from a shared store. See [Update panel](/docs/core/panels/update)
+for how to change these values after a panel has been created and react to the
+change.
+
 </FrameworkSpecific>
 
 <FrameworkSpecific framework='Angular'>


### PR DESCRIPTION
## Description

The panel registration docs only explained how to receive a custom `params` value in the Angular section. The Vue, React and JavaScript sections showed how to register a component but never how to read a value passed via `addPanel({ params: ... })`. This is a recurring point of confusion for Vue users in particular, because the whole `IDockviewPanelProps` object is passed as the single `params` prop, so custom values live one level down at `params.params.foo`.

This came up again in [#897](https://github.com/mathuo/dockview/issues/897), where multiple users independently worked out the pattern and documented it in the thread.

Changes to `packages/docs/docs/core/panels/register.mdx`:

- **Vue**: added a "Receiving params inside a panel" subsection with a `<script setup>` + `defineProps` example showing `params.params.foo`, the matching `addPanel` call, and the layout-serialisation caveat (with a pointer to `provide`/`inject` and the Update panel docs).
- **React**: the example now reads a custom value via `props.params.foo`.
- **JavaScript**: the vanilla renderer example now reads `parameters.params.foo`.

All four framework variants now demonstrate reading a custom param, matching the shape each framework actually uses.

Docs only; no library code changed.

## Type of change

- [x] Documentation

## Affected packages

- [x] `docs`

## How to test

Build the docs site and open Core -> Panels -> Registering panels. Switch the framework selector between React, Vue, Angular and JavaScript and confirm each shows how a registered panel reads a custom `params` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpqukjBnAk1DicE4XW8Lrs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpqukjBnAk1DicE4XW8Lrs)_