### PR TITLE
fix(dnd): render always-mode content for panels split into a floating group

### DIFF
--- a/e2e/fixtures/index.html
+++ b/e2e/fixtures/index.html
@@ -614,6 +614,45 @@
                             height: 180,
                         });
                     },
+                    // Float an `always`-rendered panel, then split a second
+                    // `always`-rendered panel into the LEFT of the floating
+                    // group. The split creates a *non-anchor* member group
+                    // inside the floating window's nested gridview; its content
+                    // must still be lifted above the window (the anchor-only
+                    // z-index lookup used to miss non-anchor members, leaving
+                    // the split panel's content painted behind the window).
+                    setupFloatingSplitAlways: () => {
+                        dockview.addPanel({
+                            id: 'main',
+                            component: 'default',
+                            title: 'main',
+                        });
+                        const floater = dockview.addPanel({
+                            id: 'floater',
+                            component: 'default',
+                            title: 'floater',
+                            renderer: 'always',
+                        });
+                        const splitter = dockview.addPanel({
+                            id: 'splitter',
+                            component: 'default',
+                            title: 'splitter',
+                            renderer: 'always',
+                        });
+                        dockview.addFloatingGroup(floater, {
+                            x: 150,
+                            y: 100,
+                            width: 360,
+                            height: 220,
+                        });
+                        dockview.moveGroupOrPanel({
+                            from: {
+                                groupId: splitter.api.group.id,
+                                panelId: 'splitter',
+                            },
+                            to: { group: floater.api.group, position: 'left' },
+                        });
+                    },
                     peekEdge: (position, on) =>
                         dockview.api.peekEdgeGroup(position, on),
                     // Two floating groups for Smart Guides: a target float on

--- a/e2e/tests/floating-group.spec.ts
+++ b/e2e/tests/floating-group.spec.ts
@@ -98,6 +98,63 @@ test.describe('floating groups', () => {
         expect(Number(probe.overlayZ)).toBeGreaterThan(Number(windowZ));
     });
 
+    test('a panel split into a floating group paints its always-rendered content above the window', async ({
+        page,
+    }) => {
+        // Regression for the split-into-float bug: dropping a panel into the
+        // edge of a floating group creates a *non-anchor* member group inside
+        // the window's nested gridview. The render-overlay z-index lookup only
+        // matched the window's anchor group, so a split `always`-rendered
+        // panel's content never got the `+1` lift over the window and rendered
+        // behind it (blank). Resolving the window by membership fixes it.
+        await page.goto('/e2e/fixtures/index.html');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() =>
+            (window as any).__dv.setupFloatingSplitAlways()
+        );
+
+        // The floating window now hosts two groups; both panels' content lives
+        // in the overlay render container.
+        await expect(page.locator('.dv-resize-container')).toHaveCount(1);
+        const splitOverlay = page.locator('.dv-render-overlay', {
+            hasText: 'splitter',
+        });
+        await expect(splitOverlay).toHaveCount(1);
+
+        // Hit-test the centre of the split panel's overlay: the topmost painted
+        // element there must be the overlay content itself, not the floating
+        // window occluding it. `toBeVisible()` ignores z-index occlusion, so an
+        // `elementFromPoint` probe is required.
+        const probe = await page.evaluate(() => {
+            const ov = Array.from(
+                document.querySelectorAll('.dv-render-overlay')
+            ).find((el) => /splitter/.test(el.textContent || ''));
+            if (!ov) {
+                return { hit: false, overlayZ: null as string | null };
+            }
+            const r = ov.getBoundingClientRect();
+            const top = document.elementFromPoint(
+                r.left + r.width / 2,
+                r.top + r.height / 2
+            );
+            return {
+                hit: !!top && ov.contains(top),
+                overlayZ: getComputedStyle(ov).zIndex,
+            };
+        });
+        expect(probe.hit).toBe(true);
+
+        // The split panel's overlay must stack above the floating window
+        // (`.dv-resize-container`) just like the anchor group's content does.
+        const windowZ = await page.evaluate(
+            () =>
+                getComputedStyle(
+                    document.querySelector('.dv-resize-container')!
+                ).zIndex
+        );
+        expect(Number(probe.overlayZ)).toBeGreaterThan(Number(windowZ));
+    });
+
     test('a floating group survives a serialization round-trip', async ({
         page,
     }) => {

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -27,6 +27,10 @@ import {
 import { SizeEvent } from '../../api/gridviewPanelApi';
 import { setupMockWindow } from '../__mocks__/mockWindow';
 import { EdgeGroupOptions } from '../../dockview/dockviewShell';
+import {
+    exhaustMicrotaskQueue,
+    exhaustAnimationFrame,
+} from '../__test_utils__/utils';
 
 class PanelContentPartTest implements IContentRenderer {
     element: HTMLElement = document.createElement('div');
@@ -12882,6 +12886,215 @@ describe('group header direction change signal (DV-14 unblocker)', () => {
                 dockview.rootDropTargetContainer
             );
             expect(panel2.group.model.dropTargetContainer?.model).toBeDefined();
+
+            dockview.dispose();
+        });
+
+        test('relative mounting: a group split into a floating window (non-anchor member) also uses the floating container', () => {
+            const dockview = createComponent('relative');
+
+            dockview.addPanel({ id: 'panel1', component: 'default' });
+            dockview.addPanel({ id: 'panel2', component: 'default' });
+            const panel3 = dockview.addPanel({
+                id: 'panel3',
+                component: 'default',
+            });
+
+            dockview.addFloatingGroup(panel3);
+            const anchorGroup = panel3.group;
+
+            // Split panel1 into the left of the floating group -> creates a new,
+            // non-anchor member group inside the floating window.
+            dockview.moveGroupOrPanel({
+                from: { groupId: panel1Group(dockview).id, panelId: 'panel1' },
+                to: { group: anchorGroup, position: 'left' },
+            });
+
+            const memberGroup = dockview.getGroupPanel('panel1')!.group;
+            expect(memberGroup).not.toBe(anchorGroup);
+            expect(memberGroup.model.location.type).toBe('floating');
+            // The non-anchor member must route through the same always-enabled
+            // floating container so its drop overlay is visible.
+            expect(memberGroup.model.dropTargetContainer).toBe(
+                dockview.floatingDropTargetContainer
+            );
+            expect(memberGroup.model.dropTargetContainer?.model).toBeDefined();
+
+            dockview.dispose();
+        });
+
+        test('relative mounting: a floating group moved back to the grid reverts to the (disabled) root container', () => {
+            const dockview = createComponent('relative');
+
+            dockview.addPanel({ id: 'panel1', component: 'default' });
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+            });
+
+            dockview.addFloatingGroup(panel2);
+            expect(panel2.group.model.dropTargetContainer).toBe(
+                dockview.floatingDropTargetContainer
+            );
+
+            // Dock the floating group back into the main grid.
+            dockview.moveGroupOrPanel({
+                from: { groupId: panel2.group.id, panelId: 'panel2' },
+                to: {
+                    group: dockview.getGroupPanel('panel1')!.group,
+                    position: 'right',
+                },
+            });
+
+            const group = dockview.getGroupPanel('panel2')!.group;
+            expect(group.model.location.type).toBe('grid');
+            // Back in the grid it must use the root container again (in-place
+            // under relative mounting).
+            expect(group.model.dropTargetContainer).toBe(
+                dockview.rootDropTargetContainer
+            );
+            expect(group.model.dropTargetContainer?.model).toBeUndefined();
+
+            dockview.dispose();
+        });
+
+        test('the floating container stays enabled across runtime mounting-mode changes', () => {
+            const dockview = createComponent('relative');
+
+            expect(dockview.floatingDropTargetContainer.disabled).toBe(false);
+
+            dockview.updateOptions({
+                theme: {
+                    name: 'test',
+                    className: 'test',
+                    dndOverlayMounting: 'absolute',
+                },
+            });
+            expect(dockview.floatingDropTargetContainer.disabled).toBe(false);
+            expect(dockview.rootDropTargetContainer.disabled).toBe(false);
+
+            dockview.updateOptions({
+                theme: {
+                    name: 'test',
+                    className: 'test',
+                    dndOverlayMounting: 'relative',
+                },
+            });
+            expect(dockview.floatingDropTargetContainer.disabled).toBe(false);
+            expect(dockview.rootDropTargetContainer.disabled).toBe(true);
+
+            dockview.dispose();
+        });
+
+        function panel1Group(dockview: DockviewComponent) {
+            return dockview.getGroupPanel('panel1')!.group;
+        }
+    });
+
+    describe('floating group always-renderer overlay z-index', () => {
+        function createComponent(): DockviewComponent {
+            const container = document.createElement('div');
+            const dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    switch (options.name) {
+                        case 'default':
+                            return new PanelContentPartTest(
+                                options.id,
+                                options.name
+                            );
+                        default:
+                            throw new Error(`unsupported`);
+                    }
+                },
+                defaultRenderer: 'always',
+            });
+            dockview.layout(1000, 1000);
+            return dockview;
+        }
+
+        function overlayZIndexFor(
+            dockview: DockviewComponent,
+            panelId: string
+        ): string | undefined {
+            const content =
+                dockview.overlayRenderContainer.element.querySelector(
+                    `.testpanel-${panelId}`
+                );
+            return (content?.parentElement as HTMLElement | undefined)?.style
+                .zIndex;
+        }
+
+        test('getFloatingWindowForGroup resolves a non-anchor member of a floating window', () => {
+            const dockview = createComponent();
+
+            dockview.addPanel({ id: 'panel1', component: 'default' });
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+            });
+
+            dockview.addFloatingGroup(panel2);
+            const anchorGroup = panel2.group;
+
+            dockview.moveGroupOrPanel({
+                from: {
+                    groupId: dockview.getGroupPanel('panel1')!.group.id,
+                    panelId: 'panel1',
+                },
+                to: { group: anchorGroup, position: 'left' },
+            });
+
+            const memberGroup = dockview.getGroupPanel('panel1')!.group;
+            expect(memberGroup).not.toBe(anchorGroup);
+
+            // Anchor identity lookup would miss the member; membership lookup
+            // must find the same floating window for both.
+            const anchorWindow =
+                dockview.getFloatingWindowForGroup(anchorGroup);
+            const memberWindow =
+                dockview.getFloatingWindowForGroup(memberGroup);
+            expect(anchorWindow).toBeDefined();
+            expect(memberWindow).toBe(anchorWindow);
+
+            dockview.dispose();
+        });
+
+        test("a panel split into a floating group has its 'always' overlay lifted above the window (not left behind it)", async () => {
+            const dockview = createComponent();
+
+            dockview.addPanel({ id: 'panel1', component: 'default' });
+            const panel2 = dockview.addPanel({
+                id: 'panel2',
+                component: 'default',
+            });
+
+            dockview.addFloatingGroup(panel2);
+
+            await exhaustMicrotaskQueue();
+            await exhaustAnimationFrame();
+
+            dockview.moveGroupOrPanel({
+                from: {
+                    groupId: dockview.getGroupPanel('panel1')!.group.id,
+                    panelId: 'panel1',
+                },
+                to: { group: panel2.group, position: 'left' },
+            });
+
+            await exhaustMicrotaskQueue();
+            await exhaustAnimationFrame();
+            await exhaustMicrotaskQueue();
+
+            const memberZ = overlayZIndexFor(dockview, 'panel1');
+            const anchorZ = overlayZIndexFor(dockview, 'panel2');
+
+            // The lifted overlay z-index is `--dv-overlay-z-index + level*2+1`,
+            // which paints above the floating window (`+ level*2`). Before the
+            // fix the member overlay had no inline z-index and fell back to the
+            // CSS `dv-render-overlay-float` value (one *below* the window), so
+            // its content rendered behind the window.
+            expect(memberZ).toMatch(/--dv-overlay-z-index/);
+            expect(memberZ).toEqual(anchorZ);
 
             dockview.dispose();
         });

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -223,15 +223,19 @@ describe('overlayRenderContainer', () => {
         element.setAttribute('aria-level', '2');
         const spy = jest.spyOn(element, 'getAttribute');
 
+        const floatingGroup = {
+            group,
+            overlay: {
+                element,
+            },
+        };
         const accessor = fromPartial<DockviewComponent>({
-            floatingGroups: [
-                {
-                    group,
-                    overlay: {
-                        element,
-                    },
-                },
-            ],
+            floatingGroups: [floatingGroup],
+            // The container resolves the floating window by membership (so it
+            // finds nested, non-anchor members too), not by scanning
+            // `floatingGroups` for an anchor match.
+            getFloatingWindowForGroup: (candidate) =>
+                candidate === group ? (floatingGroup as any) : undefined,
         });
 
         const cut = new OverlayRenderContainer(parentContainer, accessor);

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -800,6 +800,21 @@ export class DockviewComponent
     }
 
     /**
+     * Resolve the floating window hosting `group`, matched by membership so it
+     * finds nested (non-anchor) members too — a floating window can host a
+     * whole nested gridview, not just its anchor group. Returns `undefined`
+     * when the group isn't in any floating window. `floatingGroups` alone only
+     * exposes each window's anchor, so consumers that must act on any member
+     * (e.g. lifting an `always`-rendered panel's overlay above the window)
+     * should use this instead of a `.find(f => f.group === group)`.
+     */
+    getFloatingWindowForGroup(
+        group: DockviewGroupPanel
+    ): DockviewFloatingGroupPanel | undefined {
+        return this._floatingGroupService?.findByGroup(group);
+    }
+
+    /**
      * Boxes of the floating groups other than `exclude`, in coordinates
      * relative to the floating overlay container. Supplied to a
      * `transformFloatingGroupDrag` callback as `context.others` so it can

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -314,9 +314,17 @@ export class OverlayRenderContainer extends CompositeDisposable {
         const correctLayerPosition = () => {
             if (panel.api.location.type === 'floating') {
                 queueMicrotask(() => {
-                    const floatingGroup = this.accessor.floatingGroups.find(
-                        (group) => group.group === panel.api.group
-                    );
+                    // Resolve by membership, not anchor identity: a floating
+                    // window can host a nested gridview, so a panel split into
+                    // it lives in a non-anchor member group. Matching only the
+                    // anchor (`f.group === panel.api.group`) left such panels
+                    // without the lifted z-index, so an `always`-rendered
+                    // panel's overlay (CSS `dv-render-overlay-float`, one below
+                    // the window) rendered *behind* the floating window.
+                    const floatingGroup =
+                        this.accessor.getFloatingWindowForGroup(
+                            panel.api.group
+                        );
 
                     if (!floatingGroup) {
                         return;


### PR DESCRIPTION
## Description

Follow-up to #1531. Dropping a panel into the **edge** (e.g. left) of a floating group creates a new **non-anchor member group** inside the floating window's nested gridview. With `defaultRenderer: 'always'`, that panel's content rendered blank.

**Root cause:** an `always`-rendered panel's content lives in the shell-level overlay render container, whose stacking is lifted above the floating window by `correctLayerPosition()`. That lookup matched only the window's *anchor* group (`floatingGroups.find(f => f.group === panel.api.group)`), so a split member never received the `+1` lift. Its overlay fell back to the CSS `dv-render-overlay-float` value (**z-index 998**), one *below* the floating window (`.dv-resize-container`, **z-index 999**), so the content painted behind the window and appeared blank.

**Fix:** resolve the floating window by **membership** rather than anchor identity. Added `DockviewComponent.getFloatingWindowForGroup()` (delegating to the floating group service's membership-aware `findByGroup`) and used it in `correctLayerPosition()`, so every member of a floating window — anchor or nested — has its overlay lifted above the window (to **z-index 1000**).

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`

## How to test

1. Configure a component with `defaultRenderer: 'always'`.
2. Create a floating group and a panel in the main grid.
3. Drag the grid panel onto the **left/right/top/bottom** of the floating group (splitting it into a second group inside the floating window).
4. The split panel's content now renders (previously blank / painted behind the window).

### Automated coverage

**Unit (`dockviewComponent.spec.ts`):**
- `always-renderer overlay z-index` describe: a panel split into a floating group has its `always` overlay lifted above the window; `getFloatingWindowForGroup` resolves non-anchor members.
- Strengthened `floating group drop overlays` describe (from #1531): a split-created floating member also routes through the floating drop-target container; a floating group docked back to the grid reverts to the root container; the floating container stays enabled across runtime mounting-mode changes.
- Updated the existing `overlayRenderContainer` aria-level test to mock the new membership lookup.

**E2e (`e2e/tests/floating-group.spec.ts`):** new `setupFloatingSplitAlways` fixture + a spec that hit-tests (`elementFromPoint`) the split panel's content painting above the floating window, and asserts its overlay z-index exceeds the window's. Verified it fails without the fix.

## Checklist

- [x] `yarn test` passes (2317 passed across all projects)
- [x] `tsc --noEmit` typecheck clean
- [x] `biome format` / `biome lint` clean; `gen:check` clean
- [x] e2e (`floating-group`) passes in Chromium
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented (none — additive `getFloatingWindowForGroup` method only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP)_