### PR TITLE
fix(core): render inactive panels in new groups

### DIFF
--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -10235,16 +10235,18 @@ describe('dockviewComponent', () => {
             });
             expect(api.activePanel).toBe(panel1);
 
-            api.addPanel({
+            const panel2 = api.addPanel({
                 id: 'panel_2',
                 component: 'default',
                 position: { direction: 'within', referencePanel: panel1 },
                 inactive: true,
             });
             expect(api.activePanel).toBe(panel1);
+            expect(panel1.group.model.activePanel).toBe(panel1);
+            expect(panel2.view.content.element.parentElement).toBeNull();
         });
 
-        test('that can add panel positional to another (not within)', () => {
+        test('that can add an inactive panel to a new group without activating the group', () => {
             const container = document.createElement('div');
 
             const dockview = new DockviewComponent(container, {
@@ -10270,13 +10272,16 @@ describe('dockviewComponent', () => {
             });
             expect(api.activePanel).toBe(panel1);
 
-            api.addPanel({
+            const panel2 = api.addPanel({
                 id: 'panel_2',
                 component: 'default',
                 position: { direction: 'right', referencePanel: panel1 },
                 inactive: true,
             });
             expect(api.activePanel).toBe(panel1);
+            expect(panel2.group).not.toBe(panel1.group);
+            expect(panel2.group.model.activePanel).toBe(panel2);
+            expect(panel2.view.content.element.parentElement).toBeTruthy();
         });
     });
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -4024,6 +4024,9 @@ export class DockviewComponent
 
         let index: number | undefined;
 
+        const shouldSkipSetActive = (group: DockviewGroupPanel) =>
+            !!options.inactive && group.model.size > 0;
+
         if (options.position) {
             if (isPanelOptionsWithPanel(options.position)) {
                 const referencePanel =
@@ -4067,7 +4070,7 @@ export class DockviewComponent
 
                 const panel = this.createPanel(options, group);
                 group.model.openPanel(panel, {
-                    skipSetActive: options.inactive,
+                    skipSetActive: shouldSkipSetActive(group),
                     skipSetGroupActive: options.inactive,
                     index,
                 });
@@ -4114,7 +4117,7 @@ export class DockviewComponent
                 panel = this.createPanel(options, group);
 
                 group.model.openPanel(panel, {
-                    skipSetActive: options.inactive,
+                    skipSetActive: shouldSkipSetActive(group),
                     skipSetGroupActive: options.inactive,
                     index,
                 });
@@ -4125,7 +4128,7 @@ export class DockviewComponent
             ) {
                 panel = this.createPanel(options, referenceGroup);
                 referenceGroup.model.openPanel(panel, {
-                    skipSetActive: options.inactive,
+                    skipSetActive: shouldSkipSetActive(referenceGroup),
                     skipSetGroupActive: options.inactive,
                     index,
                 });
@@ -4154,7 +4157,7 @@ export class DockviewComponent
                 );
                 panel = this.createPanel(options, group);
                 group.model.openPanel(panel, {
-                    skipSetActive: options.inactive,
+                    skipSetActive: shouldSkipSetActive(group),
                     skipSetGroupActive: options.inactive,
                     index,
                 });
@@ -4182,7 +4185,7 @@ export class DockviewComponent
 
             panel = this.createPanel(options, group);
             group.model.openPanel(panel, {
-                skipSetActive: options.inactive,
+                skipSetActive: shouldSkipSetActive(group),
                 skipSetGroupActive: options.inactive,
                 index,
             });
@@ -4195,7 +4198,7 @@ export class DockviewComponent
             );
             panel = this.createPanel(options, group);
             group.model.openPanel(panel, {
-                skipSetActive: options.inactive,
+                skipSetActive: shouldSkipSetActive(group),
                 skipSetGroupActive: options.inactive,
                 index,
             });


### PR DESCRIPTION
## Description

When `inactive: true` adds the first panel to a new group, keep that panel active within its own group so its content renders. The group itself remains globally inactive, and adding an inactive panel to an existing group still preserves that group's current active panel.

Fixes #1553

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

Run:

```sh
yarn jest --selectProjects dockview-core --runInBand
```

The regression test verifies both sides of the behavior: a new inactive group renders its only panel without becoming globally active, while an existing group retains its active panel.

## Checklist

- [ ] `yarn lint:fix` passes (targeted `dockview-core:lint` passes)
- [ ] `yarn format` passes (targeted `dockview-core:format:check` passes)
- [x] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes (all 1,685 `dockview-core` tests pass)
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented (not applicable)
