### PR TITLE
fix(enterprise): bound multi-row tab wrap to the group so surplus tabs don't render off-screen

### DIFF
--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -261,6 +261,70 @@ test.describe('multi-row tabs (wrap mode)', () => {
         ).not.toHaveClass(/dv-tabs-container--wrap/);
     });
 
+    // Regression: even without `overflow.maxRows`, an unbounded wrap must not
+    // grow the header past the group and render its extra rows off-screen. The
+    // header is bounded by the group's height and the surplus rows spill into
+    // the overflow dropdown, keeping every tab reachable.
+    test('unbounded wrap is bounded by the group height: surplus rows spill to the dropdown, nothing off-screen', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html?overflow=wrap');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        // A short group with many tabs: the rows can't all fit.
+        await page.setViewportSize({ width: 500, height: 400 });
+        await page.evaluate(() => (window as any).__dv.setupWrapTabs(80));
+
+        const tabsList = page.locator('.dv-tabs-container').first();
+        // The space cap clips the strip even though no `maxRows` was set.
+        await expect(tabsList).toHaveClass(/dv-tabs-container--wrap-capped/);
+
+        // Retry until the space-cap reflow + relayout settle.
+        await expect(async () => {
+            const m = await page.evaluate(() => {
+                const group = document.querySelector(
+                    '.dv-groupview'
+                ) as HTMLElement;
+                const header = document.querySelector(
+                    '.dv-tabs-and-actions-container'
+                ) as HTMLElement;
+                const list = document.querySelector(
+                    '.dv-tabs-container'
+                ) as HTMLElement;
+                const gb = group.getBoundingClientRect();
+                const hb = header.getBoundingClientRect();
+                const lb = list.getBoundingClientRect();
+                const tabs = Array.from(
+                    list.querySelectorAll<HTMLElement>('.dv-tab')
+                );
+                // Of the tabs still visible in the clipped strip, how many
+                // escape the group box (render off-screen over the content)?
+                const visibleEscaped = tabs.filter((t) => {
+                    const r = t.getBoundingClientRect();
+                    const inStrip =
+                        r.bottom > lb.top + 0.5 && r.top < lb.bottom - 0.5;
+                    return (
+                        inStrip &&
+                        (r.bottom > gb.bottom + 1 || r.top < gb.top - 1)
+                    );
+                }).length;
+                return {
+                    headerBottom: Math.round(hb.bottom),
+                    groupBottom: Math.round(gb.bottom),
+                    visibleEscaped,
+                };
+            });
+            // The header never grows past the group's bottom edge ...
+            expect(m.headerBottom).toBeLessThanOrEqual(m.groupBottom + 1);
+            // ... so no visible tab renders off-screen.
+            expect(m.visibleEscaped).toBe(0);
+        }).toPass();
+
+        // The surplus rows are reachable in the overflow dropdown.
+        await expect(
+            page.locator('.dv-tabs-overflow-dropdown-root').first()
+        ).toBeVisible();
+    });
+
     // Phase 3: 2-D cross-row drag reorder (smooth mode). A tab dragged from a
     // lower row to a slot on an upper row reorders across the row boundary.
     // Covers both animation modes: default (per-tab drop targets — the common
@@ -696,6 +760,69 @@ test.describe('multi-row tabs (wrap mode)', () => {
             expect(wide.headerWidth).toBeLessThan(narrow.headerWidth);
             expect(wide.escaped).toBe(0);
         }).toPass();
+    });
+
+    // Regression (vertical mirror): an unbounded column wrap must not grow the
+    // header past the group's right edge and render its extra columns off-screen
+    // over the content. The header is bounded by the group's width and the
+    // surplus columns spill into the overflow dropdown.
+    test('vertical header: unbounded wrap is bounded by the group width: surplus columns spill to the dropdown, nothing off-screen', async ({
+        page,
+    }) => {
+        await page.goto('/e2e/fixtures/index.html?overflow=wrap');
+        await page.waitForFunction(() => (window as any).__ready === true);
+        // A short group so columns fill quickly, with many tabs so the columns
+        // exceed the group width.
+        await page.setViewportSize({ width: 700, height: 400 });
+        await page.evaluate(() => (window as any).__dv.setupWrapTabs(80));
+        await page.evaluate(() =>
+            (window as any).__dv.setHeaderPosition('left')
+        );
+
+        const tabsList = page.locator('.dv-tabs-container').first();
+        await expect(tabsList).toHaveClass(/dv-tabs-container--wrap-capped/);
+
+        await expect(async () => {
+            const m = await page.evaluate(() => {
+                const group = document.querySelector(
+                    '.dv-groupview'
+                ) as HTMLElement;
+                const header = document.querySelector(
+                    '.dv-tabs-and-actions-container'
+                ) as HTMLElement;
+                const list = document.querySelector(
+                    '.dv-tabs-container'
+                ) as HTMLElement;
+                const gb = group.getBoundingClientRect();
+                const hb = header.getBoundingClientRect();
+                const lb = list.getBoundingClientRect();
+                const tabs = Array.from(
+                    list.querySelectorAll<HTMLElement>('.dv-tab')
+                );
+                const visibleEscaped = tabs.filter((t) => {
+                    const r = t.getBoundingClientRect();
+                    const inStrip =
+                        r.right > lb.left + 0.5 && r.left < lb.right - 0.5;
+                    return (
+                        inStrip &&
+                        (r.right > gb.right + 1 || r.left < gb.left - 1)
+                    );
+                }).length;
+                return {
+                    headerRight: Math.round(hb.right),
+                    groupRight: Math.round(gb.right),
+                    visibleEscaped,
+                };
+            });
+            // The header never grows past the group's right edge ...
+            expect(m.headerRight).toBeLessThanOrEqual(m.groupRight + 1);
+            // ... so no visible column renders off-screen over the content.
+            expect(m.visibleEscaped).toBe(0);
+        }).toPass();
+
+        await expect(
+            page.locator('.dv-tabs-overflow-dropdown-root').first()
+        ).toBeVisible();
     });
 
     // --- Spaced themes: the wrapped tab must keep its pill inset ---

--- a/packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts
@@ -285,6 +285,91 @@ describe('multi-row tabs (wrap mode)', () => {
         dockview.dispose();
     });
 
+    test('unbounded wrap is bounded by the group height: the surplus rows beyond the fit spill to the dropdown', () => {
+        // No `maxRows`, but a group only tall enough for a couple of rows. The
+        // header must not grow past the group and push its extra rows off-screen;
+        // instead the space cap clips it and routes the surplus to the dropdown.
+        const dockview = make({ mode: 'wrap' });
+        const ids = ['p0', 'p1', 'p2', 'p3', 'p4', 'p5'];
+        const first = dockview.addPanel({ id: ids[0], component: 'default' });
+        for (const id of ids.slice(1)) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+        const header = list.closest(
+            '.dv-tabs-and-actions-container'
+        ) as HTMLElement;
+        const group = list.closest('.dv-groupview') as HTMLElement;
+
+        // 44px rows in a 132px-tall group: floor(132 / 44) - 1 = 2 visible rows
+        // (one row reserved for content). jsdom has no layout, so the line-size
+        // var and the group height are stamped.
+        header.style.setProperty(
+            '--dv-tabs-and-actions-container-height',
+            '44px'
+        );
+        Object.defineProperty(group, 'clientHeight', {
+            configurable: true,
+            value: 132,
+        });
+        // 3 natural rows of two tabs each.
+        stampRows(list, [0, 0, 44, 44, 88, 88]);
+
+        const spy = jest.spyOn(dockview, 'setForcedOverflow');
+        // Re-apply to trigger a measure with the stamped geometry in place.
+        dockview.updateOptions({ overflow: { mode: 'wrap' } });
+
+        // The space cap (2) is applied even though no `maxRows` was set.
+        expect(list.classList.contains(CAPPED_CLASS)).toBe(true);
+        expect(list.style.getPropertyValue(MAX_ROWS_VAR)).toBe('2');
+        // The third row spills into the overflow dropdown.
+        const forced = spy.mock.calls.at(-1)![1];
+        expect(forced('p4')).toBe(true);
+        expect(forced('p5')).toBe(true);
+        expect(forced('p0')).toBe(false);
+        expect(forced('p2')).toBe(false);
+
+        dockview.dispose();
+    });
+
+    test('an explicit maxRows still wins when it is stricter than the space cap', () => {
+        // The group has room for 2 rows but maxRows caps at 1: the tighter of the
+        // two (1) is applied.
+        const dockview = make({ mode: 'wrap', maxRows: 1 });
+        const ids = ['p0', 'p1', 'p2', 'p3', 'p4', 'p5'];
+        const first = dockview.addPanel({ id: ids[0], component: 'default' });
+        for (const id of ids.slice(1)) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+        const header = list.closest(
+            '.dv-tabs-and-actions-container'
+        ) as HTMLElement;
+        const group = list.closest('.dv-groupview') as HTMLElement;
+
+        header.style.setProperty(
+            '--dv-tabs-and-actions-container-height',
+            '44px'
+        );
+        Object.defineProperty(group, 'clientHeight', {
+            configurable: true,
+            value: 132, // space cap would allow 2 rows
+        });
+        stampRows(list, [0, 0, 44, 44, 88, 88]);
+
+        const spy = jest.spyOn(dockview, 'setForcedOverflow');
+        dockview.updateOptions({ overflow: { mode: 'wrap', maxRows: 1 } });
+
+        expect(list.style.getPropertyValue(MAX_ROWS_VAR)).toBe('1');
+        // Everything past the first row is surplus.
+        const forced = spy.mock.calls.at(-1)![1];
+        expect(forced('p0')).toBe(false);
+        expect(forced('p2')).toBe(true);
+        expect(forced('p4')).toBe(true);
+
+        dockview.dispose();
+    });
+
     test('within the cap nothing is forced into the dropdown', () => {
         const dockview = make({ mode: 'wrap', maxRows: 3 });
         const first = dockview.addPanel({ id: 'p0', component: 'default' });
@@ -446,6 +531,50 @@ describe('multi-row tabs (wrap mode)', () => {
 
         // Capped at 2 columns x 35px = 70px (matches the CSS max-width cap).
         expect(header.style.width).toBe('70px');
+
+        dockview.dispose();
+    });
+
+    test('vertical header: unbounded wrap is bounded by the group width and pins the header to the capped column count', () => {
+        // No `maxRows`, but a group only wide enough for a couple of columns. The
+        // header must stop growing at the group edge (not run its extra columns
+        // off-screen over the content); the surplus columns spill to the dropdown
+        // and the pinned width reflects the capped count, not the natural one.
+        const dockview = makeVertical({ mode: 'wrap' });
+        const ids = ['p0', 'p1', 'p2', 'p3', 'p4', 'p5'];
+        const first = dockview.addPanel({ id: ids[0], component: 'default' });
+        for (const id of ids.slice(1)) {
+            dockview.addPanel({ id, component: 'default' });
+        }
+        const list = first.group.model.tabsListElement;
+        const header = headerOf(list);
+        const group = list.closest('.dv-groupview') as HTMLElement;
+
+        header.style.setProperty(
+            '--dv-tabs-and-actions-container-height',
+            '35px'
+        );
+        // 35px columns in a 105px-wide group: floor(105 / 35) - 1 = 2 columns.
+        Object.defineProperty(group, 'clientWidth', {
+            configurable: true,
+            value: 105,
+        });
+        // 3 natural columns of two tabs each (vertical-rl → right-to-left).
+        stampCols(list, [88, 88, 44, 44, 0, 0]);
+
+        const spy = jest.spyOn(dockview, 'setForcedOverflow');
+        dockview.updateOptions({ overflow: { mode: 'wrap' } });
+
+        // The space cap (2) is applied without an explicit maxRows ...
+        expect(list.classList.contains(CAPPED_CLASS)).toBe(true);
+        expect(list.style.getPropertyValue(MAX_ROWS_VAR)).toBe('2');
+        // ... the header is pinned to 2 columns x 35px, not the natural 3 ...
+        expect(header.style.width).toBe('70px');
+        // ... and the left-most (surplus) column spills to the dropdown.
+        const forced = spy.mock.calls.at(-1)![1];
+        expect(forced('p4')).toBe(true);
+        expect(forced('p5')).toBe(true);
+        expect(forced('p0')).toBe(false);
 
         dockview.dispose();
     });

--- a/packages/dockview-enterprise/src/multiRowTabsService.ts
+++ b/packages/dockview-enterprise/src/multiRowTabsService.ts
@@ -168,6 +168,24 @@ function sameSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
 }
 
 /**
+ * The tighter (smaller) of two optional line caps, treating `undefined` as
+ * unbounded. Combines the explicit `overflow.maxRows` with the space-derived
+ * cap so the wrap is bounded by whichever is stricter.
+ */
+function tighterCap(
+    a: number | undefined,
+    b: number | undefined
+): number | undefined {
+    if (a === undefined) {
+        return b;
+    }
+    if (b === undefined) {
+        return a;
+    }
+    return Math.min(a, b);
+}
+
+/**
  * Drives wrap layout for one group. The wrap itself is CSS (the inert
  * `.dv-tabs-container--wrap` rules in core); this controller toggles that class
  * on the group's tab list and, when the wrapped row count changes, asks the host
@@ -180,6 +198,13 @@ function sameSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
  * (tabs on rows beyond the cap) to the free forced-overflow seam so those tabs
  * spill into the dropdown. Detection is a row-count test, not the free path's
  * horizontal-clip test, since nothing clips horizontally when tabs wrap.
+ *
+ * Even without `overflow.maxRows` the cap is bounded by the group's cross-size:
+ * a wrap that would grow the header past the group box (more rows than the group
+ * is tall, or more columns than it is wide) is clamped to what fits and the
+ * surplus routed to the dropdown, so the extra tabs never render off-screen
+ * where they can't be reached. The two caps compose: the effective cap is
+ * whichever of the explicit and the space-derived limit is stricter.
  *
  * Wraps both horizontal headers (into rows) and vertical/edge-group headers
  * (into columns); a hidden header is a no-op.
@@ -238,10 +263,11 @@ class WrapController extends CompositeDisposable {
             this._wrapped = true;
             list.classList.add(WRAP_CLASS);
 
-            // Sync the row cap (may change without a wrap on/off transition, e.g.
-            // a runtime `overflow.maxRows` update).
+            // Sync the explicit row cap (may change without a wrap on/off
+            // transition, e.g. a runtime `overflow.maxRows` update). The CSS clip
+            // is applied in `measure`, which combines this with the space-derived
+            // cap and runs at the end of `apply`.
             this._maxRows = resolveMaxRows(this.host.options.overflow);
-            this.applyCap(list);
 
             if (first) {
                 // Mutating layout synchronously inside the ResizeObserver
@@ -304,15 +330,59 @@ class WrapController extends CompositeDisposable {
     }
 
     /** Toggle the capped class + `--dv-max-tab-rows` var so CSS clips the strip
-     *  to the cap (or removes the clip when unbounded). */
-    private applyCap(list: HTMLElement): void {
-        if (this._maxRows === undefined) {
+     *  to `cap` lines (or removes the clip when `cap` is `undefined`). */
+    private applyCap(list: HTMLElement, cap: number | undefined): void {
+        if (cap === undefined) {
             list.classList.remove(CAPPED_CLASS);
             list.style.removeProperty(MAX_ROWS_VAR);
         } else {
             list.classList.add(CAPPED_CLASS);
-            list.style.setProperty(MAX_ROWS_VAR, String(this._maxRows));
+            list.style.setProperty(MAX_ROWS_VAR, String(cap));
         }
+    }
+
+    /**
+     * The per-line thickness (row height / column width) core sizes wrapped tabs
+     * by, read from the header's `--dv-tabs-and-actions-container-height`. `0`
+     * when it can't be resolved (e.g. jsdom, where stylesheet vars don't
+     * compute), which callers treat as "unmeasurable".
+     */
+    private readLineSize(list: HTMLElement): number {
+        const header = list.closest<HTMLElement>(`.${HEADER_CLASS}`);
+        if (!header) {
+            return 0;
+        }
+        const lineSize = Number.parseFloat(
+            getComputedStyle(header).getPropertyValue(LINE_SIZE_VARIABLE)
+        );
+        return Number.isFinite(lineSize) && lineSize > 0 ? lineSize : 0;
+    }
+
+    /**
+     * The number of wrapped lines that fit within the group's cross-size — the
+     * axis the header grows along (height for a horizontal header, width for a
+     * vertical one). Beyond this the header would grow past the group box and
+     * push its surplus tabs off-screen (unreachable: the wrapped strip doesn't
+     * scroll), so it bounds the effective cap even without an explicit
+     * `overflow.maxRows`. One line is reserved for content so the panel never
+     * collapses to nothing. `undefined` when the size can't be measured (no
+     * group box or unresolved line thickness — e.g. jsdom, whose `clientWidth`/
+     * `clientHeight` are 0), leaving wrap unbounded there.
+     */
+    private spaceCap(list: HTMLElement): number | undefined {
+        const lineSize = this.readLineSize(list);
+        if (lineSize <= 0) {
+            return undefined;
+        }
+        const group = list.closest<HTMLElement>('.dv-groupview');
+        if (!group) {
+            return undefined;
+        }
+        const cross = this._vertical ? group.clientWidth : group.clientHeight;
+        if (cross <= 0) {
+            return undefined;
+        }
+        return Math.max(1, Math.floor(cross / lineSize) - 1);
     }
 
     /**
@@ -406,16 +476,23 @@ class WrapController extends CompositeDisposable {
             return;
         }
 
-        const { rows, surplus } = measureRows(
-            list,
-            this._maxRows,
-            this._vertical
-        );
+        // The effective cap is the tighter of the explicit `overflow.maxRows`
+        // and the number of lines that fit within the group's cross-size. The
+        // latter stops an unbounded (or generously-capped) wrap from growing the
+        // header past the group and rendering its surplus tabs off-screen; those
+        // lines spill into the overflow dropdown instead, exactly as maxRows does.
+        const cap = tighterCap(this._maxRows, this.spaceCap(list));
+
+        // Sync the CSS clip (capped class + `--dv-max-tab-rows`) to the effective
+        // cap. It can move on a resize independently of `overflow.maxRows`, so it
+        // is applied here on every measure rather than once in `apply`.
+        this.applyCap(list, cap);
+
+        const { rows, surplus } = measureRows(list, cap, this._vertical);
 
         // Only the visible (capped) rows drive header height, so relayout keys
         // off the effective count, not the natural one.
-        const effectiveRows =
-            this._maxRows === undefined ? rows : Math.min(rows, this._maxRows);
+        const effectiveRows = cap === undefined ? rows : Math.min(rows, cap);
 
         // Route the surplus set to the dropdown (idempotent: skip when unchanged
         // so we don't rebuild the dropdown, which would loop via the observer).
@@ -461,10 +538,8 @@ class WrapController extends CompositeDisposable {
             header.style.removeProperty('width');
             return;
         }
-        const lineSize = Number.parseFloat(
-            getComputedStyle(header).getPropertyValue(LINE_SIZE_VARIABLE)
-        );
-        if (Number.isFinite(lineSize) && lineSize > 0) {
+        const lineSize = this.readLineSize(list);
+        if (lineSize > 0) {
             header.style.width = `${columns * lineSize}px`;
         }
     }


### PR DESCRIPTION
## Description

In `overflow.mode: 'wrap'` (multi-row tabs) **without** an explicit `overflow.maxRows`, the tab header grew without any bound to the group as tabs were added. A horizontal header's rows grew its height and a vertical (edge) header's columns grew its width, with no relationship to the group's cross-size. Once the header exceeded the group box, the extra rows/columns rendered **off-screen over the content**, where they could not be reached (the wrapped strip does not scroll).

Reproduced in a real browser both ways:
- **Vertical/edge header:** header pinned to `columns × thickness` grew to 1750px wide inside a 1000px group, pushing 66 tab columns off the right edge.
- **Horizontal header:** header grew to 945px tall inside a 400px group, pushing 47 rows off the bottom.

**Fix:** the effective wrap cap is now the tighter of `overflow.maxRows` and the number of lines that fit within the group's cross-size (height for a horizontal header, width for a vertical one), reserving one line for content. The surplus lines spill into the overflow-dropdown chevron via the same forced-overflow seam `overflow.maxRows` already drives, so the header never grows past the group and every tab stays reachable. The two caps compose: whichever limit is stricter wins.

The space cap is derived from the group's rendered `clientWidth`/`clientHeight`, so it is inert under jsdom (which reports 0) and the layout behaviour is verified in the real-browser e2e suite.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`
- [x] `dockview-enterprise` (`multiRowTabsService.ts`)

## How to test

Enable `overflow: { mode: 'wrap' }` (no `maxRows`) on a group and keep adding tabs, in both a top (horizontal) header and a left/right (vertical/edge) header. The header now stops growing at the group edge and the surplus tabs appear in the overflow chevron instead of rendering off-screen.

Automated:
- **Unit** (`packages/dockview-enterprise/src/__tests__/multiRowTabs.spec.ts`): horizontal space cap, vertical space cap + pinned header width, and explicit-`maxRows` precedence, all with mocked geometry — 469 passed.
- **e2e** (`e2e/tests/multi-row-tabs.spec.ts`): two real-browser regression tests asserting the header never grows past the group box and no visible tab escapes it, plus dropdown spill — 24 passed. All existing multi-row e2e still green.

## Checklist

- [x] `yarn lint:fix` passes
- [x] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes (`dockview-enterprise` + `dockview-core`)
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented (none — behaviour only changes when a wrap would otherwise overflow the group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SE6j66BAUrVCLGUkA1FPKU)_