### PR TITLE
fix(tabs): stop clipping the wrap-around tab-group accent line

### DIFF
--- a/e2e/fixtures/tab-group-indicator.html
+++ b/e2e/fixtures/tab-group-indicator.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>tab group indicator clipping</title>
+        <style>
+            html,
+            body {
+                margin: 0;
+                height: 100%;
+                width: 100%;
+                background: #0d1117;
+            }
+            /* Give the dock a fixed size so screenshots are stable. */
+            #app {
+                position: absolute;
+                top: 40px;
+                left: 40px;
+                width: 720px;
+                height: 420px;
+            }
+            .dv-test-panel {
+                height: 100%;
+                box-sizing: border-box;
+                padding: 8px;
+                color: #ddd;
+            }
+        </style>
+        <link
+            rel="stylesheet"
+            href="/packages/dockview-core/dist/styles/dockview.css"
+        />
+        <script src="/packages/dockview/dist/dockview.js"></script>
+    </head>
+    <body>
+        <div id="app"></div>
+        <script>
+            (function () {
+                const lib = window['dockview'];
+                const params = new URLSearchParams(location.search);
+                const headerPosition = params.get('header') || 'top';
+
+                const el = document.getElementById('app');
+                const dockview = new lib.DockviewComponent(el, {
+                    createComponent: (options) => {
+                        const element = document.createElement('div');
+                        element.className = 'dv-test-panel';
+                        element.textContent = options.name;
+                        return {
+                            element,
+                            init: () => {},
+                            dispose: () => {},
+                        };
+                    },
+                    // Default theme → the Chrome-style wrap-around indicator
+                    // (`tabGroupIndicator` defaults to 'wrap').
+                    theme: lib.themeDark,
+                    // Vivid palette so the accent line reads clearly at zoom.
+                    tabGroupColors: [{ id: 'brand', value: '#8b5cf6' }],
+                });
+
+                // One group holding four tabs.
+                const p1 = dockview.api.addPanel({
+                    id: 'test',
+                    component: 'default',
+                    params: { name: 'test' },
+                });
+                const groupId = p1.group.id;
+                const p2 = dockview.api.addPanel({
+                    id: 'orders',
+                    component: 'default',
+                    params: { name: 'Orders' },
+                    position: { referencePanel: 'test', direction: 'within' },
+                });
+                const p3 = dockview.api.addPanel({
+                    id: 'positions',
+                    component: 'default',
+                    params: { name: 'Positions' },
+                    position: { referencePanel: 'test', direction: 'within' },
+                });
+                const p4 = dockview.api.addPanel({
+                    id: 'history',
+                    component: 'default',
+                    params: { name: 'History' },
+                    position: { referencePanel: 'test', direction: 'within' },
+                });
+
+                // Colored tab group spanning Orders + Positions.
+                const tabGroup = dockview.api.createTabGroup({
+                    groupId,
+                    label: 'Trade',
+                    color: 'brand',
+                });
+                dockview.api.addPanelToTabGroup({
+                    groupId,
+                    tabGroupId: tabGroup.id,
+                    panelId: 'orders',
+                });
+                dockview.api.addPanelToTabGroup({
+                    groupId,
+                    tabGroupId: tabGroup.id,
+                    panelId: 'positions',
+                });
+
+                // Header orientation under test.
+                p1.group.api.setHeaderPosition(headerPosition);
+
+                // Activate a tab inside the colored group so the indicator
+                // arches over the active tab (the case that showed clipping).
+                p2.api.setActive();
+
+                // Signal readiness for the screenshot driver once the indicator
+                // has had a couple of frames to position itself.
+                requestAnimationFrame(() =>
+                    requestAnimationFrame(() => {
+                        document.body.setAttribute('data-ready', 'true');
+                    })
+                );
+            })();
+        </script>
+    </body>
+</html>

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroupIndicator.ts
@@ -640,23 +640,26 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
         svg: SVGSVGElement,
         path: SVGPathElement,
         underline: HTMLElement,
-        t: number,
         mainSize: number,
+        crossSize: number,
+        near: number,
         isVertical: boolean
     ): void {
-        if (isVertical) {
-            svg.setAttribute('width', String(t));
-            svg.setAttribute('height', String(mainSize));
-            underline.style.width = `${t}px`;
-            underline.style.height = `${mainSize}px`;
-            path.setAttribute('d', `M ${t / 2},0 L ${t / 2},${mainSize}`);
-        } else {
-            svg.setAttribute('width', String(mainSize));
-            svg.setAttribute('height', String(t));
-            underline.style.width = `${mainSize}px`;
-            underline.style.height = `${t}px`;
-            path.setAttribute('d', `M 0,${t / 2} L ${mainSize},${t / 2}`);
-        }
+        // Match the curved path's full cross-size SVG and inset `near` edge so
+        // the fallback bar is drawn inside the container clip box too (see the
+        // clip note in `applyShape`), never flush against it.
+        const svgW = isVertical ? crossSize : mainSize;
+        const svgH = isVertical ? mainSize : crossSize;
+        svg.setAttribute('width', String(svgW));
+        svg.setAttribute('height', String(svgH));
+        underline.style.width = `${svgW}px`;
+        underline.style.height = `${svgH}px`;
+        path.setAttribute(
+            'd',
+            isVertical
+                ? `M ${near},0 L ${near},${mainSize}`
+                : `M 0,${near} L ${mainSize},${near}`
+        );
     }
 
     /**
@@ -703,13 +706,41 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
         path.setAttribute('stroke', color);
         path.setAttribute('stroke-width', String(t));
 
+        // The tab strip (`.dv-tabs-container`) clips its children with
+        // `overflow: auto`, and that clip box lines up with this SVG's viewport
+        // (the underline element always spans the full container cross-axis).
+        // A stroke whose centre is only `half` (t/2) from an edge has its outer
+        // rim sitting exactly on the boundary, so the browser shaves it - the
+        // accent looks clipped along the tab's outer edge (most visible where
+        // the line arches over the active tab). Offset the anchored edges one
+        // full stroke-width in so the whole rim clears the clip by `half`, for
+        // every header position (top/bottom/left/right).
+        const inset = t;
+        const headerPosition = this._ctx.getHeaderPosition();
+        const isBottomHeader = !isVertical && headerPosition === 'bottom';
+        const isRightHeader = isVertical && headerPosition === 'right';
+
+        // `near`: the group's long-run edge (the strip edge adjacent to the
+        // content); `far`: the wrap-around edge that arches over the active tab.
+        // Both are cross-axis coordinates in the SVG, inset from the clip box.
+        let near: number;
+        let far: number;
+        if (isVertical) {
+            near = isRightHeader ? crossSize - inset : inset;
+            far = isRightHeader ? inset : crossSize - inset;
+        } else {
+            near = isBottomHeader ? inset : crossSize - inset;
+            far = isBottomHeader ? crossSize - inset : inset;
+        }
+
         if (!activeTabEntry) {
             this._applyStraightLine(
                 svg,
                 path,
                 underline,
-                t,
                 mainSize,
+                crossSize,
+                near,
                 isVertical
             );
             return;
@@ -745,16 +776,18 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
                 svg,
                 path,
                 underline,
-                t,
                 mainSize,
+                crossSize,
+                near,
                 isVertical
             );
             return;
         }
 
         const r = 6; // corner radius
-        const half = t / 2;
-        const headerPosition = this._ctx.getHeaderPosition();
+        // Curve direction: the sign that steps from the near edge toward the
+        // far edge (over the active tab); positive when `far` is the larger.
+        const cd = far > near ? 1 : -1;
 
         if (isVertical) {
             const svgW = crossSize;
@@ -764,23 +797,17 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
             underline.style.width = `${svgW}px`;
             underline.style.height = `${svgH}px`;
 
-            // right header: indicator on the left edge (invert x sides)
-            const isRightHeader = headerPosition === 'right';
-            const xNear = isRightHeader ? svgW - half : half;
-            const xFar = isRightHeader ? half : svgW - half;
-            const cd = isRightHeader ? -1 : 1; // curve direction
-
             const d = [
-                `M ${xNear},0`,
-                `L ${xNear},${aStart - r}`,
-                `Q ${xNear},${aStart} ${xNear + cd * r},${aStart}`,
-                `L ${xFar - cd * r},${aStart}`,
-                `Q ${xFar},${aStart} ${xFar},${aStart + r}`,
-                `L ${xFar},${aEnd - r}`,
-                `Q ${xFar},${aEnd} ${xFar - cd * r},${aEnd}`,
-                `L ${xNear + cd * r},${aEnd}`,
-                `Q ${xNear},${aEnd} ${xNear},${aEnd + r}`,
-                `L ${xNear},${svgH}`,
+                `M ${near},0`,
+                `L ${near},${aStart - r}`,
+                `Q ${near},${aStart} ${near + cd * r},${aStart}`,
+                `L ${far - cd * r},${aStart}`,
+                `Q ${far},${aStart} ${far},${aStart + r}`,
+                `L ${far},${aEnd - r}`,
+                `Q ${far},${aEnd} ${far - cd * r},${aEnd}`,
+                `L ${near + cd * r},${aEnd}`,
+                `Q ${near},${aEnd} ${near},${aEnd + r}`,
+                `L ${near},${svgH}`,
             ].join(' ');
 
             path.setAttribute('d', d);
@@ -792,23 +819,17 @@ export class WrapTabGroupIndicator extends BaseTabGroupIndicator {
             underline.style.width = `${svgW}px`;
             underline.style.height = `${svgH}px`;
 
-            // bottom header: indicator on the top edge (invert y sides)
-            const isBottomHeader = headerPosition === 'bottom';
-            const yNear = isBottomHeader ? half : svgH - half;
-            const yFar = isBottomHeader ? svgH - half : half;
-            const cd = isBottomHeader ? 1 : -1; // curve direction
-
             const d = [
-                `M 0,${yNear}`,
-                `L ${aStart - r},${yNear}`,
-                `Q ${aStart},${yNear} ${aStart},${yNear + cd * r}`,
-                `L ${aStart},${yFar - cd * r}`,
-                `Q ${aStart},${yFar} ${aStart + r},${yFar}`,
-                `L ${aEnd - r},${yFar}`,
-                `Q ${aEnd},${yFar} ${aEnd},${yFar - cd * r}`,
-                `L ${aEnd},${yNear + cd * r}`,
-                `Q ${aEnd},${yNear} ${aEnd + r},${yNear}`,
-                `L ${svgW},${yNear}`,
+                `M 0,${near}`,
+                `L ${aStart - r},${near}`,
+                `Q ${aStart},${near} ${aStart},${near + cd * r}`,
+                `L ${aStart},${far - cd * r}`,
+                `Q ${aStart},${far} ${aStart + r},${far}`,
+                `L ${aEnd - r},${far}`,
+                `Q ${aEnd},${far} ${aEnd},${far - cd * r}`,
+                `L ${aEnd},${near + cd * r}`,
+                `Q ${aEnd},${near} ${aEnd + r},${near}`,
+                `L ${svgW},${near}`,
             ].join(' ');
 
             path.setAttribute('d', d);


### PR DESCRIPTION
## Description

The Chrome-style tab-group indicator (`WrapTabGroupIndicator`) drew its accent stroke centred only **half a stroke-width** from the SVG edge. The underline SVG spans the full `.dv-tabs-container`, and that container clips its children with `overflow: auto` — so the clip box coincides exactly with the SVG viewport edge. With the stroke's outer rim sitting *flush* on that boundary, the browser shaved it, leaving the accent line looking clipped along the tab's outer edge — most visible where the line arches over the active tab.

The fix insets the anchored `near`/`far` edges by a full stroke-width so the whole rim clears the clip by ~half a pixel, for **every header position (top / bottom / left / right)**. As part of this the curved-path branch was tidied to compute `near`/`far`/`cd` once (replacing the duplicated `xNear/xFar` + `yNear/yFar` logic), and the straight-line fallback (a group with no active tab) now shares the same full cross-size SVG and inset so it is drawn inside the clip box too.

Verified before/after in the real app at 4× zoom across all four header positions — the change is clearest on the **Right** header (the vertical accent line goes from shaved-against-the-edge to full-width) and the **Top** arch (no longer touching the clip boundary).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

- Unit: the existing `WrapTabGroupIndicator` header-position geometry specs still assert the anchored edge flips correctly per header side; all `dockview-core` tests pass (1685).
- Visual: `e2e/fixtures/tab-group-indicator.html` renders a coloured tab group with the wrap-around indicator and an active tab; the header orientation is selectable via `?header=top|bottom|left|right`. Load it against the built bundles and zoom into the active tab's accent line — the stroke is fully visible on every side.

## Checklist

- [x] `yarn lint:fix` passes (Biome — only pre-existing `import type` warnings in the unchanged import block)
- [x] `yarn format` passes (Biome)
- [ ] `npm run gen` has been run and generated files are up to date (n/a — no generated inputs changed)
- [x] `yarn test` passes
- [ ] I have added or updated tests where applicable (geometry is covered by existing header-position specs; added a visual e2e fixture)
- [ ] Breaking changes are documented (n/a — no behaviour change beyond the 1px clip fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019H8H8gs2T1NYzote51MvFB