### PR TITLE
fix: replace separator ::before overlay with border to prevent content obscuring

### DIFF
--- a/packages/dockview-core/src/paneview/paneview.scss
+++ b/packages/dockview-core/src/paneview/paneview.scss
@@ -23,6 +23,8 @@
         }
 
         &:not(:first-child) {
+            border-left: none;
+            border-top: none;
             .dv-pane > .dv-pane-header {
                 border-top: 1px solid var(--dv-paneview-header-border-color);
             }

--- a/packages/dockview-core/src/splitview/splitview.scss
+++ b/packages/dockview-core/src/splitview/splitview.scss
@@ -62,15 +62,6 @@
                 cursor: e-resize;
             }
         }
-
-        & > .dv-view-container > .dv-view {
-            &:not(:first-child) {
-                &::before {
-                    height: 100%;
-                    width: 1px;
-                }
-            }
-        }
     }
 
     &.dv-vertical {
@@ -91,17 +82,6 @@
             }
             &.dv-minimum {
                 cursor: s-resize;
-            }
-        }
-
-        & > .dv-view-container > .dv-view {
-            width: 100%;
-
-            &:not(:first-child) {
-                &::before {
-                    height: 1px;
-                    width: 100%;
-                }
             }
         }
     }
@@ -176,14 +156,15 @@
     }
 
     &.dv-separator-border {
-        .dv-view:not(:first-child)::before {
-            content: ' ';
-            position: absolute;
-            top: 0;
-            left: 0;
-            z-index: 5;
-            pointer-events: none;
-            background-color: var(--dv-separator-border);
+        &.dv-horizontal {
+            .dv-view:not(:first-child) {
+                border-left: 1px solid var(--dv-separator-border);
+            }
+        }
+        &.dv-vertical {
+            .dv-view:not(:first-child) {
+                border-top: 1px solid var(--dv-separator-border);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #956

The separator was rendered as a `::before` pseudo-element overlay on top of panel content at `z-index: 5`, obscuring the content edge and making it impossible to create pixel-perfect layouts.

### Change

Replaced the pseudo-element overlay with a `border-left` (horizontal layout) / `border-top` (vertical layout) on the view container. Since `.dv-view` already uses `box-sizing: border-box`, the border automatically insets the content area by 1px, so panel content is no longer obscured by the separator line.

### Before vs After

- **Before**: separator `::before` rendered on top of content → content fills full container but left/top edge is hidden under the separator
- **After**: `border-left`/ `border-top` on the view → content area is inset by 1px via `box-sizing: border-box`, nothing is obscured

### Testing
- SCSS compiles successfully
- Paneview also updated to reset the border (previously it overrode the `::before` separator to transparent)