### PR TITLE
fix: fire onDidRemoveGroup when last panel is floated out of a group (Fixes #1025)

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -2039,6 +2039,11 @@ export class DockviewComponent
                                 referenceGroup.model.removePanel(itemToPopout);
                             group.model.openPanel(panel);
                         });
+                        // When the last panel is popped out of a group, remove
+                        // the now-empty group so onDidRemoveGroup fires.
+                        if (referenceGroup.model.size === 0) {
+                            this.removeGroup(referenceGroup);
+                        }
                     } else {
                         this.movingLock(() =>
                             moveGroupWithoutDestroying({


### PR DESCRIPTION
## Summary

When the last panel of a group is floated out (popped out via `popoutWindow`), the panel is removed from its original group and the group becomes empty. This empty group was left lingering in the grid, and `dockviewApi.onDidRemoveGroup` was never fired for the destroyed group.

## Root cause

In `popoutWindow`, when `itemToPopout instanceof DockviewPanel`, the code removes the panel from `referenceGroup.model` and opens it in the new floating group — but never cleans up the now-empty `referenceGroup`. This is inconsistent with the group-floating path (which calls `removeGroup`), and it means group-removal events aren't emitted when the last panel leaves.

## Fix

After moving the panel, check whether `referenceGroup` is now empty (`referenceGroup.model.size === 0`) and remove it via `removeGroup`, which fires `onDidRemoveGroup` and cleans up the group record.

Fixes #1025