### PR TITLE
fix: call layout() after swapping render container to ensure panel content is properly sized (Closes #989)

### DIFF
--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -1263,11 +1263,16 @@ export class DockviewGroupPanelModel
         // onlyWhenVisible renderer that loop leaves the active panel's content
         // detached. Re-show it so swapping the render container on an
         // already-populated group (e.g. restoring a popout group from JSON)
-        // keeps the active content mounted.
+        // keeps the active content mounted.  Also call layout() so the panel
+        // content is properly sized after the container switch — without it
+        // the panel's content element can end up with stale dimensions when
+        // moved back from a popout window (fixes #989).
         if (this._activePanel) {
             this.contentContainer.renderPanel(this._activePanel, {
                 asActive: true,
             });
+            const { width, height } = this.contentDimensions();
+            this._activePanel.layout(width, height);
         }
     }
 


### PR DESCRIPTION
## Summary

When a panel is popped out into a separate window and then moved back into the main grid (pop-in), the panel's content area appears blank until the user switches tabs or triggers another view change.

## Root Cause

When the render container is swapped on a group (e.g. restoring a popout group to the main grid), the `set renderContainer` setter calls `renderPanel()` to re-attach the panel content. However, unlike `doSetActivePanel()` which also calls `panel.layout()`, the `set renderContainer` path left the panel's content element with stale dimensions, causing the blank display.

## Fix

Added a `layout()` call after `renderPanel()` in the `set renderContainer` setter, matching the pattern used in `doSetActivePanel()`. This ensures the panel's content element is properly sized after the container switch.

## Tests

- Existing test 'swapping renderContainer keeps the active panel content mounted' still passes
- The fix is minimal and follows the same pattern already used in doSetActivePanel()

Fixes #989