### PR TITLE
ci(release): make the release job resumable after a partial failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,20 @@ jobs:
                   echo "tag=v${v}" >> "$GITHUB_OUTPUT"
 
             - name: Show pending changes
+              id: changes
               run: |
                   git --no-pager diff --stat
                   echo "---"
                   git --no-pager diff --name-status
+                  if git diff --quiet HEAD; then
+                      echo "any=false" >> "$GITHUB_OUTPUT"
+                      echo "No pending changes: version files are already at the target version, so the release commit is skipped and the tag is placed on the current master HEAD."
+                  else
+                      echo "any=true" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Create signed release commit on master
-              if: ${{ !inputs.dry-run }}
+              if: ${{ !inputs.dry-run && steps.changes.outputs.any == 'true' }}
               id: commit
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -138,9 +145,14 @@ jobs:
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   TAG: ${{ steps.ver.outputs.tag }}
-                  COMMIT_SHA: ${{ steps.commit.outputs.sha }}
+                  COMMIT_SHA: ${{ steps.commit.outputs.sha || steps.head.outputs.sha }}
               run: |
                   set -euo pipefail
+
+                  if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+                      echo "Tag ${TAG} already exists; refusing to move it." >&2
+                      exit 1
+                  fi
 
                   tag_resp=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/git/tags" \
                       -f tag="${TAG}" \


### PR DESCRIPTION
## Why

Run [31214917528](https://github.com/dockview/dockview/actions/runs/31214917528) landed the version-bump commit on master (`ff927412`) but failed to create `v8.0.0`, because a tag ruleset had lost its bypass entry. That left the release half-applied, and the workflow could not be re-run to finish the job:

- `nx release version 8.0.0` is a no-op once the files are already bumped, so `git diff` is empty and the commit step would send an empty `fileChanges` set to `createCommitOnBranch`.
- With the commit step contributing no output, the tag step's `COMMIT_SHA` resolves to an empty string.

## What changed

- **Skip the commit when there is nothing to commit.** `Show pending changes` now sets a `changes.any` output, and the commit step is gated on it. A re-run at an already-committed version goes straight to tagging.
- **Fall back to the baseline HEAD for the tag target.** `COMMIT_SHA` is `steps.commit.outputs.sha || steps.head.outputs.sha`, which is the correct sha precisely when the commit step is skipped.
- **Guard against an existing tag.** Check the ref up front and fail with a readable message instead of a bare `422 Reference update failed`.

## Verification

`git diff --quiet HEAD` inside the `if` does not trip the step's `bash -e`; confirmed both branches in a scratch repo:

| tree | output | exit |
|---|---|---|
| clean | `any=false` | 0 |
| dirty | `any=true` | 0 |

The tag guard was checked against the live repo — `v7.0.4` resolves (would abort), `v8.0.0` 404s (passes).

Unblocks finishing v8.0.0 by dispatching Release with the explicit version `8.0.0`, which tags the existing `ff927412` without adding a second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)