### PR TITLE
fix(enterprise): render context menus above auto-hide edge group peek

### DIFF
--- a/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
@@ -307,6 +307,108 @@ describe('ContextMenuController', () => {
         });
     });
 
+    describe('popover z-index for peeking auto-hide edge groups', () => {
+        // A peeking edge group slides its panel out as an overlay on the shell
+        // (z-index 999 / header 1001). A tab context menu shares the shell
+        // stacking context but anchors earlier in DOM order, so at the default
+        // overlay z-index it renders *behind* the peek. The clicked strip tab
+        // isn't inside the peek overlay, so the ancestor walk can't find its
+        // z-index — the menu must key off the peek state and lift clear of it.
+        function dispatchContextMenu(target: HTMLElement): MouseEvent {
+            const event = new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+            });
+            target.dispatchEvent(event);
+            return event;
+        }
+
+        const peekingGroup = () =>
+            fromPartial<DockviewGroupPanel>({
+                panels: [],
+                api: { isPeeking: () => true },
+            });
+
+        test('lifts the tab menu above the peek band while peeking', () => {
+            const { accessor, openPopover } = makeAccessor({
+                getTabContextMenuItems: jest.fn().mockReturnValue(['close']),
+            });
+            const controller = new ContextMenuController(accessor);
+
+            // A strip tab with no z-indexed ancestor: at the default overlay
+            // z-index it would render behind the peek.
+            const tab = document.createElement('div');
+            document.body.appendChild(tab);
+
+            try {
+                const event = dispatchContextMenu(tab);
+                controller.show(makePanel(), peekingGroup(), event);
+
+                expect(openPopover).toHaveBeenCalledWith(
+                    expect.any(HTMLElement),
+                    expect.objectContaining({
+                        zIndex: 'calc(var(--dv-overlay-z-index, 999) + 100)',
+                    })
+                );
+            } finally {
+                document.body.removeChild(tab);
+            }
+        });
+
+        test('peek lift takes precedence over a z-indexed ancestor', () => {
+            const { accessor, openPopover } = makeAccessor({
+                getTabContextMenuItems: jest.fn().mockReturnValue(['close']),
+            });
+            const controller = new ContextMenuController(accessor);
+
+            const floating = document.createElement('div');
+            floating.style.zIndex = '1001';
+            const tab = document.createElement('div');
+            floating.appendChild(tab);
+            document.body.appendChild(floating);
+
+            try {
+                const event = dispatchContextMenu(tab);
+                controller.show(makePanel(), peekingGroup(), event);
+
+                expect(openPopover).toHaveBeenCalledWith(
+                    expect.any(HTMLElement),
+                    expect.objectContaining({
+                        zIndex: 'calc(var(--dv-overlay-z-index, 999) + 100)',
+                    })
+                );
+            } finally {
+                document.body.removeChild(floating);
+            }
+        });
+
+        test('lifts the chip menu above the peek band while peeking', () => {
+            const { accessor, openPopover } = makeAccessor({
+                getTabGroupChipContextMenuItems: jest
+                    .fn()
+                    .mockReturnValue([{ label: 'Rename', action: jest.fn() }]),
+            });
+            const controller = new ContextMenuController(accessor);
+
+            const chip = document.createElement('div');
+            document.body.appendChild(chip);
+
+            try {
+                const event = dispatchContextMenu(chip);
+                controller.showForChip(fromPartial({}), peekingGroup(), event);
+
+                expect(openPopover).toHaveBeenCalledWith(
+                    expect.any(HTMLElement),
+                    expect.objectContaining({
+                        zIndex: 'calc(var(--dv-overlay-z-index, 999) + 100)',
+                    })
+                );
+            } finally {
+                document.body.removeChild(chip);
+            }
+        });
+    });
+
     describe('ARIA attributes', () => {
         test('built-in label items have role="menuitem"', () => {
             const { accessor, openPopover } = makeAccessor({

--- a/packages/dockview-enterprise/src/contextMenu.ts
+++ b/packages/dockview-enterprise/src/contextMenu.ts
@@ -12,7 +12,21 @@ import {
     IContextMenuService,
 } from 'dockview';
 
-function popoverZIndexFor(target: EventTarget | null): string | undefined {
+function popoverZIndexFor(
+    target: EventTarget | null,
+    group: DockviewGroupPanel
+): string | undefined {
+    // A peeking auto-hide edge group slides its active panel out as an overlay
+    // (inline z-index 999) with a title bar above it (z-index 1001), both
+    // mounted on the shell. A context menu opened from that group's tab strip
+    // shares the shell stacking context but anchors *earlier* in DOM order, so
+    // at the default overlay z-index it renders behind the peek. The clicked
+    // tab isn't a descendant of the peek overlay, so the ancestor walk below
+    // can't discover the peek's z-index — key off the peek state directly and
+    // lift the menu clear of the peek band (mirrors the smart-guide "+100").
+    if (group.api?.isPeeking?.()) {
+        return 'calc(var(--dv-overlay-z-index, 999) + 100)';
+    }
     if (!(target instanceof HTMLElement)) {
         return undefined;
     }
@@ -358,7 +372,7 @@ export class ContextMenuController implements IContextMenuService {
         popupService.openPopover(menuEl, {
             x: event.clientX,
             y: event.clientY,
-            zIndex: popoverZIndexFor(event.target),
+            zIndex: popoverZIndexFor(event.target, group),
         });
     }
 
@@ -429,7 +443,7 @@ export class ContextMenuController implements IContextMenuService {
         popupService.openPopover(menuEl, {
             x: event.clientX,
             y: event.clientY,
-            zIndex: popoverZIndexFor(event.target),
+            zIndex: popoverZIndexFor(event.target, group),
         });
     }
 }


### PR DESCRIPTION
## Description

When an auto-hide edge group is **peeking**, the peek slides the active panel out as an overlay mounted on the shell with inline `z-index: 999` (content) and `1001` (title bar). A tab or chip context menu opened from that group's strip renders through `PopupService`, whose anchor is *prepended* to the same shell element and defaults to `z-index: var(--dv-overlay-z-index)` (999). Two things stacked against the menu:

- **Equal z-index (999)** with the peek's content overlay, but the popover anchor sits *earlier* in DOM order than the appended peek → the peek paints on top.
- The existing `popoverZIndexFor` logic only lifts the menu when it finds a z-indexed *ancestor* of the clicked element (the floating-group case). A collapsed edge-group tab lives in the strip, **not inside the peek overlay**, so that walk never discovers the peek's z-index and returned `undefined`.

Result: context menus rendered *below* the peek view.

**Fix:** `popoverZIndexFor` now takes the `group` and checks the existing `group.api.isPeeking()` hook first. When the group is peeking it returns `calc(var(--dv-overlay-z-index, 999) + 100)`, lifting the menu clear of the entire peek band (content **and** the 1001 title bar), mirroring the `+100` convention already used for smart guides. Both `show()` and `showForChip()` pass the group through. The peek check is gated with optional chaining, so the non-peeking floating-group path is unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`
- [x] `dockview-enterprise` (`contextMenu.ts`)

## How to test

1. Set up an auto-hide edge group with a tab context menu (`getTabContextMenuItems`).
2. Click a collapsed edge tab to peek the panel out over the content.
3. Right-click a tab in the strip to open the context menu.
4. **Before:** the menu renders behind the peek overlay. **After:** the menu renders above the peek.

Covered by unit tests in `contextMenu.spec.ts` (tab menu while peeking, peek precedence over a z-indexed ancestor, chip menu while peeking).

## Checklist

- [x] `yarn test` passes (enterprise suite: 464 passed)
- [x] I have added or updated tests where applicable
- [x] `nx build dockview-enterprise` passes (TypeScript typecheck across the dependency chain)

---
_Generated by [Claude Code](https://claude.ai/code/session_014836vmqmCok1J4L5ayZpdC)_