### PR TITLE
fix(dnd): show drop overlays on floating groups under 'relative' mounting

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -12782,4 +12782,110 @@ describe('group header direction change signal (DV-14 unblocker)', () => {
 
         dockview.dispose();
     });
+
+    describe('floating group drop overlays', () => {
+        function createComponent(
+            mounting: 'relative' | 'absolute'
+        ): DockviewComponent {
+            const container = document.createElement('div');
+            const dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+                theme: {
+                    name: 'test',
+                    className: 'test',
+                    dndOverlayMounting: mounting,
+                },
+            });
+            dockview.layout(1000, 1000);
+            return dockview;
+        }
+
+        test('relative mounting: a floating group anchors its drop overlay at the shell level', () => {
+            const dockview = createComponent('relative');
+
+            // The root container is disabled by 'relative' mounting so grid
+            // groups render their drop overlays in-place.
+            expect(dockview.rootDropTargetContainer.disabled).toBe(true);
+
+            dockview.addPanel({ id: 'panel1', component: 'default' });
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+            });
+
+            dockview.addFloatingGroup(panel2);
+
+            const floatingGroup = panel2.group;
+            expect(floatingGroup.model.location.type).toBe('floating');
+
+            // A floating group must NOT fall back to an in-place overlay: its
+            // container is the always-enabled, shell-level floating container so
+            // the overlay renders above the floating panel's render overlay.
+            expect(floatingGroup.model.dropTargetContainer).toBe(
+                dockview.floatingDropTargetContainer
+            );
+            expect(dockview.floatingDropTargetContainer.disabled).toBe(false);
+            expect(
+                floatingGroup.model.dropTargetContainer?.model
+            ).toBeDefined();
+
+            dockview.dispose();
+        });
+
+        test('grid groups still use the (disabled) root container under relative mounting', () => {
+            const dockview = createComponent('relative');
+
+            const panel1 = dockview.addPanel({
+                id: 'panel1',
+                component: 'default',
+            });
+
+            expect(panel1.group.model.location.type).toBe('grid');
+            expect(panel1.group.model.dropTargetContainer).toBe(
+                dockview.rootDropTargetContainer
+            );
+            // disabled -> the group renders an in-place ('relative') overlay
+            expect(
+                panel1.group.model.dropTargetContainer?.model
+            ).toBeUndefined();
+
+            dockview.dispose();
+        });
+
+        test('absolute mounting: a floating group shares the (enabled) root container', () => {
+            const dockview = createComponent('absolute');
+
+            // Absolute mounting keeps the root container enabled, so grid and
+            // floating groups share it and the anchored overlay can slide
+            // between them without a stale copy being left behind.
+            expect(dockview.rootDropTargetContainer.disabled).toBe(false);
+
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+            });
+
+            dockview.addFloatingGroup(panel2);
+
+            expect(panel2.group.model.location.type).toBe('floating');
+            expect(panel2.group.model.dropTargetContainer).toBe(
+                dockview.rootDropTargetContainer
+            );
+            expect(
+                panel2.group.model.dropTargetContainer?.model
+            ).toBeDefined();
+
+            dockview.dispose();
+        });
+    });
 });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -12881,9 +12881,7 @@ describe('group header direction change signal (DV-14 unblocker)', () => {
             expect(panel2.group.model.dropTargetContainer).toBe(
                 dockview.rootDropTargetContainer
             );
-            expect(
-                panel2.group.model.dropTargetContainer?.model
-            ).toBeDefined();
+            expect(panel2.group.model.dropTargetContainer?.model).toBeDefined();
 
             dockview.dispose();
         });

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -539,6 +539,18 @@ export class DockviewComponent
     readonly overlayRenderContainer: OverlayRenderContainer;
     readonly popupService: PopupService;
     readonly rootDropTargetContainer: DropTargetAnchorContainer;
+    /**
+     * Shell-level anchor container dedicated to floating groups. Unlike
+     * {@link rootDropTargetContainer} it is never disabled by the
+     * `dndOverlayMounting: 'relative'` theme setting: a floating group cannot
+     * use an in-place ('relative') overlay because the overlay would be
+     * appended inside the floating window's stacking context
+     * (`.dv-resize-container`, a lower z-index than the shell-level render
+     * overlay that hosts the floating panel's content) and be painted over.
+     * Routing floating groups through this always-anchored container keeps
+     * their drop overlays visible in both mounting modes.
+     */
+    readonly floatingDropTargetContainer: DropTargetAnchorContainer;
 
     private readonly _onWillDragPanel = new Emitter<TabDragEvent>();
     readonly onWillDragPanel: Event<TabDragEvent> = this._onWillDragPanel.event;
@@ -1544,6 +1556,14 @@ export class DockviewComponent
             this._shellManager.element,
             { disabled: true }
         );
+        // Floating groups always anchor their drop overlays at the shell level
+        // (see the field docs): in-place overlays would be trapped beneath the
+        // floating panel's render overlay, so this container stays enabled
+        // regardless of the `dndOverlayMounting` mode.
+        this.floatingDropTargetContainer = new DropTargetAnchorContainer(
+            this._shellManager.element,
+            { disabled: false }
+        );
         this.overlayRenderContainer = new OverlayRenderContainer(
             this._shellManager.element,
             this
@@ -1567,6 +1587,7 @@ export class DockviewComponent
 
         this.addDisposables(
             this.rootDropTargetContainer,
+            this.floatingDropTargetContainer,
             this.overlayRenderContainer,
             this._onWillDragPanel,
             this._onWillDragGroup,

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1283,6 +1283,23 @@ export class DockviewGroupPanelModel
     }
 
     get dropTargetContainer(): DropTargetAnchorContainer | null {
+        // A floating group can't use an in-place ('relative') drop overlay: the
+        // overlay would be appended inside the floating window's stacking
+        // context (`.dv-resize-container`), which sits *below* the shell-level
+        // render overlay hosting the floating panel's content, so it would be
+        // painted over and never seen. Under 'relative' mounting the root
+        // container is disabled (grid groups render in-place), so route
+        // floating groups through the always-enabled, shell-level floating
+        // container instead. Under 'absolute' mounting the root container is
+        // enabled and already anchors overlays at the shell level, so floating
+        // groups keep sharing it (a single container lets the anchored overlay
+        // slide between grid and floating groups without leaving a stale copy).
+        if (
+            this._location.type === 'floating' &&
+            this.accessor.rootDropTargetContainer.disabled
+        ) {
+            return this.accessor.floatingDropTargetContainer;
+        }
         return (
             this._overwriteDropTargetContainer ??
             this.accessor.rootDropTargetContainer


### PR DESCRIPTION
## Description

Drop-target overlays were invisible on floating groups when a theme used `dndOverlayMounting: 'relative'` — for example when splitting a floating group into two groups within one floating window. Absolute mounting worked fine.

**Root cause:** In relative mode the shell-level anchor container (`rootDropTargetContainer`) is disabled, so groups render their drop overlay *in-place* (appended into the group's own content element). For a floating group that content lives inside the floating window's `.dv-resize-container`, which establishes a stacking context at `z-index: 997`. Meanwhile the floating panel's *content* is promoted to the shell-level render overlay at `z-index: calc(var(--dv-overlay-z-index) + level*2+1)` (≥1002, set by `overlayRenderContainer.correctLayerPosition()`). The in-place overlay (z-index 1000) is therefore trapped beneath the panel content and never seen. In absolute mode the overlay is anchored into the shell-level container (z-index 9999), so it shows.

**Fix:** Add a dedicated, always-enabled shell-level `floatingDropTargetContainer` and route floating groups through it whenever the root container is disabled (i.e. relative mounting). The routing lives in the `DockviewGroupPanelModel.dropTargetContainer` getter and is location-driven, so it automatically covers every path that makes a group floating — including splitting a group *within* a floating window (`setGroupLocationForRoot`), not just `addFloatingGroup`.

Absolute mounting is deliberately left unchanged: floating and grid groups keep sharing the enabled root container, so the anchored overlay still slides between them without leaving a stale copy. Diverging only in relative mode avoids introducing a stale-overlay regression in the currently-working absolute mode.

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`

## How to test

1. Use a theme with `dndOverlayMounting: 'relative'` (the default themes set `'absolute'`).
2. Create a floating group containing two tabs.
3. Drag one tab over the group's content to split it (left/right/top/bottom).
4. The drop overlay is now visible during the drag (previously nothing showed).
5. Confirm the equivalent flow in an `'absolute'`-mounting theme is unchanged.

Automated coverage added in `dockviewComponent.spec.ts` (`floating group drop overlays`):
- relative mounting: a floating group anchors its drop overlay at the shell level (enabled container)
- grid groups still use the disabled root container under relative mounting (in-place)
- absolute mounting: a floating group keeps sharing the enabled root container

## Checklist

- [x] `yarn test` passes (1671 passed)
- [x] `tsc --noEmit` typecheck clean
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented (none — no public API or behavior change in absolute mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP)_