### PR TITLE
chore: update mathuo/dockview references to dockview/dockview org

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ NX handles build ordering automatically via `dependsOn: ["^build"]`. The depende
     the same PR. If Sonar reports a new issue, fix it (or, if genuinely a false
     positive, mark it Won't Fix / Accepted in SonarCloud with a justification)
     before merging. Fetch the exact findings from
-    `https://sonarcloud.io/api/issues/search?componentKeys=mathuo_dockview&pullRequest=<PR>&issueStatuses=OPEN,CONFIRMED&resolved=false`
+    `https://sonarcloud.io/api/issues/search?componentKeys=dockview_dockview-1&pullRequest=<PR>&issueStatuses=OPEN,CONFIRMED&resolved=false`
     rather than trusting the summary comment, which can lag a commit behind.
 
 ## Development Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ NX handles build ordering automatically via `dependsOn: ["^build"]`. The depende
     the same PR. If Sonar reports a new issue, fix it (or, if genuinely a false
     positive, mark it Won't Fix / Accepted in SonarCloud with a justification)
     before merging. Fetch the exact findings from
-    `https://sonarcloud.io/api/issues/search?componentKeys=dockview_dockview-1&pullRequest=<PR>&issueStatuses=OPEN,CONFIRMED&resolved=false`
+    `https://sonarcloud.io/api/issues/search?componentKeys=dockview_dockview&pullRequest=<PR>&issueStatuses=OPEN,CONFIRMED&resolved=false`
     rather than trusting the summary comment, which can lag a commit behind.
 
 ## Development Notes

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 [![npm version](https://img.shields.io/npm/v/dockview)](https://www.npmjs.com/package/dockview)
 [![npm downloads](https://img.shields.io/npm/dm/dockview)](https://www.npmjs.com/package/dockview-core)
-[![CI](https://img.shields.io/github/actions/workflow/status/mathuo/dockview/main.yml?branch=master&label=CI)](https://github.com/mathuo/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
+[![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview?label=size)](https://bundlephobia.com/result?p=dockview)
 
 </div>
@@ -104,7 +104,7 @@ yarn format     # Format all packages
 
 ## Contributing
 
-Contributions are welcome! Please open an [issue](https://github.com/mathuo/dockview/issues) or submit a pull request.
+Contributions are welcome! Please open an [issue](https://github.com/dockview/dockview/issues) or submit a pull request.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://img.shields.io/npm/v/dockview)](https://www.npmjs.com/package/dockview)
 [![npm downloads](https://img.shields.io/npm/dm/dockview)](https://www.npmjs.com/package/dockview-core)
 [![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview?label=size)](https://bundlephobia.com/result?p=dockview)
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,7 @@ Out of scope:
 
 - All build and publish workflows are public and live under [`.github/workflows`](https://github.com/dockview/dockview/tree/master/.github/workflows).
 - npm releases are published with [provenance statements](https://docs.npmjs.com/generating-provenance-statements/) so the source commit and workflow run can be verified.
-- Code is statically analysed by [SonarCloud](https://sonarcloud.io/summary/overall?id=dockview_dockview-1) on every pull request and by [CodeQL](https://github.com/dockview/dockview/security/code-scanning) on a nightly schedule.
+- Code is statically analysed by [SonarCloud](https://sonarcloud.io/summary/overall?id=dockview_dockview) on every pull request and by [CodeQL](https://github.com/dockview/dockview/security/code-scanning) on a nightly schedule.
 
 ## Configuration guidance
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please **do not** open a public GitHub issue for security reports.
 
-Preferred: use [GitHub's private vulnerability reporting](https://github.com/mathuo/dockview/security/advisories/new) on this repository.
+Preferred: use [GitHub's private vulnerability reporting](https://github.com/dockview/dockview/security/advisories/new) on this repository.
 
 Alternative: email **contact@dockview.dev** or **github.mathuo@gmail.com**.
 
@@ -38,9 +38,9 @@ Out of scope:
 
 ## Build and release integrity
 
-- All build and publish workflows are public and live under [`.github/workflows`](https://github.com/mathuo/dockview/tree/master/.github/workflows).
+- All build and publish workflows are public and live under [`.github/workflows`](https://github.com/dockview/dockview/tree/master/.github/workflows).
 - npm releases are published with [provenance statements](https://docs.npmjs.com/generating-provenance-statements/) so the source commit and workflow run can be verified.
-- Code is statically analysed by [SonarCloud](https://sonarcloud.io/summary/overall?id=mathuo_dockview) on every pull request and by [CodeQL](https://github.com/mathuo/dockview/security/code-scanning) on a nightly schedule.
+- Code is statically analysed by [SonarCloud](https://sonarcloud.io/summary/overall?id=dockview_dockview-1) on every pull request and by [CodeQL](https://github.com/dockview/dockview/security/code-scanning) on a nightly schedule.
 
 ## Configuration guidance
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -335,7 +335,7 @@ Custom themes can be created using CSS custom properties (CSS variables).
 - API Reference: https://dockview.dev/docs/api/dockview/overview
 - Licensing: https://dockview.dev/docs/overview/licence
 - Live Demo: https://dockview.dev/demo
-- GitHub: https://github.com/mathuo/dockview
+- GitHub: https://github.com/dockview/dockview
 - npm: https://www.npmjs.com/package/dockview-react
 - Blog / Release Notes: https://dockview.dev/blog
 - License: MIT (core); commercial for Dockview Enterprise

--- a/llms.txt
+++ b/llms.txt
@@ -49,7 +49,7 @@ Dockview is an open-source docking layout library that lets you build IDE-like a
 - API Reference: https://dockview.dev/docs/api/dockview/overview
 - Licensing: https://dockview.dev/docs/overview/licence
 - Live Demo: https://dockview.dev/demo
-- GitHub: https://github.com/mathuo/dockview
+- GitHub: https://github.com/dockview/dockview
 - npm: https://www.npmjs.com/package/dockview-react
 - Blog / Release Notes: https://dockview.dev/blog
 - License: MIT (core); commercial for Dockview Enterprise

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
     "name": "dockview-monorepo-root",
     "private": true,
-    "description": "Monorepo for https://github.com/mathuo/dockview",
-    "homepage": "https://github.com/mathuo/dockview#readme",
+    "description": "Monorepo for https://github.com/dockview/dockview",
+    "homepage": "https://github.com/dockview/dockview#readme",
     "bugs": {
-        "url": "https://github.com/mathuo/dockview/issues"
+        "url": "https://github.com/dockview/dockview/issues"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mathuo/dockview.git"
+        "url": "git+https://github.com/dockview/dockview.git"
     },
     "license": "MIT",
     "author": "https://github.com/mathuo",

--- a/packages/dockview-angular/README.md
+++ b/packages/dockview-angular/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
-  <img src="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
+  <img src="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
 </picture>
 
 <h1>dockview-angular</h1>
@@ -11,16 +11,16 @@
 
 [![npm version](https://img.shields.io/npm/v/dockview-angular)](https://www.npmjs.com/package/dockview-angular)
 [![npm downloads](https://img.shields.io/npm/dm/dockview-angular)](https://www.npmjs.com/package/dockview-angular)
-[![CI](https://img.shields.io/github/actions/workflow/status/mathuo/dockview/main.yml?branch=master&label=CI)](https://github.com/mathuo/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
+[![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview-angular?label=size)](https://bundlephobia.com/result?p=dockview-angular)
 
 </div>
 
 ---
 
-![A Dockview layout showing docked, tabbed and split panels in a trading workbench](https://github.com/mathuo/dockview/blob/HEAD/static/img/demo-hero.webp?raw=true)
+![A Dockview layout showing docked, tabbed and split panels in a trading workbench](https://github.com/dockview/dockview/blob/HEAD/static/img/demo-hero.webp?raw=true)
 
 Please see the website: https://dockview.dev
 

--- a/packages/dockview-angular/README.md
+++ b/packages/dockview-angular/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://img.shields.io/npm/v/dockview-angular)](https://www.npmjs.com/package/dockview-angular)
 [![npm downloads](https://img.shields.io/npm/dm/dockview-angular)](https://www.npmjs.com/package/dockview-angular)
 [![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview-angular?label=size)](https://bundlephobia.com/result?p=dockview-angular)
 
 </div>

--- a/packages/dockview-angular/package.json
+++ b/packages/dockview-angular/package.json
@@ -33,13 +33,13 @@
         "angular",
         "angular-component"
     ],
-    "homepage": "https://github.com/mathuo/dockview",
+    "homepage": "https://github.com/dockview/dockview",
     "bugs": {
-        "url": "https://github.com/mathuo/dockview/issues"
+        "url": "https://github.com/dockview/dockview/issues"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mathuo/dockview.git",
+        "url": "git+https://github.com/dockview/dockview.git",
         "directory": "packages/dockview-angular"
     },
     "license": "MIT",

--- a/packages/dockview-core/README.md
+++ b/packages/dockview-core/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
-  <img src="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
+  <img src="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
 </picture>
 
 <h1>dockview-core</h1>

--- a/packages/dockview-core/package.json
+++ b/packages/dockview-core/package.json
@@ -32,13 +32,13 @@
         "workbench",
         "vanilla"
     ],
-    "homepage": "https://github.com/mathuo/dockview",
+    "homepage": "https://github.com/dockview/dockview",
     "bugs": {
-        "url": "https://github.com/mathuo/dockview/issues"
+        "url": "https://github.com/dockview/dockview/issues"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mathuo/dockview.git",
+        "url": "git+https://github.com/dockview/dockview.git",
         "directory": "packages/dockview-core"
     },
     "license": "MIT",

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -10880,7 +10880,7 @@ describe('dockviewComponent', () => {
         });
 
         test('issue 1020: addGroup + moveTo with defaultRenderer="always" repositions panel overlay', async () => {
-            // Reproduces https://github.com/mathuo/dockview/issues/1020
+            // Reproduces https://github.com/dockview/dockview/issues/1020
             // The user split a group by creating a new adjacent group and
             // moving the active panel into it. With defaultRenderer="always"
             // the panel's content overlay stayed at the old grid coordinates

--- a/packages/dockview-enterprise/README.md
+++ b/packages/dockview-enterprise/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
-  <img src="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
+  <img src="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
 </picture>
 
 <h1>dockview-enterprise</h1>
@@ -11,9 +11,9 @@
 
 [![npm version](https://img.shields.io/npm/v/dockview-enterprise)](https://www.npmjs.com/package/dockview-enterprise)
 [![npm downloads](https://img.shields.io/npm/dm/dockview-enterprise)](https://www.npmjs.com/package/dockview-enterprise)
-[![CI](https://img.shields.io/github/actions/workflow/status/mathuo/dockview/main.yml?branch=master&label=CI)](https://github.com/mathuo/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
+[![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
 
 </div>
 

--- a/packages/dockview-enterprise/README.md
+++ b/packages/dockview-enterprise/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://img.shields.io/npm/v/dockview-enterprise)](https://www.npmjs.com/package/dockview-enterprise)
 [![npm downloads](https://img.shields.io/npm/dm/dockview-enterprise)](https://www.npmjs.com/package/dockview-enterprise)
 [![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
 
 </div>
 

--- a/packages/dockview-enterprise/package.json
+++ b/packages/dockview-enterprise/package.json
@@ -9,13 +9,13 @@
         "docking",
         "enterprise"
     ],
-    "homepage": "https://github.com/mathuo/dockview",
+    "homepage": "https://github.com/dockview/dockview",
     "bugs": {
-        "url": "https://github.com/mathuo/dockview/issues"
+        "url": "https://github.com/dockview/dockview/issues"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mathuo/dockview.git",
+        "url": "git+https://github.com/dockview/dockview.git",
         "directory": "packages/dockview-enterprise"
     },
     "license": "SEE LICENSE IN LICENCE.md",

--- a/packages/dockview-react/README.md
+++ b/packages/dockview-react/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
-  <img src="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
+  <img src="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
 </picture>
 
 <h1>dockview-react</h1>
@@ -11,16 +11,16 @@
 
 [![npm version](https://img.shields.io/npm/v/dockview-react)](https://www.npmjs.com/package/dockview-react)
 [![npm downloads](https://img.shields.io/npm/dm/dockview-react)](https://www.npmjs.com/package/dockview-react)
-[![CI](https://img.shields.io/github/actions/workflow/status/mathuo/dockview/main.yml?branch=master&label=CI)](https://github.com/mathuo/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
+[![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview-react?label=size)](https://bundlephobia.com/result?p=dockview-react)
 
 </div>
 
 ---
 
-![A Dockview layout showing docked, tabbed and split panels in a trading workbench](https://github.com/mathuo/dockview/blob/HEAD/static/img/demo-hero.webp?raw=true)
+![A Dockview layout showing docked, tabbed and split panels in a trading workbench](https://github.com/dockview/dockview/blob/HEAD/static/img/demo-hero.webp?raw=true)
 
 Please see the website: https://dockview.dev
 

--- a/packages/dockview-react/README.md
+++ b/packages/dockview-react/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://img.shields.io/npm/v/dockview-react)](https://www.npmjs.com/package/dockview-react)
 [![npm downloads](https://img.shields.io/npm/dm/dockview-react)](https://www.npmjs.com/package/dockview-react)
 [![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview-react?label=size)](https://bundlephobia.com/result?p=dockview-react)
 
 </div>

--- a/packages/dockview-react/package.json
+++ b/packages/dockview-react/package.json
@@ -33,13 +33,13 @@
         "react",
         "react-component"
     ],
-    "homepage": "https://github.com/mathuo/dockview",
+    "homepage": "https://github.com/dockview/dockview",
     "bugs": {
-        "url": "https://github.com/mathuo/dockview/issues"
+        "url": "https://github.com/dockview/dockview/issues"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mathuo/dockview.git",
+        "url": "git+https://github.com/dockview/dockview.git",
         "directory": "packages/dockview-react"
     },
     "license": "MIT",

--- a/packages/dockview-vue/README.md
+++ b/packages/dockview-vue/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
-  <img src="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
+  <img src="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
 </picture>
 
 <h1>dockview-vue</h1>
@@ -11,16 +11,16 @@
 
 [![npm version](https://img.shields.io/npm/v/dockview-vue)](https://www.npmjs.com/package/dockview-vue)
 [![npm downloads](https://img.shields.io/npm/dm/dockview-vue)](https://www.npmjs.com/package/dockview-vue)
-[![CI](https://img.shields.io/github/actions/workflow/status/mathuo/dockview/main.yml?branch=master&label=CI)](https://github.com/mathuo/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
+[![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview-vue?label=size)](https://bundlephobia.com/result?p=dockview-vue)
 
 </div>
 
 ---
 
-![A Dockview layout showing docked, tabbed and split panels in a trading workbench](https://github.com/mathuo/dockview/blob/HEAD/static/img/demo-hero.webp?raw=true)
+![A Dockview layout showing docked, tabbed and split panels in a trading workbench](https://github.com/dockview/dockview/blob/HEAD/static/img/demo-hero.webp?raw=true)
 
 Please see the website: https://dockview.dev
 

--- a/packages/dockview-vue/README.md
+++ b/packages/dockview-vue/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://img.shields.io/npm/v/dockview-vue)](https://www.npmjs.com/package/dockview-vue)
 [![npm downloads](https://img.shields.io/npm/dm/dockview-vue)](https://www.npmjs.com/package/dockview-vue)
 [![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview-vue?label=size)](https://bundlephobia.com/result?p=dockview-vue)
 
 </div>

--- a/packages/dockview-vue/package.json
+++ b/packages/dockview-vue/package.json
@@ -51,13 +51,13 @@
         "**/*.css",
         "**/*.scss"
     ],
-    "homepage": "https://github.com/mathuo/dockview",
+    "homepage": "https://github.com/dockview/dockview",
     "bugs": {
-        "url": "https://github.com/mathuo/dockview/issues"
+        "url": "https://github.com/dockview/dockview/issues"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mathuo/dockview.git",
+        "url": "git+https://github.com/dockview/dockview.git",
         "directory": "packages/dockview-vue"
     },
     "type": "module",

--- a/packages/dockview-vue/src/__tests__/dockview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/dockview.spec.ts
@@ -323,7 +323,7 @@ describe('DockviewVue Component', () => {
     });
 });
 
-// Regression coverage for https://github.com/mathuo/dockview/issues/1301
+// Regression coverage for https://github.com/dockview/dockview/issues/1301
 // `<script setup>` users (and anyone not using the Options API) need to be
 // able to supply panel components without registering globally in main.ts.
 describe('DockviewVue components prop (issue #1301)', () => {

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -204,7 +204,7 @@ describe('VueGridviewPanelView', () => {
     });
 });
 
-// Regression coverage for https://github.com/mathuo/dockview/issues/1301
+// Regression coverage for https://github.com/dockview/dockview/issues/1301
 describe('GridviewVue components prop resolves without registration', () => {
     let wrapper: ReturnType<typeof mount>;
 

--- a/packages/dockview-vue/src/__tests__/keepalive.spec.ts
+++ b/packages/dockview-vue/src/__tests__/keepalive.spec.ts
@@ -17,7 +17,7 @@ import PaneviewVue from '../paneview/paneview.vue';
 import { Orientation } from 'dockview';
 
 /**
- * Regression coverage for https://github.com/mathuo/dockview/issues/1369
+ * Regression coverage for https://github.com/dockview/dockview/issues/1369
  *
  * Panels are mounted via `<Teleport>` (rendered by `<DockviewPortals>`), which
  * keeps them as real descendants of the host component in the Vue component

--- a/packages/dockview-vue/src/__tests__/paneview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/paneview.spec.ts
@@ -182,7 +182,7 @@ describe('PaneviewVue events', () => {
     });
 });
 
-// Regression coverage for https://github.com/mathuo/dockview/issues/1301
+// Regression coverage for https://github.com/dockview/dockview/issues/1301
 describe('PaneviewVue components prop resolves without registration', () => {
     let wrapper: ReturnType<typeof mount>;
 

--- a/packages/dockview-vue/src/__tests__/splitview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/splitview.spec.ts
@@ -144,7 +144,7 @@ describe('VueSplitviewPanelView', () => {
     });
 });
 
-// Regression coverage for https://github.com/mathuo/dockview/issues/1301
+// Regression coverage for https://github.com/dockview/dockview/issues/1301
 describe('SplitviewVue components prop resolves without registration', () => {
     let wrapper: ReturnType<typeof mount>;
 

--- a/packages/dockview-vue/src/__tests__/utils.spec.ts
+++ b/packages/dockview-vue/src/__tests__/utils.spec.ts
@@ -656,7 +656,7 @@ describe('VueHeaderActionsRenderer', () => {
     });
 
     test('should preserve full params including api after reactive updates', () => {
-        // Regression test for https://github.com/mathuo/dockview/issues/1127
+        // Regression test for https://github.com/dockview/dockview/issues/1127
         // Partial updates (e.g. isGroupActive) must not discard api and other fields
         const renderer = new VueHeaderActionsRenderer(
             mockComponent,

--- a/packages/dockview/README.md
+++ b/packages/dockview/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
-  <img src="https://github.com/mathuo/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-dark.svg?raw=true">
+  <img src="https://github.com/dockview/dockview/blob/HEAD/static/img/dockview-lockup-light.svg?raw=true" alt="Dockview" width="480">
 </picture>
 
 <h1>dockview</h1>
@@ -11,16 +11,16 @@
 
 [![npm version](https://img.shields.io/npm/v/dockview)](https://www.npmjs.com/package/dockview)
 [![npm downloads](https://img.shields.io/npm/dm/dockview)](https://www.npmjs.com/package/dockview)
-[![CI](https://img.shields.io/github/actions/workflow/status/mathuo/dockview/main.yml?branch=master&label=CI)](https://github.com/mathuo/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/mathuo_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=mathuo_dockview)
+[![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview?label=size)](https://bundlephobia.com/result?p=dockview)
 
 </div>
 
 ---
 
-![A Dockview layout showing docked, tabbed and split panels in a trading workbench](https://github.com/mathuo/dockview/blob/HEAD/static/img/demo-hero.webp?raw=true)
+![A Dockview layout showing docked, tabbed and split panels in a trading workbench](https://github.com/dockview/dockview/blob/HEAD/static/img/demo-hero.webp?raw=true)
 
 Please see the website: https://dockview.dev
 

--- a/packages/dockview/README.md
+++ b/packages/dockview/README.md
@@ -12,8 +12,8 @@
 [![npm version](https://img.shields.io/npm/v/dockview)](https://www.npmjs.com/package/dockview)
 [![npm downloads](https://img.shields.io/npm/dm/dockview)](https://www.npmjs.com/package/dockview)
 [![CI](https://img.shields.io/github/actions/workflow/status/dockview/dockview/main.yml?branch=master&label=CI)](https://github.com/dockview/dockview/actions?query=workflow%3ACI)
-[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
-[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview-1?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview-1)
+[![Coverage](https://img.shields.io/sonar/coverage/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
+[![Quality gate](https://img.shields.io/sonar/quality_gate/dockview_dockview?server=https%3A%2F%2Fsonarcloud.io)](https://sonarcloud.io/summary/overall?id=dockview_dockview)
 [![Bundle size](https://img.shields.io/bundlephobia/minzip/dockview?label=size)](https://bundlephobia.com/result?p=dockview)
 
 </div>

--- a/packages/dockview/package.json
+++ b/packages/dockview/package.json
@@ -31,13 +31,13 @@
         "serialization",
         "workbench"
     ],
-    "homepage": "https://github.com/mathuo/dockview",
+    "homepage": "https://github.com/dockview/dockview",
     "bugs": {
-        "url": "https://github.com/mathuo/dockview/issues"
+        "url": "https://github.com/dockview/dockview/issues"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mathuo/dockview.git",
+        "url": "git+https://github.com/dockview/dockview.git",
         "directory": "packages/dockview"
     },
     "license": "MIT",

--- a/packages/docs/docs/core/security.mdx
+++ b/packages/docs/docs/core/security.mdx
@@ -85,7 +85,7 @@ Dockview is also compatible with [Trusted Types](https://developer.mozilla.org/e
 
 ## Project security
 
-- The codebase is statically analysed by [SonarCloud](https://sonarcloud.io/summary/overall?id=dockview_dockview-1) for security issues.
+- The codebase is statically analysed by [SonarCloud](https://sonarcloud.io/summary/overall?id=dockview_dockview) for security issues.
 - npm releases are published with [provenance statements](https://docs.npmjs.com/generating-provenance-statements/), so the source commit and workflow run behind a published package can be verified.
 - To report a vulnerability, use [private vulnerability reporting](https://github.com/dockview/dockview/security/advisories/new) rather than a public issue. The [security policy](https://github.com/dockview/dockview/blob/master/SECURITY.md) covers supported versions, what is in scope, and response times.
 

--- a/packages/docs/docs/core/security.mdx
+++ b/packages/docs/docs/core/security.mdx
@@ -85,11 +85,11 @@ Dockview is also compatible with [Trusted Types](https://developer.mozilla.org/e
 
 ## Project security
 
-- The codebase is statically analysed by [SonarCloud](https://sonarcloud.io/summary/overall?id=mathuo_dockview) for security issues.
+- The codebase is statically analysed by [SonarCloud](https://sonarcloud.io/summary/overall?id=dockview_dockview-1) for security issues.
 - npm releases are published with [provenance statements](https://docs.npmjs.com/generating-provenance-statements/), so the source commit and workflow run behind a published package can be verified.
-- To report a vulnerability, use [private vulnerability reporting](https://github.com/mathuo/dockview/security/advisories/new) rather than a public issue. The [security policy](https://github.com/mathuo/dockview/blob/master/SECURITY.md) covers supported versions, what is in scope, and response times.
+- To report a vulnerability, use [private vulnerability reporting](https://github.com/dockview/dockview/security/advisories/new) rather than a public issue. The [security policy](https://github.com/dockview/dockview/blob/master/SECURITY.md) covers supported versions, what is in scope, and response times.
 
 ## See also
 
 - [Popout windows](/docs/core/groups/popoutGroups): the main feature affected by CSP and same-origin rules
-- [Security policy](https://github.com/mathuo/dockview/blob/master/SECURITY.md): reporting, supported versions, and scope
+- [Security policy](https://github.com/dockview/dockview/blob/master/SECURITY.md): reporting, supported versions, and scope

--- a/packages/docs/docs/releases/whats-new/whats-new-v6.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v6.mdx
@@ -19,7 +19,7 @@ you need to be aware of when upgrading from v5.
 Panels inside a single Dockview group can now be sub-grouped by a coloured chip
 that sits in the tab bar. Tab groups support drag-and-drop reordering, collapse
 / expand, inline rename, and a 9-colour palette that can be customised or
-disabled entirely. ([#1154](https://github.com/mathuo/dockview/pull/1154))
+disabled entirely. ([#1154](https://github.com/dockview/dockview/pull/1154))
 
 ```ts
 api.createTabGroup({
@@ -42,8 +42,8 @@ Edge groups are persistent, single-purpose panels anchored to one edge of the
 Dockview shell, useful for activity bars, status panels, or output panes that
 shouldn't participate in normal layout drag-and-drop. They support collapse /
 expand with size memory and survive `toJSON` / `fromJSON`.
-([#1122](https://github.com/mathuo/dockview/pull/1122),
-[#1155](https://github.com/mathuo/dockview/pull/1155))
+([#1122](https://github.com/dockview/dockview/pull/1122),
+[#1155](https://github.com/dockview/dockview/pull/1155))
 
 ```ts
 const leftApi = api.addEdgeGroup('left', {
@@ -69,7 +69,7 @@ Right-click on a tab now invokes an opt-in context menu driven by the new
 `getTabContextMenuItems` option. Built-in shortcuts (`'close'`,
 `'closeOthers'`, `'closeAll'`, `'separator'`) are mixable with framework
 component renderers via `ContextMenuItemConfig`.
-([#1147](https://github.com/mathuo/dockview/pull/1147))
+([#1147](https://github.com/dockview/dockview/pull/1147))
 
 ```ts
 const options: DockviewOptions = {
@@ -93,7 +93,7 @@ chips, with `'colorPicker'` and `'rename'` shortcuts on top of the standard
 panels are attached to / detached from the DOM under
 `renderer: 'onlyWhenVisible'`. This matters for renderers
 that need to detach from a host framework's lifecycle (notably Angular
-`TemplateRef` views). ([#1158](https://github.com/mathuo/dockview/pull/1158))
+`TemplateRef` views). ([#1158](https://github.com/dockview/dockview/pull/1158))
 
 ### Tab group events on `DockviewApi`
 
@@ -107,7 +107,7 @@ Six new events make tab groups observable from anywhere in the layout:
 - `onDidTabGroupCollapsedChange`
 
 Edge group changes also flow through `onDidLayoutChange`, `onDidAddGroup`,
-and `onDidRemoveGroup`. ([#1212](https://github.com/mathuo/dockview/pull/1212))
+and `onDidRemoveGroup`. ([#1212](https://github.com/dockview/dockview/pull/1212))
 
 ## New theme system
 
@@ -126,7 +126,7 @@ control without touching SCSS:
 The pre-existing spaced themes (`abyssSpaced`, `lightSpaced`) have been
 migrated to the CSS-variable system, which is also what powers the new
 [interactive theme builder](/demo).
-([#1145](https://github.com/mathuo/dockview/pull/1145))
+([#1145](https://github.com/dockview/dockview/pull/1145))
 
 ### New built-in themes
 
@@ -145,7 +145,7 @@ Seven new themes ship in v6:
 
 `tabAnimation` is no longer a top-level `DockviewOptions` property; it now
 lives on the `DockviewTheme` object alongside `gap`, `dndPanelOverlay`, etc.
-([#1181](https://github.com/mathuo/dockview/pull/1181))
+([#1181](https://github.com/dockview/dockview/pull/1181))
 
 ```ts
 // v5
@@ -170,7 +170,7 @@ In v5.0–5.2 the cjs/esm bundles of `dockview-core`, `dockview`, and
 `inject: true`, so importing the JS entry would append `dockview.css` to
 `<head>` at module-load time. v6 removes that side-effect: you must import
 the stylesheet yourself, as documented in
-[Installation](/docs/overview/installation). ([#1206](https://github.com/mathuo/dockview/pull/1206))
+[Installation](/docs/overview/installation). ([#1206](https://github.com/dockview/dockview/pull/1206))
 
 ```ts
 import 'dockview/dist/styles/dockview.css';

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -41,7 +41,7 @@ const config = {
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.
-    organizationName: 'mathuo', // Usually your GitHub org/user name.
+    organizationName: 'dockview', // Usually your GitHub org/user name.
     projectName: 'dockview', // Usually your repo name.
 
     // Even if you don't use internalization, you can use this field to set useful
@@ -232,7 +232,7 @@ const config = {
                 description:
                     'A zero dependency docking layout manager for building IDE-like interfaces with tabs, groups, grids, splitviews, drag and drop, floating panels, and popout windows. Touch and mobile ready. Supports React, Vue, Angular, and vanilla TypeScript.',
                 url: 'https://dockview.dev',
-                codeRepository: 'https://github.com/mathuo/dockview',
+                codeRepository: 'https://github.com/dockview/dockview',
                 programmingLanguage: ['TypeScript', 'JavaScript'],
                 runtimePlatform: ['Browser'],
                 license: 'https://opensource.org/licenses/MIT',
@@ -361,7 +361,7 @@ const config = {
                         position: 'right',
                     },
                     {
-                        href: 'https://github.com/mathuo/dockview',
+                        href: 'https://github.com/dockview/dockview',
                         position: 'right',
                         className: 'header-github-link',
                         'aria-label': 'GitHub repository',
@@ -423,7 +423,7 @@ const config = {
                         items: [
                             {
                                 label: 'GitHub',
-                                href: 'https://github.com/mathuo/dockview',
+                                href: 'https://github.com/dockview/dockview',
                             },
                             {
                                 label: 'LinkedIn',
@@ -461,7 +461,7 @@ const config = {
             },
             announcementBar: {
                 id: 'announcementBar', // Increment on change
-                content: `⭐️ If you like Dockview, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/mathuo/dockview">GitHub</a>`,
+                content: `⭐️ If you like Dockview, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/dockview/dockview">GitHub</a>`,
             },
             tableOfContents: {
                 maxHeadingLevel: 5,

--- a/packages/docs/scripts/buildTemplates.mjs
+++ b/packages/docs/scripts/buildTemplates.mjs
@@ -243,9 +243,9 @@ const COMPONENT_SELECTORS = {
 const list = [];
 
 const githubUrl =
-    'https://github.com/mathuo/dockview/tree/master/packages/docs/templates';
+    'https://github.com/dockview/dockview/tree/master/packages/docs/templates';
 const codeSandboxUrl =
-    'https://codesandbox.io/p/sandbox/github/mathuo/dockview/tree/gh-pages/templates';
+    'https://codesandbox.io/p/sandbox/github/dockview/dockview/tree/gh-pages/templates';
 
 async function buildTemplates() {
     for (const component of COMPONENTS) {

--- a/packages/docs/src/components/ui/codeRunner.tsx
+++ b/packages/docs/src/components/ui/codeRunner.tsx
@@ -4,7 +4,7 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 import { useColorMode } from '@docusaurus/theme-common';
 
 const BASE_SANDBOX_URL =
-    'https://codesandbox.io/s/github/mathuo/dockview/tree/gh-pages';
+    'https://codesandbox.io/s/github/dockview/dockview/tree/gh-pages';
 
 export const _CodeRunner = (props: { id: string; height?: number }) => {
     const [framework] = useActiveFramework();

--- a/packages/docs/src/components/ui/codeSandboxButton.tsx
+++ b/packages/docs/src/components/ui/codeSandboxButton.tsx
@@ -3,7 +3,7 @@ import './codeSandboxButton.scss';
 import { ThemePicker } from './container';
 
 const BASE_SANDBOX_URL =
-    'https://codesandbox.io/s/github/mathuo/dockview/tree/master/packages/docs/sandboxes';
+    'https://codesandbox.io/s/github/dockview/dockview/tree/master/packages/docs/sandboxes';
 
 const createSvgElementFromPath = (params: {
     height: string;

--- a/packages/docs/src/pages/demo.tsx
+++ b/packages/docs/src/pages/demo.tsx
@@ -9,7 +9,7 @@ import { DockviewTheme, themeAbyss, themeLight } from 'dockview-react';
 import styles from './demo.module.css';
 
 const CODESANDBOX_URL =
-    'https://codesandbox.io/s/github/mathuo/dockview/tree/master/packages/docs/sandboxes/react/dockview/demo-dockview';
+    'https://codesandbox.io/s/github/dockview/dockview/tree/master/packages/docs/sandboxes/react/dockview/demo-dockview';
 
 const updateTheme = (theme: DockviewTheme) => {
     const urlParams = new URLSearchParams(window.location.search);

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -26,7 +26,7 @@ const STATS: { value: string; label: string; href?: string }[] = [
     {
         value: '3.3k+',
         label: 'GitHub stars',
-        href: 'https://github.com/mathuo/dockview',
+        href: 'https://github.com/dockview/dockview',
     },
     {
         value: '540k+',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=dockview_dockview
-sonar.organization=dockview
+sonar.organization=dockview-1
 
 sonar.inclusions=packages/dockview/src/**/*,packages/dockview-core/src/**/*,packages/dockview-vue/src/**/*,packages/dockview-react/src/**/*,packages/dockview-angular/src/**/*,packages/dockview-enterprise/src/**/*
 sonar.exclusions=packages/dockview/docs/**/*,packages/dockview/src/__tests__/**/*,packages/dockview-core/src/__tests__/**/*,packages/dockview-vue/src/__tests__/**/*,packages/dockview-react/src/__tests__/**/*,packages/dockview-angular/src/__tests__/**/*,packages/dockview-enterprise/src/__tests__/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=mathuo_dockview
+sonar.projectKey=dockview_dockview-1
 sonar.organization=dockview
 
 sonar.inclusions=packages/dockview/src/**/*,packages/dockview-core/src/**/*,packages/dockview-vue/src/**/*,packages/dockview-react/src/**/*,packages/dockview-angular/src/**/*,packages/dockview-enterprise/src/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.projectKey=dockview_dockview-1
+sonar.projectKey=dockview_dockview
 sonar.organization=dockview
 
 sonar.inclusions=packages/dockview/src/**/*,packages/dockview-core/src/**/*,packages/dockview-vue/src/**/*,packages/dockview-react/src/**/*,packages/dockview-angular/src/**/*,packages/dockview-enterprise/src/**/*


### PR DESCRIPTION
## Description

The repository moved from `mathuo/dockview` to the `dockview` organization. This updates the stale owner references left behind by the transfer so links, badges, and tooling point at the new location.

- Repo URLs across the monorepo: `github.com/mathuo/dockview` → `github.com/dockview/dockview` (package `homepage`/`bugs`/`repository`, README + per-package CI badges, docs, CodeSandbox links, issue/PR references, `SECURITY.md`, `llms.txt`/`llms-full.txt`).
- SonarCloud project key → `dockview_dockview-1` in `sonar-project.properties`, the coverage/quality badges, docs, and `AGENTS.md` (Sonar keys are immutable and don't auto-migrate). `sonar.organization` was already `dockview`.
- Docusaurus `organizationName` → `dockview` (affects the gh-pages deploy target).

Personal-identity references are intentionally left unchanged: package `author` fields, `Copyright (c) 2021 mathuo`, `@mathuo` in `CODEOWNERS`, the docs blog author, and the personal contact email — these name the maintainer, not the repo.

> Note: this covers the in-repo references only. The release/publish pipeline also depends on config that lives outside the repo and does **not** transfer with an org move — the Release App needing `Contents: write` on the new org, and the npm trusted-publisher configs for all six packages needing to be repointed to `dockview/dockview`. Those must be updated in the GitHub/npm settings separately.

## Type of change

- [x] Documentation
- [x] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [x] `dockview` (vanilla JS)
- [x] `dockview-react`
- [x] `dockview-vue`
- [x] `dockview-angular`
- [x] `docs`

## How to test

Reference-only change (URLs, badge slugs, config strings) — no runtime behavior is affected. Verify no unintended references remain:

```
git grep -n "mathuo/dockview"   # expect: no matches
git grep -n "mathuo_dockview"    # expect: no matches
```

Remaining `mathuo` hits (`author`, `LICENCE` copyright, `CODEOWNERS`, blog author, contact email) are the intentional identity references above.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013rm6TSwfmmsTnzfYgDYwEb)_