### PR TITLE
fix: make titlebar action buttons keyboard focusable (Closes #1012)

### DIFF
--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.scss
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.scss
@@ -146,11 +146,22 @@
             box-sizing: border-box;
             font-size: 18px;
             cursor: pointer;
+            border: none;
+            background: none;
+            color: inherit;
+            font-family: inherit;
+            line-height: 1;
 
             &:hover {
                 border-radius: 2px;
                 color: var(--dv-activegroup-visiblepanel-tab-color);
                 background-color: var(--dv-icon-hover-background-color);
+            }
+
+            &:focus-visible {
+                outline: 2px solid var(--dv-activegroup-visiblepanel-tab-color);
+                outline-offset: -2px;
+                border-radius: 2px;
             }
         }
     }

--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/controls.tsx
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/controls.tsx
@@ -7,15 +7,29 @@ const Icon = (props: {
     title?: string;
     onClick?: (event: React.MouseEvent) => void;
 }) => {
+    const onKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            props.onClick?.(e as unknown as React.MouseEvent);
+        }
+    };
+
     return (
-        <div title={props.title} className="action" onClick={props.onClick}>
+        <button
+            title={props.title}
+            className="action"
+            onClick={props.onClick}
+            onKeyDown={onKeyDown}
+            type="button"
+            aria-label={props.title}
+        >
             <span
                 style={{ fontSize: 'inherit' }}
                 className="material-symbols-outlined"
             >
                 {props.icon}
             </span>
-        </div>
+        </button>
     );
 };
 


### PR DESCRIPTION
## Description

The titlebar action buttons (star icon, maximize, popout, close, etc.) in the demo app were rendered as `<div>` elements with `onClick` handlers but no keyboard accessibility support, making them unreachable and unusable via keyboard navigation.

## Changes

1. **controls.tsx**: Changed the `Icon` component from `<div>` to `<button>` with proper `type="button"`, `aria-label`, and `onKeyDown` handler for Enter/Space key activation.

2. **app.scss**: Added button reset styles (`border: none; background: none; color: inherit; font-family: inherit; line-height: 1`) and a `:focus-visible` outline style so keyboard users can see which button is focused.

## Testing

- Tab into a panel group, press Tab again to reach the right-aligned buttons
- Tab through the star, maximize, popout, and close buttons
- Press Enter or Space to activate each button
- Focus-visible outline appears on the focused button

Closes #1012