### PR TITLE
fix(themes): style auto-hide edge-group peek + tool window for spaced themes

### DIFF
--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -287,3 +287,154 @@ test.describe('auto-hide edge groups (peek)', () => {
         await expect.poll(visibleOverlays).toBe(1);
     });
 });
+
+/**
+ * Spaced-theme styling of the peek + docked tool window. The spaced themes turn
+ * every group into a rounded, gapped card; the peek overlay and the docked
+ * (pinned) chrome must follow suit rather than render as sharp, frame-coloured
+ * boxes. Real-browser only (the CSS custom-property + computed-radius resolution
+ * jsdom can't model).
+ */
+test.describe('auto-hide edge groups — spaced theme styling', () => {
+    const setup = async (page, theme = 'abyssSpaced') => {
+        await page.goto(`/e2e/fixtures/index.html?theme=${theme}`);
+        await page.waitForFunction(() => (window as any).__ready === true);
+        await page.evaluate(() => (window as any).__dv.setupAutoHideEdge());
+    };
+    const edgeTab = (page) =>
+        page.locator('.dv-groupview-edge .dv-tab').first();
+    const px = (v: string) => parseFloat(v);
+
+    test('the peek title bar uses the tab/chrome colour, not the near-black group frame', async ({
+        page,
+    }) => {
+        await setup(page);
+        await edgeTab(page).click();
+        await expect(page.locator('.dv-edge-peek-header')).toBeVisible();
+
+        const c = await page.evaluate(() => {
+            const cs = (el: Element | null) =>
+                el ? getComputedStyle(el).backgroundColor : '';
+            const group = document.querySelector('.dv-groupview-edge');
+            return {
+                header: cs(document.querySelector('.dv-edge-peek-header')),
+                strip: cs(
+                    group!.querySelector('.dv-tabs-and-actions-container')
+                ),
+                // the group element paints the frame (--dv-group-view-background)
+                frame: cs(group),
+            };
+        });
+        // the title bar matches the tab strip (chrome), NOT the group frame
+        // (which is the near-black inter-group gap colour that read as black)
+        expect(c.header).toBe(c.strip);
+        expect(c.header).not.toBe(c.frame);
+    });
+
+    test('the spaced peek is a rounded card (title bar + backdrop)', async ({
+        page,
+    }) => {
+        await setup(page);
+        await edgeTab(page).click();
+        await expect(page.locator('.dv-edge-peek')).toBeVisible();
+
+        const r = await page.evaluate(() => {
+            const cs = (sel: string, prop: string) => {
+                const el = document.querySelector(sel);
+                return el
+                    ? getComputedStyle(el).getPropertyValue(prop)
+                    : '0px';
+            };
+            return {
+                headerTop: cs(
+                    '.dv-edge-peek-header',
+                    'border-top-left-radius'
+                ),
+                overlayBottom: cs(
+                    '.dv-edge-peek',
+                    'border-bottom-left-radius'
+                ),
+                clipBottom: cs(
+                    '.dv-edge-peek-clip',
+                    'border-bottom-left-radius'
+                ),
+            };
+        });
+        expect(px(r.headerTop)).toBeGreaterThan(0);
+        expect(px(r.overlayBottom)).toBeGreaterThan(0);
+        expect(px(r.clipBottom)).toBeGreaterThan(0);
+    });
+
+    test('the docked tool window is a cohesive rounded card (no mid-card content notch)', async ({
+        page,
+    }) => {
+        await setup(page);
+        await edgeTab(page).click();
+        await page.locator('.dv-edge-peek-pin').click(); // pin → dock
+
+        const group = page.locator('.dv-groupview-edge');
+        await expect(group).toHaveClass(/dv-edge-tool-window/);
+
+        const r = await page.evaluate(() => {
+            const g = document.querySelector('.dv-groupview-edge')!;
+            const cs = (sel: string, prop: string) =>
+                getComputedStyle(g.querySelector(sel)!).getPropertyValue(prop);
+            return {
+                // the title bar caps the top of the card
+                headerTop: cs(
+                    '.dv-edge-peek-header',
+                    'border-top-left-radius'
+                ),
+                // the content is flush — its default bottom rounding (which would
+                // carve a frame-coloured notch above the bottom tab strip) is off
+                contentBottom: cs(
+                    '.dv-content-container',
+                    'border-bottom-left-radius'
+                ),
+                // the tab strip caps the bottom (and drops its top rounding)
+                tabsTop: cs(
+                    '.dv-tabs-and-actions-container',
+                    'border-top-left-radius'
+                ),
+                tabsBottom: cs(
+                    '.dv-tabs-and-actions-container',
+                    'border-bottom-left-radius'
+                ),
+            };
+        });
+        expect(px(r.headerTop)).toBeGreaterThan(0);
+        expect(px(r.contentBottom)).toBe(0);
+        expect(px(r.tabsTop)).toBe(0);
+        expect(px(r.tabsBottom)).toBeGreaterThan(0);
+    });
+
+    test('un-pinning removes the tool-window styling hook', async ({ page }) => {
+        await setup(page);
+        await edgeTab(page).click();
+        await page.locator('.dv-edge-peek-pin').click(); // dock
+        await expect(page.locator('.dv-groupview-edge')).toHaveClass(
+            /dv-edge-tool-window/
+        );
+
+        // the docked pushpin auto-hides back to the strip
+        await page.locator('.dv-groupview-edge .dv-edge-peek-pin').click();
+        await expect(page.locator('.dv-groupview-edge')).not.toHaveClass(
+            /dv-edge-tool-window/
+        );
+    });
+
+    test('a non-spaced theme leaves the peek square (spaced rules stay scoped)', async ({
+        page,
+    }) => {
+        await setup(page, 'abyss');
+        await edgeTab(page).click();
+        await expect(page.locator('.dv-edge-peek')).toBeVisible();
+
+        const radius = await page.evaluate(() =>
+            getComputedStyle(
+                document.querySelector('.dv-edge-peek')!
+            ).getPropertyValue('border-bottom-left-radius')
+        );
+        expect(px(radius)).toBe(0);
+    });
+});

--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -305,7 +305,7 @@ test.describe('auto-hide edge groups — spaced theme styling', () => {
         page.locator('.dv-groupview-edge .dv-tab').first();
     const px = (v: string) => parseFloat(v);
 
-    test('the peek title bar uses the tab/chrome colour, not the near-black group frame', async ({
+    test('the peek title bar uses the tab-bar colour, not the near-black group frame', async ({
         page,
     }) => {
         await setup(page);
@@ -325,8 +325,8 @@ test.describe('auto-hide edge groups — spaced theme styling', () => {
                 frame: cs(group),
             };
         });
-        // the title bar matches the tab strip (chrome), NOT the group frame
-        // (which is the near-black inter-group gap colour that read as black)
+        // the title bar matches the tab strip (tab-bar colour), NOT the group
+        // frame (the near-black inter-group gap colour that read as black)
         expect(c.header).toBe(c.strip);
         expect(c.header).not.toBe(c.frame);
     });

--- a/packages/dockview-core/src/theme/_space-mixin.scss
+++ b/packages/dockview-core/src/theme/_space-mixin.scss
@@ -189,5 +189,51 @@
             border-bottom-left-radius: var(--dv-border-radius);
             border-bottom-right-radius: var(--dv-border-radius);
         }
+
+        // Docked (pinned) auto-hide edge group — a "tool window": title bar on
+        // top, content in the middle, tab strip at the bottom (the header is
+        // moved to the bottom, so the group is laid out `column-reverse`). The
+        // group is already a rounded, overflow-hidden card, but the shared rules
+        // above round the WRONG edges for this flipped layout: the tab strip
+        // rounds its top (now interior) corners and the content-container rounds
+        // its bottom (now interior) corners, carving frame-coloured notches
+        // mid-card. Re-cap the card for the flipped order: title bar rounds the
+        // top, tab strip rounds the bottom, content stays flush between them.
+        &.dv-edge-tool-window {
+            .dv-edge-peek-header {
+                border-top-left-radius: var(--dv-border-radius);
+                border-top-right-radius: var(--dv-border-radius);
+            }
+
+            .dv-content-container {
+                border-radius: 0;
+            }
+
+            .dv-tabs-and-actions-container {
+                border-top-left-radius: 0;
+                border-top-right-radius: 0;
+                border-bottom-left-radius: var(--dv-border-radius);
+                border-bottom-right-radius: var(--dv-border-radius);
+            }
+        }
+    }
+
+    // Auto-hide edge group "peek": a floating tool-window preview mounted in the
+    // overlay root (a sibling title bar over a clipped content backdrop). Round
+    // it into a card matching the spaced aesthetic — the title bar caps the top,
+    // the content backdrop fills the rounded bottom.
+    .dv-edge-peek {
+        border-bottom-left-radius: var(--dv-border-radius);
+        border-bottom-right-radius: var(--dv-border-radius);
+    }
+
+    .dv-edge-peek-clip {
+        border-bottom-left-radius: var(--dv-border-radius);
+        border-bottom-right-radius: var(--dv-border-radius);
+    }
+
+    .dv-edge-peek-header {
+        border-top-left-radius: var(--dv-border-radius);
+        border-top-right-radius: var(--dv-border-radius);
     }
 }

--- a/packages/dockview-enterprise/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -251,24 +251,24 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
-    test('the title bar takes the tab-strip (chrome) colour, the backdrop the group frame', () => {
+    test('the title bar takes the tab-bar colour, the backdrop the group frame', () => {
         const d = make(true);
         collapsedEdgeWithPanel(d);
-        // Distinct frame (group) vs chrome (tab strip) colours — in dark/spaced
+        // Distinct frame (group) vs tab-bar (tab strip) colours — in dark/spaced
         // themes the frame is the near-black inter-group gap colour, so the title
-        // bar must take the lighter chrome colour rather than reading as black.
+        // bar must take the lighter tab-bar colour rather than reading as black.
         strip(d).style.backgroundColor = 'rgb(11, 6, 17)'; // frame
         const stripBar = strip(d).querySelector(
             '.dv-tabs-and-actions-container'
         ) as HTMLElement;
         expect(stripBar).toBeTruthy();
-        stripBar.style.backgroundColor = 'rgb(22, 18, 31)'; // chrome
+        stripBar.style.backgroundColor = 'rgb(22, 18, 31)'; // tab bar
 
         d.api.peekEdgeGroup('left', true);
         const header = container.querySelector(
             '.dv-edge-peek-header'
         ) as HTMLElement;
-        expect(header.style.backgroundColor).toBe('rgb(22, 18, 31)'); // chrome
+        expect(header.style.backgroundColor).toBe('rgb(22, 18, 31)'); // tab bar
         expect(peek()!.style.backgroundColor).toBe('rgb(11, 6, 17)'); // frame
 
         d.dispose();

--- a/packages/dockview-enterprise/src/__tests__/autoHideEdgeGroups.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/autoHideEdgeGroups.spec.ts
@@ -251,6 +251,29 @@ describe('auto-hide edge groups', () => {
         d.dispose();
     });
 
+    test('the title bar takes the tab-strip (chrome) colour, the backdrop the group frame', () => {
+        const d = make(true);
+        collapsedEdgeWithPanel(d);
+        // Distinct frame (group) vs chrome (tab strip) colours — in dark/spaced
+        // themes the frame is the near-black inter-group gap colour, so the title
+        // bar must take the lighter chrome colour rather than reading as black.
+        strip(d).style.backgroundColor = 'rgb(11, 6, 17)'; // frame
+        const stripBar = strip(d).querySelector(
+            '.dv-tabs-and-actions-container'
+        ) as HTMLElement;
+        expect(stripBar).toBeTruthy();
+        stripBar.style.backgroundColor = 'rgb(22, 18, 31)'; // chrome
+
+        d.api.peekEdgeGroup('left', true);
+        const header = container.querySelector(
+            '.dv-edge-peek-header'
+        ) as HTMLElement;
+        expect(header.style.backgroundColor).toBe('rgb(22, 18, 31)'); // chrome
+        expect(peek()!.style.backgroundColor).toBe('rgb(11, 6, 17)'); // frame
+
+        d.dispose();
+    });
+
     test('off (default): peeking is a no-op', () => {
         const d = make(undefined);
         collapsedEdgeWithPanel(d);
@@ -309,6 +332,31 @@ describe('auto-hide edge groups', () => {
             // strip orientation restored to the edge position
             expect(d.getEdgeGroupPanel('left')!.api.getHeaderPosition()).toBe(
                 'left'
+            );
+
+            d.dispose();
+        });
+
+        test('pinning tags the group as a tool window; auto-hiding untags it', () => {
+            const d = make(true);
+            collapsedEdgeWithPanel(d);
+            d.api.peekEdgeGroup('left', true);
+
+            // pin (dock) → the group is a tool window (spaced themes reshape its
+            // rounding off this class)
+            (
+                container.querySelector('.dv-edge-peek-pin') as HTMLElement
+            ).click();
+            expect(strip(d).classList.contains('dv-edge-tool-window')).toBe(
+                true
+            );
+
+            // the docked pushpin auto-hides → the tag is removed
+            (
+                strip(d).querySelector('.dv-edge-peek-pin') as HTMLElement
+            ).click();
+            expect(strip(d).classList.contains('dv-edge-tool-window')).toBe(
+                false
             );
 
             d.dispose();

--- a/packages/dockview-enterprise/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-enterprise/src/autoHideEdgeGroupService.ts
@@ -180,13 +180,13 @@ class EdgeGroupController extends CompositeDisposable {
         return location.type === 'edge' ? location.position : undefined;
     }
 
-    /** The opaque backdrop for the tool-window chrome (peek + docked title
-     *  bars). Resolved from the group's tab strip so the bar adopts the theme's
-     *  tab/chrome colour rather than the group-view *frame* colour — the latter
-     *  is the near-black inter-group gap colour in dark (and spaced) themes,
-     *  which made the header read as a plain black band. Falls back to the group
-     *  element when the strip has no opaque background of its own. */
-    private _chromeBackground(): string {
+    /** The opaque backdrop for the tool-window title bars (peek + docked).
+     *  Resolved from the group's tab strip so the bar adopts the theme's tab-bar
+     *  colour rather than the group-view *frame* colour — the latter is the
+     *  near-black inter-group gap colour in dark (and spaced) themes, which made
+     *  the header read as a plain black band. Falls back to the group element
+     *  when the strip has no opaque background of its own. */
+    private _titleBarBackground(): string {
         const strip = this.group.element.querySelector<HTMLElement>(
             '.dv-tabs-and-actions-container'
         );
@@ -303,7 +303,7 @@ class EdgeGroupController extends CompositeDisposable {
             closeLabel: 'Close',
             onPin: () => this.host.setEdgeGroupCollapsed(this.group, true),
             onClose: () => this.group.activePanel?.api.close(),
-            background: this._chromeBackground(),
+            background: this._titleBarBackground(),
         });
         element.style.flexShrink = '0';
         element.style.height = `${TITLEBAR_HEIGHT}px`;
@@ -368,10 +368,10 @@ class EdgeGroupController extends CompositeDisposable {
 
         const doc = this.group.element.ownerDocument;
         // Backdrop = the group *frame* colour (it only shows at the sliding
-        // edges); the title bar uses the tab/chrome colour so it doesn't read
-        // as a black band in dark/spaced themes.
+        // edges); the title bar uses the tab-bar colour so it doesn't read as a
+        // black band in dark/spaced themes.
         const background = resolveOpaqueBackground(this.group.element);
-        const chrome = this._chromeBackground();
+        const titleBarBackground = this._titleBarBackground();
 
         // --- peek backdrop (slides inside the clip frame) ---
         const overlay = doc.createElement('div');
@@ -397,7 +397,7 @@ class EdgeGroupController extends CompositeDisposable {
             closeLabel: 'Close',
             onPin: () => this.pin(),
             onClose: () => this.close(),
-            background: chrome,
+            background: titleBarBackground,
         });
         header.style.position = 'absolute';
         header.style.zIndex = '1001';

--- a/packages/dockview-enterprise/src/autoHideEdgeGroupService.ts
+++ b/packages/dockview-enterprise/src/autoHideEdgeGroupService.ts
@@ -180,6 +180,19 @@ class EdgeGroupController extends CompositeDisposable {
         return location.type === 'edge' ? location.position : undefined;
     }
 
+    /** The opaque backdrop for the tool-window chrome (peek + docked title
+     *  bars). Resolved from the group's tab strip so the bar adopts the theme's
+     *  tab/chrome colour rather than the group-view *frame* colour — the latter
+     *  is the near-black inter-group gap colour in dark (and spaced) themes,
+     *  which made the header read as a plain black band. Falls back to the group
+     *  element when the strip has no opaque background of its own. */
+    private _chromeBackground(): string {
+        const strip = this.group.element.querySelector<HTMLElement>(
+            '.dv-tabs-and-actions-container'
+        );
+        return resolveOpaqueBackground(strip ?? this.group.element);
+    }
+
     /** Map a pointer/keyboard target to the panel of the strip tab under it, or
      *  `undefined` for non-tab regions. Uses the core's authoritative tab→panel
      *  lookup (no DOM-order assumptions). */
@@ -290,10 +303,16 @@ class EdgeGroupController extends CompositeDisposable {
             closeLabel: 'Close',
             onPin: () => this.host.setEdgeGroupCollapsed(this.group, true),
             onClose: () => this.group.activePanel?.api.close(),
-            background: resolveOpaqueBackground(this.group.element),
+            background: this._chromeBackground(),
         });
         element.style.flexShrink = '0';
         element.style.height = `${TITLEBAR_HEIGHT}px`;
+        // Mark the group as a docked tool window so the spaced themes can
+        // reshape its rounding (title bar caps the top; tab strip caps the
+        // bottom; the content-container's default bottom rounding — which would
+        // otherwise carve notches mid-card now the header is at the bottom — is
+        // dropped). Removed on teardown.
+        this.group.element.classList.add('dv-edge-tool-window');
         // Appended last → under the group's `column-reverse` (header-bottom)
         // flow it lands at the visual top, above the content, with the tab
         // strip at the bottom.
@@ -307,6 +326,7 @@ class EdgeGroupController extends CompositeDisposable {
         }
         this._docked.bar.remove();
         this._docked = undefined;
+        this.group.element.classList.remove('dv-edge-tool-window');
         // Restore the strip's edge orientation (left/right/top/bottom).
         this.group.api.setHeaderPosition(this._position ?? 'top');
     }
@@ -347,7 +367,11 @@ class EdgeGroupController extends CompositeDisposable {
         }
 
         const doc = this.group.element.ownerDocument;
+        // Backdrop = the group *frame* colour (it only shows at the sliding
+        // edges); the title bar uses the tab/chrome colour so it doesn't read
+        // as a black band in dark/spaced themes.
         const background = resolveOpaqueBackground(this.group.element);
+        const chrome = this._chromeBackground();
 
         // --- peek backdrop (slides inside the clip frame) ---
         const overlay = doc.createElement('div');
@@ -373,7 +397,7 @@ class EdgeGroupController extends CompositeDisposable {
             closeLabel: 'Close',
             onPin: () => this.pin(),
             onClose: () => this.close(),
-            background,
+            background: chrome,
         });
         header.style.position = 'absolute';
         header.style.zIndex = '1001';


### PR DESCRIPTION
## Description

On the **spaced themes**, the auto-hide ("pinnable") edge-group peek and its docked tool-window chrome were not adapted to the spaced aesthetic, and the title bar took the wrong colour in every theme. Reproduced with headless-Chromium screenshots across abyss/light/nord spaced + non-spaced themes.

Three defects fixed:

1. **Peek container lacked styles** — the slide-out peek rendered as a sharp-cornered box while the spaced themes round every card. Now rounded into a card (title bar caps the top, content backdrop fills the rounded bottom).
2. **No clean gap between the docked container and the bottom tab strip** — when pinned, the header moves to the bottom (`column-reverse`), but the spaced theme's shared group rules rounded the *wrong* (now-interior) edges; the content-container's bottom rounding carved frame-coloured notches mid-card above the tab strip. The docked group is now tagged `dv-edge-tool-window` and the card is re-capped for the flipped order: title bar rounds the top, tab strip rounds the bottom, content stays flush between them (its own tab margin gives the pill breathing room).
3. **Title bar always rendered a black background** — it resolved to `--dv-group-view-background-color`, the near-black inter-group *frame* colour, so the header read as a black band regardless of theme. It now resolves from the group's tab strip (chrome colour); the sliding backdrop keeps the frame colour (it only shows at the reveal edges).

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core`

<!-- Also touches dockview-enterprise (the auto-hide edge-group service) and the e2e suite; no checkbox exists for those. -->

## How to test

Open an auto-hide (pinnable) edge group under a spaced theme (e.g. `themeAbyssSpaced`):

- Click a collapsed edge tab to peek → the floating peek is a rounded card with the title bar in the tab/chrome colour (not a black band).
- Pin it → the docked tool window is a single cohesive rounded card: title bar on top, content flush, tab strip capping the rounded bottom (no mid-card notch/gap).
- Repeat on a non-spaced theme → the peek stays square (spaced rules stay scoped).

Automated coverage:

- `packages/dockview-enterprise` unit tests (466 pass) — added chrome-coloured title bar + `dv-edge-tool-window` class lifecycle.
- `e2e/tests/auto-hide-edge-groups.spec.ts` (14 pass) — added peek/tool-window rounding, chrome-coloured title bar, and non-spaced scope-isolation tests.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes (dockview-enterprise unit suite + e2e auto-hide suite)
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gdyb5zJo4bHeaowFZ9FSdV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gdyb5zJo4bHeaowFZ9FSdV)_