### PR TITLE
feat(edge-groups): expose isAutoHide() and toggle auto-hide from the demo context menu

### DIFF
--- a/packages/dockview-core/src/__tests__/api/dockviewGroupPanelApi.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/dockviewGroupPanelApi.spec.ts
@@ -721,6 +721,34 @@ describe('DockviewGroupPanelApiImpl', () => {
                 undefined
             );
         });
+
+        test('isAutoHide returns false when not initialized', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                isEdgeGroupAutoHide: jest.fn(),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+
+            expect(cut.isAutoHide()).toBe(false);
+            expect(accessor.isEdgeGroupAutoHide).not.toHaveBeenCalled();
+        });
+
+        test('isAutoHide delegates to accessor.isEdgeGroupAutoHide', () => {
+            const accessor = fromPartial<DockviewComponent>({
+                isEdgeGroupAutoHide: jest.fn().mockReturnValue(true),
+            });
+            const cut = new DockviewGroupPanelApiImpl(
+                'test-id',
+                accessor as unknown as DockviewComponent
+            );
+            const group = fromPartial<DockviewGroupPanel>({});
+            cut.initialize(group);
+
+            expect(cut.isAutoHide()).toBe(true);
+            expect(accessor.isEdgeGroupAutoHide).toHaveBeenCalledWith(group);
+        });
     });
 
     describe('event passthrough', () => {

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -115,6 +115,12 @@ export interface DockviewGroupPanelApi extends GridviewPanelApi {
      * non-edge groups or without the auto-hide module.
      */
     setAutoHide(value: boolean | undefined): void;
+    /**
+     * The resolved auto-hide state of this edge group: the per-group override
+     * if one is set, otherwise the global `autoHideEdgeGroups` option for this
+     * edge. Always returns false for non-edge groups.
+     */
+    isAutoHide(): boolean;
 }
 
 export interface DockviewGroupPanelLocationChangeEvent {
@@ -339,6 +345,13 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             return;
         }
         this.accessor.setEdgeGroupAutoHide(this._group, value);
+    }
+
+    isAutoHide(): boolean {
+        if (!this._group) {
+            return false;
+        }
+        return this.accessor.isEdgeGroupAutoHide(this._group);
     }
 
     initialize(group: DockviewGroupPanel): void {

--- a/packages/docs/docs/core/groups/autoHideEdgeGroups.mdx
+++ b/packages/docs/docs/core/groups/autoHideEdgeGroups.mdx
@@ -125,7 +125,7 @@ Each edge group's `api` exposes its peek state alongside the existing collapse s
 
 <DocRef
     declaration="DockviewGroupPanelApi"
-    methods={['isPeeking', 'onDidPeekChange']}
+    methods={['isPeeking', 'onDidPeekChange', 'isAutoHide']}
 />
 
 ```ts
@@ -136,6 +136,10 @@ const isPeeking = groupApi?.isPeeking(); // boolean
 groupApi?.onDidPeekChange((event) => {
     console.log('peeking:', event.isPeeking);
 });
+
+// whether this group auto-hides at all: the per-group override set by
+// `setAutoHide`, or the `autoHideEdgeGroups` option for this edge
+const autoHides = groupApi?.isAutoHide(); // boolean
 ```
 
 :::info

--- a/packages/docs/docs/core/groups/edgeGroups.mdx
+++ b/packages/docs/docs/core/groups/edgeGroups.mdx
@@ -143,7 +143,7 @@ With the `dockToEdgeGroups` option an edge takes up **zero space** when empty an
 
 ## Auto-hide co-existence
 
-Auto-hide (the pinnable tool-window behaviour) is opt-in **per edge group**, so a static always-docked edge group and an auto-hiding one can co-exist in the same layout. Pass `autoHide` to `addEdgeGroup`, or toggle it at runtime with `api.setAutoHide`; either overrides the per-edge `autoHideEdgeGroups` option for that group.
+Auto-hide (the pinnable tool-window behaviour) is opt-in **per edge group**, so a static always-docked edge group and an auto-hiding one can co-exist in the same layout. Pass `autoHide` to `addEdgeGroup`, or toggle it at runtime with `api.setAutoHide`; either overrides the per-edge `autoHideEdgeGroups` option for that group. `api.isAutoHide()` reads the resolved value back: the per-group override if one is set, otherwise the `autoHideEdgeGroups` option for that edge.
 
 ```ts
 // this edge group auto-hides; others follow the per-edge option
@@ -151,7 +151,12 @@ api.addEdgeGroup('left', { id: 'left-group', autoHide: true });
 
 // toggle at runtime
 api.getEdgeGroup('right')?.setAutoHide(true);
+
+// read the resolved state (per-group override, else the global option)
+const autoHides = api.getEdgeGroup('right')?.isAutoHide(); // boolean
 ```
+
+Turning auto-hide **off** on a group that is currently collapsed leaves a strip with no way to open it: the click-to-peek trigger goes away with auto-hide and the sash is locked at the collapsed size. Call `expand()` alongside `setAutoHide(false)` if the group might be collapsed.
 
 ## Custom header actions
 

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.tsx
@@ -473,6 +473,55 @@ const TabModeMenuItem = ({
     );
 };
 
+/**
+ * Checkable toggle for an edge group's auto-hide mode. `setAutoHide` writes a
+ * per-group override of the global `autoHideEdgeGroups` option and the auto-hide
+ * controller reconciles the group's chrome live, so a single edge can be flipped
+ * between a pinnable tool window and a static docked panel while the dock runs.
+ *
+ * One toggling item rather than an on/off pair: every edge group here starts
+ * auto-hiding, so in a pair the ticked row is the one you'd reach for first and
+ * clicking it would do nothing.
+ */
+const EdgeAutoHideMenuItem = ({
+    group,
+    close,
+}: IContextMenuItemComponentProps) => {
+    const autoHide = group.api.isAutoHide();
+
+    return (
+        <div
+            className="dv-context-menu-item"
+            onClick={() => {
+                group.api.setAutoHide(!autoHide);
+                if (autoHide) {
+                    // Turning it off: nothing expands a collapsed edge group
+                    // once auto-hide is gone (the strip's click-to-peek goes
+                    // with it and the sash is locked at the collapsed size), so
+                    // open it here rather than leave a dead strip.
+                    group.api.expand();
+                }
+                close();
+            }}
+            style={{ display: 'flex', alignItems: 'center', gap: '12px' }}
+        >
+            Auto-hide edge
+            {/* Kept mounted (not conditionally rendered) so the reserved space
+                stops the menu width changing as the tick comes and goes. */}
+            <span
+                className="material-symbols-outlined"
+                style={{
+                    fontSize: '14px',
+                    marginLeft: 'auto',
+                    visibility: autoHide ? 'visible' : 'hidden',
+                }}
+            >
+                check
+            </span>
+        </div>
+    );
+};
+
 const colors = [
     'rgba(255,0,0,0.2)',
     'rgba(0,255,0,0.2)',
@@ -835,11 +884,18 @@ const DockviewDemo = (props: {
                     } satisfies TabModeMenuItemProps,
                 })),
                 'separator',
-                // Float / popout are shown here as custom component items (with
-                // icons); the `'float'` and `'popout'` built-in shortcuts do the
-                // same thing without custom rendering.
-                { component: FloatMenuItem },
-                { component: PopoutMenuItem },
+                ...(group.api.location.type === 'edge'
+                    ? // An edge group can't float or pop out, but it can switch
+                      // between a pinnable tool window and a static docked
+                      // panel, so that toggle takes the slot instead.
+                      [{ component: EdgeAutoHideMenuItem }]
+                    : // Float / popout are shown here as custom component items
+                      // (with icons); the `'float'` and `'popout'` built-in
+                      // shortcuts do the same thing without custom rendering.
+                      [
+                          { component: FloatMenuItem },
+                          { component: PopoutMenuItem },
+                      ]),
             ];
 
             if (api) {


### PR DESCRIPTION
Right-clicking a tab in an edge group in the demo now offers a checkable **Auto-hide edge** row, flipping that edge between a pinnable tool window and a static docked panel while the dock runs.

## Core

`DockviewGroupPanelApi.setAutoHide` had no matching getter, so nothing could read back whether an edge group auto-hides. This adds `isAutoHide()`, alongside the existing `isCollapsed()` / `isPeeking()`:

```ts
const autoHides = api.getEdgeGroup('right')?.isAutoHide(); // boolean
```

The resolution logic is not new. It delegates to `DockviewComponent.isEdgeGroupAutoHide`, which was already there: the per-group override if one is set, otherwise the `autoHideEdgeGroups` option for that edge. Returns `false` for non-edge groups and before the group is initialised.

## Demo

The new row takes the slot held by Float / Popout, neither of which apply to an edge group. Grid groups are unchanged.

It is **one toggling item rather than an on/off pair**. Every edge group in the demo starts auto-hiding, so in a radio pair the ticked row is the one you would reach for first, and clicking it would do nothing.

Turning auto-hide off also calls `expand()`. A collapsed edge group loses its click-to-peek trigger along with auto-hide, and its sash is locked at the collapsed size, so without this it is left as a strip with no way to open it. That trap applies to anyone calling `setAutoHide(false)` directly, so it is called out on the edge groups docs page too.

## Testing

- Two new cases in `dockviewGroupPanelApi.spec.ts` (uninitialised returns `false` without touching the accessor; initialised delegates to `isEdgeGroupAutoHide`). Full spec passes, 53 tests.
- Exercised in the running demo on the left and bottom edges, both directions: tick clears and the edge expands to a static docked panel; clicking again restores the tick and the tool-window chrome (pushpin + close, tabs to the bottom).

## Noted, not fixed

The tab context menu can render below the viewport for bottom-edge tabs. The menu is in the DOM but positioned off-screen, so nothing appears. It flips upward correctly in some layouts but not others. Pre-existing context-menu positioning, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
