### PR TITLE
Remove github.mathuo@gmail.com from security contact info

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Please **do not** open a public GitHub issue for security reports.
 
 Preferred: use [GitHub's private vulnerability reporting](https://github.com/dockview/dockview/security/advisories/new) on this repository.
 
-Alternative: email **contact@dockview.dev** or **github.mathuo@gmail.com**.
+Alternative: email **contact@dockview.dev**.
 
 When reporting, please include:
 


### PR DESCRIPTION
## Description

Removes the personal email address `github.mathuo@gmail.com` from the security reporting contact information in `SECURITY.md`. The `contact@dockview.dev` email remains as the alternative contact alongside GitHub's private vulnerability reporting.

## Type of change

- [x] Documentation

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

_None — this change only touches the root `SECURITY.md` policy file._

## How to test

Review `SECURITY.md` and confirm the "Reporting a Vulnerability" section no longer references `github.mathuo@gmail.com` and still lists `contact@dockview.dev` as the alternative contact.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented

_Documentation-only change; no code, tests, or generated files affected._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaKBCTEor6FFBEd9EAoHZp)_