### PR TITLE
docs(v8): fix docs/code mismatches found in pre-release review

### DIFF
--- a/packages/dockview-core/src/dockview/options.ts
+++ b/packages/dockview-core/src/dockview/options.ts
@@ -660,7 +660,6 @@ export interface PinnedTabsOptions {
     /**
      * `'inline'` (default) keeps pinned tabs first within the existing strip;
      * `'separate-row'` renders them on their own VS-Code-style row.
-     * (Phase 1 implements `'inline'` only.)
      */
     mode?: 'inline' | 'separate-row';
     /**

--- a/packages/docs/docs/core/dnd/smartGuides.mdx
+++ b/packages/docs/docs/core/dnd/smartGuides.mdx
@@ -9,7 +9,7 @@ sidebar_custom_props:
 
 import { DocRef } from '@site/src/components/ui/reference/docRef';
 
-**Smart Guides** bring Figma / Keynote-style alignment guides and magnetic snapping to Dockview's **floating groups**. While you drag a floating group, Dockview draws crisp alignment lines and gently snaps the dragged group when one of its edges or centers lines up with another floating group, the container, or (optionally) the grid splitters behind it.
+**Smart Guides** bring Figma / Keynote-style alignment guides and magnetic snapping to Dockview's **floating groups**. While you drag a floating group, Dockview draws crisp alignment lines and gently snaps the dragged group when one of its edges or centres lines up with another floating group, the container, or (optionally) the grid splitters behind it.
 
 :::info
 Smart Guides apply to **floating groups only**. Docked groups in the grid are unaffected, and no guides are shown when dragging them.
@@ -53,7 +53,7 @@ const api = createDockview(element, {
 
 ### How snapping works
 
-- **Alignment.** As a floating group is dragged, its leading edge, center, and trailing edge on each axis are compared against the alignment lines contributed by the other floating groups and the container. When a probe lands within `snapDistance` of a line, the group snaps so the two align exactly, and a guide line is drawn.
+- **Alignment.** As a floating group is dragged, its leading edge, centre, and trailing edge on each axis are compared against the alignment lines contributed by the other floating groups and the container. When a probe lands within `snapDistance` of a line, the group snaps so the two align exactly, and a guide line is drawn.
 - **Independent X and Y.** The horizontal and vertical axes are resolved independently; a group can snap horizontally to one neighbour and vertically to another at the same time, drawing a guide for each alignment.
 - **Hysteresis.** To avoid the group "sticking then jumping" at the snap boundary, a snap engages at `snapDistance` but only releases once the pointer moves past `snapDistance + releaseDistance`. This asymmetric threshold keeps snapping stable and stops oscillation.
 - **Guides.** Set `showGuides: false` to keep the magnetic snapping behaviour but hide the alignment lines.
@@ -64,8 +64,8 @@ Choose which sources a dragged floating group aligns against with `snapTargets`:
 
 <DocRef declaration="SmartGuidesSnapTargets" />
 
-- `floats` (default `true`): align to the other floating groups' edges and centers.
-- `container` (default `true`): align to the container's edges and center. Set `containerInset` to also emit guide lines a fixed number of pixels inside the container edges (e.g. a content margin).
+- `floats` (default `true`): align to the other floating groups' edges and centres.
+- `container` (default `true`): align to the container's edges and centre. Set `containerInset` to also emit guide lines a fixed number of pixels inside the container edges (e.g. a content margin).
 - `splitters` (default `false`): align to the underlying grid's splitter (sash) positions, so a floating group can line up with the docked layout behind it.
 
 ```ts

--- a/packages/docs/docs/core/groups/autoHideEdgeGroups.mdx
+++ b/packages/docs/docs/core/groups/autoHideEdgeGroups.mdx
@@ -15,7 +15,7 @@ Auto-hide turns a collapsed edge group into a **Visual Studio-style pinnable too
 
 For the basics of creating, sizing, collapsing, and serializing edge groups, see [Edge Groups](/docs/core/groups/edgeGroups).
 
-The `autoHideEdgeGroups` option sets the per-edge default, but auto-hide is also resolved **per group**: pass `autoHide` to `addEdgeGroup`, or call `api.setAutoHide` at runtime, to opt a single edge group in or out. This lets a static always-docked edge group and an auto-hiding one co-exist in the same layout.
+The `autoHideEdgeGroups` option sets the per-edge default, but auto-hide is also resolved **per group**: pass `autoHide` to `addEdgeGroup`, or call `api.getEdgeGroup(position)?.setAutoHide(...)` at runtime, to opt a single edge group in or out. This lets a static always-docked edge group and an auto-hiding one co-exist in the same layout.
 
 Enable it with the `autoHideEdgeGroups` option: pass `true` for all four edges, or an object to enable specific edges:
 
@@ -117,7 +117,7 @@ api.pinEdgeGroup('left');
 api.autoHideEdgeGroup('left');
 ```
 
-`peekEdgeGroup` and `pinEdgeGroup` require the enterprise auto-hide edge groups feature and are no-ops without it; `autoHideEdgeGroup` collapses the group in all cases.
+`peekEdgeGroup`, `pinEdgeGroup` and `autoHideEdgeGroup` all require the enterprise auto-hide edge groups feature; without it they log a missing-module note and do nothing. To collapse an edge group without the feature, use the group API's `collapse()` (see [Edge Groups](/docs/core/groups/edgeGroups)).
 
 ## Observing the peek state
 

--- a/packages/docs/docs/core/panels/contextMenus.mdx
+++ b/packages/docs/docs/core/panels/contextMenus.mdx
@@ -311,3 +311,11 @@ getTabContextMenuItems: (params) =>
 
 Omitting the builder entirely disables the menu everywhere and lets the native
 browser context menu through.
+
+:::info Pinning adds an item even without a builder
+When `pinnedTabs` is enabled (and `pinnedTabs.contextMenuItem` is left at its
+default), a built-in `'pin'` item is prepended to the tab menu automatically, so
+the menu still opens even when the builder returns an empty array or is omitted.
+Set `pinnedTabs.contextMenuItem: false` to drop it and restore full suppression.
+This applies to the tab menu only; the chip menu is unaffected.
+:::

--- a/packages/docs/docs/core/panels/pinnedTabs.mdx
+++ b/packages/docs/docs/core/panels/pinnedTabs.mdx
@@ -129,7 +129,7 @@ api.onDidPanelPinnedChange((event) => {
 
 ## Context menu
 
-When `contextMenuItem` is left enabled (the default) a "Pin"/"Unpin" item is added to the tab context menu, toggling based on the tab's current state. If you build your own tab context menu, you can include the built-in `'pin'` item:
+When `contextMenuItem` is left enabled (the default) a "Pin"/"Unpin" item is added to the tab context menu automatically, toggling based on the tab's current state. If you want to place it yourself, set `pinnedTabs.contextMenuItem: false` to stop the automatic injection (otherwise the item appears twice), then include the built-in `'pin'` item in your own builder:
 
 ```tsx
 getTabContextMenuItems={({ panel }) => [

--- a/packages/docs/docs/core/panels/tabGroups.mdx
+++ b/packages/docs/docs/core/panels/tabGroups.mdx
@@ -98,9 +98,9 @@ tabGroup.indexOfPanel('panel-1');
 
 ## Colour palette
 
-`tabGroup.color` is any CSS color string: either an id from the active palette
+`tabGroup.color` is any CSS colour string: either an id from the active palette
 or a raw CSS literal (`'#abc123'`, `'rgb(...)'`). Resolution to a concrete value
-is handled by Dockview's color palette.
+is handled by Dockview's colour palette.
 
 The default palette ships with 9 named entries:
 
@@ -123,7 +123,7 @@ purely via CSS overrides. The full set is exported as `DEFAULT_TAB_GROUP_COLORS`
 
 Replace the default palette with `tabGroupColors`. The list fully replaces the
 defaults; there is no merge. Each entry needs an `id` (stored on `tabGroup.color`
-and serialized) and a `value` (any CSS color expression). An optional `label`
+and serialized) and a `value` (any CSS colour expression). An optional `label`
 appears as a tooltip in the context-menu picker.
 
 ```ts
@@ -169,9 +169,9 @@ chip renderers that want to read from it (e.g. to render their own picker).
 
 ### Disabling colour
 
-Set `tabGroupAccent: 'off'` to opt out of the built-in color concept entirely.
+Set `tabGroupAccent: 'off'` to opt out of the built-in colour concept entirely.
 Dockview stops writing the `--dv-tab-group-color` custom property, hides
-the color picker, and applies `dv-tab-group-chip--accent-off` to chips. The
+the colour picker, and applies `dv-tab-group-chip--accent-off` to chips. The
 `tabGroup.color` field is still preserved as data, so pair this with a
 `createTabGroupChipComponent` to own the chip visual end-to-end.
 
@@ -303,7 +303,7 @@ Pass string shortcuts to render standard menu entries without any extra code:
 | Value           | Behaviour                                                             |
 | --------------- | -------------------------------------------------------------------- |
 | `'rename'`      | An inline text input to rename the tab group                         |
-| `'colorPicker'` | A grid of color swatches to change the tab group color               |
+| `'colorPicker'` | A grid of colour swatches to change the tab group colour             |
 | `'collapse'`    | Collapse the tab group. Renders as `Expand` when already collapsed   |
 | `'close'`       | Close every panel belonging to the tab group                         |
 | `'separator'`   | Render a visual divider                                              |
@@ -330,7 +330,7 @@ getTabGroupChipContextMenuItems: (params) => [
 
 ## Custom chip renderer
 
-To fully customize how tab group chips look, provide a `createTabGroupChipComponent` factory. It receives the `ITabGroup` and must return an `ITabGroupChipRenderer`.
+To fully customise how tab group chips look, provide a `createTabGroupChipComponent` factory. It receives the `ITabGroup` and must return an `ITabGroupChipRenderer`.
 
 <FrameworkSpecific framework="React">
     <DocRef
@@ -406,15 +406,15 @@ Tab group appearance can be customised through CSS custom properties:
 
 | Property | Default | Description |
 | --- | --- | --- |
-| `--dv-tab-group-color-grey` | `#5f6368` | Color for grey chips |
-| `--dv-tab-group-color-blue` | `#1a73e8` | Color for blue chips |
-| `--dv-tab-group-color-red` | `#d93025` | Color for red chips |
-| `--dv-tab-group-color-yellow` | `#f9ab00` | Color for yellow chips |
-| `--dv-tab-group-color-green` | `#188038` | Color for green chips |
-| `--dv-tab-group-color-pink` | `#d01884` | Color for pink chips |
-| `--dv-tab-group-color-purple` | `#a142f4` | Color for purple chips |
-| `--dv-tab-group-color-cyan` | `#007b83` | Color for cyan chips |
-| `--dv-tab-group-color-orange` | `#e8710a` | Color for orange chips |
+| `--dv-tab-group-color-grey` | `#5f6368` | Colour for grey chips |
+| `--dv-tab-group-color-blue` | `#1a73e8` | Colour for blue chips |
+| `--dv-tab-group-color-red` | `#d93025` | Colour for red chips |
+| `--dv-tab-group-color-yellow` | `#f9ab00` | Colour for yellow chips |
+| `--dv-tab-group-color-green` | `#188038` | Colour for green chips |
+| `--dv-tab-group-color-pink` | `#d01884` | Colour for pink chips |
+| `--dv-tab-group-color-purple` | `#a142f4` | Colour for purple chips |
+| `--dv-tab-group-color-cyan` | `#007b83` | Colour for cyan chips |
+| `--dv-tab-group-color-orange` | `#e8710a` | Colour for orange chips |
 | `--dv-tab-group-chip-padding` | `4px 8px` | Chip padding |
 | `--dv-tab-group-chip-border-radius` | `6px` | Chip border radius |
 | `--dv-tab-group-chip-font-size` | `11px` | Chip font size |

--- a/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
+++ b/packages/docs/docs/releases/migrating/migrating-to-v8.mdx
@@ -94,7 +94,7 @@ free-versus-enterprise list.
 | `pinnedTabs`           | [Pinned tabs](/docs/core/panels/pinnedTabs)                            |
 | `overflow`             | [Multi-row / wrapping tabs & overflow](/docs/core/panels/multiRowTabs) |
 | `dndCompass`             | [DnD compass](/docs/core/dnd/dndCompass)                         |
-| `dropPositionResolver` | [Custom drop-position resolution](/docs/core/dnd/dndCompass)            |
+| `dropPositionResolver` | [Custom drop-position resolution](/docs/core/dnd/dropPosition) (free)   |
 | `smartGuides`          | [Smart guides, floating-group snapping](/docs/core/dnd/smartGuides)   |
 | `layoutHistory`        | [Layout history (undo/redo)](/docs/core/state/history)                 |
 | `autoHideEdgeGroups`   | [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups)          |

--- a/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
@@ -28,8 +28,8 @@ unchanged.
 The new [`pinnedTabs`](/docs/core/panels/pinnedTabs) option lets a panel be
 pinned to the front of the tab strip, keeping it in place while other tabs come
 and go. Pinned tabs stay ahead of unpinned ones, are excluded from the overflow
-dropdown, and can render compact (hiding the close button, Chrome-style) or on a
-separate row. Pin and unpin by dragging tabs into or out of that separate row, from
+dropdown, and can render compact (icon-only, hiding the title and close button, Chrome-style)
+or on a separate row. Pin and unpin by dragging tabs into or out of that separate row, from
 the keyboard with `Ctrl+Shift+Enter`, or from the built-in tab context menu via the
 new `'pin'` item; in inline mode pinned tabs can stay stuck to the left edge as the
 strip scrolls. Pinning round-trips through serialization.
@@ -84,7 +84,7 @@ The new [`dndCompass`](/docs/core/dnd/dndCompass) option replaces the
 cursor-quadrant drop logic with a VS Code-style "compass" that highlights the
 cell you are aiming at while dragging, and previews docking a group to the
 whole-layout edge. For finer control, the new
-[`dropPositionResolver`](/docs/core/dnd/dndCompass) option lets you override how a
+[`dropPositionResolver`](/docs/core/dnd/dropPosition) option lets you override how a
 pointer location maps to a drop position on the group and layout-edge targets.
 See [DnD compass](/docs/core/dnd/dndCompass).
 
@@ -102,8 +102,8 @@ snap together into a docked or merged group. See
 
 The new [`layoutHistory`](/docs/core/state/history) option records structural
 layout mutations and lets you undo and redo them (move, float, popout,
-maximize, add, and remove) coalescing resize gestures and spanning popout
-windows. See [Layout history](/docs/core/state/history).
+maximize, add, remove, and tab-group changes) coalescing resize gestures and
+spanning popout windows. See [Layout history](/docs/core/state/history).
 
 ### Auto-hide edge groups
 
@@ -112,7 +112,7 @@ back into view on demand, VS Code tool-window style. Enable it with the new
 [`autoHideEdgeGroups`](/docs/core/groups/autoHideEdgeGroups) option; clicking a collapsed
 tab peeks the group, and you can pin it back to a docked group or dismiss it.
 Auto-hide is resolved **per edge** (and can be toggled per group via
-`addEdgeGroup({ autoHide })` / `api.setAutoHide`), so a static and an auto-hiding
+`addEdgeGroup({ autoHide })` / `api.getEdgeGroup(position)?.setAutoHide(...)`), so a static and an auto-hiding
 edge group can co-exist; peek animation is tuned globally through the new
 `edgeGroupPeek` option. See
 [Auto-hide edge groups](/docs/core/groups/autoHideEdgeGroups).
@@ -130,9 +130,9 @@ docks an edge group) and with auto-hide, and can be driven programmatically via
 
 ### Keyboard docking across popout windows & refreshed a11y
 
-Keyboard docking now works across popout windows, so you can move a group into or
-out of a popout entirely from the keyboard, with a dedicated "float" terminal
-action. It builds on refreshed accessibility work: per-window live regions with
+Keyboard docking now works across popout windows, so you can move the active
+panel into or out of a popout entirely from the keyboard, with a dedicated
+"float" terminal action that lifts it into a floating group. It builds on refreshed accessibility work: per-window live regions with
 focus-aware routing, `:focus-visible` focus indicators, and honest, localised
 accessible names on tab controls. See [Keyboard navigation](/docs/advanced/keyboard)
 and [Accessibility](/docs/advanced/accessibility).


### PR DESCRIPTION
## Description

Pre-release review of the v8 docs against the shipped code surfaced several places where the documentation claimed behaviour the code does not implement (and one stale JSDoc line that renders into the generated API reference). This corrects them. No runtime behaviour changes; the only non-docs edit is a comment removal in `dockview-core`.

- **Context-menu suppression** (`contextMenus.mdx`, `pinnedTabs.mdx`): the docs said returning `[]` or omitting the builder suppresses the tab menu. When `pinnedTabs` is enabled the built-in `'pin'` item is auto-prepended (`contextMenu.ts` `_resolveTabItems`), so the menu still opens. Documented the auto-injection and the `pinnedTabs.contextMenuItem: false` opt-out (which also avoids a duplicate `'pin'` in the pinned-tabs example).
- **Stale "Phase 1" JSDoc** (`dockview-core/src/dockview/options.ts`): removed `(Phase 1 implements 'inline' only.)` from `PinnedTabsOptions.mode`. `'separate-row'` ships (`SecondRowController`, with tests), and the note was rendering into the `PinnedTabsOptions` reference table on the pinned-tabs page.
- **`dropPositionResolver`** (`migrating-to-v8.mdx`, `whats-new-v8.mdx`): it is a free core option (no `OPTION_MODULE_RULES` entry, ungated), so it was mislabelled as enterprise. Tagged `(free)` and pointed both links at the free `/docs/core/dnd/dropPosition` page instead of the enterprise `dndCompass` page.
- **`api.autoHideEdgeGroup`** (`autoHideEdgeGroups.mdx`): corrected "collapses the group in all cases" — without the enterprise module it logs a missing-module note and does nothing. Point readers at the group API `collapse()` for the module-independent path.
- **`setAutoHide`** (`autoHideEdgeGroups.mdx`, `whats-new-v8.mdx`): lives on `DockviewGroupPanelApi`, not `DockviewApi`; corrected to `api.getEdgeGroup(position)?.setAutoHide(...)`.
- **whats-new wording**: keyboard docking moves the active *panel* (floats it into a floating group), not "a group into/out of a popout"; added the `tab-group` kind to the layout-history list; `compact` hides title + close button (icon-only), not just the close button.
- **British spelling** in prose (`tabGroups.mdx`, `smartGuides.mdx`): colour/centre. Code identifiers, CSS variables, and API literals left unchanged.

## Type of change

- [x] Documentation
- [x] Refactor / cleanup <!-- comment-only removal in options.ts -->

## Affected packages

- [x] `dockview-core` <!-- JSDoc comment only -->
- [x] `docs`

## How to test

- Read the changed pages; each corrected claim now matches the cited code (`contextMenu.ts`, `options.ts` `PinnedTabsOptions`, `optionsModules.ts`, `dockviewComponent.ts` edge-group api, `keyboardDockingService.ts`, `layoutHistoryService.ts`).
- The `dropPositionResolver` links now resolve to `/docs/core/dnd/dropPosition` (free page).
- No code paths change; the `options.ts` edit is a comment removal only.

## Checklist

- [x] I have added or updated tests where applicable <!-- n/a: docs + comment-only change -->
- [x] Breaking changes are documented <!-- no breaking changes in this PR -->
- [ ] `yarn test` passes <!-- not run locally: docs + comment-only change; CI will run it -->

Docs style verified against `packages/docs/CLAUDE.md`: no em dashes, no banned marketing words, British spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxuYTfwcN4PAEva6dS2Edf)_