### PR TITLE
docs(site): surface what's new from the landing page and footer

### DIFF
--- a/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
@@ -14,6 +14,10 @@ This page covers the headline additions. For the upgrade notes and the single
 [breaking change](#breaking-changes), see
 [Migrating to v8](/docs/releases/migrating/migrating-to-v8).
 
+[Dockview launches an enterprise version](/blog/dockview-enterprise) explains why
+v8 starts shipping a commercially licensed package alongside the free one, and
+what it means if you already use Dockview.
+
 :::info The `dockview-enterprise` package
 v8 introduces `dockview-enterprise`, a separately-licensed package. Most of the
 additions below are part of it; [Licensing](/docs/overview/licence) is the full

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -379,6 +379,10 @@ const config = {
                                 to: '/docs/overview/introduction',
                             },
                             {
+                                label: "What's new",
+                                to: '/whats-new',
+                            },
+                            {
                                 label: 'Demo',
                                 to: '/demo',
                             },

--- a/packages/docs/src/pages/index.scss
+++ b/packages/docs/src/pages/index.scss
@@ -39,6 +39,52 @@
     margin: 0 auto;
 }
 
+// ─── Hero release pill ────────────────────────────────────────────────────────
+
+.hero-release {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 13px 4px 4px;
+    border-radius: 999px;
+    // Deliberately borderless and shadowless, unlike .hero-fw-btn directly
+    // below it, so the row of framework buttons stays the obvious call to
+    // action and this reads as a notice rather than a fourth button.
+    background: var(--dv-accent-soft);
+    color: var(--ifm-color-content-secondary);
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: color 0.15s;
+
+    &:hover {
+        color: var(--ifm-color-content);
+        text-decoration: none;
+
+        .hero-release-arrow {
+            transform: translateX(2px);
+        }
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--ifm-color-primary);
+        outline-offset: 2px;
+    }
+}
+
+.hero-release-chip {
+    padding: 2px 9px;
+    border-radius: 999px;
+    background: var(--ifm-color-primary);
+    color: #fff;
+    font-size: 0.7rem;
+    font-weight: 700;
+}
+
+.hero-release-arrow {
+    transition: transform 0.15s ease;
+}
+
 // ─── Hero stats ───────────────────────────────────────────────────────────────
 
 .hero-stats {
@@ -349,6 +395,15 @@
     .hero-fw-btn,
     .framework-item {
         transition: none;
+    }
+
+    .hero-release,
+    .hero-release-arrow {
+        transition: none;
+    }
+
+    .hero-release:hover .hero-release-arrow {
+        transform: none;
     }
 
     .hero-preview,

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -20,6 +20,26 @@ const FRAMEWORK_LINKS: { label: string; icon: string; param: string }[] = [
     { label: 'JavaScript', icon: 'img/js-icon.svg', param: 'javascript' },
 ];
 
+// ─── Latest release ───────────────────────────────────────────────────────────
+
+// Bump on each major, alongside the `RELEASES` array in whats-new.tsx. Links
+// straight at the release notes rather than the /whats-new index so the pill
+// lands on the actual content in one click.
+const LATEST_VERSION = 'v8.0';
+const LATEST_RELEASE_NOTES = '/docs/releases/whats-new/whats-new-v8';
+
+function HeroRelease() {
+    return (
+        <Link to={LATEST_RELEASE_NOTES} className="hero-release">
+            <span className="hero-release-chip">{LATEST_VERSION}</span>
+            <span>What's new</span>
+            <span className="hero-release-arrow" aria-hidden="true">
+                →
+            </span>
+        </Link>
+    );
+}
+
 // ─── Social proof stats ───────────────────────────────────────────────────────
 
 const STATS: { value: string; label: string; href?: string }[] = [
@@ -144,6 +164,7 @@ function Hero() {
                         mobile ready. Zero dependencies.
                     </p>
                     <div className="hero-actions">
+                        <HeroRelease />
                         <div className="hero-fw-btns">
                             {FRAMEWORK_LINKS.map((fw) => (
                                 <Link


### PR DESCRIPTION
## Why

`/whats-new` was reachable from exactly one place on the whole site: a sidebar entry under Overview in `sidebars.js`. Not the navbar, not the footer, not the landing page.

## What changed

**Landing page hero** (`src/pages/index.tsx`, `index.scss`) — a version pill in the hero action row, directly above the framework buttons:

`[v8.0] What's new →`

It links straight at `/docs/releases/whats-new/whats-new-v8` rather than the `/whats-new` index, so it lands on the content in one click. The version and URL are two constants at the top of the file with a comment pointing at the `RELEASES` array in `whats-new.tsx`, so a major bump is one obvious edit in each place.

The pill is deliberately borderless and shadowless, unlike `.hero-fw-btn` directly below it, so the framework row stays the obvious call to action and this reads as a notice rather than a fourth button. It has a `:focus-visible` outline matching the framework buttons, and entries in the `prefers-reduced-motion` block.

**Footer** (`docusaurus.config.js`) — "What's new" in the Documentation group, between Get Started and Demo. This one points at the `/whats-new` index rather than v8, since a permanent footer link shouldn't need editing every major.

**v8 release notes** (`whats-new-v8.mdx`) — link the enterprise launch post from the intro, next to the migration signpost. It's the only place explaining why the split happened and it carries the early-user and small-business discount offers, which weren't reachable from that page at all.

## Notes

- No navbar entry. It's already at seven items plus the GitHub icon, and an eighth pushes it toward overflow at common widths.
- `docusaurus build` passes. The one broken-anchor warning on `/docs/core/panels/register` is pre-existing and unrelated.
- Formatter not run, per the docs-package rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)