### PR TITLE
fix(v8): three code issues confirmed in pre-release review

### DIFF
--- a/e2e/tests/keyboard-docking.spec.ts
+++ b/e2e/tests/keyboard-docking.spec.ts
@@ -47,6 +47,27 @@ test.describe('cross-window keyboard docking', () => {
         );
     });
 
+    test('the on-screen docking hint appears in the popout it was armed in, not the opener', async ({
+        page,
+        context,
+    }) => {
+        const win = await popout(page, context);
+
+        await win.locator('.dv-test-panel').first().click();
+        await win.keyboard.press('Control+m');
+
+        // The narration routes to the popout (already covered above). The
+        // visible on-screen hint must follow: a keyboard user working inside the
+        // popout needs to see the guidance in the window they are looking at.
+        await expect(win.locator('.dv-keyboard-docking-hint')).toContainText(
+            'Moving beta'
+        );
+        // And it must NOT appear in the opener window.
+        await expect(page.locator('.dv-keyboard-docking-hint')).toHaveCount(0);
+
+        await win.keyboard.press('Escape');
+    });
+
     test('a keyboard split committed inside a popout acts on the popout group', async ({
         page,
         context,

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -12428,7 +12428,7 @@ describe('dockviewComponent', () => {
                 dv2.dispose();
             });
 
-            test('revealing into an existing edge with autoHide fires the change event', () => {
+            test('revealing into an existing static edge leaves its auto-hide state untouched', () => {
                 const c = document.createElement('div');
                 const dv = createFixedDockview(c, ['left'], {
                     left: { id: 'left-group' },
@@ -12450,12 +12450,19 @@ describe('dockviewComponent', () => {
                     { autoHide: true }
                 );
 
-                // the reuse path must fire the event so a listener (the
-                // auto-hide controller) can reconcile the group's chrome
-                expect(fired).toContain('left-group');
+                // The reuse path adds the panel but must NOT change the existing
+                // group's auto-hide: a drag-reveal (which always passes
+                // autoHide:true) can't be allowed to silently convert a static
+                // edge group into an auto-hiding one. Programmatic callers use
+                // `getEdgeGroup(position).setAutoHide(...)` for that. So no
+                // change event fires and the group stays static.
+                expect(
+                    dv.getEdgeGroupPanel('left')!.panels.map((p) => p.id)
+                ).toContain('p1');
+                expect(fired).toEqual([]);
                 expect(
                     dv.isEdgeGroupAutoHide(dv.getEdgeGroupPanel('left')!)
-                ).toBe(true);
+                ).toBe(false);
                 dv.dispose();
             });
 

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -3022,11 +3022,15 @@ export class DockviewComponent
     /**
      * Reveal (create-or-fill) the edge group at `position` and move the dragged
      * item described by `data` into it. A newly created edge group is created
-     * collapsed and flagged `autoReveal` so it tears down to zero footprint when
-     * later emptied. If an edge group already exists there it is reused: the
-     * panel is added to its tabs and its collapsed/toggled state is left as-is
-     * (never re-created; `addEdgeGroup` throws on a duplicate position). No-op if
-     * the EdgeGroup module is absent.
+     * collapsed, flagged `autoReveal` so it tears down to zero footprint when
+     * later emptied, and takes its auto-hide state from `options.autoHide`. If an
+     * edge group already exists there it is reused: the panel is added to its
+     * tabs and its collapsed/toggled *and auto-hide* state are left as-is (never
+     * re-created; `addEdgeGroup` throws on a duplicate position). This keeps a
+     * drag-reveal from silently converting a static edge group into an
+     * auto-hiding one; to change an existing group's auto-hide, call
+     * `api.getEdgeGroup(position)?.setAutoHide(...)` directly. No-op if the
+     * EdgeGroup module is absent.
      *
      * This is the primitive behind the dock-to-edge groups: the two-band
      * drag-reveal affordance routes its outer-band drops here.
@@ -3052,12 +3056,11 @@ export class DockviewComponent
                     collapsed: true,
                 });
                 group = service.get(position);
-            } else if (options?.autoHide !== undefined) {
-                // Route through setEdgeGroupAutoHide (not the raw service) so
-                // onDidEdgeGroupAutoHideChange fires and the auto-hide
-                // controller reconciles the group's chrome.
-                this.setEdgeGroupAutoHide(group, options.autoHide);
             }
+            // An existing edge group is reused with its auto-hide state left
+            // as-is: a drag-reveal must not flip a static edge group into an
+            // auto-hiding one. Programmatic callers that intend to change it use
+            // `api.getEdgeGroup(position)?.setAutoHide(...)`.
             if (!group) {
                 return;
             }

--- a/packages/dockview-core/src/dockview/moduleContracts.ts
+++ b/packages/dockview-core/src/dockview/moduleContracts.ts
@@ -597,6 +597,11 @@ export interface IPinnedTabsHost {
     readonly options: DockviewComponentOptions;
     readonly onDidAddGroup: Event<DockviewGroupPanel>;
     readonly onDidRemoveGroup: Event<DockviewGroupPanel>;
+    /** Fires after `updateOptions`; the service re-applies the pinned-tabs
+     *  presentation (mode / sticky) to every existing group so a runtime
+     *  `pinnedTabs` change takes effect. New groups pick it up in
+     *  `onDidAddGroup`; this retrofits the ones that already exist. */
+    readonly onDidOptionsChange: Event<void>;
     /** Fires after a panel's pinned flag is mutated via the gated
      *  `setPanelPinned`; the service's sole trigger to re-order the strip. */
     readonly onDidPanelPinnedChange: Event<DockviewPanelPinnedChangeEvent>;

--- a/packages/dockview-enterprise/src/__tests__/keyboardDocking.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/keyboardDocking.spec.ts
@@ -132,6 +132,52 @@ describe('accessibility: keyboard docking', () => {
         expect(hint()).toBeNull();
     });
 
+    test('the on-screen hint mounts in the focused popout window, not the opener', () => {
+        make(true);
+        twoGroups();
+
+        // Simulate a focused popout window whose document reports focus. The
+        // hint must follow focus into that window (jsdom cannot open a real
+        // second window, so stub the popout set the service reads).
+        const popoutDoc = document.implementation.createHTMLDocument('popout');
+        popoutDoc.hasFocus = () => true;
+        const fakeWin = { document: popoutDoc } as unknown as Window;
+        jest.spyOn(dockview, 'getPopoutWindows').mockReturnValue([fakeWin]);
+
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+
+        // The hint is in the focused popout document, not the main container.
+        expect(
+            popoutDoc.querySelector('.dv-keyboard-docking-hint')?.textContent
+        ).toContain('Moving P2');
+        expect(container.querySelector('.dv-keyboard-docking-hint')).toBeNull();
+
+        fireEvent.keyDown(dockview.element, { key: 'Escape' });
+    });
+
+    test('a popout whose document throws on access is skipped (hint falls back to the main window)', () => {
+        make(true);
+        twoGroups();
+
+        // A closing / cross-origin popout can throw on `.document`; the focus
+        // scan must swallow that and fall back to the main window.
+        const fakeWin = {
+            get document(): Document {
+                throw new Error('window is closing');
+            },
+        } as unknown as Window;
+        jest.spyOn(dockview, 'getPopoutWindows').mockReturnValue([fakeWin]);
+
+        fireEvent.keyDown(dockview.element, { key: 'm', ctrlKey: true });
+
+        // Fell back to the main container without throwing.
+        expect(
+            container.querySelector('.dv-keyboard-docking-hint')?.textContent
+        ).toContain('Moving P2');
+
+        fireEvent.keyDown(dockview.element, { key: 'Escape' });
+    });
+
     test('renders the drop preview during the move and clears it on cancel', () => {
         make(true);
         twoGroups();

--- a/packages/dockview-enterprise/src/__tests__/pinnedTabs.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/pinnedTabs.spec.ts
@@ -444,6 +444,7 @@ describe('pinned tabs: reorder guard', () => {
             onDidPanelPinnedChange: stub,
             onDidAddGroup: stub,
             onDidRemoveGroup: stub,
+            onDidOptionsChange: stub,
             onDidLayoutFromJSON: stub,
             onDidRemovePanel: stub,
         } as any);

--- a/packages/dockview-enterprise/src/__tests__/v8ReviewTriage.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/v8ReviewTriage.spec.ts
@@ -1,0 +1,194 @@
+import {
+    DockviewComponent,
+    DockviewEmitter as Emitter,
+    IContentRenderer,
+} from 'dockview';
+import type {
+    DockviewWillDropEvent,
+    DockviewWillShowOverlayLocationEvent,
+} from 'dockview';
+import { AutoEdgeGroupService } from '../autoEdgeGroupService';
+
+/**
+ * Triage reproductions for issues raised in the v8 pre-release review. Each
+ * test encodes the *expected* (correct) behaviour, so a failure here confirms
+ * the reported defect is real. These are written against the real
+ * `DockviewComponent` (the enterprise jest setup registers every module and a
+ * valid licence globally), so they exercise the shipped wiring, not mocks.
+ */
+
+class TestPanel implements IContentRenderer {
+    element = document.createElement('div');
+    init(): void {
+        /* noop */
+    }
+    layout(): void {
+        /* noop */
+    }
+    dispose(): void {
+        /* noop */
+    }
+}
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r));
+
+const peekHeader = (el: HTMLElement): Element | null =>
+    el.querySelector('.dv-edge-peek-header');
+
+describe('v8 review triage', () => {
+    let container: HTMLElement;
+
+    afterEach(() => {
+        container?.remove();
+        document.body.innerHTML = '';
+    });
+
+    /**
+     * Issue: a drag-reveal drop onto a *pre-existing static* edge group flips it
+     * to auto-hide. `AutoEdgeGroupService._onWillDrop` unconditionally calls
+     * `revealEdgeGroupWithData(pos, data, { autoHide: true })`, and the reuse
+     * branch of `revealEdgeGroupWithData` routes a defined `autoHide` through
+     * `setEdgeGroupAutoHide`, mutating a group the user explicitly created static.
+     * `autoEdgeGroups.mdx` promises dropping onto an existing edge "leaves the
+     * group's state untouched".
+     */
+    test('drag-reveal onto an existing STATIC edge group must not convert it to auto-hide', async () => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            autoHideEdgeGroups: false,
+            dockToEdgeGroups: { left: true },
+        });
+        dockview.layout(1000, 1000);
+
+        // Two panels in the main grid; we drag one toward the left edge.
+        dockview.addPanel({ id: 'p1', component: 'default' });
+        dockview.addPanel({ id: 'p2', component: 'default' });
+        const sourceGroupId = dockview.panels.find((p) => p.id === 'p1')!.group
+            .id;
+
+        // A pre-existing STATIC (autoHide: false) left edge group.
+        dockview.addEdgeGroup('left', {
+            id: 'edge-left',
+            initialSize: 200,
+            autoHide: false,
+        });
+        dockview.addPanel({
+            id: 'l1',
+            component: 'default',
+            position: { referenceGroup: 'edge-left' },
+        });
+        await flush();
+
+        const edgeEl = dockview.getEdgeGroupPanel('left')!.element;
+        // Sanity: static edge group has no tool-window (peek) chrome.
+        expect(peekHeader(edgeEl)).toBeNull();
+
+        // Drive the real drag-reveal path: a service whose host delegates
+        // `revealEdgeGroupWithData` to the real component. Firing an outer-band
+        // left-edge drop is exactly what a user dragging p1 into the left edge
+        // band does.
+        const rect = {
+            left: 0,
+            top: 0,
+            right: 1000,
+            bottom: 1000,
+            width: 1000,
+            height: 1000,
+        } as DOMRect;
+        const willShow = new Emitter<DockviewWillShowOverlayLocationEvent>();
+        const willDrop = new Emitter<DockviewWillDropEvent>();
+        const svcHost = {
+            options: { dockToEdgeGroups: { left: true } },
+            overlayRoot: document.createElement('div'),
+            getDropZoneRect: () => rect,
+            onWillShowOverlay: willShow.event,
+            onWillDrop: willDrop.event,
+            revealEdgeGroupWithData: (
+                pos: any,
+                data: any,
+                opts: any
+            ): void => dockview.revealEdgeGroupWithData(pos, data, opts),
+        };
+        const service = new AutoEdgeGroupService(svcHost as any);
+
+        willDrop.fire({
+            kind: 'edge',
+            position: 'left',
+            nativeEvent: { clientX: 4, clientY: 500 },
+            getData: () => ({ groupId: sourceGroupId, panelId: 'p1' }),
+            preventDefault: () => undefined,
+        } as any);
+        await flush();
+
+        // The drop landed: p1 is now in the left edge group (proves the gesture
+        // was not a no-op).
+        expect(
+            dockview
+                .getEdgeGroupPanel('left')!
+                .model.panels.some((p) => p.id === 'p1')
+        ).toBe(true);
+
+        // EXPECTED: the pre-existing static edge group is still static. Fails
+        // today because it was silently flipped to auto-hide.
+        expect(peekHeader(dockview.getEdgeGroupPanel('left')!.element)).toBeNull();
+
+        service.dispose();
+        dockview.dispose();
+    });
+
+    /**
+     * Issue: `PinnedTabsService` reads `mode` only when a group is added and does
+     * not subscribe to `onDidOptionsChange`, so switching `pinnedTabs.mode` at
+     * runtime does not retrofit existing groups. A group created after the change
+     * honours the new mode; a group that already existed does not.
+     */
+    test('switching pinnedTabs.mode to separate-row at runtime must retrofit existing groups', async () => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            pinnedTabs: { enabled: true, mode: 'inline' },
+        });
+        dockview.layout(1000, 1000);
+
+        // An existing group with a pinned panel, created under inline mode.
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        p1.api.setPinned(true);
+        await flush();
+
+        const originalGroup = dockview.panels.find((p) => p.id === 'p1')!.group;
+        // Inline mode: no separate pinned row.
+        expect(
+            originalGroup.element.querySelector('.dv-pinned-row')
+        ).toBeNull();
+
+        // Switch to separate-row at runtime.
+        dockview.updateOptions({
+            pinnedTabs: { enabled: true, mode: 'separate-row' },
+        });
+        await flush();
+
+        // Control: a NEW group created after the switch does honour separate-row.
+        const p2 = dockview.addPanel({
+            id: 'p2',
+            component: 'default',
+            position: { direction: 'right' },
+        });
+        p2.api.setPinned(true);
+        await flush();
+        const newGroup = dockview.panels.find((p) => p.id === 'p2')!.group;
+        expect(
+            newGroup.element.querySelector('.dv-pinned-row')
+        ).toBeTruthy();
+
+        // EXPECTED: the pre-existing group is retrofitted with a pinned row too.
+        // Fails today: no onDidOptionsChange subscription retrofits it.
+        expect(
+            originalGroup.element.querySelector('.dv-pinned-row')
+        ).toBeTruthy();
+
+        dockview.dispose();
+    });
+});

--- a/packages/dockview-enterprise/src/__tests__/v8ReviewTriage.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/v8ReviewTriage.spec.ts
@@ -188,4 +188,37 @@ describe('v8 review triage', () => {
 
         dockview.dispose();
     });
+
+    /**
+     * The reconciliation must work in both directions: switching from
+     * separate-row back to inline at runtime tears the pinned row down on
+     * existing groups (the else branch of the mode reconciliation).
+     */
+    test('switching pinnedTabs.mode back to inline at runtime tears down the pinned row', async () => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        const dockview = new DockviewComponent(container, {
+            createComponent: () => new TestPanel(),
+            pinnedTabs: { enabled: true, mode: 'separate-row' },
+        });
+        dockview.layout(1000, 1000);
+
+        const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+        p1.api.setPinned(true);
+        await flush();
+
+        const group = dockview.panels.find((p) => p.id === 'p1')!.group;
+        // separate-row: the pinned row is present.
+        expect(group.element.querySelector('.dv-pinned-row')).toBeTruthy();
+
+        dockview.updateOptions({
+            pinnedTabs: { enabled: true, mode: 'inline' },
+        });
+        await flush();
+
+        // Back to inline: the pinned row is torn down on the existing group.
+        expect(group.element.querySelector('.dv-pinned-row')).toBeNull();
+
+        dockview.dispose();
+    });
 });

--- a/packages/dockview-enterprise/src/__tests__/v8ReviewTriage.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/v8ReviewTriage.spec.ts
@@ -10,9 +10,9 @@ import type {
 import { AutoEdgeGroupService } from '../autoEdgeGroupService';
 
 /**
- * Triage reproductions for issues raised in the v8 pre-release review. Each
- * test encodes the *expected* (correct) behaviour, so a failure here confirms
- * the reported defect is real. These are written against the real
+ * Regression guards for issues found in the v8 pre-release review. Each test
+ * encodes the correct behaviour and was first written to fail against the
+ * unfixed code (see the accompanying fix commit). They run against the real
  * `DockviewComponent` (the enterprise jest setup registers every module and a
  * valid licence globally), so they exercise the shipped wiring, not mocks.
  */
@@ -105,11 +105,8 @@ describe('v8 review triage', () => {
             getDropZoneRect: () => rect,
             onWillShowOverlay: willShow.event,
             onWillDrop: willDrop.event,
-            revealEdgeGroupWithData: (
-                pos: any,
-                data: any,
-                opts: any
-            ): void => dockview.revealEdgeGroupWithData(pos, data, opts),
+            revealEdgeGroupWithData: (pos: any, data: any, opts: any): void =>
+                dockview.revealEdgeGroupWithData(pos, data, opts),
         };
         const service = new AutoEdgeGroupService(svcHost as any);
 
@@ -130,9 +127,11 @@ describe('v8 review triage', () => {
                 .model.panels.some((p) => p.id === 'p1')
         ).toBe(true);
 
-        // EXPECTED: the pre-existing static edge group is still static. Fails
-        // today because it was silently flipped to auto-hide.
-        expect(peekHeader(dockview.getEdgeGroupPanel('left')!.element)).toBeNull();
+        // The pre-existing static edge group must stay static: a drag-reveal
+        // must not silently flip it to auto-hide.
+        expect(
+            peekHeader(dockview.getEdgeGroupPanel('left')!.element)
+        ).toBeNull();
 
         service.dispose();
         dockview.dispose();
@@ -179,12 +178,10 @@ describe('v8 review triage', () => {
         p2.api.setPinned(true);
         await flush();
         const newGroup = dockview.panels.find((p) => p.id === 'p2')!.group;
-        expect(
-            newGroup.element.querySelector('.dv-pinned-row')
-        ).toBeTruthy();
+        expect(newGroup.element.querySelector('.dv-pinned-row')).toBeTruthy();
 
-        // EXPECTED: the pre-existing group is retrofitted with a pinned row too.
-        // Fails today: no onDidOptionsChange subscription retrofits it.
+        // The pre-existing group must be retrofitted with a pinned row too
+        // (the onDidOptionsChange subscription reconciles existing groups).
         expect(
             originalGroup.element.querySelector('.dv-pinned-row')
         ).toBeTruthy();

--- a/packages/dockview-enterprise/src/keyboardDockingService.ts
+++ b/packages/dockview-enterprise/src/keyboardDockingService.ts
@@ -411,13 +411,38 @@ export class KeyboardDockingService
      */
     private _showHint(text: string): void {
         if (!this._hint) {
-            const doc = this.host.rootElement.ownerDocument;
+            const mainDoc = this.host.rootElement.ownerDocument;
+            // Mount the hint in the window that currently has focus, so a move
+            // armed inside a popout shows its guidance in that popout, not the
+            // opener (mirrors how announcements route to the focused window's
+            // live region).
+            const doc = this._focusedDocument();
+            // In the main window scope the hint to the dock shell (a positioned
+            // ancestor). A popout exposes no shell handle, so anchor it to that
+            // window's body; the hint is `position: absolute; bottom`, so it
+            // lands at the foot of whichever window armed the move.
+            const parent = doc === mainDoc ? this.host.rootElement : doc.body;
             this._hint = doc.createElement('div');
             this._hint.className = 'dv-keyboard-docking-hint';
             this._hint.setAttribute('aria-hidden', 'true');
-            this.host.rootElement.appendChild(this._hint);
+            parent.appendChild(this._hint);
         }
         this._hint.textContent = text;
+    }
+
+    /** The document of the window that currently has focus (a popout, if a
+     *  keydown was made there), falling back to the main window. */
+    private _focusedDocument(): Document {
+        for (const win of this.host.getPopoutWindows()) {
+            try {
+                if (win.document.hasFocus()) {
+                    return win.document;
+                }
+            } catch {
+                // A closing / cross-origin window can throw on access; ignore.
+            }
+        }
+        return this.host.rootElement.ownerDocument;
     }
 
     private _hideHint(): void {

--- a/packages/dockview-enterprise/src/pinnedTabsService.ts
+++ b/packages/dockview-enterprise/src/pinnedTabsService.ts
@@ -634,8 +634,42 @@ export class PinnedTabsService
                 for (const group of this._groups) {
                     this._seedFromRestore(group);
                 }
+            }),
+            // A runtime `updateOptions` can flip the mode (inline <-> separate
+            // row) or toggle sticky. `onDidAddGroup` only reads the mode for
+            // groups added afterwards, so retrofit the existing ones here.
+            this._host.onDidOptionsChange(() => {
+                for (const group of this._groups) {
+                    this._reapplyMode(group);
+                }
             })
         );
+    }
+
+    /** Re-apply the current pinned-tabs mode to an already-tracked group after
+     *  a runtime option change: create or tear down its separate row and set
+     *  inline sticky, then re-assert the pinned-first order and overflow so the
+     *  main strip stays consistent. Idempotent, so a no-op change costs nothing
+     *  visible. */
+    private _reapplyMode(group: DockviewGroupPanel): void {
+        if (this._separateRow) {
+            let row = this._secondRows.get(group);
+            if (!row) {
+                row = new SecondRowController(group, this);
+                this._secondRows.set(group, row);
+            }
+            group.model.header.setPinnedSticky(false);
+            row.render();
+        } else {
+            const row = this._secondRows.get(group);
+            if (row) {
+                row.dispose();
+                this._secondRows.delete(group);
+            }
+            group.model.header.setPinnedSticky(this._inlineSticky);
+        }
+        this.enforceOrder(group);
+        group.model.header.refreshOverflow();
     }
 
     /** Seed the pinned set from a restored group's panels (already in


### PR DESCRIPTION
## Description

Follow-up to the v8 docs review (#1582). The docs review surfaced several behavioural discrepancies; this PR fixes the three that reproduce with a failing test. Each fix ships with a test that fails before it and passes after.

**1. Edge auto-hide mutation (MEDIUM).** A drag-reveal drop onto a pre-existing **static** edge group silently converted it to auto-hide. `AutoEdgeGroupService._onWillDrop` always calls `revealEdgeGroupWithData(..., { autoHide: true })`, and the reuse branch of `revealEdgeGroupWithData` routed that through `setEdgeGroupAutoHide`. `autoEdgeGroups.mdx` promises a drop onto an existing edge "leaves the group's state untouched." Fix: the reuse branch no longer applies `autoHide`; it is set only when the edge is **created**. Programmatic callers change an existing group via `api.getEdgeGroup(position)?.setAutoHide(...)`.

**2. Keyboard docking hint mounted in the wrong window (MEDIUM).** The on-screen `.dv-keyboard-docking-hint` was always appended to the main-window root, so a move armed *inside a popout* showed its hint in the opener even though the narration correctly routed to the popout's live region. Fix: mount the hint in the focused window's document, mirroring how live-region announcements already route (`liveRegionService._focusedRegions`).

**3. Pinned tabs ignored runtime option changes (LOW).** `PinnedTabsService` read `pinnedTabs.mode` only when a group was added and never subscribed to `onDidOptionsChange`, so switching the mode at runtime retrofitted new groups but not existing ones. Fix: add `onDidOptionsChange` to `IPinnedTabsHost` and re-apply the mode (create/tear down the separate row, set inline sticky) to every existing group, mirroring `MultiRowTabsService`.

## Type of change

- [x] Bug fix

## Affected packages

- [x] `dockview-core` <!-- reveal reuse branch; IPinnedTabsHost contract member -->
- [x] `dockview-enterprise` <!-- keyboard docking hint; pinned-tabs option-change wiring -->

## How to test

- **Unit reproductions** (`packages/dockview-enterprise/src/__tests__/v8ReviewTriage.spec.ts`): drive the real `DockviewComponent`. The edge test proves the drop lands (p1 moves into the edge group) *and* the group stays static; the pinned-tabs test proves a new group honours `separate-row` while the pre-existing group is now retrofitted too.
- **Cross-window e2e** (`e2e/tests/keyboard-docking.spec.ts`): asserts the docking hint appears in the popout the move was armed in and not the opener. jsdom cannot model a second document, so this needs the browser harness.
- Updated one core test that had pinned the old reuse-branch behaviour (`dockviewComponent.spec.ts`), and the `pinnedTabs.spec.ts` mock host for the new contract member.

Suites run locally: **core 1685**, **enterprise 476**, **e2e 127** — all passing.

## Checklist

- [x] `yarn test` passes (core + enterprise)
- [x] `yarn test:e2e` passes (full suite, 127)
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented <!-- none: revealEdgeGroupWithData's reuse behaviour is aligned with its documented "state untouched" contract; the new IPinnedTabsHost member is an internal module contract -->

## Not fixed here (triaged, lower value)

Confirmed by code reading but left for a follow-up: `dropPositionResolver` shadowing the drag-reveal resolver, advanced-overflow view not disposed on popover close, compass outer-cell clipping on small floats. Plausible but not reproduced deterministically: the layout-history popout-close re-entrancy asymmetry and auto-hide focus-restore for `renderer:'always'` (both need runtime/e2e conditions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxuYTfwcN4PAEva6dS2Edf)_