### PR TITLE
fix(dnd): clear stale anchored drop overlay left after an HTML5 drag

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -13099,4 +13099,90 @@ describe('group header direction change signal (DV-14 unblocker)', () => {
             dockview.dispose();
         });
     });
+
+    describe('stale drop overlay cleanup on dragend', () => {
+        function createComponent(
+            mounting: 'relative' | 'absolute'
+        ): DockviewComponent {
+            const container = document.createElement('div');
+            const dockview = new DockviewComponent(container, {
+                createComponent(options) {
+                    return new PanelContentPartTest(options.id, options.name);
+                },
+                theme: {
+                    name: 'test',
+                    className: 'test',
+                    dndOverlayMounting: mounting,
+                },
+            });
+            dockview.layout(1000, 1000);
+            return dockview;
+        }
+
+        // Simulate an anchored overlay left behind in a container (as an HTML5
+        // drag would after showing a drop target), then assert `dragend` clears
+        // it. HTML5 `dragend` fires only on the drag source, and each drop
+        // target clears only its own container, so an overlay shown in a
+        // different container than the source's would otherwise linger.
+        test('a dragend clears a lingering overlay in the floating container (relative mounting)', () => {
+            const dockview = createComponent('relative');
+            const shell = (dockview as any)._shellManager
+                .element as HTMLElement;
+
+            // Materialize an overlay in the floating container.
+            dockview.floatingDropTargetContainer.model!.getElements();
+            expect(dockview.floatingDropTargetContainer.model!.exists()).toBe(
+                true
+            );
+
+            fireEvent.dragEnd(shell);
+
+            expect(dockview.floatingDropTargetContainer.model!.exists()).toBe(
+                false
+            );
+
+            dockview.dispose();
+        });
+
+        test('a dragend clears a lingering overlay in the root container (absolute mounting)', () => {
+            const dockview = createComponent('absolute');
+            const shell = (dockview as any)._shellManager
+                .element as HTMLElement;
+
+            dockview.rootDropTargetContainer.model!.getElements();
+            expect(dockview.rootDropTargetContainer.model!.exists()).toBe(true);
+
+            fireEvent.dragEnd(shell);
+
+            expect(dockview.rootDropTargetContainer.model!.exists()).toBe(
+                false
+            );
+
+            dockview.dispose();
+        });
+
+        test('a dragend clears both shell containers at once', () => {
+            const dockview = createComponent('absolute');
+            const shell = (dockview as any)._shellManager
+                .element as HTMLElement;
+
+            dockview.rootDropTargetContainer.model!.getElements();
+            dockview.floatingDropTargetContainer.model!.getElements();
+            expect(dockview.rootDropTargetContainer.model!.exists()).toBe(true);
+            expect(dockview.floatingDropTargetContainer.model!.exists()).toBe(
+                true
+            );
+
+            fireEvent.dragEnd(shell);
+
+            expect(dockview.rootDropTargetContainer.model!.exists()).toBe(
+                false
+            );
+            expect(dockview.floatingDropTargetContainer.model!.exists()).toBe(
+                false
+            );
+
+            dockview.dispose();
+        });
+    });
 });

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1603,6 +1603,27 @@ export class DockviewComponent
         this.addDisposables(
             this.rootDropTargetContainer,
             this.floatingDropTargetContainer,
+            // Safety net for a stale anchored drop overlay after an HTML5 drag.
+            // `dragend` fires only on the drag *source* element, and each drop
+            // target clears only its own group's container. When a drag shows an
+            // overlay in one shell-level container but ends via a source bound to
+            // a different one — e.g. dragging a grid tab (whose disabled root
+            // container renders in-place) over a floating group's tab (anchored
+            // in `floatingDropTargetContainer`), then releasing over the grid —
+            // nothing clears the first container and its overlay lingers.
+            // `dragend` fires at the end of every HTML5 drag (drop or cancel),
+            // so clearing both shell containers here guarantees no overlay
+            // survives the drag. The pointer backend clears on drag-leave already
+            // and doesn't emit `dragend`, so this is HTML5-only by construction.
+            addDisposableListener(
+                this._shellManager.element,
+                'dragend',
+                () => {
+                    this.rootDropTargetContainer.model?.clear();
+                    this.floatingDropTargetContainer.model?.clear();
+                },
+                true
+            ),
             this.overlayRenderContainer,
             this._onWillDragPanel,
             this._onWillDragGroup,


### PR DESCRIPTION
## Description

An anchored drop-target overlay could persist after a drag ended — the tab drop-target highlight staying visible, "as if it's not cleaned up".

**Cause:** HTML5 `dragend` fires only on the drag *source* element, and each drop target clears only its own group's drop-target container. The HTML5 anchored drop target intentionally does **not** clear on `dragleave` (to preserve the overlay's slide animation and avoid churn on spurious child-crossing leaves), relying on `drop`/`dragend` to clear. When a drag showed its overlay in one shell-level container but ended via a source bound to a *different* one — e.g. dragging a grid tab (whose disabled root container renders in-place, so its source has nothing to clear) over a **floating group's tab** (anchored in the `floatingDropTargetContainer` introduced in #1531), then releasing back over the grid — nothing cleared the floating container and its overlay lingered.

The mechanism requires the floating container, which is only active under `dndOverlayMounting: 'relative'` (in pure absolute mounting all main-window groups share the root container, which the source always clears). The fix is deliberately **mode-agnostic** so it covers the reported case regardless of mounting mode or a mode transition.

**Fix:** add a `dragend` safety net on the shell element that clears **both** shell-level drop-target containers. `dragend` fires at the end of every HTML5 drag (drop or cancel), so no anchored overlay can survive a drag regardless of which container held it or which source ended the drag. The pointer backend already clears on drag-leave and emits no `dragend`, so this is HTML5-only by construction and does not disturb the mid-drag slide animation.

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`

## How to test

1. Use a theme with `dndOverlayMounting: 'relative'` and the HTML5 DnD backend.
2. Create a floating group and a grid group with tabs.
3. Drag a grid tab over the floating group's tab (a drop overlay appears on the floating tab), then release back over the grid.
4. The floating tab's drop overlay is now cleared (previously it lingered).

### Automated coverage

Unit (`dockviewComponent.spec.ts` → `stale drop overlay cleanup on dragend`):
- a `dragend` on the shell clears a lingering overlay in the floating container (relative mounting),
- in the root container (absolute mounting),
- and both containers at once.

Each is guard-verified — the tests fail without the fix.

**No e2e:** this bug is HTML5-DnD-specific, and the e2e harness drives the *pointer* backend (Playwright can't reliably dispatch native HTML5 drag-and-drop). The cross-container mechanism was instead confirmed directly against `Droptarget` during development.

## Checklist

- [x] `yarn test` passes (2320 passed across all projects)
- [x] `tsc --noEmit` typecheck clean
- [x] `biome format` / `biome lint` clean; `gen:check` clean
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented (none — internal drag-cleanup only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP)_