### PR TITLE
refactor(dockview-core): drive titlebar tab collapse with the Web Animations API

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
@@ -498,6 +498,184 @@ describe('TabGroupManager', () => {
         });
     });
 
+    describe('collapse animation (Web Animations API)', () => {
+        interface MockAnimation {
+            finished: Promise<void>;
+            cancel: jest.Mock;
+            resolveFinished: () => void;
+            rejectFinished: (reason?: unknown) => void;
+        }
+
+        function installAnimateMock(): {
+            animations: MockAnimation[];
+            restore: () => void;
+        } {
+            const proto = HTMLElement.prototype as unknown as {
+                animate?: (...args: unknown[]) => Animation;
+            };
+            const original = proto.animate;
+            const animations: MockAnimation[] = [];
+            proto.animate = function (): Animation {
+                let resolveFinished!: () => void;
+                let rejectFinished!: (reason?: unknown) => void;
+                const finished = new Promise<void>((resolve, reject) => {
+                    resolveFinished = resolve;
+                    rejectFinished = reject;
+                });
+                // Prevent unhandled-rejection noise; production attaches .catch.
+                finished.catch(() => {});
+                const anim: MockAnimation = {
+                    finished,
+                    cancel: jest.fn(() =>
+                        rejectFinished(new Error('AbortError'))
+                    ),
+                    resolveFinished,
+                    rejectFinished,
+                };
+                animations.push(anim);
+                return anim as unknown as Animation;
+            };
+            return {
+                animations,
+                restore: () => {
+                    proto.animate = original;
+                },
+            };
+        }
+
+        const flush = () =>
+            new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+        let mock: { animations: MockAnimation[]; restore: () => void };
+
+        beforeEach(() => {
+            mock = installAnimateMock();
+        });
+
+        afterEach(() => {
+            mock.restore();
+        });
+
+        test('collapse drives element.animate, adds the class and suppresses the CSS transition', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            tg.collapse();
+            manager.update();
+
+            const el = tabs[0].value.element;
+            expect(mock.animations).toHaveLength(1);
+            expect(el.classList.contains('dv-tab--group-collapsed')).toBe(true);
+            // CSS transition suppressed inline so only the scripted animation
+            // plays.
+            expect(el.style.transition).toBe('none');
+        });
+
+        test('finishing the animation removes the inline transition and leaves the class', async () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            tg.collapse();
+            manager.update();
+
+            mock.animations[0].resolveFinished();
+            await flush();
+
+            const el = tabs[0].value.element;
+            expect(el.style.transition).toBe('');
+            expect(el.classList.contains('dv-tab--group-collapsed')).toBe(true);
+            // No leaked inline geometry.
+            expect(el.style.width).toBe('');
+            expect(el.style.height).toBe('');
+        });
+
+        test('expanding mid-collapse cancels the running animation and clears suppression', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            tg.collapse();
+            manager.update();
+
+            const el = tabs[0].value.element;
+            expect(el.style.transition).toBe('none');
+
+            // Reverse before the animation settles.
+            tg.expand();
+            manager.update();
+
+            expect(mock.animations[0].cancel).toHaveBeenCalledTimes(1);
+            expect(el.style.transition).toBe('');
+            expect(el.classList.contains('dv-tab--group-expanding')).toBe(true);
+            expect(el.classList.contains('dv-tab--group-collapsed')).toBe(false);
+        });
+
+        test('a second collapse does not stack a new animation while collapsed', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            tg.collapse();
+            manager.update();
+            // Re-running update while already collapsing must not re-animate.
+            manager.update();
+
+            expect(mock.animations).toHaveLength(1);
+        });
+
+        test('disposeAll cancels an in-flight collapse animation', () => {
+            const tabs = [createTab('p1')];
+            const tg = makeGroup('g1', ['p1']);
+            const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+            manager.update();
+            tg.collapse();
+            manager.update();
+
+            manager.disposeAll();
+
+            expect(mock.animations[0].cancel).toHaveBeenCalledTimes(1);
+            expect(tabs[0].value.element.style.transition).toBe('');
+        });
+
+        test('reduced motion skips the scripted animation and applies instantly', () => {
+            const win = document.defaultView as Window & {
+                matchMedia?: (q: string) => MediaQueryList;
+            };
+            const originalMatchMedia = win.matchMedia;
+            win.matchMedia = ((query: string) =>
+                ({
+                    matches: true,
+                    media: query,
+                }) as MediaQueryList) as typeof win.matchMedia;
+
+            try {
+                const tabs = [createTab('p1')];
+                const tg = makeGroup('g1', ['p1']);
+                const { manager } = createManager({ tabs, tabGroups: [tg] });
+
+                manager.update();
+                tg.collapse();
+                manager.update();
+
+                const el = tabs[0].value.element;
+                expect(mock.animations).toHaveLength(0);
+                expect(el.classList.contains('dv-tab--group-collapsed')).toBe(
+                    true
+                );
+                expect(el.style.transition).toBe('');
+            } finally {
+                win.matchMedia = originalMatchMedia;
+            }
+        });
+    });
+
     describe('underline / indicator', () => {
         test('groupUnderlines is empty before any update', () => {
             const { manager } = createManager();

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabGroups.spec.ts
@@ -612,7 +612,9 @@ describe('TabGroupManager', () => {
             expect(mock.animations[0].cancel).toHaveBeenCalledTimes(1);
             expect(el.style.transition).toBe('');
             expect(el.classList.contains('dv-tab--group-expanding')).toBe(true);
-            expect(el.classList.contains('dv-tab--group-collapsed')).toBe(false);
+            expect(el.classList.contains('dv-tab--group-collapsed')).toBe(
+                false
+            );
         });
 
         test('a second collapse does not stack a new animation while collapsed', () => {

--- a/packages/dockview-core/src/__tests__/dom.spec.ts
+++ b/packages/dockview-core/src/__tests__/dom.spec.ts
@@ -5,9 +5,11 @@ import {
     findRelativeZIndexParent,
     isChildEntirelyVisibleWithinParent,
     isInDocument,
+    parseCssTimeMs,
     prefersReducedMotion,
     quasiDefaultPrevented,
     quasiPreventDefault,
+    resolveCssDurationMs,
     resolveOpaqueBackground,
 } from '../dom';
 
@@ -379,6 +381,47 @@ describe('prefersReducedMotion', () => {
     test('false when matchMedia is unavailable', () => {
         delete (win as { matchMedia?: unknown }).matchMedia;
         expect(prefersReducedMotion(document)).toBe(false);
+    });
+});
+
+describe('parseCssTimeMs', () => {
+    test.each([
+        ['200ms', 200],
+        ['0.2s', 200],
+        ['1s', 1000],
+        ['0', 0],
+        ['  150ms  ', 150],
+        ['.5s', 500],
+    ])('parses %p as %p ms', (value, expected) => {
+        expect(parseCssTimeMs(value, 999)).toBe(expected);
+    });
+
+    test.each(['', '   ', 'abc', '10', '10px', 'fast'])(
+        'falls back for the unparseable value %p',
+        (value) => {
+            expect(parseCssTimeMs(value, 42)).toBe(42);
+        }
+    );
+});
+
+describe('resolveCssDurationMs', () => {
+    test('reads a CSS time custom property from computed style', () => {
+        const el = document.createElement('div');
+        el.style.setProperty('--dv-transition-duration', '0.3s');
+        document.body.appendChild(el);
+        expect(
+            resolveCssDurationMs(el, '--dv-transition-duration', 200)
+        ).toBe(300);
+        el.remove();
+    });
+
+    test('falls back when the property is absent', () => {
+        const el = document.createElement('div');
+        document.body.appendChild(el);
+        expect(
+            resolveCssDurationMs(el, '--dv-transition-duration', 175)
+        ).toBe(175);
+        el.remove();
     });
 });
 

--- a/packages/dockview-core/src/__tests__/dom.spec.ts
+++ b/packages/dockview-core/src/__tests__/dom.spec.ts
@@ -396,12 +396,16 @@ describe('parseCssTimeMs', () => {
         expect(parseCssTimeMs(value, 999)).toBe(expected);
     });
 
-    test.each(['', '   ', 'abc', '10', '10px', 'fast'])(
-        'falls back for the unparseable value %p',
-        (value) => {
-            expect(parseCssTimeMs(value, 42)).toBe(42);
-        }
-    );
+    test.each([
+        '',
+        '   ',
+        'abc',
+        '10',
+        '10px',
+        'fast',
+    ])('falls back for the unparseable value %p', (value) => {
+        expect(parseCssTimeMs(value, 42)).toBe(42);
+    });
 });
 
 describe('resolveCssDurationMs', () => {
@@ -409,18 +413,18 @@ describe('resolveCssDurationMs', () => {
         const el = document.createElement('div');
         el.style.setProperty('--dv-transition-duration', '0.3s');
         document.body.appendChild(el);
-        expect(
-            resolveCssDurationMs(el, '--dv-transition-duration', 200)
-        ).toBe(300);
+        expect(resolveCssDurationMs(el, '--dv-transition-duration', 200)).toBe(
+            300
+        );
         el.remove();
     });
 
     test('falls back when the property is absent', () => {
         const el = document.createElement('div');
         document.body.appendChild(el);
-        expect(
-            resolveCssDurationMs(el, '--dv-transition-duration', 175)
-        ).toBe(175);
+        expect(resolveCssDurationMs(el, '--dv-transition-duration', 175)).toBe(
+            175
+        );
         el.remove();
     });
 });

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -976,7 +976,9 @@ export class TabGroupManager {
             }
             settled = true;
             el.style.removeProperty('transition');
-            if (this._collapseAnimations.get(panelId)?.animation === animation) {
+            if (
+                this._collapseAnimations.get(panelId)?.animation === animation
+            ) {
                 this._collapseAnimations.delete(panelId);
             }
         };

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -1,4 +1,8 @@
-import { toggleClass } from '../../../dom';
+import {
+    prefersReducedMotion,
+    resolveCssDurationMs,
+    toggleClass,
+} from '../../../dom';
 import { addDisposableListener } from '../../../events';
 import {
     getPanelData,
@@ -84,6 +88,17 @@ export class TabGroupManager {
     private _indicator: ITabGroupIndicator | null = null;
     private _skipNextCollapseAnimation = false;
     private readonly _pendingTransitionCleanups = new Map<string, () => void>();
+    /**
+     * In-flight Web Animations API collapse animations, keyed by panel id, so a
+     * rapid expand/collapse, another collapse, or disposal can cancel the
+     * running animation cleanly (see `_cancelCollapseAnimation`). Each entry
+     * carries a `cleanup` that releases the inline transition-suppression the
+     * animation set up.
+     */
+    private readonly _collapseAnimations = new Map<
+        string,
+        { animation: Animation; cleanup: () => void }
+    >();
 
     get chipRenderers(): ReadonlyMap<string, ChipRendererEntry> {
         return this._chipRenderers;
@@ -345,6 +360,10 @@ export class TabGroupManager {
             cleanup();
         }
         this._pendingTransitionCleanups.clear();
+
+        for (const panelId of [...this._collapseAnimations.keys()]) {
+            this._cancelCollapseAnimation(panelId);
+        }
 
         for (const [, entry] of this._chipRenderers) {
             entry.chip.element.remove();
@@ -713,6 +732,13 @@ export class TabGroupManager {
                 if (!tg.collapsed && isCollapsed) {
                     // Collapsed → expanding: animate back
                     hasAnimation = true;
+
+                    // Cancel any in-flight animated collapse for this tab so
+                    // the scripted animation and its inline transition
+                    // suppression are torn down before the CSS expand
+                    // transition takes over.
+                    this._cancelCollapseAnimation(panelId);
+
                     tab.element.classList.remove('dv-tab--group-collapsed');
                     tab.element.classList.add('dv-tab--group-expanding');
 
@@ -769,11 +795,18 @@ export class TabGroupManager {
                 if (this._skipNextCollapseAnimation) {
                     // Apply collapsed state instantly (no animation).
                     // Disable transitions so the CSS transition on
-                    // dv-tab--group-collapsed doesn't fire.
+                    // dv-tab--group-collapsed doesn't fire, committing the
+                    // change with a single forced reflow before re-enabling
+                    // them. This path only suppresses a style; it drives no
+                    // animation, so the Web Animations API does not apply.
                     const affected: HTMLElement[] = [];
                     for (const pid of tg.panelIds) {
                         const te = tabMap.get(pid);
                         if (te) {
+                            // Stop any in-flight animated collapse first so we
+                            // don't leave a running animation on a tab we are
+                            // about to force to its resting state.
+                            this._cancelCollapseAnimation(pid);
                             te.value.element.style.transition = 'none';
                             te.value.element.classList.add(
                                 'dv-tab--group-collapsed'
@@ -798,16 +831,10 @@ export class TabGroupManager {
                                 'dv-tab--group-collapsed'
                             )
                         ) {
-                            const rect =
-                                te.value.element.getBoundingClientRect();
-                            if (isVert) {
-                                te.value.element.style.height = `${rect.height}px`;
-                            } else {
-                                te.value.element.style.width = `${rect.width}px`;
-                            }
-                            void te.value.element.offsetHeight; // force reflow
-                            te.value.element.classList.add(
-                                'dv-tab--group-collapsed'
+                            this._animateTabCollapse(
+                                te.value.element,
+                                pid,
+                                isVert
                             );
                         }
                     }
@@ -827,5 +854,157 @@ export class TabGroupManager {
                 this._indicator.positionUnderlines();
             }
         }
+    }
+
+    /**
+     * Collapse a single tab, animating it from its current geometry to the
+     * collapsed rest state.
+     *
+     * This replaces the former "pin an inline size → force a synchronous
+     * reflow → toggle the `dv-tab--group-collapsed` class" pattern with the
+     * Web Animations API. `.dv-tab--group-collapsed` still provides the resting
+     * state (size/opacity zeroed via `!important`); we add it up front as the
+     * animation's base, suppress its CSS transition with an inline
+     * `transition: none`, and let a scripted animation play the same geometry
+     * the CSS transition would have. Because the class is the base, the
+     * animation uses `fill: 'none'` and leaks no inline geometry once it
+     * settles — only the inline transition-suppression, which the cleanup
+     * removes.
+     *
+     * Timing and easing mirror the theme's CSS transition exactly: the duration
+     * is read from `--dv-transition-duration` (default 200ms) and the easing is
+     * `ease-out`, matching `tabs.scss`.
+     */
+    private _animateTabCollapse(
+        el: HTMLElement,
+        panelId: string,
+        isVert: boolean
+    ): void {
+        // Tear down any competing in-flight work for this tab so rapid toggles
+        // don't stack: a pending expand cleanup, then any running collapse
+        // animation.
+        this._pendingTransitionCleanups.get(panelId)?.();
+        this._cancelCollapseAnimation(panelId);
+
+        // Reduced motion mirrors the CSS `@media (prefers-reduced-motion)` rule
+        // that disables the transition: apply the collapsed class with no
+        // scripted animation. No reflow is needed because the media query has
+        // already stripped the CSS transition.
+        if (prefersReducedMotion(el.ownerDocument)) {
+            el.classList.add('dv-tab--group-collapsed');
+            return;
+        }
+
+        // Environments without the Web Animations API (notably jsdom under
+        // test, and very old browsers): fall back to the original
+        // pin + forced-reflow + class pattern so the CSS transition still
+        // drives the collapse where one exists.
+        if (typeof el.animate !== 'function') {
+            const rect = el.getBoundingClientRect();
+            if (isVert) {
+                el.style.height = `${rect.height}px`;
+            } else {
+                el.style.width = `${rect.width}px`;
+            }
+            void el.offsetHeight; // force reflow
+            el.classList.add('dv-tab--group-collapsed');
+            return;
+        }
+
+        const win = el.ownerDocument.defaultView;
+        const computed = win?.getComputedStyle(el);
+        const sizeStart = isVert
+            ? `${el.getBoundingClientRect().height}px`
+            : `${el.getBoundingClientRect().width}px`;
+
+        // Only geometry (and opacity) is expressed as keyframes; colours and
+        // other themed properties stay in CSS. Longhands are used on both
+        // keyframes so each animates as a matched pair.
+        const from: Keyframe = {
+            paddingTop: computed?.paddingTop ?? '',
+            paddingRight: computed?.paddingRight ?? '',
+            paddingBottom: computed?.paddingBottom ?? '',
+            paddingLeft: computed?.paddingLeft ?? '',
+            marginTop: computed?.marginTop ?? '',
+            marginRight: computed?.marginRight ?? '',
+            marginBottom: computed?.marginBottom ?? '',
+            marginLeft: computed?.marginLeft ?? '',
+            opacity: computed?.opacity ?? '1',
+        };
+        const to: Keyframe = {
+            paddingTop: '0px',
+            paddingRight: '0px',
+            paddingBottom: '0px',
+            paddingLeft: '0px',
+            marginTop: '0px',
+            marginRight: '0px',
+            marginBottom: '0px',
+            marginLeft: '0px',
+            opacity: '0',
+        };
+        // Vertical collapses the block (height) axis; horizontal the inline
+        // (width) axis — matching the CSS transition per direction.
+        if (isVert) {
+            from.height = sizeStart;
+            to.height = '0px';
+        } else {
+            from.width = sizeStart;
+            to.width = '0px';
+        }
+
+        const duration = resolveCssDurationMs(
+            el,
+            '--dv-transition-duration',
+            200
+        );
+
+        // Suppress the class's CSS transition so only the scripted animation
+        // plays, then add the class as the animation's resting base.
+        el.style.transition = 'none';
+        el.classList.add('dv-tab--group-collapsed');
+
+        const animation = el.animate([from, to], {
+            duration,
+            easing: 'ease-out',
+            fill: 'none',
+        });
+
+        let settled = false;
+        const cleanup = () => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            el.style.removeProperty('transition');
+            if (this._collapseAnimations.get(panelId)?.animation === animation) {
+                this._collapseAnimations.delete(panelId);
+            }
+        };
+
+        this._collapseAnimations.set(panelId, { animation, cleanup });
+
+        animation.finished.then(cleanup).catch(() => {
+            // `finished` rejects when the animation is cancelled; cancellation
+            // runs its own cleanup via `_cancelCollapseAnimation`, so there is
+            // nothing to do here.
+        });
+    }
+
+    /**
+     * Cancel an in-flight animated collapse for a tab, if any. The tab is left
+     * in its collapsed resting state (the `.dv-tab--group-collapsed` class),
+     * and the inline transition-suppression is removed so a subsequent expand
+     * transition can play. Idempotent.
+     */
+    private _cancelCollapseAnimation(panelId: string): void {
+        const entry = this._collapseAnimations.get(panelId);
+        if (!entry) {
+            return;
+        }
+        // Remove first so the `finished` rejection handler and `cleanup`'s
+        // guard both see the entry as already gone.
+        this._collapseAnimations.delete(panelId);
+        entry.cleanup();
+        entry.animation.cancel();
     }
 }

--- a/packages/dockview-core/src/dom.ts
+++ b/packages/dockview-core/src/dom.ts
@@ -557,6 +557,48 @@ export function prefersReducedMotion(doc: Document = document): boolean {
     return !!mq?.matches;
 }
 
+/** Parse a CSS `<time>` value (e.g. `"200ms"`, `"0.2s"`, `"0"`) into
+ *  milliseconds. Returns `fallbackMs` for an empty or unparseable value so a
+ *  scripted animation can mirror a themed CSS transition without hardcoding a
+ *  duration. */
+export function parseCssTimeMs(value: string, fallbackMs: number): number {
+    const trimmed = value.trim();
+    if (trimmed === '') {
+        return fallbackMs;
+    }
+    const match = /^(-?\d*\.?\d+)(ms|s)?$/.exec(trimmed);
+    if (!match) {
+        return fallbackMs;
+    }
+    const amount = parseFloat(match[1]);
+    if (!Number.isFinite(amount)) {
+        return fallbackMs;
+    }
+    // A unitless value is only valid CSS when it is zero.
+    if (match[2] === undefined) {
+        return amount === 0 ? 0 : fallbackMs;
+    }
+    return match[2] === 's' ? amount * 1000 : amount;
+}
+
+/** Read a CSS `<time>` custom property (e.g. `--dv-transition-duration`) from
+ *  `element`'s resolved style and return it in milliseconds, falling back to
+ *  `fallbackMs` when the property is absent, unparseable, or the element has no
+ *  associated window (e.g. detached documents in tests). Lets a scripted
+ *  animation inherit the theme's timing instead of duplicating it in JS. */
+export function resolveCssDurationMs(
+    element: HTMLElement,
+    property: string,
+    fallbackMs: number
+): number {
+    const win = element.ownerDocument?.defaultView;
+    if (!win) {
+        return fallbackMs;
+    }
+    const raw = win.getComputedStyle(element).getPropertyValue(property);
+    return parseCssTimeMs(raw, fallbackMs);
+}
+
 /** The first opaque computed background colour walking up from `element` (the
  *  element itself, then its ancestors). Use to give a floating/overlapping
  *  surface a non-see-through backdrop derived from the live DOM. Returns `''`


### PR DESCRIPTION
## Description

Refactors the animated tab-group **collapse** in dockview-core's titlebar to use the Web Animations API (WAAPI) instead of the "pin an inline style → force a synchronous reflow → toggle a CSS class" pattern. This eliminates the forced synchronous reflow and the async `transitionend`/`setTimeout` fragility for that path, with **zero intended change** to how the animation looks or behaves.

`.dv-tab--group-collapsed` still provides the resting state (size/opacity zeroed via `!important`). It is now added up front as the animation's base with its CSS transition suppressed inline, and a scripted `element.animate()` plays the same geometry the CSS transition would have. Because the class is the base, the animation uses `fill: 'none'` and leaks no inline geometry once it settles.

- **Timing/easing preserved from the theme:** duration is read from `--dv-transition-duration` via `getComputedStyle` (default `200ms`); easing is `ease-out`, matching `tabs.scss` exactly. No duration is hardcoded.
- **Theming preserved:** only geometry (`width`/`height`, `padding`, `margin`) and `opacity` move into JS keyframes — the exact set the CSS `transition` animated. Colours and other themed properties stay in CSS.

### Reflow-site inventory & classification

Grepped the whole package for `offsetHeight` / `offsetWidth` / `getBoundingClientRect`. The forced-reflow (write-then-read) sites are:

| Site | Classification | Action |
| --- | --- | --- |
| `tabGroups.ts` ~795–814 — animated group collapse | **Drives an animation** | ✅ **Converted to WAAPI** (`_animateTabCollapse`) |
| `tabGroups.ts` ~785 — skip-animation *instant* collapse | Suppress/instant-apply | Left as-is (reflow retained, comment expanded) — see rationale |
| `tabs.ts` ~965 — drag: collapse source tab instantly | Suppress/instant-apply | Left as-is (reflow retained) |
| `tabs.ts` ~1412 — batched reflow for chip drag collapse | Suppress/instant-apply | Left as-is (reflow retained) |
| `tabReorderController.ts` ~1056 — `_removeClassInstantlyBatch` | Suppress/instant-apply | Left as-is (reflow retained) |
| `tabReorderController.ts` ~1245 — `_setMargin` instant positioning | Suppress/instant-apply | Left as-is (reflow retained) |

**Why the instant/suppress sites keep their reflow:** they drive no animation — they set `transition: none`, apply a style, force one synchronous reflow to commit it, then re-enable transitions so a subsequent CSS transition doesn't fire from the intermediate state. WAAPI does not apply to a non-animation. Removing the reflow here would require either restructuring the CSS or deferring the transition re-enable to a `requestAnimationFrame`, i.e. *adding* the async fragility this change is meant to reduce. The synchronous reflow is the least-fragile option, so those sites are left intact with clarified comments. (Other `getBoundingClientRect` calls in the titlebar are pure measurements, not write-then-read forced reflows.)

### Cancellation / robustness

In-flight collapse animations are tracked per panel id in `_collapseAnimations`. The animation is cancelled cleanly — leaving the tab in its collapsed resting state and removing the inline transition suppression — on every interruption:

- **Rapid expand mid-collapse:** the expand branch cancels the running animation before removing `dv-tab--group-collapsed` / adding `dv-tab--group-expanding`, so the inline `transition: none` is cleared and the CSS expand transition takes over. Cancel + class swap happen synchronously in the same `update()`, so there is no intermediate paint.
- **A second collapse:** the class is added synchronously, so re-running `update()` while already collapsing does not stack a new animation.
- **Skip-animation instant path:** cancels any running animation before forcing the resting state.
- **Disposal (`disposeAll`):** cancels all in-flight animations.

No leaked animations, no stuck inline styles.

### Reduced motion

The code already relies on CSS `@media (prefers-reduced-motion: reduce)` (which sets `transition: none !important`). WAAPI ignores that media query, so `_animateTabCollapse` explicitly checks `prefersReducedMotion(...)` and applies the collapsed class instantly with no scripted animation — keeping the reduced-motion path instant, matching today.

### How timing was verified to match

- Duration comes from the same `--dv-transition-duration` custom property the SCSS uses (`getComputedStyle`), default 200ms — identical source of truth.
- Easing string `ease-out` equals the CSS keyword `ease-out` (`cubic-bezier(0, 0, 0.58, 1)`).
- Keyframes animate exactly the properties the CSS `transition` listed (`width`/`height`, `padding`, `margin`, `opacity`), from the measured/computed start to the collapsed `0` values, so start and end frames are unchanged.

### jsdom / fallback

`element.animate`, layout, and real reflow don't exist under jsdom. When `element.animate` is undefined the code falls back to the original pin + reflow + class behaviour, so the CSS transition still drives the collapse in browsers without WAAPI, and existing tests (which assert the class is applied synchronously) are unaffected. New tests mock `HTMLElement.prototype.animate` to exercise the WAAPI path.

## Type of change

- [x] Refactor / cleanup

## Affected packages

- [x] `dockview-core`

## How to test

Automated:
- `yarn nx test dockview-core` — **1705 passed** (89 suites). Adds WAAPI-path tests in `tabGroups.spec.ts` (animate is driven, class applied, transition suppressed, finish cleans up inline transition with no leaked geometry, expand-mid-collapse cancels, no double-animation, `disposeAll` cancels, reduced-motion stays instant) and `parseCssTimeMs` / `resolveCssDurationMs` unit tests in `dom.spec.ts`.
- `yarn nx build dockview-core` — tsc clean.
- `yarn nx lint dockview-core` — no new warnings.

Manual (jsdom can't exercise real animation):
- In a themed harness, collapse and expand a tab group and confirm the collapse still animates over `--dv-transition-duration` with `ease-out` and no visual jump/flash at start or end.
- Rapidly toggle collapse/expand and confirm smooth interruption with no stuck-collapsed or stuck-width tabs.
- Drag tabs and group chips and confirm the instant collapse-on-drag behaviour is unchanged.
- Enable "reduce motion" and confirm collapse/expand apply instantly.

## Checklist

- [x] `yarn test` passes (`dockview-core`)
- [x] I have added or updated tests where applicable
- [ ] `npm run gen` — not applicable (no generated files affected)
- [ ] Breaking changes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fyb552HGXHhFS42ibNvoBF)_