### PR TITLE
fix(core): stop vertical wrap headers clipping their leading tab columns

### DIFF
--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -649,10 +649,13 @@ test.describe('multi-row tabs (wrap mode)', () => {
         expect(before.escaped).toBe(0);
 
         // Shrink the viewport so the (shorter) group reflows the tabs into more
-        // columns than the header was originally sized for. Retry the whole
-        // assertion until the reflow + header re-pin + relayout settle (the pin
-        // lands a frame after the column count changes).
-        await page.setViewportSize({ width: 900, height: 700 });
+        // columns than the header was originally sized for. A vertical strip
+        // wraps on its HEIGHT, so the height has to drop far enough to change
+        // how many tabs fit in a column; trimming the width alone reflows
+        // nothing. Retry the whole assertion until the reflow + header re-pin +
+        // relayout settle (the pin lands a frame after the column count
+        // changes).
+        await page.setViewportSize({ width: 900, height: 400 });
         await expect(async () => {
             const after = await headerMetrics(page);
             // More columns than before ...
@@ -675,8 +678,9 @@ test.describe('multi-row tabs (wrap mode)', () => {
         await expect.poll(() => columnCount(page)).toBeGreaterThan(1);
         const initial = await headerMetrics(page);
 
-        // Shrink → strictly more columns, a wider header (retry until settled).
-        await page.setViewportSize({ width: 900, height: 700 });
+        // Shrink (on the wrap axis, height) → strictly more columns, a wider
+        // header (retry until settled).
+        await page.setViewportSize({ width: 900, height: 400 });
         await expect(async () => {
             const m = await headerMetrics(page);
             expect(m.cols).toBeGreaterThan(initial.cols);

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.scss
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.scss
@@ -91,5 +91,14 @@
     &.dv-groupview-header-vertical:has(.dv-tabs-container--wrap) {
         width: auto;
         min-width: var(--dv-tabs-and-actions-container-height);
+
+        // The multi-row module pins the header to `columns x thickness` once it
+        // knows the column count. The scrollable wrapper doesn't inherit that
+        // width and its `overflow: hidden` then clips whatever doesn't fit.
+        // `vertical-rl` stacks columns right-to-left, so the columns lost are
+        // the leading ones: the first tabs disappear and stop hit-testing.
+        > .dv-scrollable {
+            align-self: stretch;
+        }
     }
 }


### PR DESCRIPTION
## Problem

In a vertical (left/right) header with `overflow: { mode: 'wrap' }`, the leading tab columns are clipped away: **the first tabs are invisible and cannot be clicked, focused or dropped onto.**

`MultiRowTabsService.sizeVerticalHeader` pins the header width once it knows the column count:

```ts
header.style.width = `${columns * lineSize}px`;   // 8 columns x 35 = 280px
```

The `.dv-scrollable` wrapper between the header and the tab list never picks that width up, and it has `overflow: hidden`. Measured with 24 tabs at 1280x720:

| element | width |
| --- | --- |
| header | 280px (pinned inline) |
| `.dv-scrollable` | **210px** |
| tab list | 280px |

The 70px shortfall clips two whole columns. Because `writing-mode: vertical-rl` stacks columns right-to-left, the clipped region is where column 0 lives, so it is the **first** six tabs that vanish rather than the last. `elementsFromPoint` at the centre of tab 0 returns the header container and skips the tab entirely, so those tabs are not hit-testable either.

This is enterprise-only surface (`MultiRowTabsModule`); the free packages are unaffected.

## Fix

Stretch the scrollable to the header's cross size, scoped to the vertical + wrap case so no other layout is touched:

```scss
&.dv-groupview-header-vertical:has(.dv-tabs-container--wrap) {
    > .dv-scrollable {
        align-self: stretch;
    }
}
```

| | scrollable | header | clipped tabs | tab 0 hit-testable |
| --- | --- | --- | --- | --- |
| before | 210px | 280px | 6 | no |
| after | 280px | 280px | 0 | yes |

## Test changes

`vertical header: a tab drags across columns to reorder` was failing for exactly this reason: it targets tab 0, which was not hit-testable, so the drop never landed. Short drags passed because they never left the unclipped region, which is why only this one test caught the bug. It now passes without modification.

The two `vertical header ... resize` tests were separately asserting a reflow that could not happen. They shrank the viewport `1280x720` -> `900x700`, but a vertical strip wraps on its **height**, and a 20px height drop never changes how many tabs fit in a column:

| viewport | list height | columns | header |
| --- | --- | --- | --- |
| 1280x720 | 603 | 8 | 280px |
| 900x700 | 586 | **8** | 280px |
| 900x400 | 335 | 12 | 420px |

They now shrink on the wrap axis (`900x400`) and observe a real 8 -> 12 column reflow.

## Verification

Rebuilt the UMD bundles, confirmed the rule reaches `dist/styles/dockview.css`, and ran the full cross-window suite:

```
before:  115 passed, 3 failed
after:   118 passed
```

The three previously-failing tests pass on their own merits, not through relaxed assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)