### PR TITLE
fix(smart-guides): make alignment-only by default, gate merging behind snapTogether

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -132,9 +132,12 @@
                     // Smart Guides — alignment + snapping for floating groups.
                     // Float-only here so the harness geometry is deterministic
                     // (container-edge snapping is covered by unit tests).
+                    // `snapTogether` is opt-in (alignment-only by default); the
+                    // harness enables it to exercise the dock/merge e2e path.
                     smartGuides: {
                         snapDistance: 12,
                         snapTargets: { container: false },
+                        snapTogether: true,
                     },
                     // Enable auto-hide edge groups (collapsed-strip peek).
                     autoHideEdgeGroups: true,

--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -243,7 +243,9 @@ export interface SmartGuidesOptions {
     showGuides?: boolean;
     /** Detect a dock/merge intent when the dragged float comes flush against
      *  another float (edge-adjacency) or overlaps its tab strip (tabset merge),
-     *  and commit it on drop. Default `true`. */
+     *  and commit it on drop. Opt-in: Smart Guides is an alignment-only tool by
+     *  default and never merges floating groups unless this is set. Default
+     *  `false`. */
     snapTogether?: boolean;
     /** Which alignment sources to snap against (floats + container by default). */
     snapTargets?: SmartGuidesSnapTargets;

--- a/packages/dockview-enterprise/src/__tests__/smartGuides.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/smartGuides.spec.ts
@@ -323,9 +323,12 @@ describe('smart guides', () => {
     const preview = (): HTMLElement | null =>
         container.querySelector('.dv-smart-guide-preview');
     // Disable alignment (no float/container candidates) so the snapped box is
-    // the raw proposed box, so the snap-together geometry is then exact.
+    // the raw proposed box, so the snap-together geometry is then exact. Merge
+    // is opt-in (Smart Guides is alignment-only by default), so enable it here;
+    // callers can still override via `extra` (see the `snapTogether: false` test).
     const noAlign = (extra: SmartGuidesOptions = {}): SmartGuidesOptions => ({
         snapTargets: { floats: false, container: false },
+        snapTogether: true,
         ...extra,
     });
 
@@ -378,6 +381,24 @@ describe('smart guides', () => {
     test('`snapTogether: false` never suggests or commits a merge', () => {
         const t: Box = { left: 300, top: 100, width: 200, height: 200 };
         make(noAlign({ snapTogether: false }), [
+            { group: targetGroup, box: t },
+        ]);
+
+        service.transformFloatingGroupDrag(
+            ctx({ left: 150, top: 100, width: 150, height: 200 }, [])
+        );
+        expect(preview()?.style.display ?? 'none').toBe('none');
+
+        endEmitter.fire(group);
+        expect(mergeCalls).toHaveLength(0);
+    });
+
+    test('does not merge by default: alignment-only unless snapTogether is opted into', () => {
+        // Smart Guides is an alignment tool by default; merging floating groups
+        // is opt-in. With `snapTogether` unset, an edge flush against a target
+        // suggests nothing and commits nothing on drop.
+        const t: Box = { left: 300, top: 100, width: 200, height: 200 };
+        make({ snapTargets: { floats: false, container: false } }, [
             { group: targetGroup, box: t },
         ]);
 

--- a/packages/dockview-enterprise/src/smartGuidesService.ts
+++ b/packages/dockview-enterprise/src/smartGuidesService.ts
@@ -46,7 +46,7 @@ function resolveOptions(o: SmartGuidesOptions | undefined): ResolvedOptions {
         snapDistance: o?.snapDistance ?? 8,
         releaseDistance: o?.releaseDistance ?? 4,
         showGuides: o?.showGuides ?? true,
-        snapTogether: o?.snapTogether ?? true,
+        snapTogether: o?.snapTogether ?? false,
         disableSnapModifier: o?.disableSnapModifier ?? 'alt',
         className: o?.className,
         snapFloats: o?.snapTargets?.floats ?? true,

--- a/packages/docs/docs/core/dnd/smartGuides.mdx
+++ b/packages/docs/docs/core/dnd/smartGuides.mdx
@@ -83,12 +83,21 @@ const api = createDockview(element, {
 
 ### Snap-together (dock / merge)
 
-With `snapTogether` enabled (the default), Smart Guides also detects a **dock or merge intent** while dragging:
+By default Smart Guides is an alignment tool only: it aligns and snaps floating groups but never docks or merges them. Set `snapTogether: true` to opt in, and Smart Guides also detects a **dock or merge intent** while dragging:
 
 - Dragging a floating group flush against another group's opposite edge (with sufficient perpendicular overlap) suggests docking it **beside** the target.
 - Dragging a floating group so its tab strip overlaps another's suggests **merging** the two into a shared tabset (a `center` drop).
 
-A drop preview is shown during the drag, and the dock/merge is committed on drop. Set `snapTogether: false` to keep pure alignment snapping without dock/merge suggestions.
+A drop preview is shown during the drag, and the dock/merge is committed on drop.
+
+```ts
+const api = createDockview(element, {
+    smartGuides: {
+        // Opt in to dock/merge suggestions (off by default)
+        snapTogether: true,
+    },
+});
+```
 
 ### Disabling snapping mid-drag
 


### PR DESCRIPTION
## Description

Smart Guides previously docked/merged floating groups on drop whenever they came flush against each other, because `snapTogether` defaulted to `true`. This makes Smart Guides a pure **alignment tool** by default: it aligns and snaps floating groups but never merges them unless an app explicitly opts in with `smartGuides.snapTogether: true`.

The dock/merge feature is unchanged and still fully available; it is just no longer on by default.

**Behaviour change to note for reviewers:** apps that were relying on the default-on merge will need to set `snapTogether: true` to keep it. Given the feature is recent and enterprise-only, this is a default tuning rather than a stable-API break, so it's filed as a bug fix.

What changed:
- Default `snapTogether` to `false` in the service option resolver (`smartGuidesService.ts`, in `dockview-enterprise`).
- Update the `SmartGuidesOptions.snapTogether` JSDoc to describe merging as opt-in (default `false`).
- Rewrite the "Snap-together" docs section to present it as opt-in, with an example.
- Unit tests: the merge-focused `noAlign` helper now enables `snapTogether`, and a new test asserts no merge happens by default.
- e2e fixture: opt into `snapTogether` so the dock/merge path stays covered.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

Also touches `dockview-enterprise` (where the Smart Guides service lives) and the `e2e` fixture, which aren't listed as checkboxes above.

## How to test

- `dockview-enterprise` Jest suite passes (461 tests, incl. 38 Smart Guides specs). The new spec `does not merge by default: alignment-only unless snapTogether is opted into` verifies the new default; the existing `snapTogether: false` and opt-in merge specs still pass.
- Manually: enable `smartGuides` (without `snapTogether`), float two groups, drag one flush against the other. Guides + edge snapping appear, but no dock/merge preview shows and dropping leaves two separate floats. Set `snapTogether: true` to restore dock/merge.
- e2e `smart-guides.spec.ts` still exercises the merge path via the fixture's opt-in.

## Checklist

- [ ] `yarn lint:fix` passes <!-- ran `nx lint dockview-enterprise`: passes (only pre-existing repo-wide warnings) -->
- [ ] `yarn format` passes <!-- not run across the repo; changed files conform to the project Prettier config -->
- [x] `npm run gen` has been run and generated files are up to date <!-- no changes produced -->
- [x] `yarn test` passes <!-- dockview-enterprise suite -->
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented <!-- soft default change; described above rather than in a migration note -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXNh8VGeYZWvuiEywhVmBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXNh8VGeYZWvuiEywhVmBE)_