### PR TITLE
fix(dnd): tear down anchored drop overlay when a drag leaves mid-flight

### DIFF
--- a/packages/dockview-core/src/__tests__/dnd/droptargetDeferredClear.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/droptargetDeferredClear.spec.ts
@@ -1,0 +1,138 @@
+import { Droptarget } from '../../dnd/droptarget';
+import { DropTargetAnchorContainer } from '../../dnd/dropTargetAnchorContainer';
+import { fireEvent } from '@testing-library/dom';
+import { createOffsetDragOverEvent } from '../__test_utils__/utils';
+
+/**
+ * The HTML5 backend renders anchored drop overlays into a shared container and
+ * does not clear on `dragleave` (that would kill the overlay's slide between
+ * adjacent targets). Instead it *schedules* a clear that a subsequent render
+ * cancels — so the overlay slides between targets but is torn down when the
+ * drag leaves to somewhere that doesn't re-render into the container.
+ */
+describe('Droptarget: deferred anchor-overlay clear on dragleave', () => {
+    const flush = () => new Promise((r) => setTimeout(r, 5));
+
+    function makeTarget(
+        container: DropTargetAnchorContainer,
+        opts?: {
+            overrideDisabled?: boolean;
+        }
+    ) {
+        const el = document.createElement('div');
+        jest.spyOn(el, 'offsetWidth', 'get').mockReturnValue(100);
+        jest.spyOn(el, 'offsetHeight', 'get').mockReturnValue(30);
+        el.getBoundingClientRect = () =>
+            ({ left: 0, top: 0, width: 100, height: 30 }) as DOMRect;
+        const target = new Droptarget(el, {
+            canDisplayOverlay: () => true,
+            acceptedTargetZones: ['left', 'right'],
+            getOverrideTarget: () =>
+                opts?.overrideDisabled ? undefined : container.model,
+        });
+        return { el, target };
+    }
+
+    test('leaving a target to dead space tears the overlay down (no lingering overlay)', async () => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const container = new DropTargetAnchorContainer(host, {
+            disabled: false,
+        });
+        const { el, target } = makeTarget(container);
+
+        fireEvent.dragEnter(el);
+        fireEvent(el, createOffsetDragOverEvent({ clientX: 80, clientY: 15 }));
+        expect(container.model?.exists()).toBe(true);
+
+        // Drag is still active; cursor leaves to dead space (no re-render).
+        fireEvent.dragLeave(el);
+        // Not cleared synchronously (a sibling render this tick could reuse it).
+        expect(container.model?.exists()).toBe(true);
+
+        await flush();
+        expect(container.model?.exists()).toBe(false);
+
+        target.dispose();
+        container.dispose();
+        host.remove();
+    });
+
+    test('sliding to another target in the same container cancels the scheduled clear (overlay preserved)', async () => {
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+        const container = new DropTargetAnchorContainer(host, {
+            disabled: false,
+        });
+        const a = makeTarget(container);
+        const b = makeTarget(container);
+
+        fireEvent.dragEnter(a.el);
+        fireEvent(
+            a.el,
+            createOffsetDragOverEvent({ clientX: 80, clientY: 15 })
+        );
+        expect(container.model?.exists()).toBe(true);
+
+        // Cross from A to B (both render into the same container).
+        fireEvent.dragLeave(a.el);
+        fireEvent.dragEnter(b.el);
+        fireEvent(
+            b.el,
+            createOffsetDragOverEvent({ clientX: 20, clientY: 15 })
+        );
+
+        await flush();
+        // B's render cancelled A's scheduled clear: the overlay survives.
+        expect(container.model?.exists()).toBe(true);
+
+        a.target.dispose();
+        b.target.dispose();
+        container.dispose();
+        host.remove();
+    });
+
+    test('leaving a floating-container target for an in-place (other-container) target clears it — no dragend needed', async () => {
+        // This is the #1534 scenario (grid tab whose own container is disabled
+        // renders in-place; floating tab anchors in a separate container),
+        // resolved purely by the leave-scheduled clear — no `dragend` involved.
+        const floatHost = document.createElement('div');
+        document.body.appendChild(floatHost);
+        const floatContainer = new DropTargetAnchorContainer(floatHost, {
+            disabled: false,
+        });
+        const floatTab = makeTarget(floatContainer);
+        // Grid tab: its override container is disabled -> in-place, no anchor.
+        const gridContainer = new DropTargetAnchorContainer(
+            document.createElement('div'),
+            { disabled: true }
+        );
+        const gridTab = makeTarget(gridContainer, { overrideDisabled: true });
+
+        // Hover the floating tab -> anchored overlay in floatContainer.
+        fireEvent.dragEnter(floatTab.el);
+        fireEvent(
+            floatTab.el,
+            createOffsetDragOverEvent({ clientX: 80, clientY: 15 })
+        );
+        expect(floatContainer.model?.exists()).toBe(true);
+
+        // Move to the grid tab (in-place render, does not touch floatContainer).
+        fireEvent.dragLeave(floatTab.el);
+        fireEvent.dragEnter(gridTab.el);
+        fireEvent(
+            gridTab.el,
+            createOffsetDragOverEvent({ clientX: 20, clientY: 15 })
+        );
+
+        await flush();
+        // The floating overlay is gone even though the drag never ended.
+        expect(floatContainer.model?.exists()).toBe(false);
+
+        floatTab.target.dispose();
+        gridTab.target.dispose();
+        floatContainer.dispose();
+        gridContainer.dispose();
+        floatHost.remove();
+    });
+});

--- a/packages/dockview-core/src/dnd/dropTargetAnchorContainer.ts
+++ b/packages/dockview-core/src/dnd/dropTargetAnchorContainer.ts
@@ -10,6 +10,17 @@ export class DropTargetAnchorContainer extends CompositeDisposable {
 
     private _disabled = false;
 
+    /**
+     * Handle for a deferred {@link DropTargetTargetModel.scheduleClear}. The
+     * HTML5 backend does not clear this container on `dragleave` (that would
+     * churn the shared overlay and kill its slide transition on every crossing
+     * between adjacent targets). Instead it *schedules* a clear, which a
+     * subsequent `getElements` (the next target rendering into this container)
+     * cancels — so the overlay slides between targets, but is torn down when the
+     * drag genuinely leaves to somewhere that doesn't re-render here.
+     */
+    private _pendingClear: ReturnType<typeof setTimeout> | undefined;
+
     get disabled(): boolean {
         return this._disabled;
     }
@@ -22,8 +33,23 @@ export class DropTargetAnchorContainer extends CompositeDisposable {
         this._disabled = value;
 
         if (value) {
-            this.model?.clear();
+            this._clearNow();
         }
+    }
+
+    private _cancelPendingClear(): void {
+        if (this._pendingClear !== undefined) {
+            clearTimeout(this._pendingClear);
+            this._pendingClear = undefined;
+        }
+    }
+
+    private _clearNow(): void {
+        this._cancelPendingClear();
+        if (this._model) {
+            this._model.root.remove();
+        }
+        this._model = undefined;
     }
 
     get model(): DropTargetTargetModel | undefined {
@@ -33,15 +59,26 @@ export class DropTargetAnchorContainer extends CompositeDisposable {
 
         return {
             clear: () => {
-                if (this._model) {
-                    this._model.root.remove();
+                this._clearNow();
+            },
+            scheduleClear: () => {
+                if (this._pendingClear !== undefined || !this._model) {
+                    return;
                 }
-                this._model = undefined;
+                this._pendingClear = setTimeout(() => {
+                    this._pendingClear = undefined;
+                    this._clearNow();
+                }, 0);
             },
             exists: () => {
                 return !!this._model;
             },
             getElements: (event?: DragEvent, outline?: HTMLElement) => {
+                // A render means the overlay is (still) live: cancel any clear
+                // scheduled by the target the cursor just left, so the overlay
+                // slides here instead of being torn down.
+                this._cancelPendingClear();
+
                 const changed = this._outline !== outline;
                 this._outline = outline;
 

--- a/packages/dockview-core/src/dnd/droptarget.ts
+++ b/packages/dockview-core/src/dnd/droptarget.ts
@@ -172,6 +172,15 @@ export interface DropTargetTargetModel {
     };
     exists(): boolean;
     clear(): void;
+    /**
+     * Clear the overlay on the next tick unless a {@link getElements} call (a
+     * target rendering into this container) cancels it first. Used by the HTML5
+     * backend on `dragleave`: clearing immediately would kill the overlay's
+     * slide between adjacent targets, but never clearing leaves the overlay
+     * behind when the drag leaves to somewhere that doesn't re-render here.
+     * Optional so lightweight/mocked target models need not implement it.
+     */
+    scheduleClear?(): void;
 }
 
 export interface DroptargetOptions {
@@ -372,20 +381,25 @@ export class Droptarget extends CompositeDisposable implements IDropTarget {
                 const target = this.options.getOverrideTarget?.();
 
                 if (target) {
-                    // The anchor container owns its own lifecycle — the overlay
-                    // slides to whichever target the cursor reaches next, and
-                    // `drop`/`dragend` tear it down — so don't clear it here.
-                    // HTML5 fires `dragleave` spuriously when crossing between
-                    // child elements, and clearing would churn the container
-                    // (and kill its move transition) on every one.
+                    // Don't clear the shared anchor container immediately: the
+                    // overlay must slide to whichever target the cursor reaches
+                    // next, and HTML5 fires `dragleave` spuriously when crossing
+                    // between a target's own child elements — clearing on every
+                    // one would churn the container and kill its move transition.
                     //
-                    // The latched state must still go: `onDragEnd` commits
+                    // Instead *schedule* a clear: the next target rendering into
+                    // this container (its `getElements`) cancels it, so the
+                    // overlay slides; but if the drag leaves to somewhere that
+                    // doesn't re-render here (dead space, or a target in another
+                    // container), the clear fires and the overlay doesn't linger.
+                    //
+                    // The latched state must still go now: `onDragEnd` commits
                     // `_state` when this is the actual target, so a drag that
                     // leaves the layout and is released outside would otherwise
-                    // drop at the last hovered position. A spurious leave is
-                    // harmless — the next `dragover` frame re-resolves it.
+                    // drop at the last hovered position.
                     this._state = undefined;
                     this._edge = false;
+                    target.scheduleClear?.();
                     return;
                 }
 


### PR DESCRIPTION
## Description

While an HTML5 drag was still active, leaving an anchored drop target (e.g. a tab in a floating group) and moving to dead space — or to a target in a different overlay container — left the drop overlay visible until the drag ended.

**Reproduction:** a floating group with two tabs; drag one tab over the other (a drop overlay appears on the target tab's edge), then move the mouse off the floating group — the overlay stays.

**Cause:** the HTML5 backend intentionally does not clear the shared anchor container on `dragleave` — doing so would kill the overlay's slide between adjacent targets and churn on the spurious `dragleave`s HTML5 fires when crossing a target's own child elements. But never clearing means the overlay lingers whenever the drag leaves to somewhere that doesn't re-render into that container.

**Fix:** on `dragleave` the target now *schedules* a clear on the anchor container (a new optional `DropTargetTargetModel.scheduleClear`) instead of doing nothing. The next target that renders into the same container cancels it (via `getElements`), so the overlay still slides between adjacent targets; but if the drag leaves to dead space or another container, the deferred clear fires and the overlay is torn down. The pointer backend already clears on drag-leave, so this is HTML5-only.

### Relationship to #1534

This is the root-cause fix and also covers the cross-container **end-of-drag** case addressed by the earlier `dragend` safety net in #1534 (releasing elsewhere first involves *leaving* the target, which now schedules the clear). The #1534 `dragend` listener is retained as belt-and-suspenders for the narrow case of a drag that ends with no clearing `dragleave` at all (e.g. an ESC-cancel where the browser skips `dragleave`).

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`

## How to test

Steps above (floating group, two tabs, drag one over the other, then leave the group — overlay no longer lingers).

Automated (`droptargetDeferredClear.spec.ts`):
- leaving a target to dead space tears the overlay down;
- sliding to another target in the same container preserves the overlay (the scheduled clear is cancelled by the re-render);
- leaving a floating-container target for an in-place (other-container) target clears it purely from the leave — no `dragend` needed.

## Checklist

- [x] `yarn test` passes (1683 dockview-core tests)
- [x] `tsc --noEmit` typecheck clean
- [x] `biome format` / `biome lint` clean
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented (none — `scheduleClear` is an optional addition to an internal model interface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjU3r4fnmpLUz7Bx1SjNvP)_