### PR TITLE
test(dnd): verify pointer mode clears the anchor overlay on drag-leave

### DIFF
--- a/packages/dockview-core/src/__tests__/dnd/pointer/pointerDropTargetAnchor.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/pointer/pointerDropTargetAnchor.spec.ts
@@ -211,6 +211,64 @@ describe('PointerDropTarget: anchor / override target path', () => {
         document.body.removeChild(dropEl);
     });
 
+    test('drag-leave clears the anchor overlay (pointer mode leaves no stale overlay behind)', () => {
+        // The HTML5 backend intentionally does NOT clear the anchor container on
+        // drag-leave (it relies on drop/dragend, which is why a stale overlay
+        // could survive a cross-container drag — see the shell `dragend` safety
+        // net). The pointer backend has no such gap: it clears the override
+        // target the moment the pointer leaves, so moving off a floating group's
+        // tab onto another group never leaves the floating anchor overlay behind.
+        // This test locks in that difference.
+        const dropEl = document.createElement('div');
+        document.body.appendChild(dropEl);
+        jest.spyOn(dropEl, 'offsetWidth', 'get').mockReturnValue(200);
+        jest.spyOn(dropEl, 'offsetHeight', 'get').mockReturnValue(100);
+        jest.spyOn(dropEl, 'getBoundingClientRect').mockReturnValue({
+            top: 0,
+            left: 0,
+            right: 200,
+            bottom: 100,
+            width: 200,
+            height: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        });
+
+        const { targetModel, clear } = makeAnchorTarget();
+
+        const target = new PointerDropTarget(dropEl, {
+            acceptedTargetZones: ['left', 'right'],
+            canDisplayOverlay: () => true,
+            getOverrideTarget: () => targetModel,
+        });
+
+        const dragEvent = {
+            clientX: 10,
+            clientY: 50,
+            pointerEvent: new PointerEvent('pointermove', {
+                clientX: 10,
+                clientY: 50,
+                pointerId: 1,
+                pointerType: 'touch',
+            }),
+        };
+
+        // Show the anchored overlay, then leave without dropping.
+        (target as any)._onDragOver(dragEvent);
+        expect(target.state).toBe('left');
+        expect(clear).not.toHaveBeenCalled();
+
+        (target as any)._onDragLeave();
+
+        // The container is cleared and no drop position stays latched.
+        expect(clear).toHaveBeenCalled();
+        expect(target.state).toBeUndefined();
+
+        target.dispose();
+        document.body.removeChild(dropEl);
+    });
+
     test('pointerup over a target with an anchor calls clear() and fires onDrop with the latched position', () => {
         const dropEl = document.createElement('div');
         document.body.appendChild(dropEl);


### PR DESCRIPTION
## Description

Verification follow-up to this series of floating-group drop-target fixes (#1531, #1533, #1534), confirming they hold under `dndStrategy: 'pointer'` as well as HTML5. **No code fixes were required — pointer mode was already correct; this PR adds one guarding test.**

Analysis per fix:

| Fix | Backend-specific? | Pointer status |
|---|---|---|
| #1531 — floating drop-overlay routing | No | Lives in the backend-agnostic `DockviewGroupPanelModel.dropTargetContainer` getter, which both backends read via `getOverrideTarget`; the pointer anchor-render path is already covered. |
| #1533 — always-render split z-index | No | `correctLayerPosition` involves no DnD backend (split is driven by `moveGroupOrPanel`), so behavior is identical. |
| #1534 — stale overlay after drag | **Yes (HTML5-only)** | The pointer backend clears the anchor container on drag-leave (`_onDragLeave` → `overrideTarget.clear()`), and the drag controller fires that leave on every target transition and at drag end/cancel — so the cross-container stale overlay cannot occur. The #1534 shell `dragend` listener only responds to HTML5 `dragend`, which pointer drags never emit, so it is inert (and harmless) for pointer. |

The one genuine coverage gap was that no test pinned down the pointer backend's drag-leave clearing — the exact reason it is immune to the #1534 stale overlay. This PR adds that test.

## Type of change

- [x] Build / CI / tooling (test-only)

## Affected packages

- [x] `dockview-core`

## How to test

`yarn test` — the new `PointerDropTarget` test (`drag-leave clears the anchor overlay (pointer mode leaves no stale overlay behind)`) asserts that `_onDragLeave` clears the override target and drops the latched drop position.

## Checklist

- [x] `yarn test` passes (1680 dockview-core tests)
- [x] `biome format` clean
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented (none — test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP)_