### PR TITLE
chore: reduce comment slope across source and tests

### DIFF
--- a/e2e/tests/advanced-overflow.spec.ts
+++ b/e2e/tests/advanced-overflow.spec.ts
@@ -41,13 +41,11 @@ test.describe('advanced overflow dropdown', () => {
         const search = popover.locator('.dv-tabs-overflow-search');
         await expect(search).toBeFocused();
 
-        // A discriminating substring narrows the list; a nonsense one empties it.
         await search.fill('long-title-1');
         await expect(popover.locator('[role="option"]')).not.toHaveCount(0);
         await search.fill('zzz-no-match');
         await expect(popover.locator('[role="option"]')).toHaveCount(0);
 
-        // Escape dismisses.
         await search.press('Escape');
         await expect(popover).toHaveCount(0);
     });

--- a/e2e/tests/auto-edge-groups.spec.ts
+++ b/e2e/tests/auto-edge-groups.spec.ts
@@ -76,7 +76,6 @@ test.describe('auto edge groups (drag reveal)', () => {
                 (window as any).__dv.edgeGroupPanelIds('left')
             )
         ).toContain('side');
-        // the indicator line is cleared after the drop
         await expect(page.locator('.dv-auto-edge-band')).toHaveCount(0);
     });
 

--- a/e2e/tests/auto-hide-edge-groups.spec.ts
+++ b/e2e/tests/auto-hide-edge-groups.spec.ts
@@ -37,7 +37,6 @@ test.describe('auto-hide edge groups (peek)', () => {
         expect((await overlay.boundingBox())!.width).toBeGreaterThan(100);
         await expect(overlay.locator('.dv-test-panel')).toBeVisible();
 
-        // title bar with the panel title + pin + close
         await expect(page.locator('.dv-edge-peek-title')).toHaveText('Sidebar');
         await expect(page.locator('.dv-edge-peek-pin')).toBeVisible();
         await expect(page.locator('.dv-edge-peek-close')).toBeVisible();
@@ -45,7 +44,6 @@ test.describe('auto-hide edge groups (peek)', () => {
         const during = (await mainBox(page))!;
         expect(Math.abs(during.width - before.width)).toBeLessThan(2);
 
-        // click outside → hide
         await page.mouse.click(900, 500);
         await expect(overlay).toHaveCount(0);
     });
@@ -111,7 +109,7 @@ test.describe('auto-hide edge groups (peek)', () => {
         await page.mouse.move(900, 500);
         await expect(overlay).toBeVisible();
 
-        // clicking the peeked tab again hides it (still no reflow)
+        // still no reflow
         await edgeTab(page).click();
         await expect(overlay).toHaveCount(0);
         expect(
@@ -174,7 +172,6 @@ test.describe('auto-hide edge groups (peek)', () => {
 
         await page.locator('.dv-edge-peek-close').click();
         await expect(page.locator('.dv-edge-peek')).toHaveCount(0);
-        // the sidebar panel is gone
         await expect(
             page.locator('.dv-test-panel', { hasText: 'sidebar' })
         ).toHaveCount(0);
@@ -263,7 +260,6 @@ test.describe('auto-hide edge groups (peek)', () => {
         await tabs.nth(0).click(); // peek Alpha
         await expect(page.locator('.dv-edge-peek')).toBeVisible();
 
-        // switch to Bravo, then back to Alpha
         await tabs.nth(1).click();
         await tabs.nth(0).click();
 

--- a/e2e/tests/context-menu.spec.ts
+++ b/e2e/tests/context-menu.spec.ts
@@ -29,14 +29,12 @@ test.describe('tab context menu', () => {
         const menu = page.locator('.dv-context-menu');
         await expect(menu).toBeVisible();
         await expect(menu).toHaveAttribute('role', 'menu');
-        // The three configured built-ins render as clickable items.
         await expect(menu.locator('.dv-context-menu-item')).toHaveCount(3);
         await expect(menu).toContainText('Close');
     });
 
     test('clicking "Close" closes just that panel', async ({ page }) => {
         await setup(page);
-        // Right-click the "alpha" tab specifically.
         await page
             .locator('.dv-tab', { hasText: 'alpha' })
             .click({ button: 'right' });
@@ -47,7 +45,6 @@ test.describe('tab context menu', () => {
             .first()
             .click();
 
-        // The menu dismisses and only "alpha" is gone.
         await expect(page.locator('.dv-context-menu')).toHaveCount(0);
         await expect(page.locator('.dv-tab')).toHaveCount(2);
         await expect(page.locator('.dv-tab', { hasText: 'alpha' })).toHaveCount(
@@ -91,7 +88,6 @@ test.describe('tab context menu', () => {
             .locator('.dv-context-menu-item', { hasText: 'Close All' })
             .click();
 
-        // The whole group is emptied — no tabs remain.
         await expect(page.locator('.dv-context-menu')).toHaveCount(0);
         await expect(page.locator('.dv-tab')).toHaveCount(0);
     });

--- a/e2e/tests/dnd-compass.spec.ts
+++ b/e2e/tests/dnd-compass.spec.ts
@@ -53,7 +53,6 @@ test.describe('DnD compass', () => {
         await expect
             .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
             .toBe(1);
-        // ...and the compass is gone
         await expect(page.locator('.dv-dnd-compass')).toHaveCount(0);
     });
 

--- a/e2e/tests/dnd-docking.spec.ts
+++ b/e2e/tests/dnd-docking.spec.ts
@@ -80,7 +80,6 @@ test.describe('pointer dnd docking', () => {
         await expect
             .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
             .toBe(1);
-        // Both panels now share the surviving group's strip.
         await expect(page.locator('.dv-tab')).toHaveText(['two', 'one']);
     });
 });

--- a/e2e/tests/floating-group.spec.ts
+++ b/e2e/tests/floating-group.spec.ts
@@ -19,14 +19,12 @@ test.describe('floating groups', () => {
     }) => {
         await setup(page);
 
-        // Exactly one floating group, rendered as a single resize-container.
         expect(
             await page.evaluate(() => (window as any).__dv.floatingCount())
         ).toBe(1);
         const overlay = page.locator('.dv-resize-container');
         await expect(overlay).toHaveCount(1);
 
-        // Its panel content is mounted and the docked `main` panel still shows.
         await expect(overlay.locator('.dv-test-panel')).toContainText(
             'floater'
         );

--- a/e2e/tests/keyboard-navigation.spec.ts
+++ b/e2e/tests/keyboard-navigation.spec.ts
@@ -14,7 +14,6 @@ test.describe('keyboard navigation (F6)', () => {
         const ids = await page.evaluate(() =>
             (window as any).__dv.setupTwoGroups()
         );
-        // Two side-by-side groups exist.
         await expect(
             page.locator('.dv-tabs-and-actions-container')
         ).toHaveCount(2);
@@ -29,15 +28,12 @@ test.describe('keyboard navigation (F6)', () => {
     }) => {
         const ids = await setup(page);
 
-        // Focus the first group by clicking its tab, then make it active.
         await page.locator('.dv-tab', { hasText: 'one' }).click();
         await expect.poll(() => activeGroupId(page)).toBe(ids.first);
 
-        // F6 → next group becomes active.
         await page.keyboard.press('F6');
         await expect.poll(() => activeGroupId(page)).toBe(ids.second);
 
-        // Shift+F6 → back to the first group (round-trip).
         await page.keyboard.press('Shift+F6');
         await expect.poll(() => activeGroupId(page)).toBe(ids.first);
     });

--- a/e2e/tests/layout-history-grid.spec.ts
+++ b/e2e/tests/layout-history-grid.spec.ts
@@ -28,17 +28,14 @@ test.describe('layout history (in-grid undo/redo)', () => {
             (window as any).__dv.addPanelAt('beta', 'right')
         );
 
-        // Two side-by-side groups, and the split is on the undo stack.
         expect(await groupCount(page)).toBe(2);
         expect(await canUndo(page)).toBe(true);
         expect(await canRedo(page)).toBe(false);
 
-        // Undo → beta's add is reverted, back to a single group.
         await page.evaluate(() => (window as any).__dv.undo());
         await expect.poll(() => groupCount(page)).toBe(1);
         expect(await canRedo(page)).toBe(true);
 
-        // Redo → the split returns.
         await page.evaluate(() => (window as any).__dv.redo());
         await expect.poll(() => groupCount(page)).toBe(2);
     });
@@ -54,7 +51,6 @@ test.describe('layout history (in-grid undo/redo)', () => {
         await page.evaluate(() => (window as any).__dv.closePanel('beta'));
         await expect(page.locator('.dv-tab')).toHaveCount(1);
 
-        // Undo the close → beta comes back.
         await page.evaluate(() => (window as any).__dv.undo());
         await expect(page.locator('.dv-tab')).toHaveCount(2);
         await expect(
@@ -77,7 +73,6 @@ test.describe('layout history (in-grid undo/redo)', () => {
             )
             .toBe(true);
 
-        // Undo → the maximize is lifted.
         await page.evaluate(() => (window as any).__dv.undo());
         await expect
             .poll(() =>

--- a/e2e/tests/layout-history.spec.ts
+++ b/e2e/tests/layout-history.spec.ts
@@ -32,7 +32,6 @@ test.describe('cross-window layout history', () => {
             await page.evaluate(() => (window as any).__dv.popoutCount())
         ).toBe(1);
 
-        // Undo the popout → the window closes and the group goes back.
         await Promise.all([
             (win as Page).waitForEvent('close'),
             page.evaluate(() => (window as any).__dv.undo()),
@@ -45,7 +44,6 @@ test.describe('cross-window layout history', () => {
     test('undo re-opens a closed popout window', async ({ page, context }) => {
         await ready(page);
 
-        // pop the active group out
         const [win1] = await Promise.all([
             context.waitForEvent('page'),
             page.evaluate(() => (window as any).__dv.popoutActiveGroup()),

--- a/e2e/tests/live-region.spec.ts
+++ b/e2e/tests/live-region.spec.ts
@@ -43,9 +43,8 @@ test.describe('cross-window live regions', () => {
         await win.locator('.dv-test-panel').first().focus();
         await page.evaluate(() => (window as any).__dv.closePanel('beta'));
 
-        // The close lands in the popout's region...
         await expect(win.locator('.dv-live-region')).toHaveText('beta closed');
-        // ...and never leaks into the opener's region. (The opener's region
+        // It must never leak into the opener's region. (The opener's region
         // still holds the earlier "opened in a new window" note, which routed
         // to it because the main window had focus at popout time.)
         await expect(page.locator('.dv-live-region')).not.toHaveText(

--- a/e2e/tests/locked-group.spec.ts
+++ b/e2e/tests/locked-group.spec.ts
@@ -74,7 +74,6 @@ test.describe('locked group', () => {
         await expect(page.locator('.dv-dnd-compass')).toBeVisible();
         await page.mouse.up();
 
-        // The two groups merged into one.
         await expect.poll(() => groupCount(page)).toBe(1);
         await expect(page.locator('.dv-tab')).toHaveText(['two', 'one']);
     });

--- a/e2e/tests/multi-row-tabs.spec.ts
+++ b/e2e/tests/multi-row-tabs.spec.ts
@@ -96,7 +96,6 @@ test.describe('multi-row tabs (wrap mode)', () => {
             .first()
             .boundingBox())!;
 
-        // multi-row header
         expect(headerBox.height).toBeGreaterThan(44);
 
         // the active panel was laid out with the shrunk content area, not the
@@ -163,7 +162,6 @@ test.describe('multi-row tabs (wrap mode)', () => {
         await page.waitForFunction(() => (window as any).__ready === true);
         await page.evaluate(() => (window as any).__dv.setupWrapTabs(20));
 
-        // Open the chevron dropdown.
         const handle = page.locator('.dv-tabs-overflow-dropdown-default');
         await expect(handle).toBeVisible();
         await handle.click();
@@ -180,7 +178,6 @@ test.describe('multi-row tabs (wrap mode)', () => {
         expect(listed).toContain('wrap-tab-long-title-19');
         expect(listed).not.toContain('wrap-tab-long-title-0');
 
-        // Picking a spilled tab activates it and closes the dropdown.
         await overflow
             .locator('.dv-tab', { hasText: 'wrap-tab-long-title-19' })
             .click();
@@ -197,7 +194,6 @@ test.describe('multi-row tabs (wrap mode)', () => {
         await page.waitForFunction(() => (window as any).__ready === true);
         await page.evaluate(() => (window as any).__dv.setupWrapTabs(20));
 
-        // Surplus present → dropdown shown.
         await expect(
             page.locator('.dv-tabs-overflow-dropdown-root').first()
         ).toBeVisible();

--- a/e2e/tests/pinned-tabs.spec.ts
+++ b/e2e/tests/pinned-tabs.spec.ts
@@ -35,7 +35,6 @@ test.describe('pinned tabs', () => {
             (window as any).__dv.setupPinned(['a', 'b', 'c'], [])
         );
 
-        // Baseline: single-row header, no pinned row.
         const headerBefore = (await box(
             page,
             '.dv-tabs-and-actions-container'
@@ -43,7 +42,6 @@ test.describe('pinned tabs', () => {
         const contentBefore = (await box(page, '.dv-content-container'))!;
         expect(await page.locator('.dv-pinned-row').count()).toBe(0);
 
-        // Pin a tab → the second row mounts.
         await page.evaluate(() => (window as any).__dv.setPinned('a', true));
         await expect(page.locator('.dv-pinned-row')).toBeVisible();
 
@@ -55,22 +53,18 @@ test.describe('pinned tabs', () => {
         ))!;
         const contentAfter = (await box(page, '.dv-content-container'))!;
 
-        // The pinned row sits above the main strip.
         expect(pinnedRow.y).toBeLessThan(mainStrip.y);
 
-        // The header grew by a row and the content shrank by the same amount.
         const grow = headerAfter.height - headerBefore.height;
         const shrink = contentBefore.height - contentAfter.height;
         expect(grow).toBeGreaterThan(0);
         expect(shrink).toBeGreaterThan(0);
         expect(Math.abs(grow - shrink)).toBeLessThan(2);
 
-        // The pinned tab renders in the row.
         await expect(page.locator('.dv-pinned-row .dv-pinned-tab')).toHaveText(
             'a'
         );
 
-        // Unpinning the last pinned tab collapses the row back.
         await page.evaluate(() => (window as any).__dv.setPinned('a', false));
         await expect(page.locator('.dv-pinned-row')).toHaveCount(0);
         const headerRestored = (await box(
@@ -179,7 +173,6 @@ test.describe('pinned tabs', () => {
             mainTab.dispatchEvent(new DragEvent('dragend', { bubbles: true }));
         });
 
-        // 'c' is now pinned and shows in the row after 'a'.
         await expect(page.locator('.dv-pinned-row .dv-pinned-tab')).toHaveText([
             'a',
             'c',
@@ -193,7 +186,6 @@ test.describe('pinned tabs', () => {
         page,
     }) => {
         await setup(page, { mode: 'separate-row', dnd: 'html5' });
-        // Pin a & b (row [a, b]); c stays unpinned and visible in the strip.
         await page.evaluate(() =>
             (window as any).__dv.setupPinned(['a', 'b', 'c'], ['a', 'b'])
         );
@@ -236,7 +228,6 @@ test.describe('pinned tabs', () => {
             rowTab.dispatchEvent(new DragEvent('dragend', { bubbles: true }));
         });
 
-        // 'a' is unpinned and gone from the row (only 'b' remains pinned).
         await expect
             .poll(() => page.evaluate(() => (window as any).__dv.isPinned('a')))
             .toBe(false);
@@ -305,7 +296,6 @@ test.describe('pinned tabs', () => {
             { ids, pinned }
         );
 
-        // The strip overflows: the dropdown handle appears.
         const handle = page.locator('.dv-tabs-overflow-dropdown-default');
         await expect(handle).toBeVisible();
         await handle.click();
@@ -337,7 +327,6 @@ test.describe('pinned tabs', () => {
         await page.evaluate(() =>
             (window as any).__dv.setupPinned(['a', 'b', 'c'], [])
         );
-        // Added in order, nothing pinned yet.
         expect(
             await page.evaluate(() => (window as any).__dv.tabTitles())
         ).toEqual(['a', 'b', 'c']);
@@ -395,7 +384,6 @@ test.describe('pinned tabs', () => {
         // Precondition: the strip really does overflow (so sticky matters).
         const rest = await drift();
         expect(rest.scrollWidth).toBeGreaterThan(rest.clientWidth);
-        // At rest the pinned tab hugs the left edge.
         expect(rest.fromLeft).toBeLessThan(8);
 
         // Scroll the strip right and fire the on-scroll self-heal recompute.
@@ -518,7 +506,6 @@ test.describe('pinned tabs', () => {
         await page.keyboard.press('Control+Shift+Enter');
         await expect(page.locator('.dv-tab--pinned')).toContainText('bravo');
 
-        // Pressing again unpins.
         await page.evaluate(() =>
             document.querySelector<HTMLElement>('.dv-tab')?.focus()
         );

--- a/e2e/tests/popout-lifecycle.spec.ts
+++ b/e2e/tests/popout-lifecycle.spec.ts
@@ -48,7 +48,6 @@ test.describe('cross-window popout lifecycle', () => {
             .poll(() => page.evaluate(() => (window as any).__dv.popoutCount()))
             .toBe(0);
 
-        // Both tabs are back in the opener's single group, beta still rendered.
         await expect(page.locator('.dv-tab')).toHaveCount(2);
         await expect(page.locator('.dv-test-panel')).toContainText('beta');
         expect(
@@ -88,13 +87,11 @@ test.describe('cross-window popout lifecycle', () => {
         await win.locator('.dv-sash').first().waitFor();
         await expect(win.locator('.dv-groupview')).toHaveCount(2);
 
-        // Close the popout window → both of its groups return to the opener.
         await win.close({ runBeforeUnload: true });
 
         await expect
             .poll(() => page.evaluate(() => (window as any).__dv.popoutCount()))
             .toBe(0);
-        // Two groups re-docked, all three tabs present, active content rendered.
         await expect
             .poll(() => page.evaluate(() => (window as any).__dv.groupCount()))
             .toBe(2);
@@ -119,7 +116,6 @@ test.describe('cross-window popout lifecycle', () => {
         context: BrowserContext
     ): Promise<Page> => {
         const win = await twoPanelPopout(page, context);
-        // The serialized layout must carry the popout group.
         const json = await page.evaluate(() =>
             JSON.stringify((window as any).__dv.snapshot())
         );
@@ -147,7 +143,6 @@ test.describe('cross-window popout lifecycle', () => {
     }) => {
         const restored = await snapshotThenReloadAndRestore(page, context);
 
-        // The popout window is back, with the group's tab strip and both tabs.
         await expect
             .poll(() => page.evaluate(() => (window as any).__dv.popoutCount()))
             .toBe(1);

--- a/e2e/tests/popout-multi-window.spec.ts
+++ b/e2e/tests/popout-multi-window.spec.ts
@@ -37,7 +37,6 @@ test.describe('popout multi-window popup routing', () => {
             popout.locator('.dv-tab', { hasText: 'beta' })
         ).toBeVisible();
 
-        // right-click beta's tab (in the popout) to open its context menu
         await popout
             .locator('.dv-tab', { hasText: 'beta' })
             .click({ button: 'right' });
@@ -58,7 +57,6 @@ test.describe('popout multi-window popup routing', () => {
             (window as any).__dv.addPanelAt('alpha', 'right'); // separate group
         });
 
-        // pop out alpha's (active) group, then drag 'beta' into the popout
         const popout = await popoutActiveGroup(page, context);
         await page.evaluate(() => (window as any).__dv.splitIntoPopout('beta'));
         await expect(

--- a/e2e/tests/serialization-roundtrip.spec.ts
+++ b/e2e/tests/serialization-roundtrip.spec.ts
@@ -31,7 +31,6 @@ test.describe('serialization round-trips', () => {
         const maxId = await page.evaluate(() =>
             (window as any).__dv.setupTwoGroupsMaximizeFirst()
         );
-        // Live: one group is maximized.
         expect(
             await page.evaluate(() => (window as any).__dv.hasMaximizedGroup())
         ).toBe(true);
@@ -44,7 +43,6 @@ test.describe('serialization round-trips', () => {
 
         await reloadAndRestore(page, json);
 
-        // The same group is maximized again after the round-trip.
         await expect
             .poll(() =>
                 page.evaluate(() => (window as any).__dv.hasMaximizedGroup())
@@ -71,8 +69,6 @@ test.describe('serialization round-trips', () => {
 
         await reloadAndRestore(page, json);
 
-        // The edge group is rebuilt at its position, still holding its panel,
-        // and the panel content renders.
         await expect
             .poll(() =>
                 page.evaluate(() =>
@@ -108,7 +104,6 @@ test.describe('serialization round-trips', () => {
 
         await reloadAndRestore(page, json);
 
-        // The chip is rebuilt with its label.
         await expect(page.locator('.dv-tab-group-chip')).toHaveText(
             'Monitoring'
         );

--- a/e2e/tests/smart-guides.spec.ts
+++ b/e2e/tests/smart-guides.spec.ts
@@ -115,7 +115,6 @@ test.describe('smart guides (floating snap)', () => {
             { steps: 25 }
         );
 
-        // a drop-preview rectangle is shown over the merge target
         await expect(page.locator('.dv-smart-guide-preview')).toBeVisible();
 
         await page.mouse.up();
@@ -184,7 +183,6 @@ test.describe('smart guides (floating snap)', () => {
         await page.mouse.move(targetBox.x + grab + 5, startY, { steps: 20 });
         await page.mouse.up();
 
-        // The event fired at least once, reporting an X-axis snap.
         const snaps = await page.evaluate(() => (window as any).__dv.snaps());
         expect(snaps.length).toBeGreaterThan(0);
         expect(snaps.some((s: any) => s.axes.includes('x'))).toBe(true);

--- a/e2e/tests/tab-group-chips.spec.ts
+++ b/e2e/tests/tab-group-chips.spec.ts
@@ -56,7 +56,6 @@ test.describe('tab-group chips', () => {
         await page.waitForTimeout(250);
         await page.mouse.click(600, 450);
         await expect(page.locator('.dv-context-menu')).toHaveCount(0);
-        // The chip itself survives.
         await expect(chip).toBeVisible();
     });
 

--- a/e2e/tests/tab-overflow-dropdown.spec.ts
+++ b/e2e/tests/tab-overflow-dropdown.spec.ts
@@ -26,23 +26,19 @@ test.describe('tab overflow dropdown', () => {
     }) => {
         await setup(page);
 
-        // The strip overflows: the dropdown handle appears.
         const handle = page.locator('.dv-tabs-overflow-dropdown-default');
         await expect(handle).toBeVisible();
         await handle.click();
 
-        // The dropdown lists the overflowed tabs.
         const overflow = page.locator('.dv-tabs-overflow-container');
         await expect(overflow).toBeVisible();
         await expect(overflow.locator('.dv-tab')).not.toHaveCount(0);
 
-        // Pick the first hidden tab → it becomes the active tab…
         const hiddenTab = overflow.locator('.dv-tab').first();
         const title = (await hiddenTab.textContent())!.trim();
         await hiddenTab.click();
 
         await expect(page.locator('.dv-active-tab')).toHaveText(title);
-        // …and the dropdown closes.
         await expect(overflow).toHaveCount(0);
     });
 

--- a/e2e/tests/vue-attribute-forwarding.spec.ts
+++ b/e2e/tests/vue-attribute-forwarding.spec.ts
@@ -50,7 +50,6 @@ test.describe('dockview-vue fallthrough attribute forwarding', () => {
         expect(rect.width).toBeGreaterThan(100);
         expect(rect.height).toBeGreaterThan(100);
 
-        // The panel content is visible, end to end.
         await expect(page.locator('.vue-panel')).toBeVisible();
     });
 });

--- a/e2e/tests/vue-keep-alive.spec.ts
+++ b/e2e/tests/vue-keep-alive.spec.ts
@@ -43,11 +43,9 @@ test.describe('dockview-vue <keep-alive>', () => {
         const before = await page.evaluate(() =>
             (window as any).__vue.counters('one')
         );
-        // Sanity: it mounted exactly once and hasn't been destroyed.
         expect(before.mounted).toBe(1);
         expect(before.unmounted).toBe(0);
 
-        // Switch away to `two`, then back to `one`.
         await page.evaluate(() => (window as any).__vue.setActive('two'));
         await expect(page.locator('[data-pid="two"] .field')).toBeVisible();
         // While cached, panel one's content is removed from the DOM.
@@ -92,7 +90,6 @@ test.describe('dockview-vue <keep-alive>', () => {
         expect(before.mounted).toBe(1);
         expect(before.unmounted).toBe(0);
 
-        // Pop the active group out into its own window and capture that window.
         const [win] = await Promise.all([
             context.waitForEvent('page'),
             page.evaluate(() => (window as any).__vue.popoutActiveGroup()),
@@ -206,7 +203,6 @@ test.describe('dockview-vue <keep-alive>', () => {
         );
         expect(beforeGamma).toMatchObject({ mounted: 1, unmounted: 0 });
 
-        // Close the popout window → BOTH groups evacuate back to the opener.
         await win.close({ runBeforeUnload: true });
 
         await expect

--- a/packages/dockview-angular/src/__tests__/angular-renderer.spec.ts
+++ b/packages/dockview-angular/src/__tests__/angular-renderer.spec.ts
@@ -152,8 +152,7 @@ describe('AngularRenderer', () => {
         // Reproduces the disposal-order bug from issue #1220: dockview-core's
         // OverlayRenderContainer reads `panel.view.content.element` while
         // tearing down its own disposables, by which point the renderer has
-        // already been disposed. Previously the getter threw "Angular
-        // renderer not initialized" here.
+        // already been disposed.
         const renderer = new AngularRenderer<TestComponent>({
             component: TestComponent,
             injector,
@@ -225,7 +224,6 @@ describe('AngularRenderer', () => {
     });
 
     it('should render view from template', () => {
-        // Create component with template
         const templateRenderer = new AngularRenderer({
             component: TemplateHolderComponent,
             injector,
@@ -238,7 +236,6 @@ describe('AngularRenderer', () => {
 
         expect(template).toBeDefined();
 
-        // Create view from template
         const renderer = new AngularRenderer({
             component: template,
             injector: templateRenderer.component.injector, // use container injector to ensure we have a view

--- a/packages/dockview-angular/src/__tests__/dockview-angular.component.spec.ts
+++ b/packages/dockview-angular/src/__tests__/dockview-angular.component.spec.ts
@@ -107,11 +107,9 @@ describe('DockviewAngularComponent', () => {
     });
 
     it('forwards every PROPERTY_KEYS_DOCKVIEW input to dockview-core on update', () => {
-        // Regression for the missing-input gap: scrollbars, disableTabsOverflowList,
-        // theme, defaultRenderer, defaultHeaderPosition, disableDnd, dndStrategy,
-        // dndEdges, and noPanelsOverlay used to have no @Input() declared, so
-        // PROPERTY_KEYS_DOCKVIEW.forEach found `undefined` for them and they
-        // were silently unsettable from Angular templates.
+        // Every PROPERTY_KEYS_DOCKVIEW entry needs an @Input() declared, or
+        // PROPERTY_KEYS_DOCKVIEW.forEach reads `undefined` for it and it stays
+        // silently unsettable from Angular templates.
         component.ngOnInit();
         const api = component.getDockviewApi()!;
         const updateOptionsSpy = jest.spyOn(api, 'updateOptions');

--- a/packages/dockview-angular/src/__tests__/dockview-context-menu.spec.ts
+++ b/packages/dockview-angular/src/__tests__/dockview-context-menu.spec.ts
@@ -78,7 +78,6 @@ describe('DockviewAngularComponent – context menu', () => {
     it('createContextMenuItemComponent returns an AngularRenderer for a component', () => {
         component.ngOnInit();
 
-        // Access the private method via casting to any
         const frameworkOptions = (component as any).createFrameworkOptions();
         const factory = frameworkOptions.createContextMenuItemComponent;
 

--- a/packages/dockview-angular/src/__tests__/empty.spec.ts
+++ b/packages/dockview-angular/src/__tests__/empty.spec.ts
@@ -1,6 +1,5 @@
 describe('dockview-angular package', () => {
     it('should export all main components', () => {
-        // Basic smoke test to ensure the package structure is correct
         expect(true).toBeTruthy();
     });
 });

--- a/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/dockview/dockview-angular.component.ts
@@ -127,10 +127,9 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
     )[];
     @Input() tabGroupColors?: DockviewTabGroupColorEntry[];
     @Input() tabGroupAccent?: 'palette' | 'off';
-    // These option keys are in PROPERTY_KEYS_DOCKVIEW but were missing an
-    // @Input(), so bindings like [overflow] raised NG0303 and never reached
-    // dockview-core. Typed via indexed access so they always track the core
-    // option shape.
+    // These option keys are in PROPERTY_KEYS_DOCKVIEW; without an @Input()
+    // bindings like [overflow] raise NG0303 and never reach dockview-core.
+    // Typed via indexed access so they track the core option shape.
     @Input() overflow?: DockviewOptions['overflow'];
     @Input() pinnedTabs?: DockviewOptions['pinnedTabs'];
     @Input() smartGuides?: DockviewOptions['smartGuides'];
@@ -174,7 +173,6 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             const coreChanges: Partial<DockviewOptions> = {};
             let hasChanges = false;
 
-            // Check for changes in core dockview properties
             PROPERTY_KEYS_DOCKVIEW.forEach((key) => {
                 if (changes[key] && !changes[key].isFirstChange()) {
                     (coreChanges as any)[key] = changes[key].currentValue;
@@ -182,7 +180,6 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
                 }
             });
 
-            // Handle tabGroupChipComponent → createTabGroupChipComponent mapping
             if (
                 changes['tabGroupChipComponent'] &&
                 !changes['tabGroupChipComponent'].isFirstChange()
@@ -200,7 +197,6 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
                 hasChanges = true;
             }
 
-            // Handle groupDragGhostComponent → createGroupDragGhostComponent mapping
             if (
                 changes['groupDragGhostComponent'] &&
                 !changes['groupDragGhostComponent'].isFirstChange()
@@ -261,10 +257,8 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             ...frameworkOptions,
         });
 
-        // Set up event listeners
         this.setupEventListeners();
 
-        // Emit ready event
         this.ready.emit({ api: this.dockviewApi });
     }
 
@@ -395,7 +389,6 @@ export class DockviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             return;
         }
 
-        // Set up event subscriptions using lifecycle manager
         const api = this.dockviewApi;
 
         if (this.didDrop.observers.length > 0) {

--- a/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/gridview/gridview-angular.component.ts
@@ -89,7 +89,6 @@ export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             const coreChanges: Partial<GridviewOptions> = {};
             let hasChanges = false;
 
-            // Check for changes in core gridview properties
             PROPERTY_KEYS_GRIDVIEW.forEach((key) => {
                 if (changes[key] && !changes[key].isFirstChange()) {
                     (coreChanges as any)[key] = changes[key].currentValue;
@@ -122,7 +121,6 @@ export class GridviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             ...frameworkOptions,
         });
 
-        // Emit ready event
         this.ready.emit({ api: this.gridviewApi });
     }
 

--- a/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/paneview/paneview-angular.component.ts
@@ -93,7 +93,6 @@ export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             const coreChanges: Partial<PaneviewOptions> = {};
             let hasChanges = false;
 
-            // Check for changes in core paneview properties
             PROPERTY_KEYS_PANEVIEW.forEach((key) => {
                 if (changes[key] && !changes[key].isFirstChange()) {
                     (coreChanges as any)[key] = changes[key].currentValue;
@@ -126,10 +125,8 @@ export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             ...frameworkOptions,
         });
 
-        // Set up event listeners
         this.setupEventListeners();
 
-        // Emit ready event
         this.ready.emit({ api: this.paneviewApi });
     }
 
@@ -175,7 +172,6 @@ export class PaneviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             return;
         }
 
-        // Set up event subscriptions using lifecycle manager
         const api = this.paneviewApi;
 
         if (this.drop.observers.length > 0) {

--- a/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
+++ b/packages/dockview-angular/src/lib/splitview/splitview-angular.component.ts
@@ -89,7 +89,6 @@ export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             const coreChanges: Partial<SplitviewOptions> = {};
             let hasChanges = false;
 
-            // Check for changes in core splitview properties
             PROPERTY_KEYS_SPLITVIEW.forEach((key) => {
                 if (changes[key] && !changes[key].isFirstChange()) {
                     (coreChanges as any)[key] = changes[key].currentValue;
@@ -122,7 +121,6 @@ export class SplitviewAngularComponent implements OnInit, OnDestroy, OnChanges {
             ...frameworkOptions,
         });
 
-        // Emit ready event
         this.ready.emit({ api: this.splitviewApi });
     }
 

--- a/packages/dockview-angular/src/lib/utils/angular-renderer.ts
+++ b/packages/dockview-angular/src/lib/utils/angular-renderer.ts
@@ -95,7 +95,6 @@ export class AngularRenderer<T = unknown>
             instance[key] = params[key];
         }
 
-        // Trigger change detection
         if (this.viewRef) {
             this.viewRef.markForCheck();
         }
@@ -115,7 +114,6 @@ export class AngularRenderer<T = unknown>
     }
 
     private setupComponent(component: Type<T>, parameters: Parameters): void {
-        // Create the component using modern Angular API
         this.componentRef = createComponent(component, {
             environmentInjector:
                 this.options.environmentInjector ||
@@ -123,27 +121,22 @@ export class AngularRenderer<T = unknown>
             elementInjector: this.options.injector,
         });
 
-        // Set initial parameters
         this.update(parameters);
 
-        // Get the DOM element
         this.viewRef = this.componentRef.hostView as EmbeddedViewRef<T>;
         this._element = this.viewRef.rootNodes[0] as HTMLElement;
 
-        // always attach for now
         this.appRef.attachView(this.viewRef);
         this.viewRef.markForCheck();
     }
 
     private setupView(template: TemplateRef<T>): void {
-        // Create embedded view from template
         this.viewRef = template.createEmbeddedView(
             <never>{},
             this.options.injector
         );
         this._element = this.viewRef.rootNodes[0] as HTMLElement;
 
-        // always attach for now
         this.appRef.attachView(this.viewRef);
         this.viewRef.markForCheck();
     }

--- a/packages/dockview-angular/src/lib/utils/component-factory.ts
+++ b/packages/dockview-angular/src/lib/utils/component-factory.ts
@@ -55,7 +55,6 @@ export class AngularFrameworkComponentFactory {
         this.defaultTabComponent = maps.defaultTabComponent;
     }
 
-    // For DockviewComponent
     createDockviewComponent(options: CreateComponentOptions): IContentRenderer {
         const component = this.components[options.name];
         if (!component) {
@@ -74,7 +73,6 @@ export class AngularFrameworkComponentFactory {
         return renderer;
     }
 
-    // For GridviewComponent
     createGridviewComponent(options: CreateComponentOptions): GridviewPanel {
         const component = this.components[options.name];
         if (!component) {
@@ -92,7 +90,6 @@ export class AngularFrameworkComponentFactory {
         );
     }
 
-    // For SplitviewComponent
     createSplitviewComponent(options: CreateComponentOptions): SplitviewPanel {
         const component = this.components[options.name];
         if (!component) {
@@ -110,7 +107,6 @@ export class AngularFrameworkComponentFactory {
         );
     }
 
-    // For PaneviewComponent
     createPaneviewComponent(options: CreateComponentOptions): IPanePart {
         const component = this.components[options.name];
         if (!component) {

--- a/packages/dockview-core/src/__tests__/api/dockviewGroupPanelApi.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/dockviewGroupPanelApi.spec.ts
@@ -106,7 +106,6 @@ describe('DockviewGroupPanelApiImpl', () => {
             );
 
             expect(cut.isCollapsed()).toBe(false);
-            // accessor should not have been called since there is no group
             expect(accessor.isEdgeGroupCollapsed).not.toHaveBeenCalled();
         });
     });

--- a/packages/dockview-core/src/__tests__/dnd/backend.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/backend.spec.ts
@@ -1,11 +1,6 @@
 import { fireEvent } from '@testing-library/dom';
 import { html5Backend } from '../../dnd/backend';
 
-/**
- * The HTML5 backend's `createDragSource` replaced the abstract
- * `DragHandler` class. These tests carry forward the behaviors that the
- * old `abstractDragHandler.spec.ts` covered.
- */
 describe('Html5DragSource (html5Backend.createDragSource)', () => {
     const noopGetData = () => ({ dispose: () => undefined });
 
@@ -188,7 +183,6 @@ describe('Html5DragSource (html5Backend.createDragSource)', () => {
             getData: noopGetData,
         });
 
-        // No-op methods must exist and not throw.
         expect(() => source.setTouchOnly(true)).not.toThrow();
         expect(() => source.setTouchOnly(false)).not.toThrow();
         expect(() => source.cancelPending()).not.toThrow();

--- a/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/droptarget.spec.ts
@@ -605,7 +605,6 @@ describe('droptarget', () => {
                 height: string;
             }
         ) {
-            // Check positioning (back to top/left with GPU layer maintained)
             expect(element.style.top).toBe(box.top);
             expect(element.style.left).toBe(box.left);
             expect(element.style.width).toBe(box.width);

--- a/packages/dockview-core/src/__tests__/dnd/pointer/pointerDragController.spec.ts
+++ b/packages/dockview-core/src/__tests__/dnd/pointer/pointerDragController.spec.ts
@@ -285,10 +285,10 @@ describe('PointerDragController', () => {
     });
 
     test('hit-testing prefers the inner / more-specific target when nested targets overlap', () => {
-        // Regression: previously `_findTargetUnder` accepted any registered
-        // target whose element contains the cursor element. Because the
-        // layout-root drop target is registered first and contains every
-        // tab, it always won the race and per-tab targets were unreachable.
+        // `_findTargetUnder` must prefer the inner / more-specific target. The
+        // layout-root drop target is registered first and contains every tab,
+        // so a naive "first registered target that contains the cursor" lets
+        // root eclipse every per-tab target.
         const controller = PointerDragController.getInstance();
 
         const root = document.createElement('div');
@@ -296,7 +296,8 @@ describe('PointerDragController', () => {
         root.appendChild(inner);
         document.body.appendChild(root);
 
-        // Order matters: register OUTER first to recreate the original bug.
+        // Order matters: register OUTER first, the ordering under which root
+        // would eclipse inner in a naive containment check.
         const rootHandle = makeTarget(root);
         const innerHandle = makeTarget(inner);
         const r1 = controller.registerTarget(rootHandle.target);
@@ -316,8 +317,6 @@ describe('PointerDragController', () => {
             makePointerEvent('pointermove', { clientX: 10, clientY: 10 })
         );
 
-        // Inner target should have received the drag-over; root must not
-        // have received it (it'd have eclipsed inner under the old logic).
         expect(innerHandle.handleDragOver).toHaveBeenCalled();
         expect(rootHandle.handleDragOver).not.toHaveBeenCalled();
 
@@ -345,7 +344,6 @@ describe('PointerDragController', () => {
             document.body.appendChild(span);
             document.body.appendChild(source);
 
-            // pre-condition
             expect(iframe.style.pointerEvents).toBeFalsy();
             expect(webview.style.pointerEvents).toBeFalsy();
             expect(span.style.pointerEvents).toBeFalsy();

--- a/packages/dockview-core/src/__tests__/dockview/components/panel/content.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/panel/content.spec.ts
@@ -98,12 +98,10 @@ describe('contentContainer', () => {
         expect(focus).toBe(0);
         expect(blur).toBe(0);
 
-        // container has focus within
         fireEvent.focus(contentRenderer.element);
         expect(focus).toBe(1);
         expect(blur).toBe(0);
 
-        // container looses focus
         fireEvent.blur(contentRenderer.element);
         jest.runAllTimers();
         expect(focus).toBe(1);
@@ -122,12 +120,10 @@ describe('contentContainer', () => {
         // expect(focus).toBe(2);
         // expect(blur).toBe(1);
 
-        // new panel recieves focus
         fireEvent.focus(contentRenderer2.element);
         expect(focus).toBe(2);
         expect(blur).toBe(1);
 
-        // new panel looses focus
         fireEvent.blur(contentRenderer2.element);
         jest.runAllTimers();
         expect(focus).toBe(2);

--- a/packages/dockview-core/src/__tests__/dockview/components/tab.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/tab.spec.ts
@@ -600,12 +600,10 @@ describe('tab', () => {
 
             expect(cut.element.draggable).toBe(true);
 
-            // Simulate option change
             options.disableDnd = true;
             cut.updateDragAndDropState();
             expect(cut.element.draggable).toBe(false);
 
-            // Change back
             options.disableDnd = false;
             cut.updateDragAndDropState();
             expect(cut.element.draggable).toBe(true);
@@ -673,13 +671,11 @@ describe('tab', () => {
                 new groupMock()
             );
 
-            // Initially not disabled
             let event = new Event('dragstart');
             let spy = jest.spyOn(event, 'preventDefault');
             fireEvent(cut.element, event);
             expect(spy).toHaveBeenCalledTimes(0);
 
-            // Simulate option change to disabled
             options.disableDnd = true;
             cut.updateDragAndDropState();
             event = new Event('dragstart');
@@ -687,7 +683,6 @@ describe('tab', () => {
             fireEvent(cut.element, event);
             expect(spy).toHaveBeenCalledTimes(1);
 
-            // Change back to enabled
             options.disableDnd = false;
             cut.updateDragAndDropState();
             event = new Event('dragstart');
@@ -733,7 +728,6 @@ describe('tab', () => {
             });
 
             expect(onDragStart).not.toHaveBeenCalled();
-            // No transfer data should have been set.
             expect(
                 LocalSelectionTransfer.getInstance().hasData(
                     PanelTransfer.prototype

--- a/packages/dockview-core/src/__tests__/dockview/components/tab/defaultTab.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/tab/defaultTab.spec.ts
@@ -80,7 +80,6 @@ describe('defaultTab', () => {
 
         let el = cut.element.querySelector('.dv-default-tab-action');
 
-        // Create a custom event to verify preventDefault is called
         const clickEvent = new Event('click', { cancelable: true });
         const preventDefaultSpy = jest.spyOn(clickEvent, 'preventDefault');
 
@@ -108,13 +107,11 @@ describe('defaultTab', () => {
 
         let el = cut.element.querySelector('.dv-default-tab-action');
 
-        // Create a custom event and prevent it before dispatching
         const clickEvent = new Event('click', { cancelable: true });
         clickEvent.preventDefault();
 
         el!.dispatchEvent(clickEvent);
 
-        // Close should not be called if event was already prevented
         expect(api.close).not.toHaveBeenCalled();
     });
 

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/tabsContainer.spec.ts
@@ -267,9 +267,8 @@ describe('tabsContainer', () => {
             () => 100
         );
 
-        // simulate an internal same-accessor drag (the buggy path):
-        // the void container previously short-circuited to `return true`
-        // for same-accessor drags regardless of the group's locked state.
+        // an internal same-accessor drag: the void container must honour the
+        // group's locked state rather than short-circuiting to `return true`.
         LocalSelectionTransfer.getInstance().setData(
             [new PanelTransfer('testcomponentid', 'anothergroupid', 'panel1')],
             PanelTransfer.prototype
@@ -455,8 +454,6 @@ describe('tabsContainer', () => {
         expect(query).toHaveLength(1);
         expect(query[0].children).toHaveLength(0);
 
-        // add left action
-
         const left = document.createElement('div');
         left.className = 'test-left-actions-element';
         cut.setLeftActionsElement(left);
@@ -470,8 +467,6 @@ describe('tabsContainer', () => {
         );
         expect(query[0].children).toHaveLength(1);
 
-        // add left action
-
         const left2 = document.createElement('div');
         left2.className = 'test-left-actions-element-2';
         cut.setLeftActionsElement(left2);
@@ -484,8 +479,6 @@ describe('tabsContainer', () => {
             'test-left-actions-element-2'
         );
         expect(query[0].children).toHaveLength(1);
-
-        // remove left action
 
         cut.setLeftActionsElement(undefined);
         query = cut.element.querySelectorAll(
@@ -523,8 +516,6 @@ describe('tabsContainer', () => {
         expect(query).toHaveLength(1);
         expect(query[0].children).toHaveLength(0);
 
-        // add right action
-
         const right = document.createElement('div');
         right.className = 'test-right-actions-element';
         cut.setRightActionsElement(right);
@@ -538,8 +529,6 @@ describe('tabsContainer', () => {
         );
         expect(query[0].children).toHaveLength(1);
 
-        // add right action
-
         const right2 = document.createElement('div');
         right2.className = 'test-right-actions-element-2';
         cut.setRightActionsElement(right2);
@@ -552,8 +541,6 @@ describe('tabsContainer', () => {
             'test-right-actions-element-2'
         );
         expect(query[0].children).toHaveLength(1);
-
-        // remove right action
 
         cut.setRightActionsElement(undefined);
         query = cut.element.querySelectorAll(
@@ -1171,7 +1158,6 @@ describe('tabsContainer', () => {
             const cut = new TabsContainer(accessor, groupPanel);
             (cut as any).tabs = mockTabs;
 
-            // Simulate overflow tabs
             (cut as any).toggleDropdown({
                 tabs: ['test-panel'],
                 tabGroups: [],
@@ -1179,41 +1165,32 @@ describe('tabsContainer', () => {
                 reset: false,
             });
 
-            // Find the dropdown trigger and click it
             const dropdownTrigger = cut.element.querySelector(
                 '.dv-tabs-overflow-dropdown-root'
             );
             expect(dropdownTrigger).toBeTruthy();
 
-            // Simulate clicking the dropdown trigger
             fireEvent.click(dropdownTrigger!);
 
-            // Verify popup was opened
             expect(mockPopupService.openPopover).toHaveBeenCalled();
 
-            // Get the popover content
             const popoverContent =
                 mockPopupService.openPopover.mock.calls[0][0];
             expect(popoverContent).toBeTruthy();
 
-            // Find the tab wrapper in the popover
             const tabWrapper = popoverContent.querySelector('.dv-tab');
             expect(tabWrapper).toBeTruthy();
 
-            // Verify the close button is visible in dropdown
             const closeButton = tabWrapper!.querySelector(
                 '.dv-default-tab-action'
             ) as HTMLElement;
             expect(closeButton).toBeTruthy();
             expect(closeButton.style.display).not.toBe('none');
 
-            // Simulate clicking the close button
             fireEvent.click(closeButton!);
 
-            // Verify that the close method was called
             expect(mockClose).toHaveBeenCalledTimes(1);
 
-            // Verify that tab activation methods were NOT called when clicking close button
             expect(mockScrollIntoView).not.toHaveBeenCalled();
             expect(mockSetActive).not.toHaveBeenCalled();
         });
@@ -1314,7 +1291,6 @@ describe('tabsContainer', () => {
             const cut = new TabsContainer(accessor, groupPanel);
             (cut as any).tabs = mockTabs;
 
-            // Simulate overflow tabs
             (cut as any).toggleDropdown({
                 tabs: ['test-panel'],
                 tabGroups: [],
@@ -1322,32 +1298,26 @@ describe('tabsContainer', () => {
                 reset: false,
             });
 
-            // Find the dropdown trigger and click it
             const dropdownTrigger = cut.element.querySelector(
                 '.dv-tabs-overflow-dropdown-root'
             );
             expect(dropdownTrigger).toBeTruthy();
 
-            // Simulate clicking the dropdown trigger
             fireEvent.click(dropdownTrigger!);
 
-            // Get the popover content
             const popoverContent =
                 mockPopupService.openPopover.mock.calls[0][0];
             const tabWrapper = popoverContent.querySelector('.dv-tab');
 
-            // Simulate clicking the tab content (not the close button)
             const tabContent = tabWrapper!.querySelector(
                 '.dv-default-tab-content'
             );
             fireEvent.click(tabContent!);
 
-            // Verify that tab activation methods were called
             expect(mockPopupService.close).toHaveBeenCalled();
             expect(mockScrollIntoView).toHaveBeenCalled();
             expect(mockSetActive).toHaveBeenCalled();
 
-            // Verify that close was NOT called when clicking content
             expect(mockClose).not.toHaveBeenCalled();
         });
 
@@ -1447,7 +1417,6 @@ describe('tabsContainer', () => {
             const cut = new TabsContainer(accessor, groupPanel);
             (cut as any).tabs = mockTabs;
 
-            // Simulate overflow tabs
             (cut as any).toggleDropdown({
                 tabs: ['test-panel'],
                 tabGroups: [],
@@ -1455,13 +1424,11 @@ describe('tabsContainer', () => {
                 reset: false,
             });
 
-            // Find the dropdown trigger and click it
             const dropdownTrigger = cut.element.querySelector(
                 '.dv-tabs-overflow-dropdown-root'
             );
             fireEvent.click(dropdownTrigger!);
 
-            // Get the popover content
             const popoverContent =
                 mockPopupService.openPopover.mock.calls[0][0];
             const tabWrapper = popoverContent.querySelector('.dv-tab');

--- a/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/components/titlebar/voidContainer.spec.ts
@@ -67,12 +67,10 @@ describe('voidContainer', () => {
 
             expect(cut.element.draggable).toBe(true);
 
-            // Simulate option change
             options.disableDnd = true;
             cut.updateDragAndDropState();
             expect(cut.element.draggable).toBe(false);
 
-            // Change back
             options.disableDnd = false;
             cut.updateDragAndDropState();
             expect(cut.element.draggable).toBe(true);
@@ -108,12 +106,10 @@ describe('voidContainer', () => {
 
             expect(cut.element.classList.contains('dv-draggable')).toBe(true);
 
-            // Simulate option change
             options.disableDnd = true;
             cut.updateDragAndDropState();
             expect(cut.element.classList.contains('dv-draggable')).toBe(false);
 
-            // Change back
             options.disableDnd = false;
             cut.updateDragAndDropState();
             expect(cut.element.classList.contains('dv-draggable')).toBe(true);
@@ -169,13 +165,11 @@ describe('voidContainer', () => {
             });
             const cut = new VoidContainer(accessor, group);
 
-            // Initially not disabled
             let event = new Event('dragstart');
             let spy = jest.spyOn(event, 'preventDefault');
             fireEvent(cut.element, event);
             expect(spy).toHaveBeenCalledTimes(0);
 
-            // Simulate option change to disabled
             options.disableDnd = true;
             cut.updateDragAndDropState();
             event = new Event('dragstart');
@@ -183,7 +177,6 @@ describe('voidContainer', () => {
             fireEvent(cut.element, event);
             expect(spy).toHaveBeenCalledTimes(1);
 
-            // Change back to enabled
             options.disableDnd = false;
             cut.updateDragAndDropState();
             event = new Event('dragstart');

--- a/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewComponent.spec.ts
@@ -177,7 +177,6 @@ describe('dockviewComponent', () => {
                 disableDnd: false,
             });
 
-            // Add some panels to create tabs
             const panel1 = dockview.addPanel({
                 id: 'panel1',
                 component: 'default',
@@ -187,7 +186,6 @@ describe('dockviewComponent', () => {
                 component: 'default',
             });
 
-            // Get all tab elements and void containers
             const tabElements = Array.from(
                 dockview.element.querySelectorAll('.dv-tab')
             ) as HTMLElement[];
@@ -195,7 +193,6 @@ describe('dockviewComponent', () => {
                 dockview.element.querySelectorAll('.dv-void-container')
             ) as HTMLElement[];
 
-            // Initially tabs should be draggable (disableDnd: false)
             tabElements.forEach((tab) => {
                 expect(tab.draggable).toBe(true);
             });
@@ -203,10 +200,8 @@ describe('dockviewComponent', () => {
                 expect(container.draggable).toBe(true);
             });
 
-            // Update options to disable DnD
             dockview.updateOptions({ disableDnd: true });
 
-            // Now tabs should not be draggable
             tabElements.forEach((tab) => {
                 expect(tab.draggable).toBe(false);
             });
@@ -214,10 +209,8 @@ describe('dockviewComponent', () => {
                 expect(container.draggable).toBe(false);
             });
 
-            // Update options to enable DnD again
             dockview.updateOptions({ disableDnd: false });
 
-            // Tabs should be draggable again
             tabElements.forEach((tab) => {
                 expect(tab.draggable).toBe(true);
             });
@@ -366,7 +359,6 @@ describe('dockviewComponent', () => {
             const tab = dockview.element.querySelector(
                 '.dv-tab'
             ) as HTMLElement;
-            // disableDnd: true wins regardless of strategy.
             expect(tab.draggable).toBe(false);
         });
 
@@ -386,16 +378,13 @@ describe('dockviewComponent', () => {
                 disableDnd: false,
             });
 
-            // Set disableDnd to true
             dockview.updateOptions({ disableDnd: true });
 
-            // Add a panel after the option change
             const panel = dockview.addPanel({
                 id: 'panel1',
                 component: 'default',
             });
 
-            // New tab should not be draggable
             const tabElement = dockview.element.querySelector(
                 '.dv-tab'
             ) as HTMLElement;
@@ -496,7 +485,6 @@ describe('dockviewComponent', () => {
                 position: 'center',
             });
 
-            // tab groups: create, collapse, move panels between groups, and destroy
             const targetGroup = panel6.api.group;
             const tg1 = dockview.api.createTabGroup({
                 groupId: targetGroup.id,
@@ -527,19 +515,16 @@ describe('dockviewComponent', () => {
 
             tg1.collapse();
 
-            // remove a panel from its tab group
             dockview.api.removePanelFromTabGroup({
                 groupId: targetGroup.id,
                 panelId: panel4.id,
             });
 
-            // explicitly dissolve a tab group
             dockview.api.dissolveTabGroup({
                 groupId: targetGroup.id,
                 tabGroupId: tg2.id,
             });
 
-            // edge groups: add, toggle visibility, collapse, add panels, remove
             dockview.addEdgeGroup('left', {
                 id: 'edge-left',
                 initialSize: 200,
@@ -701,18 +686,15 @@ describe('dockviewComponent', () => {
             expect(panel1.api.location.type).toBe('popout');
             expect(dockview.groups).toHaveLength(3); // panel2 + hidden reference + popout
 
-            // Move popout group to left of panel2
             panel1.api.group.api.moveTo({
                 group: panel2.api.group,
                 position: 'left',
             });
 
-            // Core assertions: should be back in grid and positioned correctly
             expect(panel1.api.location.type).toBe('grid');
-            expect(dockview.groups).toHaveLength(2); // Should clean up properly
+            expect(dockview.groups).toHaveLength(2);
             expect(dockview.panels).toHaveLength(2);
 
-            // Verify both panels are visible and accessible
             expect(panel1.api.isVisible).toBe(true);
             expect(panel2.api.isVisible).toBe(true);
         });
@@ -749,14 +731,12 @@ describe('dockviewComponent', () => {
             await dockview.addPopoutGroup(panel1.api.group);
             expect(panel1.api.location.type).toBe('popout');
 
-            // Test moving to different positions
             ['top', 'bottom', 'left', 'right'].forEach((position) => {
                 panel1.api.group.api.moveTo({
                     group: panel2.api.group,
                     position: position as any,
                 });
 
-                // Should be back in grid and work correctly regardless of position
                 expect(panel1.api.location.type).toBe('grid');
                 expect(panel1.api.isVisible).toBe(true);
                 expect(panel2.api.isVisible).toBe(true);
@@ -794,14 +774,12 @@ describe('dockviewComponent', () => {
                 position: { direction: 'right' },
             });
 
-            // Store reference group ID before popout
             const originalGroupId = panel1.group.id;
 
             await dockview.addPopoutGroup(panel1.api.group);
             expect(panel1.api.location.type).toBe('popout');
             expect(dockview.groups).toHaveLength(3); // panel2 + hidden reference + popout
 
-            // Move to new position - should clean up reference group
             panel1.api.group.api.moveTo({
                 group: panel2.api.group,
                 position: 'right',
@@ -810,7 +788,6 @@ describe('dockviewComponent', () => {
             expect(panel1.api.location.type).toBe('grid');
             expect(dockview.groups).toHaveLength(2); // Just panel2 + panel1 in new position
 
-            // Reference group should be cleaned up (no longer exist)
             const referenceGroupStillExists = dockview.groups.some(
                 (g) => g.id === originalGroupId
             );
@@ -1038,27 +1015,23 @@ describe('dockviewComponent', () => {
         });
         const group2 = panel1!.group;
 
-        // Verify panel1 is active after move (default behavior)
         expect(dockview.activeGroup).toBe(group2);
         expect(dockview.activePanel).toBe(panel1);
 
-        // Set a different group active and make panel2 the active panel
         dockview.doSetGroupActive(group1);
         group1.model.openPanel(panel2!);
         expect(dockview.activeGroup).toBe(group1);
         expect(dockview.activePanel?.id).toBe(panel2?.id);
 
-        // Move panel3 to group2 with skipSetActive
         dockview.moveGroupOrPanel({
             from: { groupId: group1.id, panelId: 'panel3' },
             to: { group: group2, position: 'center' },
             skipSetActive: true,
         });
 
-        // group1 should still be active, not group2
         expect(dockview.activeGroup).toBe(group1);
-        expect(dockview.activePanel?.id).toBe(panel2?.id); // panel2 should still be active in group1
-        expect(panel3!.group).toBe(group2); // panel3 should have moved to group2
+        expect(dockview.activePanel?.id).toBe(panel2?.id);
+        expect(panel3!.group).toBe(group2);
 
         dockview.dispose();
     });
@@ -1101,27 +1074,22 @@ describe('dockviewComponent', () => {
         const panel2 = dockview.getGroupPanel('panel2')!;
         const panel3 = dockview.getGroupPanel('panel3')!;
 
-        // Create separate groups
         panel2.api.moveTo({ position: 'right' });
         panel3.api.moveTo({ group: panel2.group, position: 'center' });
 
-        // Set panel1's group as active and ensure panel1 is the active panel
         dockview.doSetGroupActive(panel1.group);
         panel1.group.model.openPanel(panel1);
         expect(dockview.activeGroup).toBe(panel1.group);
         expect(dockview.activePanel?.id).toBe(panel1.id);
 
-        // Move panel2's entire group to panel1's group with skipSetActive
         dockview.moveGroupOrPanel({
             from: { groupId: panel2.group.id },
             to: { group: panel1.group, position: 'center' },
             skipSetActive: true,
         });
 
-        // panel1's group should still be active and there should be an active panel
         expect(dockview.activeGroup).toBe(panel1.group);
         expect(dockview.activePanel).toBeTruthy();
-        // All panels should now be in the same group
         expect(panel2.group).toBe(panel1.group);
         expect(panel3.group).toBe(panel1.group);
 
@@ -1148,7 +1116,6 @@ describe('dockviewComponent', () => {
         const panel3 = dockview.getGroupPanel('panel3')!;
         const sourceGroup = panel1.group;
 
-        // Create a tab group containing panel1 and panel2
         const tabGroup = sourceGroup.model.createTabGroup({
             label: 'Feature',
             color: 'blue',
@@ -1156,9 +1123,6 @@ describe('dockviewComponent', () => {
         sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
         sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel2');
 
-        // Create a second group to be the destination by moving panel1 out
-        // and then moving it back, using moveGroupOrPanel to ensure a
-        // separate group exists
         dockview.moveGroupOrPanel({
             from: { groupId: sourceGroup.id, panelId: 'panel3' },
             to: { group: sourceGroup, position: 'right' },
@@ -1166,7 +1130,6 @@ describe('dockviewComponent', () => {
         const destGroup = panel3.group;
         expect(destGroup).not.toBe(sourceGroup);
 
-        // Move the tab group to the destination group
         dockview.moveGroupOrPanel({
             from: {
                 groupId: sourceGroup.id,
@@ -1219,7 +1182,6 @@ describe('dockviewComponent', () => {
         sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
         tabGroup.collapse();
 
-        // Create destination by splitting panel2 out
         dockview.moveGroupOrPanel({
             from: { groupId: sourceGroup.id, panelId: 'panel2' },
             to: { group: sourceGroup, position: 'right' },
@@ -1268,7 +1230,6 @@ describe('dockviewComponent', () => {
         sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
         tabGroup.collapse();
 
-        // Split panel2 out to make a destination group
         dockview.moveGroupOrPanel({
             from: { groupId: sourceGroup.id, panelId: 'panel2' },
             to: { group: sourceGroup, position: 'right' },
@@ -1348,7 +1309,6 @@ describe('dockviewComponent', () => {
         sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
         sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel2');
 
-        // Move tab group to the right (creates a new group)
         dockview.moveGroupOrPanel({
             from: {
                 groupId: sourceGroup.id,
@@ -1357,7 +1317,6 @@ describe('dockviewComponent', () => {
             to: { group: sourceGroup, position: 'right' },
         });
 
-        // Should have 2 groups now
         expect(dockview.groups).toHaveLength(2);
 
         // panel3 stays in source
@@ -1399,7 +1358,6 @@ describe('dockviewComponent', () => {
         const panel4 = dockview.getGroupPanel('panel4')!;
         const sourceGroup = panel1.group;
 
-        // Create tab group with only panel1 and panel2
         const tabGroup = sourceGroup.model.createTabGroup({
             label: 'Partial',
             color: 'purple',
@@ -1407,7 +1365,6 @@ describe('dockviewComponent', () => {
         sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel1');
         sourceGroup.model.addPanelToTabGroup(tabGroup.id, 'panel2');
 
-        // Create destination by moving panel4 via moveGroupOrPanel
         dockview.moveGroupOrPanel({
             from: { groupId: sourceGroup.id, panelId: 'panel4' },
             to: { group: sourceGroup, position: 'right' },
@@ -1455,7 +1412,6 @@ describe('dockviewComponent', () => {
         const panel2 = dockview.getGroupPanel('panel2')!;
         const sourceGroup = panel1.group;
 
-        // Create a tab group on the source spanning both panels.
         const tabGroup = sourceGroup.model.createTabGroup({
             label: 'Feature',
             color: 'blue',
@@ -2630,14 +2586,11 @@ describe('dockviewComponent', () => {
             const panel2 = dockview.getGroupPanel('panel2')!;
             const panel3 = dockview.getGroupPanel('panel3')!;
 
-            // Verify that always visible panels have been positioned
             const overlayContainer = dockview.overlayRenderContainer;
 
-            // Check that panels with renderer: 'always' are attached to overlay container
             expect(panel2.api.renderer).toBe('always');
             expect(panel3.api.renderer).toBe('always');
 
-            // Get the overlay elements for always visible panels
             const panel2Overlay = overlayContainer.element.querySelector(
                 '[data-panel-id]'
             ) as HTMLElement;
@@ -2645,7 +2598,6 @@ describe('dockviewComponent', () => {
                 '[data-panel-id]:not(:first-child)'
             ) as HTMLElement;
 
-            // Verify positioning has been applied (should not be 0 after layout)
             if (panel2Overlay) {
                 const style = getComputedStyle(panel2Overlay);
                 expect(style.position).toBe('absolute');
@@ -2655,16 +2607,13 @@ describe('dockviewComponent', () => {
                 expect(style.height).not.toBe('0px');
             }
 
-            // Test that updateAllPositions method works correctly
             const updateSpy = jest.spyOn(
                 overlayContainer,
                 'updateAllPositions'
             );
 
-            // Call fromJSON again to trigger position updates
             dockview.fromJSON(dockview.toJSON());
 
-            // Wait for the position update to be called
             await new Promise((resolve) => requestAnimationFrame(resolve));
 
             expect(updateSpy).toHaveBeenCalled();
@@ -7731,16 +7680,13 @@ describe('dockviewComponent', () => {
             dockview.layout(800, 600);
 
             try {
-                // 1. Create a panel
                 const panel = dockview.addPanel({
                     id: 'test-panel',
                     component: 'default',
                 });
 
-                // Verify initial state
                 expect(panel.api.location.type).toBe('grid');
 
-                // 2. Move to floating group
                 dockview.addFloatingGroup(panel, {
                     position: {
                         bottom: 50,
@@ -7750,17 +7696,14 @@ describe('dockviewComponent', () => {
                     height: 300,
                 });
 
-                // Verify floating state
                 expect(panel.api.location.type).toBe('floating');
 
-                // 3. Move back to grid using addGroup + moveTo pattern (reproducing user's exact issue)
+                // Move back to grid using addGroup + moveTo pattern (reproducing user's exact issue)
                 const addGroup = dockview.addGroup();
                 panel.api.moveTo({ group: addGroup });
 
-                // THIS IS THE FIX: Component should still be visible
                 expect(panel.api.location.type).toBe('grid');
 
-                // Test multiple scenarios
                 const panel2 = dockview.addPanel({
                     id: 'panel-2',
                     component: 'default',
@@ -8162,7 +8105,6 @@ describe('dockviewComponent', () => {
             await dockview.addPopoutGroup(panel2);
             panel2.api.moveTo({ group: panel1.api.group, position: 'right' });
 
-            // confirm panel is rendered on DOM
             expect(
                 panel2.group.element.querySelectorAll(
                     '.dv-content-container > .testpanel-panel_2'
@@ -8172,7 +8114,6 @@ describe('dockviewComponent', () => {
             await dockview.addPopoutGroup(panel3);
             panel3.api.moveTo({ group: panel1.api.group, position: 'right' });
 
-            // confirm panel is rendered to always overlay container
             // Query from `container` because the overlay render container is
             // anchored to the shell element (parent of dockview.element).
             expect(
@@ -9361,7 +9302,6 @@ describe('dockviewComponent', () => {
             const didLayoutChangeHandler = jest.fn();
             dockview.onDidLayoutChange(didLayoutChangeHandler);
 
-            // add panel
             const panel1 = dockview.addPanel({
                 id: 'panel_1',
                 component: 'default',
@@ -9374,22 +9314,18 @@ describe('dockviewComponent', () => {
             jest.runAllTimers();
             expect(didLayoutChangeHandler).toHaveBeenCalledTimes(1);
 
-            // add group
             const group = dockview.addGroup();
             jest.runAllTimers();
             expect(didLayoutChangeHandler).toHaveBeenCalledTimes(2);
 
-            // remove group
             group.api.close();
             jest.runAllTimers();
             expect(didLayoutChangeHandler).toHaveBeenCalledTimes(3);
 
-            // active panel
             panel1.api.setActive();
             jest.runAllTimers();
             expect(didLayoutChangeHandler).toHaveBeenCalledTimes(4);
 
-            // move panel
             dockview.moveGroupOrPanel({
                 from: {
                     groupId: panel1.group.api.id,
@@ -9402,7 +9338,6 @@ describe('dockviewComponent', () => {
                 },
             });
 
-            // remove panel
             panel2.api.close();
             jest.runAllTimers();
             expect(didLayoutChangeHandler).toHaveBeenCalledTimes(5);
@@ -9450,7 +9385,6 @@ describe('dockviewComponent', () => {
             const didLayoutChangeHandler = jest.fn();
             dockview.onDidLayoutChange(didLayoutChangeHandler);
 
-            // add edge group
             dockview.addEdgeGroup('left', { id: 'edge-left' });
             jest.runAllTimers();
             expect(didLayoutChangeHandler).toHaveBeenCalledTimes(1);
@@ -10024,30 +9958,23 @@ describe('dockviewComponent', () => {
             const panel2 = dockview.getGroupPanel('panel2')!;
             const panel3 = dockview.getGroupPanel('panel3')!;
 
-            // Move panel2 to a new group to create separate groups
             panel2.api.moveTo({ position: 'right' });
 
-            // Move panel3 to panel2's group
             panel3.api.moveTo({ group: panel2.group, position: 'center' });
 
-            // panel2's group should be active
             expect(dockview.activeGroup).toBe(panel2.group);
 
-            // Set panel1's group as active
             dockview.doSetGroupActive(panel1.group);
             expect(dockview.activeGroup).toBe(panel1.group);
 
-            // Now move panel2's group to panel1's group without setting it active
             panel2.group.api.moveTo({
                 group: panel1.group,
                 position: 'center',
                 skipSetActive: true,
             });
 
-            // panel1's group should still be active and there should be an active panel
             expect(dockview.activeGroup).toBe(panel1.group);
             expect(dockview.activePanel).toBeTruthy();
-            // panel2 and panel3 should now be in panel1's group
             expect(panel2.group).toBe(panel1.group);
             expect(panel3.group).toBe(panel1.group);
         });
@@ -10084,20 +10011,16 @@ describe('dockviewComponent', () => {
             const panel1 = dockview.getGroupPanel('panel1')!;
             const panel2 = dockview.getGroupPanel('panel2')!;
 
-            // Move panel2 to a new group to the right
             panel2.api.moveTo({ position: 'right' });
 
-            // Set panel1's group as active
             dockview.doSetGroupActive(panel1.group);
             expect(dockview.activeGroup).toBe(panel1.group);
 
-            // Move panel1 to panel2's group (should activate panel2's group)
             panel1.api.moveTo({
                 group: panel2.group,
                 position: 'center',
             });
 
-            // panel2's group should now be active and panel1 should be the active panel
             expect(dockview.activeGroup).toBe(panel2.group);
             expect(dockview.activePanel?.id).toBe(panel1.id);
             expect(panel1.group).toBe(panel2.group);
@@ -10546,7 +10469,6 @@ describe('dockviewComponent', () => {
         });
     });
 
-    // Adding back tests one by one to identify problematic expectations
     describe('GitHub Issue #991 - Group remains active after tab header space drag', () => {
         let container: HTMLElement;
 
@@ -10570,7 +10492,6 @@ describe('dockviewComponent', () => {
             });
             dockview.layout(1000, 1000);
 
-            // Create panel in first group
             dockview.addPanel({
                 id: 'panel1',
                 component: 'default',
@@ -10579,15 +10500,12 @@ describe('dockviewComponent', () => {
             const panel1 = dockview.getGroupPanel('panel1')!;
             const originalGroup = panel1.group;
 
-            // Set up initial state - make sure group is active
             dockview.doSetGroupActive(originalGroup);
             expect(dockview.activeGroup).toBe(originalGroup);
             expect(dockview.activePanel?.id).toBe('panel1');
 
-            // Move panel to edge position
             panel1.api.moveTo({ position: 'right' });
 
-            // After move, there should still be an active group and panel
             expect(dockview.activeGroup).toBeTruthy();
             expect(dockview.activePanel).toBeTruthy();
             expect(dockview.activePanel?.id).toBe('panel1');
@@ -10614,7 +10532,6 @@ describe('dockviewComponent', () => {
             });
             dockview.layout(1000, 1000);
 
-            // Create two groups with panels
             dockview.addPanel({
                 id: 'panel1',
                 component: 'default',
@@ -10631,21 +10548,17 @@ describe('dockviewComponent', () => {
             const group1 = panel1.group;
             const group2 = panel2.group;
 
-            // Set group1 as active initially
             dockview.doSetGroupActive(group1);
             expect(dockview.activeGroup).toBe(group1);
             expect(dockview.activePanel?.id).toBe('panel1');
 
-            // Move panel2's group to panel1's group (center merge)
             dockview.moveGroupOrPanel({
                 from: { groupId: group2.id },
                 to: { group: group1, position: 'center' },
             });
 
-            // After move, the target group should be active and have an active panel
             expect(dockview.activeGroup).toBeTruthy();
             expect(dockview.activePanel).toBeTruthy();
-            // Both panels should now be in the same group
             expect(panel1.group).toBe(panel2.group);
         });
 
@@ -10665,7 +10578,6 @@ describe('dockviewComponent', () => {
             });
             dockview.layout(1000, 1000);
 
-            // Create panel
             dockview.addPanel({
                 id: 'panel1',
                 component: 'default',
@@ -10673,17 +10585,13 @@ describe('dockviewComponent', () => {
 
             const panel1 = dockview.getGroupPanel('panel1')!;
 
-            // Verify content is initially rendered
             expect(panel1.view.content.element.parentElement).toBeTruthy();
 
-            // Move panel to edge position
             panel1.api.moveTo({ position: 'left' });
 
-            // After move, panel content should still be rendered (fixes content disappearing)
             expect(panel1.view.content.element.parentElement).toBeTruthy();
             expect(dockview.activePanel?.id).toBe('panel1');
 
-            // Panel should be visible and active
             expect(panel1.api.isVisible).toBe(true);
             expect(panel1.api.isActive).toBe(true);
         });
@@ -10704,7 +10612,6 @@ describe('dockviewComponent', () => {
             });
             dockview.layout(1000, 1000);
 
-            // Create group with one panel
             dockview.addPanel({
                 id: 'panel1',
                 component: 'default',
@@ -10713,15 +10620,12 @@ describe('dockviewComponent', () => {
             const panel1 = dockview.getGroupPanel('panel1')!;
             const group = panel1.group;
 
-            // Verify initial state
             expect(dockview.activeGroup).toBe(group);
             expect(dockview.activePanel?.id).toBe('panel1');
             expect(panel1.view.content.element.parentElement).toBeTruthy();
 
-            // Move panel to trigger group move logic
             panel1.api.moveTo({ position: 'right' });
 
-            // Panel content should render correctly (the fix ensures first panel is not skipped)
             expect(panel1.view.content.element.parentElement).toBeTruthy();
             expect(dockview.activePanel?.id).toBe('panel1');
             expect(panel1.api.isActive).toBe(true);
@@ -10743,7 +10647,6 @@ describe('dockviewComponent', () => {
             });
             dockview.layout(1000, 1000);
 
-            // Create two groups
             dockview.addPanel({
                 id: 'panel1',
                 component: 'default',
@@ -10760,19 +10663,15 @@ describe('dockviewComponent', () => {
             const group1 = panel1.group;
             const group2 = panel2.group;
 
-            // Set group2 as active
             dockview.doSetGroupActive(group2);
             expect(dockview.activeGroup).toBe(group2);
 
-            // Move group2 to group1 with skipSetActive option
             dockview.moveGroupOrPanel({
                 from: { groupId: group2.id },
                 to: { group: group1, position: 'center' },
                 skipSetActive: true,
             });
 
-            // After merge, there should still be an active group and panel
-            // The skipSetActive should be respected in the implementation
             expect(dockview.activeGroup).toBeTruthy();
             expect(dockview.activePanel).toBeTruthy();
         });
@@ -10798,7 +10697,6 @@ describe('dockviewComponent', () => {
 
             dockview.layout(800, 600);
 
-            // Add two panels so we have layout that can be resized
             const panel1 = dockview.addPanel({
                 id: 'panel1',
                 component: 'default',
@@ -10810,20 +10708,16 @@ describe('dockviewComponent', () => {
                 position: { direction: 'right' },
             });
 
-            // Initial state should be 400px each
             expect(panel1.group.api.width).toBe(400);
             expect(panel2.group.api.width).toBe(400);
 
-            // Set size to 350px width and immediately set invisible
             panel1.group.api.setSize({ width: 350 });
-            expect(panel1.group.api.width).toBe(350); // Should work immediately
+            expect(panel1.group.api.width).toBe(350);
 
             panel1.group.api.setVisible(false);
 
-            // Group should be invisible
             expect(panel1.group.api.isVisible).toBe(false);
 
-            // Make visible again
             panel1.group.api.setVisible(true);
 
             // The width should be preserved as 350px, not reverted to initial/minimal size
@@ -10860,19 +10754,15 @@ describe('dockviewComponent', () => {
                 position: { direction: 'right' },
             });
 
-            // Set size to 350px width
             panel1.group.api.setSize({ width: 350 });
             expect(panel1.group.api.width).toBe(350);
 
-            // Set different size while visible
             panel1.group.api.setSize({ width: 400 });
             expect(panel1.group.api.width).toBe(400);
 
-            // Then set invisible
             panel1.group.api.setVisible(false);
             expect(panel1.group.api.isVisible).toBe(false);
 
-            // Make visible again
             panel1.group.api.setVisible(true);
 
             // The most recent size (400px) should be preserved
@@ -10926,10 +10816,8 @@ describe('dockviewComponent', () => {
                 skipSetActive: false,
             });
 
-            // Move is wired correctly.
             expect(panel1.group).toBe(newGroup);
             expect(newGroup.activePanel?.id).toBe('panel1');
-            // The single-panel source group should have been cleaned up.
             expect(dv.groups).not.toContain(sourceGroup);
 
             // The fix schedules updateAllPositions on the next animation
@@ -10939,7 +10827,6 @@ describe('dockviewComponent', () => {
             await new Promise((resolve) => requestAnimationFrame(resolve));
             expect(updateSpy).toHaveBeenCalled();
 
-            // Content node must still be in the DOM tree.
             expect(panel1.view.content.element.parentElement).toBeTruthy();
 
             updateSpy.mockRestore();
@@ -11110,13 +10997,11 @@ describe('dockviewComponent', () => {
 
             expect(tabGroup.panelIds).toEqual(['panel1', 'panel2']);
 
-            // Move panel2 to the other group
             dockview.moveGroupOrPanel({
                 from: { groupId: groupId, panelId: 'panel2' },
                 to: { group: panel3.group, position: 'center' },
             });
 
-            // panel2 should no longer be in the tab group
             expect(tabGroup.containsPanel('panel2')).toBe(false);
             expect(tabGroup.panelIds).toEqual(['panel1']);
         });
@@ -11147,7 +11032,6 @@ describe('dockviewComponent', () => {
             tabGroup.collapse();
             expect(tabGroup.collapsed).toBe(true);
 
-            // Close the only panel in the group
             dockview.removePanel(panel1);
 
             // Tab group should have been auto-destroyed (isEmpty triggers dispose)
@@ -11178,10 +11062,8 @@ describe('dockviewComponent', () => {
             // normally batched via queueMicrotask)
             (panel1.group.model as any).tabsContainer.tabs.updateTabGroups();
 
-            // The tab group was created without a label
             expect(tabGroup.label).toBe('');
 
-            // Verify the chip exists with empty label class via DOM
             const chips =
                 panel1.group.element.querySelectorAll('.dv-tab-group-chip');
             expect(chips.length).toBeGreaterThan(0);
@@ -11240,11 +11122,9 @@ describe('dockviewComponent', () => {
                 panelId: 'panel3',
             });
 
-            // Snapshot and restore
             const state = dockview.toJSON();
             dockview.fromJSON(state);
 
-            // Verify tab groups survived the round-trip
             const restoredGroup = dockview.api.panels[0].group;
             const restored = dockview.api.getTabGroups({
                 groupId: restoredGroup.id,
@@ -11287,7 +11167,6 @@ describe('dockviewComponent', () => {
 
             const groupId = panel1.group.id;
 
-            // Create a collapsed tab group containing panel1 and panel2
             const tg1 = dockview.api.createTabGroup({
                 groupId,
                 label: 'Collapsed',
@@ -11308,7 +11187,6 @@ describe('dockviewComponent', () => {
             // panel3 is ungrouped and should be the active panel
             expect(panel1.group.activePanel?.id).toBe('panel3');
 
-            // Snapshot and restore
             const state = dockview.toJSON();
             dockview.fromJSON(state);
 
@@ -11318,7 +11196,6 @@ describe('dockviewComponent', () => {
 
             expect(activeId).toBe('panel3');
 
-            // Verify collapsed group was restored correctly
             const restored = dockview.api.getTabGroups({
                 groupId: restoredGroup.id,
             });

--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanel.spec.ts
@@ -95,8 +95,6 @@ describe('dockviewGroupPanel', () => {
             maximumWidth: 200,
         });
 
-        // initial constraints
-
         expect(cut.minimumWidth).toBe(20);
         expect(cut.minimumHeight).toBe(10);
         expect(cut.maximumHeight).toBe(100);
@@ -134,10 +132,10 @@ describe('dockviewGroupPanel', () => {
 
         // explicit group constraints now override panel constraints
 
-        expect(cut.minimumWidth).toBe(20); // group constraint overrides panel constraint
-        expect(cut.minimumHeight).toBe(10); // group constraint overrides panel constraint
-        expect(cut.maximumHeight).toBe(100); // group constraint overrides panel constraint
-        expect(cut.maximumWidth).toBe(200); // group constraint overrides panel constraint
+        expect(cut.minimumWidth).toBe(20);
+        expect(cut.minimumHeight).toBe(10);
+        expect(cut.maximumHeight).toBe(100);
+        expect(cut.maximumWidth).toBe(200);
 
         const panel2 = new DockviewPanel(
             'panel_id',
@@ -160,10 +158,10 @@ describe('dockviewGroupPanel', () => {
 
         // explicit group constraints still override panel constraints
 
-        expect(cut.minimumWidth).toBe(20); // group constraint overrides panel constraint
-        expect(cut.minimumHeight).toBe(10); // group constraint overrides panel constraint
-        expect(cut.maximumHeight).toBe(100); // group constraint overrides panel constraint
-        expect(cut.maximumWidth).toBe(200); // group constraint overrides panel constraint
+        expect(cut.minimumWidth).toBe(20);
+        expect(cut.minimumHeight).toBe(10);
+        expect(cut.maximumHeight).toBe(100);
+        expect(cut.maximumWidth).toBe(200);
 
         const panel3 = new DockviewPanel(
             'panel_id',

--- a/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewGroupPanelModel.spec.ts
@@ -2075,12 +2075,10 @@ describe('dockviewGroupPanelModel', () => {
             const json = groupview.model.toJSON();
             expect(json.tabGroups!).toHaveLength(2);
 
-            // Dissolve existing groups
             groupview.model.dissolveTabGroup(tg1.id);
             groupview.model.dissolveTabGroup(tg2.id);
             expect(groupview.model.getTabGroups()).toHaveLength(0);
 
-            // Restore from JSON
             groupview.model.restoreTabGroups(json.tabGroups!);
             const restored = groupview.model.getTabGroups();
             expect(restored).toHaveLength(2);

--- a/packages/dockview-core/src/__tests__/dockview/dockviewPanel.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewPanel.spec.ts
@@ -247,7 +247,6 @@ describe('dockviewPanel', () => {
         cut.init({ params: { a: '1', b: '2' }, title: 'A title' });
         expect(cut.params).toEqual({ a: '1', b: '2' });
 
-        // update 'a' and add 'c'
         cut.update({ params: { a: '-1', c: '3' } });
         expect(cut.params).toEqual({ a: '-1', b: '2', c: '3' });
         expect(model.update).toHaveBeenCalledWith({

--- a/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/dockviewShell.spec.ts
@@ -164,7 +164,6 @@ describe('EdgeGroupView', () => {
             const view = new EdgeGroupView({ id: 'test' }, group, 'horizontal');
             view.setCollapsed(true);
             const afterFirst = view.isCollapsed;
-            // Calling again with same value should not throw and state stays same
             view.setCollapsed(true);
             expect(view.isCollapsed).toBe(afterFirst);
         });

--- a/packages/dockview-core/src/__tests__/dockview/multiRowTabsSeam.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/multiRowTabsSeam.spec.ts
@@ -128,7 +128,6 @@ describe('multi-row tabs seam', () => {
         cut.setForcedOverflow(a.group, (id) => id === 'b');
         expect(dropdown()).not.toBeNull();
 
-        // Clearing the forcing removes it again.
         cut.setForcedOverflow(a.group, () => false);
         expect(dropdown()).toBeNull();
 

--- a/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/popoutLifecycle.spec.ts
@@ -94,8 +94,6 @@ describe('popout lifecycle', () => {
         // a genuine user close fires `beforeunload`, which drives teardown
         expect(() => popoutWindow.close()).not.toThrow();
 
-        // the removal is reported once, the popout is no longer enumerable, and
-        // the panel survives in the grid
         expect(removed).toEqual([popoutId]);
         expect(dockview.getPopouts()).toEqual([]);
         expect(dockview.panels.find((p) => p.id === 'p1')).toBeDefined();

--- a/packages/dockview-core/src/__tests__/dockview/popupService.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/popupService.spec.ts
@@ -125,7 +125,6 @@ describe('PopupService', () => {
 
         expect(root.contains(el2)).toBe(false);
 
-        // Firing Escape again should not throw
         expect(() =>
             fireEvent.keyDown(window, { key: 'Escape' })
         ).not.toThrow();

--- a/packages/dockview-core/src/__tests__/dockview/tabGroupChips.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/tabGroupChips.spec.ts
@@ -42,7 +42,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
     test('fromJSON with tab groups fires correct events', () => {
         dockview.layout(1000, 1000);
 
-        // Set up panels and tab groups first
         const panel1 = dockview.addPanel({
             id: 'panel1',
             component: 'default',
@@ -71,7 +70,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
 
         const state = dockview.toJSON();
 
-        // Now restore from JSON and track events on the new groups
         dockview.fromJSON(state);
 
         const restoredGroup = dockview.api.panels[0].group;
@@ -104,7 +102,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
             dockview.api.onDidTabGroupChange((e) => changes.push(e.tabGroup.id))
         );
 
-        // Create a new tab group and verify events fire
         const newTg = dockview.api.createTabGroup({
             groupId: restoredGroup.id,
             label: 'New',
@@ -127,11 +124,9 @@ describe('tab group events (TabGroupChipsModule)', () => {
             panelId: 'panel1',
         });
 
-        // Change the group label; should fire change event
         newTg.setLabel('Updated');
         expect(changes).toContain(newTg.id);
 
-        // Remove the panel
         panelsRemoved.length = 0;
         dockview.api.removePanelFromTabGroup({
             groupId: restoredGroup.id,
@@ -195,7 +190,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
             dockview.api.onDidTabGroupChange((e) => changes.push(e.tabGroup.id))
         );
 
-        // 1. Create
         const tg = dockview.api.createTabGroup({
             groupId,
             label: 'Test',
@@ -203,7 +197,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
         });
         expect(created).toEqual([tg.id]);
 
-        // 2. Add panels
         dockview.api.addPanelToTabGroup({
             groupId,
             tabGroupId: tg.id,
@@ -225,17 +218,14 @@ describe('tab group events (TabGroupChipsModule)', () => {
             { tgId: tg.id, panelId: 'panel3' },
         ]);
 
-        // 3. Change label and color
         changes.length = 0;
         tg.setLabel('Updated');
         tg.setColor('red');
         expect(changes).toHaveLength(2);
 
-        // 4. Collapse and expand
         tg.collapse();
         tg.expand();
 
-        // 5. Remove one panel
         dockview.api.removePanelFromTabGroup({
             groupId,
             panelId: 'panel2',
@@ -332,7 +322,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
         const didLayoutChangeHandler = jest.fn();
         dockview.onDidLayoutChange(didLayoutChangeHandler);
 
-        // create tab group
         const tg = dockview.api.createTabGroup({
             groupId: panel1.group.id,
             label: 'My Group',
@@ -341,7 +330,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
         jest.runAllTimers();
         expect(didLayoutChangeHandler).toHaveBeenCalledTimes(1);
 
-        // add panels to tab group
         dockview.api.addPanelToTabGroup({
             groupId: panel1.group.id,
             tabGroupId: tg.id,
@@ -358,7 +346,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
         jest.runAllTimers();
         expect(didLayoutChangeHandler).toHaveBeenCalledTimes(3);
 
-        // collapse tab group
         tg.collapse();
         jest.runAllTimers();
         expect(didLayoutChangeHandler).toHaveBeenCalledTimes(4);
@@ -372,7 +359,6 @@ describe('tab group events (TabGroupChipsModule)', () => {
         jest.runAllTimers();
         expect(didLayoutChangeHandler).toHaveBeenCalledTimes(5);
 
-        // explicitly dissolve the tab group
         dockview.api.dissolveTabGroup({
             groupId: panel1.group.id,
             tabGroupId: tg.id,

--- a/packages/dockview-core/src/__tests__/dom.spec.ts
+++ b/packages/dockview-core/src/__tests__/dom.spec.ts
@@ -106,9 +106,8 @@ describe('dom', () => {
     });
 
     test('disableIframePointEvents respects the rootNode parameter', () => {
-        // Iframes in a popout document must be shieldable independently
-        // of the main document. The rootNode parameter previously was
-        // ignored, so the function always walked the main document.
+        // Iframes in a popout document must be shieldable independently of
+        // the main document, which is what the rootNode parameter selects.
         const main = document.createElement('iframe');
         document.body.appendChild(main);
 

--- a/packages/dockview-core/src/__tests__/events.spec.ts
+++ b/packages/dockview-core/src/__tests__/events.spec.ts
@@ -564,7 +564,6 @@ describe('events', () => {
             // flush any queued microtask
             await new Promise<void>((resolve) => queueMicrotask(resolve));
 
-            // the watcher entry for this emitter has been removed
             expect(Emitter.MEMORY_LEAK_WATCHER.size).toBe(0);
         });
 

--- a/packages/dockview-core/src/__tests__/gridview/gridview.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridview.spec.ts
@@ -104,7 +104,7 @@ describe('gridview', () => {
         const serialized = gridview.serialize();
         const branch = (serialized.root as any).data[1];
         expect(branch.type).toBe('branch');
-        // the fix: branch carries its visibility + cached size (was undefined)
+        // branch carries its visibility + cached size
         expect(branch.visible).toBe(false);
         expect(branch.size).toBeGreaterThan(0);
 
@@ -956,7 +956,6 @@ describe('gridview', () => {
             ).toEqual(dimensions);
         }
 
-        // base case assertions
         assertLayout();
         expect(gridview.hasMaximizedView()).toBeFalsy();
         expect(counter).toBe(0);
@@ -1224,8 +1223,6 @@ describe('gridview', () => {
             );
         }
 
-        // hide each view one by one
-
         assertVisibility([true, true, true, true, true, true]);
 
         gridview.setViewVisible(getGridLocation(view5.element), false);
@@ -1245,8 +1242,6 @@ describe('gridview', () => {
 
         gridview.setViewVisible(getGridLocation(view6.element), false);
         assertVisibility([false, false, false, false, false, false]);
-
-        // un-hide each view one by one
 
         gridview.setViewVisible(getGridLocation(view1.element), true);
         assertVisibility([true, false, false, false, false, false]);
@@ -1269,7 +1264,6 @@ describe('gridview', () => {
 
     describe('normalize', () => {
         test('should normalize after structure correctly', () => {
-            // This test verifies that the normalize method works correctly
             // Since gridview already normalizes during remove operations,
             // we'll test the method directly with known scenarios
             const gridview = new Gridview(
@@ -1279,7 +1273,6 @@ describe('gridview', () => {
             );
             gridview.layout(1000, 1000);
 
-            // Create a simple structure and test that normalize doesn't break anything
             const view1 = new MockGridview('1');
             const view2 = new MockGridview('2');
 
@@ -1315,7 +1308,6 @@ describe('gridview', () => {
 
             const afterNormalize = gridview.serialize();
 
-            // Structure should remain unchanged
             expect(afterNormalize).toEqual(beforeNormalize);
         });
 
@@ -1353,7 +1345,6 @@ describe('gridview', () => {
             );
             gridview.layout(1000, 1000);
 
-            // Call normalize on empty gridview
             expect(() => gridview.normalize()).not.toThrow();
 
             // Should still be able to add views after normalizing empty gridview
@@ -1373,7 +1364,6 @@ describe('gridview', () => {
             );
             gridview.layout(1000, 1000);
 
-            // Verify the normalize method exists and can be called
             expect(typeof gridview.normalize).toBe('function');
             expect(() => gridview.normalize()).not.toThrow();
         });

--- a/packages/dockview-core/src/__tests__/gridview/gridviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/gridview/gridviewComponent.spec.ts
@@ -2938,8 +2938,6 @@ describe('gridview', () => {
     });
 
     test('registerPanel is called after doAddGroup - panel api events work immediately', () => {
-        // This test verifies the fix for the timing issue where registerPanel
-        // was called before doAddGroup, causing "Cannot read properties of undefined" errors
         const gridview = new GridviewComponent(container, {
             proportionalLayout: false,
             orientation: Orientation.VERTICAL,
@@ -2955,23 +2953,20 @@ describe('gridview', () => {
 
         gridview.layout(800, 400);
 
-        // Add first panel
         const panel1 = gridview.addPanel({
             id: 'panel_1',
             component: 'default',
         });
 
-        // Verify the panel API is immediately accessible and functional
         expect(panel1.api).toBeDefined();
         expect(panel1.api.onDidFocusChange).toBeDefined();
 
-        // Subscribe to focus events to verify event subscription works
         let focusEventCount = 0;
         const disposable = panel1.api.onDidFocusChange((event) => {
             focusEventCount++;
         });
 
-        // This should not throw an error - before the fix, this would throw:
+        // adding a second panel must not throw
         // "Cannot read properties of undefined (reading 'onDidFocusChange')"
         const panel2 = gridview.addPanel({
             id: 'panel_2',
@@ -2979,22 +2974,18 @@ describe('gridview', () => {
             position: { referencePanel: panel1.id, direction: 'right' },
         });
 
-        // Verify both panels have working APIs
         expect(panel1.api).toBeDefined();
         expect(panel2.api).toBeDefined();
         expect(panel1.api.onDidFocusChange).toBeDefined();
         expect(panel2.api.onDidFocusChange).toBeDefined();
 
-        // Verify that the API is functional by checking properties
         expect(panel1.api.isVisible).toBeTruthy();
         expect(panel2.api.isVisible).toBeTruthy();
 
-        // Verify we can subscribe to events on the second panel too
         const disposable2 = panel2.api.onDidFocusChange((event) => {
             focusEventCount++;
         });
 
-        // Clean up
         disposable.dispose();
         disposable2.dispose();
 
@@ -3166,7 +3157,6 @@ describe('gridview', () => {
 
         panel1.api._onDidChangeFocus.fire({ isFocused: false });
 
-        // no change - panel2 remains active
         expect(panel2.api.isActive).toBeTruthy();
         expect(panel1.api.isActive).toBeFalsy();
     });
@@ -3194,7 +3184,6 @@ describe('gridview', () => {
             reference: 'panel1',
         });
 
-        // all three panels still present after the move
         expect(gridview.size).toBe(3);
         expect(gridview.getPanel('panel1')).toBeTruthy();
         expect(gridview.getPanel('panel2')).toBeTruthy();
@@ -3241,7 +3230,6 @@ describe('gridview', () => {
             })
         ).toThrow('center not supported as an option');
 
-        // Both panels survive the rejected move.
         expect(gridview.size).toBe(2);
         expect(gridview.getPanel('panel1')).toBeTruthy();
         expect(gridview.getPanel('panel2')).toBeTruthy();

--- a/packages/dockview-core/src/__tests__/lifecycle.spec.ts
+++ b/packages/dockview-core/src/__tests__/lifecycle.spec.ts
@@ -31,7 +31,6 @@ describe('lifecycle', () => {
     test('that MutableDisposable.value exposes the current disposable', () => {
         const mutableDisposable = new MutableDisposable();
 
-        // nothing set yet
         expect(mutableDisposable.value).toBeUndefined();
 
         const disposable = { dispose: () => {} };

--- a/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlay.spec.ts
@@ -437,7 +437,6 @@ describe('overlay', () => {
 
             const element = overlay.element;
 
-            // Mock container bounds (400x400 viewport)
             jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
                 () =>
                     mockGetBoundingClientRect({
@@ -464,7 +463,6 @@ describe('overlay', () => {
             ) as HTMLElement;
             expect(leftHandle).toBeTruthy();
 
-            // Simulate mousedown on left handle
             const pointerDownEvent = new MouseEvent('pointerdown', {
                 clientX: 350, // Start position at left edge of overlay
                 clientY: 100,
@@ -485,7 +483,7 @@ describe('overlay', () => {
             // Check that overlay didn't snap to full container width (400px)
             const bounds = overlay.toJSON();
             expect(bounds.width).toBeLessThan(400);
-            // After the fix, left position should be constrained to >= 0 (not negative)
+            // left position must be constrained to >= 0 (not negative)
             expect('left' in bounds ? bounds.left : 0).toBeGreaterThanOrEqual(
                 0
             );
@@ -513,7 +511,6 @@ describe('overlay', () => {
 
             const element = overlay.element;
 
-            // Mock container bounds (400x400 viewport)
             jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
                 () =>
                     mockGetBoundingClientRect({
@@ -540,7 +537,6 @@ describe('overlay', () => {
             ) as HTMLElement;
             expect(topHandle).toBeTruthy();
 
-            // Simulate mousedown on top handle
             const pointerDownEvent = new MouseEvent('pointerdown', {
                 clientX: 100,
                 clientY: 350, // Start position at top edge of overlay
@@ -561,7 +557,7 @@ describe('overlay', () => {
             // Check that overlay didn't snap to full container height (400px)
             const bounds = overlay.toJSON();
             expect(bounds.height).toBeLessThan(400);
-            // After the fix, top position should be constrained to >= 0 (not negative)
+            // top position must be constrained to >= 0 (not negative)
             expect('top' in bounds ? bounds.top : 0).toBeGreaterThanOrEqual(0);
 
             overlay.dispose();
@@ -587,7 +583,6 @@ describe('overlay', () => {
 
             const element = overlay.element;
 
-            // Mock container bounds (200x200 viewport)
             jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
                 () =>
                     mockGetBoundingClientRect({
@@ -598,7 +593,6 @@ describe('overlay', () => {
                     })
             );
 
-            // Mock overlay bounds
             jest.spyOn(element, 'getBoundingClientRect').mockImplementation(
                 () =>
                     mockGetBoundingClientRect({
@@ -614,7 +608,6 @@ describe('overlay', () => {
             ) as HTMLElement;
             expect(leftHandle).toBeTruthy();
 
-            // Simulate mousedown on left handle
             const pointerDownEvent = new MouseEvent('pointerdown', {
                 clientX: 20,
                 clientY: 70,
@@ -632,7 +625,6 @@ describe('overlay', () => {
             pointerMoveEvent.pointerId = 1;
             window.dispatchEvent(pointerMoveEvent);
 
-            // Check that left position is constrained to >= 0
             const bounds = overlay.toJSON();
             expect('left' in bounds ? bounds.left : 0).toBeGreaterThanOrEqual(
                 0
@@ -661,7 +653,6 @@ describe('overlay', () => {
 
             const element = overlay.element;
 
-            // Mock small container bounds (100x100 viewport)
             jest.spyOn(container, 'getBoundingClientRect').mockImplementation(
                 () =>
                     mockGetBoundingClientRect({
@@ -672,7 +663,6 @@ describe('overlay', () => {
                     })
             );
 
-            // Mock overlay bounds
             jest.spyOn(element, 'getBoundingClientRect').mockImplementation(
                 () =>
                     mockGetBoundingClientRect({
@@ -688,7 +678,6 @@ describe('overlay', () => {
             ) as HTMLElement;
             expect(rightHandle).toBeTruthy();
 
-            // Simulate mousedown on right handle
             const pointerDownEvent = new MouseEvent('pointerdown', {
                 clientX: 60,
                 clientY: 35,
@@ -706,7 +695,6 @@ describe('overlay', () => {
             pointerMoveEvent.pointerId = 1;
             window.dispatchEvent(pointerMoveEvent);
 
-            // Check that width is constrained to fit within container
             const bounds = overlay.toJSON();
             expect(bounds.width).toBeLessThanOrEqual(90); // 100 - 10 (left position)
 

--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -597,7 +597,7 @@ describe('overlayRenderContainer', () => {
                 onDidVisibilityChange: onDidVisibilityChange2.event,
                 onDidDimensionsChange: onDidDimensionsChange2.event,
                 onDidLocationChange: onDidLocationChange2.event,
-                isVisible: false, // This panel is not visible
+                isVisible: false,
                 location: { type: 'grid' },
             },
             view: {
@@ -612,7 +612,6 @@ describe('overlayRenderContainer', () => {
             },
         });
 
-        // Mock getBoundingClientRect for consistent testing
         jest.spyOn(
             referenceContainer.element,
             'getBoundingClientRect'
@@ -634,30 +633,24 @@ describe('overlayRenderContainer', () => {
             })
         );
 
-        // Attach both panels
         const container1 = cut.attach({ panel: panel1, referenceContainer });
         const container2 = cut.attach({ panel: panel2, referenceContainer });
 
         await exhaustMicrotaskQueue();
         await exhaustAnimationFrame();
 
-        // Clear previous calls to getBoundingClientRect
         jest.clearAllMocks();
 
-        // Call updateAllPositions
         cut.updateAllPositions();
 
         // Should trigger resize for visible panels only
         await exhaustAnimationFrame();
 
-        // Verify that positioning was updated for visible panel
         expect(container1.style.left).toBe('50px');
         expect(container1.style.top).toBe('100px');
         expect(container1.style.width).toBe('150px');
         expect(container1.style.height).toBe('250px');
 
-        // Verify getBoundingClientRect was called for visible panel only
-        // updateAllPositions should call the resize function which triggers getBoundingClientRect
         expect(
             referenceContainer.element.getBoundingClientRect
         ).toHaveBeenCalled();

--- a/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
+++ b/packages/dockview-core/src/__tests__/paneview/paneviewComponent.spec.ts
@@ -222,11 +222,9 @@ describe('paneviewComponent', () => {
             })
         );
 
-        // give panel2 a specific expanded height
         panel2.api.setSize({ size: 150 });
         expect(panel2Dimensions?.height).toBe(150);
 
-        // collapse then re-expand it
         panel2.api.setExpanded(false);
         panel2.api.setExpanded(true);
 

--- a/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
+++ b/packages/dockview-core/src/__tests__/splitview/splitview.spec.ts
@@ -622,13 +622,11 @@ describe('splitview', () => {
             .getElementsByClassName('dv-sash')
             .item(0) as HTMLElement;
 
-        // validate the expected state before drag
         expect([view1.size, view2.size]).toEqual([200, 200]);
         expect(sashElement).toBeTruthy();
         expect(view1.element.parentElement!.style.pointerEvents).toBe('');
         expect(view2.element.parentElement!.style.pointerEvents).toBe('');
 
-        // start the drag event
         fireEvent(
             sashElement,
             new MouseEvent('pointerdown', { clientX: 50, clientY: 100 })
@@ -654,7 +652,6 @@ describe('splitview', () => {
         );
         expect([view1.size, view2.size]).toEqual([225, 175]);
 
-        // end the drag event
         fireEvent(
             document,
             new MouseEvent('pointerup', { clientX: 70, clientY: 110 })
@@ -754,12 +751,10 @@ describe('splitview', () => {
             .getElementsByClassName('dv-sash')
             .item(0) as HTMLElement;
 
-        // validate the expected state before drag
         expect([view1.size, view2.size]).toEqual([200, 200]);
         expect(view1.element.parentElement!.style.pointerEvents).toBe('');
         expect(view2.element.parentElement!.style.pointerEvents).toBe('');
 
-        // start the drag event
         fireEvent(
             sashElement,
             new MouseEvent('pointerdown', { clientX: 50, clientY: 100 })
@@ -779,7 +774,6 @@ describe('splitview', () => {
         expect(view1.element.parentElement!.style.pointerEvents).toBe('');
         expect(view2.element.parentElement!.style.pointerEvents).toBe('');
 
-        // cleanup
         addEventListenerSpy.mockRestore();
         removeEventListenerSpy.mockRestore();
     });

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -212,7 +212,6 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             this._onDidPeekChange,
             this._onDidHeaderDirectionChange,
             this._onDidVisibilityChange.event((event) => {
-                // When becoming visible, apply any pending size change
                 if (event.isVisible && this._pendingSize) {
                     super.setSize(this._pendingSize);
                     this._pendingSize = undefined;
@@ -222,10 +221,8 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
     }
 
     public override setSize(event: SizeEvent): void {
-        // Always store the requested size
         this._pendingSize = { ...event };
 
-        // Apply the size change immediately
         super.setSize(event);
     }
 

--- a/packages/dockview-core/src/dnd/pointer/longPress.ts
+++ b/packages/dockview-core/src/dnd/pointer/longPress.ts
@@ -50,7 +50,6 @@ export class LongPressDetector extends CompositeDisposable {
             return;
         }
 
-        // Cancel any in-flight press first.
         this._cancelPending();
 
         this._pointerId = event.pointerId;

--- a/packages/dockview-core/src/dockview/advancedDnDService.ts
+++ b/packages/dockview-core/src/dockview/advancedDnDService.ts
@@ -14,30 +14,15 @@ import {
 import { defineModule } from './modules';
 import { IAdvancedDnDHost, IAdvancedDnDService } from './moduleContracts';
 
-/** Cursor offset of the group drag ghost, matched to the long-shipped default. */
+/** Cursor offset of the group drag ghost. */
 const GROUP_DRAG_GHOST_OFFSET_X = 30;
 const GROUP_DRAG_GHOST_OFFSET_Y = -10;
 
 /**
- * The narrow surface the {@link AdvancedDnDService} needs from the host
- * (the `DockviewComponent`).
- *
- * The `onWill*` emitters stay on the component so the public event shape is
- * unchanged whether or not this module is registered; the service is only the
- * dispatch point those fires are routed through. Engine policy (e.g. the
- * `disableDnd` guard) stays on the component, ahead of the dispatch.
- */
-/**
  * Owns the dispatch of the advanced drag-and-drop hooks: `onWillDragPanel`,
- * `onWillDragGroup`, `onWillDrop` and `onWillShowOverlay`.
- *
- * At this stage the service is a thin dispatcher that forwards to the host's
- * emitters; the customisation surface it gates (custom drop overlays, custom
- * group drag ghosts, hook veto/transform behaviour) is currently inlined in
- * core and is extracted into this service in later phases. Routing the
- * dispatch through a module slot is what lets that customisation layer move
- * into a separately-distributed package in a future major version without
- * changing the public event surface.
+ * `onWillDragGroup`, `onWillDrop` and `onWillShowOverlay`, forwarding each to
+ * the host's emitters so the public event shape is unchanged whether or not
+ * this module is registered.
  *
  * The service holds no drag state of its own. The gesture is driven by the
  * DnD backends, and the per-group subscriptions live on the component's group

--- a/packages/dockview-core/src/dockview/components/panel/content.ts
+++ b/packages/dockview-core/src/dockview/components/panel/content.ts
@@ -151,9 +151,6 @@ export class ContentContainer
             (this.panel && this.group.isPanelActive(this.panel));
 
         if (this.panel?.view.content.element.parentElement === this._element) {
-            /**
-             * If the currently attached panel is mounted directly to the content then remove it
-             */
             this.panel.view.content.element.remove();
             this.panel.view.content.onHide?.();
         }

--- a/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabGroups.ts
@@ -114,7 +114,6 @@ export class TabGroupManager {
         const model = this._ctx.group.model;
         const tabGroups = model.getTabGroups();
 
-        // Track which group IDs are still active
         const activeGroupIds = new Set<string>();
 
         for (const tabGroup of tabGroups) {
@@ -134,7 +133,6 @@ export class TabGroupManager {
             }
         }
 
-        // Update CSS classes on all tabs
         this._updateTabGroupClasses();
     }
 
@@ -651,7 +649,6 @@ export class TabGroupManager {
             return;
         }
 
-        // Find the first tab element of this group
         const firstPanelId = panelIds[0];
         const firstTabEntry = this._ctx.getTabMap().get(firstPanelId);
 
@@ -660,7 +657,6 @@ export class TabGroupManager {
             return;
         }
 
-        // Insert chip before the first tab of the group
         const firstTabEl = firstTabEntry.value.element;
         if (chipEl.nextSibling !== firstTabEl) {
             this._ctx.tabsList.insertBefore(chipEl, firstTabEl);
@@ -745,14 +741,12 @@ export class TabGroupManager {
             }
         }
 
-        // Track active group IDs for underline/collapse handling
         const activeGroupIds = new Set<string>();
 
         // Handle collapse animation per group
         for (const tg of tabGroups) {
             activeGroupIds.add(tg.id);
 
-            // Collapse animation
             const hasNewCollapse =
                 tg.collapsed &&
                 tg.panelIds.some((pid) => {
@@ -817,7 +811,6 @@ export class TabGroupManager {
 
         this._skipNextCollapseAnimation = false;
 
-        // Sync indicator underlines and position them
         this._ensureIndicator();
         if (this._indicator) {
             this._indicator.syncUnderlineElements(activeGroupIds);

--- a/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabs.ts
@@ -959,7 +959,6 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
                             OVERFLOW_WRAP_TABS_CLASS
                         );
                         if (!wrap) {
-                            // Collapse source tab instantly (no transition)
                             tab.element.style.transition = 'none';
                             toggleClass(tab.element, 'dv-tab--dragging', true);
                             void tab.element.offsetHeight; // force reflow
@@ -1389,14 +1388,12 @@ export class Tabs extends CompositeDisposable implements ITabReorderHost {
             if (!this._animState) {
                 return;
             }
-            // Collapse all group tabs instantly
             for (const t of this._tabs) {
                 if (groupPanelIds.has(t.value.panel.id)) {
                     t.value.element.style.transition = 'none';
                     toggleClass(t.value.element, 'dv-tab--dragging', true);
                 }
             }
-            // Collapse the group chip instantly
             const chipEntry = this._tabGroupManager.chipRenderers.get(
                 tabGroup.id
             );

--- a/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
+++ b/packages/dockview-core/src/dockview/components/titlebar/tabsContainer.ts
@@ -759,7 +759,6 @@ export class TabsContainer
             }
         }
 
-        // Track which groups have already been rendered.
         const renderedGroups = new Set<string>();
 
         for (const tab of this.tabs.tabs.filter((tab) =>

--- a/packages/dockview-core/src/dockview/dockviewComponent.ts
+++ b/packages/dockview-core/src/dockview/dockviewComponent.ts
@@ -1879,9 +1879,8 @@ export class DockviewComponent
         // positioned from the source element's viewport-relative rect, so it
         // is offset here by the opener window's own screen position. Doing the
         // normalisation in one place keeps the window construction below
-        // coordinate-space agnostic; previously the opener offset was added
-        // unconditionally at construction, double-offsetting a restored popout
-        // whenever the opener sat on a non-primary monitor (screenX/Y != 0).
+        // coordinate-space agnostic, and avoids double-offsetting a restored
+        // popout when the opener sits on a non-primary monitor (screenX/Y != 0).
         function getBox(): Box {
             if (options?.position) {
                 return options.position;
@@ -3521,7 +3520,6 @@ export class DockviewComponent
         const { grid, panels, activeGroup } = data;
 
         try {
-            // take note of the existing dimensions
             const width = this.width;
             const height = this.height;
 

--- a/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanel.ts
@@ -40,7 +40,6 @@ export class DockviewGroupPanel
     private readonly _explicitConstraints: Partial<Constraints> = {};
 
     override get minimumWidth(): number {
-        // Check for explicitly set group constraint first
         if (typeof this._explicitConstraints.minimumWidth === 'number') {
             return this._explicitConstraints.minimumWidth;
         }
@@ -53,7 +52,6 @@ export class DockviewGroupPanel
     }
 
     override get minimumHeight(): number {
-        // Check for explicitly set group constraint first
         if (typeof this._explicitConstraints.minimumHeight === 'number') {
             return this._explicitConstraints.minimumHeight;
         }
@@ -66,7 +64,6 @@ export class DockviewGroupPanel
     }
 
     override get maximumWidth(): number {
-        // Check for explicitly set group constraint first
         if (typeof this._explicitConstraints.maximumWidth === 'number') {
             return this._explicitConstraints.maximumWidth;
         }
@@ -79,7 +76,6 @@ export class DockviewGroupPanel
     }
 
     override get maximumHeight(): number {
-        // Check for explicitly set group constraint first
         if (typeof this._explicitConstraints.maximumHeight === 'number') {
             return this._explicitConstraints.maximumHeight;
         }
@@ -155,8 +151,6 @@ export class DockviewGroupPanel
                 this.api._onDidActivePanelChange.fire(event);
             }),
             this.api.onDidConstraintsChangeInternal((event: any) => {
-                // Track explicitly set constraints to override panel constraints
-                // Extract numeric values from functions or values
                 if (event.minimumWidth !== undefined) {
                     this._explicitConstraints.minimumWidth =
                         typeof event.minimumWidth === 'function'

--- a/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
+++ b/packages/dockview-core/src/dockview/dockviewGroupPanelModel.ts
@@ -890,7 +890,6 @@ export class DockviewGroupPanelModel
             return;
         }
 
-        // Remove and re-add at new index within the group
         tabGroup.removePanel(panelId);
         tabGroup.addPanel(panelId, newIndex);
 
@@ -1452,13 +1451,6 @@ export class DockviewGroupPanelModel
             skipSetGroupActive?: boolean;
         } = {}
     ): void {
-        /**
-         * set the panel group
-         * add the panel
-         * check if group active
-         * check if panel active
-         */
-
         if (
             typeof options.index !== 'number' ||
             options.index > this.panels.length

--- a/packages/dockview-core/src/dockview/dockviewPanel.ts
+++ b/packages/dockview-core/src/dockview/dockviewPanel.ts
@@ -217,7 +217,6 @@ export class DockviewPanel
     }
 
     public update(event: PanelUpdateEvent): void {
-        // merge the new parameters with the existing parameters
         this._params = {
             ...this._params,
             ...event.params,
@@ -233,7 +232,6 @@ export class DockviewPanel
             }
         }
 
-        // update the view with the updated props
         this.view.update({
             params: this._params,
         });

--- a/packages/dockview-core/src/dockview/edgeGroupService.ts
+++ b/packages/dockview-core/src/dockview/edgeGroupService.ts
@@ -62,9 +62,7 @@ export class EdgeGroupService implements IEdgeGroupService {
     private readonly _autoHide = new WeakMap<DockviewGroupPanel, boolean>();
     private readonly _autoReveal = new WeakMap<DockviewGroupPanel, boolean>();
 
-    // No constructor needed; the host is currently unused. The
-    // IEdgeGroupServiceHost slot stays for symmetry with the other modules
-    // and to leave room for future host callbacks.
+    // No constructor needed; the host is currently unused.
 
     add(
         position: EdgeGroupPosition,

--- a/packages/dockview-core/src/dockview/liveRegionService.ts
+++ b/packages/dockview-core/src/dockview/liveRegionService.ts
@@ -106,8 +106,8 @@ export class LiveRegionService
         const mainDoc = host.element.ownerDocument;
         this._mainWindow = mainDoc.defaultView ?? window;
 
-        // The main window's region lives inside the dockview element (existing
-        // behaviour). Popout windows get their own pair in their own document.
+        // The main window's region lives inside the dockview element. Popout
+        // windows get their own pair in their own document.
         const mainPair: RegionPair = {
             polite: createLiveRegion(mainDoc, 'polite'),
             assertive: createLiveRegion(mainDoc, 'assertive'),

--- a/packages/dockview-core/src/dockview/rootDropTargetService.ts
+++ b/packages/dockview-core/src/dockview/rootDropTargetService.ts
@@ -120,11 +120,9 @@ export class RootDropTargetService implements IRootDropTargetService {
         };
 
         // `false`, not `host.hasEdgeDragReveal`: this runs during module
-        // initialisation, where the affordance's service may not exist yet, so
-        // the honest answer here is always "no" (see `hasEdgeDragReveal`'s
-        // contract). Reading the host would look like a live gate while being
-        // incapable of returning anything else. The band this resolves is
-        // provisional; the `init` hook below re-resolves it for real.
+        // initialisation, where the affordance's service may not exist yet (see
+        // `hasEdgeDragReveal`'s contract). The band resolved here is provisional;
+        // the `init` hook below re-resolves it for real.
         const overlayModel = resolveRootOverlayModel(host.options, false);
 
         this._html5Target = html5Backend.createDropTarget(host.element, {

--- a/packages/dockview-core/src/dockview/tabGroupChipsService.ts
+++ b/packages/dockview-core/src/dockview/tabGroupChipsService.ts
@@ -46,8 +46,7 @@ export const TabGroupChipsModule = defineModule<
     serviceKey: 'tabGroupChipsService',
     create: (host) => new TabGroupChipsService(host),
     init: (host, service) => {
-        // Self-attach to existing and future groups; tear down when groups
-        // are removed. Component doesn't need to know about this wiring.
+        // Self-attach so the component doesn't need to know about this wiring.
         const perGroupDisposables = new Map<DockviewGroupPanel, IDisposable>();
         return new CompositeDisposable(
             host.onDidAddGroup((group) => {

--- a/packages/dockview-core/src/dockview/types.ts
+++ b/packages/dockview-core/src/dockview/types.ts
@@ -53,10 +53,6 @@ export interface IContentRenderer
     onHide?(): void;
 }
 
-// watermark component
-
-// constructors
-
 export interface IGroupPanelInitParameters
     extends PanelInitParameters,
         HeaderPartInitParameters {

--- a/packages/dockview-core/src/dockview/watermarkService.ts
+++ b/packages/dockview-core/src/dockview/watermarkService.ts
@@ -81,7 +81,6 @@ export const WatermarkModule = defineModule<'watermarkService', IWatermarkHost>(
         serviceKey: 'watermarkService',
         create: (host) => new WatermarkService(host),
         init: (host, service) => {
-            // Initial evaluation reflects the watermark state at construction time.
             service.update();
             return new CompositeDisposable(
                 Event.any(

--- a/packages/dockview-core/src/gridview/basePanelView.ts
+++ b/packages/dockview-core/src/gridview/basePanelView.ts
@@ -112,7 +112,6 @@ export abstract class BasePanelView<T extends PanelApiImpl>
     }
 
     update(event: PanelUpdateEvent): void {
-        // merge the new parameters with the existing parameters
         this._params = {
             ...this._params,
             params: {
@@ -131,7 +130,6 @@ export abstract class BasePanelView<T extends PanelApiImpl>
             }
         }
 
-        // update the view with the updated props
         this.part?.update({ params: this._params.params });
     }
 

--- a/packages/dockview-core/src/gridview/branchNode.ts
+++ b/packages/dockview-core/src/gridview/branchNode.ts
@@ -240,7 +240,6 @@ export class BranchNode extends CompositeDisposable implements IView {
         const wereAllChildrenHidden = this.splitview.contentSize === 0;
 
         this.splitview.setViewVisible(index, visible);
-        // }
         const areAllChildrenHidden = this.splitview.contentSize === 0;
 
         // If all children are hidden then the parent should hide the entire splitview

--- a/packages/dockview-core/src/gridview/gridview.ts
+++ b/packages/dockview-core/src/gridview/gridview.ts
@@ -729,8 +729,8 @@ export class Gridview implements IDisposable {
         oldRoot.element.remove();
 
         const child = oldRoot.removeChild(0); // Remove child to prevent double disposal
-        oldRoot.dispose(); // Dispose old root (won't dispose removed child)
-        child.dispose(); // Dispose the removed child
+        oldRoot.dispose(); // won't dispose the removed child
+        child.dispose();
 
         this._root = cloneNode(
             childReference,

--- a/packages/dockview-core/src/gridview/gridviewComponent.ts
+++ b/packages/dockview-core/src/gridview/gridviewComponent.ts
@@ -203,7 +203,6 @@ export class GridviewComponent
         try {
             const queue: Function[] = [];
 
-            // take note of the existing dimensions
             const width = this.width;
             const height = this.height;
 
@@ -259,7 +258,6 @@ export class GridviewComponent
                 this._onDidRemoveGroup.fire(group);
             }
 
-            // fires clean-up events and clears the underlying HTML gridview.
             this.clear();
 
             /**

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -107,10 +107,8 @@ export class OverlayRenderContainer extends CompositeDisposable {
             return;
         }
 
-        // Invalidate position cache to force recalculation
         this.positionCache.invalidate();
 
-        // Call resize function directly for all visible panels
         for (const entry of Object.values(this.map)) {
             if (entry.panel.api.isVisible && entry.resize) {
                 entry.resize();
@@ -225,7 +223,6 @@ export class OverlayRenderContainer extends CompositeDisposable {
                 );
                 const box2 = this.positionCache.getPosition(this.element);
 
-                // Use traditional positioning for overlay containers
                 const left = box.left - box2.left;
                 const top = box.top - box2.top;
                 const width = box.width;
@@ -431,11 +428,8 @@ export class OverlayRenderContainer extends CompositeDisposable {
             visibilityChanged();
         });
 
-        // dispose of logic asoccciated with previous reference-container
         this.map[panel.api.id].disposable.dispose();
-        // and reset the disposable to the active reference-container
         this.map[panel.api.id].disposable = disposable;
-        // store the resize function for direct access
         this.map[panel.api.id].resize = resize;
 
         return focusContainer;

--- a/packages/dockview-core/src/paneview/draggablePaneviewPanel.ts
+++ b/packages/dockview-core/src/paneview/draggablePaneviewPanel.ts
@@ -193,7 +193,6 @@ export abstract class DraggablePaneviewPanel extends PaneviewPanel {
 
         const existingPanel = containerApi.getPanel(panelId);
         if (!existingPanel) {
-            // if the panel doesn't exist
             this._onDidDrop.fire({
                 ...event,
                 panel: this,

--- a/packages/dockview-core/src/paneview/paneviewComponent.ts
+++ b/packages/dockview-core/src/paneview/paneviewComponent.ts
@@ -387,7 +387,6 @@ export class PaneviewComponent extends Resizable implements IPaneviewComponent {
 
         const queue: Function[] = [];
 
-        // take note of the existing dimensions
         const width = this.width;
         const height = this.height;
 

--- a/packages/dockview-core/src/splitview/splitview.ts
+++ b/packages/dockview-core/src/splitview/splitview.ts
@@ -247,7 +247,6 @@ export class Splitview {
 
         this.style(options.styles);
 
-        // We have an existing set of view, add them now
         if (options.descriptor) {
             this._size = options.descriptor.size;
             options.descriptor.views.forEach((viewDescriptor, index) => {
@@ -270,7 +269,6 @@ export class Splitview {
                 );
             });
 
-            // Initialize content size and proportions for first layout
             this._contentSize = this.viewItems.reduce((r, i) => r + i.size, 0);
             this.saveProportions();
         }
@@ -430,7 +428,6 @@ export class Splitview {
         this.viewItems.splice(index, 0, viewItem);
 
         if (this.viewItems.length > 1) {
-            //add sash
             const sash = document.createElement('div');
             sash.className = 'dv-sash';
 
@@ -631,11 +628,9 @@ export class Splitview {
         sizing?: Sizing,
         skipLayout = false
     ): IView {
-        // Remove view
         const viewItem = this.viewItems.splice(index, 1)[0];
         viewItem.dispose();
 
-        // Remove sash
         if (this.viewItems.length >= 1) {
             const sashIndex = Math.max(index - 1, 0);
             const sashItem = this.sashes.splice(sashIndex, 1)[0];
@@ -834,7 +829,6 @@ export class Splitview {
             [] as number[]
         );
 
-        // calculate both view and cash positions
         this.viewItems.forEach((view, i) => {
             totalLeftOffset += this.viewItems[i].size;
             viewLeftOffsets.push(totalLeftOffset);
@@ -854,7 +848,6 @@ export class Splitview {
                           marginReducedSize;
 
             if (i < this.viewItems.length - 1) {
-                // calculate sash position
                 const newSize = view.visible
                     ? offset + size - sashWidth / 2 + this.margin / 2
                     : offset;
@@ -868,8 +861,6 @@ export class Splitview {
                     this.sashes[i].container.style.top = `${newSize}px`;
                 }
             }
-
-            // calculate view position
 
             if (this._orientation === Orientation.HORIZONTAL) {
                 view.container.style.width = `${size}px`;
@@ -893,7 +884,6 @@ export class Splitview {
     }
 
     private findFirstSnapIndex(indexes: number[]): number | undefined {
-        // visible views first
         for (const index of indexes) {
             const viewItem = this.viewItems[index];
 
@@ -906,7 +896,6 @@ export class Splitview {
             }
         }
 
-        // then, hidden views
         for (const index of indexes) {
             const viewItem = this.viewItems[index];
 

--- a/packages/dockview-core/src/splitview/splitviewComponent.ts
+++ b/packages/dockview-core/src/splitview/splitviewComponent.ts
@@ -341,7 +341,6 @@ export class SplitviewComponent
 
         const queue: Function[] = [];
 
-        // take note of the existing dimensions
         const width = this.width;
         const height = this.height;
 

--- a/packages/dockview-enterprise/src/__tests__/dndCompass.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/dndCompass.spec.ts
@@ -122,8 +122,7 @@ describe('DnD compass', () => {
         make(true);
         const r = service.resolver!;
         // 200x100: the top cell ends at y=27 and the centre starts at y=31, a
-        // 4px gap that used to resolve to null (the overlay would disappear). A
-        // pointer in the gap now snaps to whichever cell is nearer, so the
+        // 4px gap. A pointer in the gap snaps to whichever cell is nearer, so the
         // overlay stays on as the cursor crosses between cells.
         expect(r.resolve(args(100, 28))).toEqual({
             position: 'top',

--- a/packages/dockview-enterprise/src/__tests__/mruTracker.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/mruTracker.spec.ts
@@ -43,7 +43,6 @@ describe('MruTracker', () => {
         mru.attach('g1', ['a', 'b']);
         mru.attach('g2', ['c', 'd']);
 
-        // Panel 'a' moves into g2 and is activated there.
         mru.activate('g2', 'a');
 
         expect(mru.order('g1')).toEqual(['b']);
@@ -74,7 +73,7 @@ describe('MruTracker', () => {
         const mru = new MruTracker();
         mru.attach('g', ['a', 'b', 'c']);
         mru.activate('g', 'c'); // -> [c, a, b]
-        mru.attach('g', ['a', 'b', 'c', 'd']); // re-attach with a new panel 'd'
+        mru.attach('g', ['a', 'b', 'c', 'd']);
         expect(mru.order('g')).toEqual(['c', 'a', 'b', 'd']);
     });
 });

--- a/packages/dockview-enterprise/src/index.ts
+++ b/packages/dockview-enterprise/src/index.ts
@@ -16,8 +16,8 @@ import { LicenseModule } from './licenseService';
 // superset of `dockview`.
 export * from 'dockview';
 
-// TabGroupChipsModule / TabGroupChipsService are now free and live in
-// dockview-core; they remain re-exported here via `export * from 'dockview'`
+// TabGroupChipsModule / TabGroupChipsService are free and live in
+// dockview-core; they are re-exported here via `export * from 'dockview'`
 // above so `dockview-enterprise` stays a drop-in superset.
 export { ContextMenuController, ContextMenuModule } from './contextMenu';
 export {

--- a/packages/dockview-enterprise/src/pinnedTabsService.ts
+++ b/packages/dockview-enterprise/src/pinnedTabsService.ts
@@ -250,7 +250,7 @@ class SecondRowController extends CompositeDisposable {
     }
 
     private _onDragOver(event: DragEvent): void {
-        // A reorder originating in this row (behaviour: within-row reorder)…
+        // A reorder originating in this row…
         if (this._dragPanelId !== undefined) {
             event.preventDefault();
             if (event.dataTransfer) {
@@ -845,9 +845,9 @@ export const PinnedTabsModule = defineModule<
     name: 'PinnedTabs',
     options: ['pinnedTabs'],
     serviceKey: 'pinnedTabsService',
-    // ContextMenuModule is an optional enhancer (a later phase adds the
-    // Pin/Unpin menu item only when it is present), not a hard dependency, so
-    // it is intentionally not listed here.
+    // ContextMenuModule is an optional enhancer (it adds the Pin/Unpin menu
+    // item only when present), not a hard dependency, so it is intentionally
+    // not listed here.
     dependsOn: [],
     create: (host) => new PinnedTabsService(host),
 });

--- a/packages/dockview-react/src/dockview/defaultTab.tsx
+++ b/packages/dockview-react/src/dockview/defaultTab.tsx
@@ -129,12 +129,9 @@ export const DockviewDefaultTab: React.FunctionComponent<
             className="dv-default-tab"
         >
             {isPinned && (
-                // Leading pin glyph. Mirrors the core vanilla tab's injected
-                // indicator (`.dv-tab-pin`), which core suppresses for custom
-                // `tabComponent`s like this one. The `dv-tab--pinned` /
-                // `dv-tab--pinned-compact` classes on the outer `.dv-tab`
-                // container (applied by core regardless of renderer) drive the
-                // glyph styling, close-button hiding, and compact title hiding.
+                // Core injects a `.dv-tab-pin` indicator for vanilla tabs but
+                // suppresses it for custom `tabComponent`s like this one, so
+                // render it here.
                 <div className="dv-tab-pin">
                     <PinButton />
                 </div>

--- a/packages/dockview-react/src/dockview/dockview.tsx
+++ b/packages/dockview-react/src/dockview/dockview.tsx
@@ -88,7 +88,6 @@ export interface IDockviewReactProps extends DockviewOptions {
      * before the browser snapshots it.
      */
     groupDragGhostComponent?: React.FunctionComponent<IDockviewGroupDragGhostProps>;
-    //
     onReady: (event: DockviewReadyEvent) => void;
     onDidDrop?: (event: DockviewDidDropEvent) => void;
     onWillDrop?: (event: DockviewWillDropEvent) => void;

--- a/packages/dockview-vue/src/__tests__/gridview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/gridview.spec.ts
@@ -78,7 +78,6 @@ describe('GridviewVue Component', () => {
                 ),
         });
 
-        // Update proportional layout
         api.updateOptions({ proportionalLayout: true });
 
         // Test passes if no errors are thrown
@@ -108,7 +107,6 @@ describe('GridviewVue Component', () => {
                 ),
         });
 
-        // Add a panel
         api.addPanel({
             id: 'grid-panel-1',
             component: 'test-component',
@@ -118,7 +116,6 @@ describe('GridviewVue Component', () => {
         expect(api.panels[0].id).toBe('grid-panel-1');
         expect(initSpy).toHaveBeenCalled();
 
-        // Remove the panel
         api.removePanel(api.panels[0]);
         expect(api.panels).toHaveLength(0);
 

--- a/packages/dockview-vue/src/__tests__/keepalive.spec.ts
+++ b/packages/dockview-vue/src/__tests__/keepalive.spec.ts
@@ -148,8 +148,7 @@ describe('Vue components under <keep-alive> (issue #1369)', () => {
             await nextTick();
 
             // Deactivate (e.g. router navigates away): the panel is cached, not
-            // unmounted, so onDeactivated fires. This was entirely missing
-            // before the teleport migration.
+            // unmounted, so onDeactivated fires.
             await wrapper.setProps({ show: false });
             await flushPromises();
             expect(deactivated).toHaveBeenCalledTimes(1);

--- a/packages/dockview-vue/src/__tests__/paneview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/paneview.spec.ts
@@ -40,11 +40,9 @@ describe('PaneviewVue Component', () => {
     });
 
     test('should create paneview with Vue framework support', () => {
-        // Test that Vue-specific components can be created with proper type safety
         expect(typeof createPaneview).toBe('function');
         expect(typeof VuePaneviewPanelView).toBe('function');
 
-        // Test that a Vue paneview panel view can be instantiated
         const mockVueComponent = { template: '<div>Test</div>' } as any;
         const mockParent = {} as any;
 
@@ -62,7 +60,6 @@ describe('PaneviewVue Component', () => {
     });
 
     test('should handle Vue component integration for panes', () => {
-        // Test Vue component factory creation for paneview
         const mockComponent = {
             template:
                 '<div class="vue-pane-panel">{{ title }}: {{ params.content }}</div>',

--- a/packages/dockview-vue/src/__tests__/simple.spec.ts
+++ b/packages/dockview-vue/src/__tests__/simple.spec.ts
@@ -1,12 +1,10 @@
 import { describe, test, expect } from 'vitest';
-// Import core functionality that we know works
 import * as core from 'dockview';
 import * as splitviewView from '../splitview/view';
 import * as gridviewView from '../gridview/view';
 import * as paneviewView from '../paneview/view';
 import * as utils from '../utils';
 
-// Simple unit tests that verify basic functionality without complex Vue component testing
 describe('Vue Components Basic Tests', () => {
     test('should be able to import core dockview functionality', () => {
         expect(core.createDockview).toBeDefined();
@@ -29,7 +27,6 @@ describe('Vue Components Basic Tests', () => {
     });
 });
 
-// Test view classes - basic import test
 describe('Vue View Classes', () => {
     test('Vue view classes should be importable', () => {
         expect(splitviewView).toBeDefined();
@@ -38,7 +35,6 @@ describe('Vue View Classes', () => {
     });
 });
 
-// Test utility functions
 describe('Utility Functions', () => {
     test('should export utility functions', () => {
         expect(utils.findComponent).toBeDefined();
@@ -65,7 +61,6 @@ describe('Utility Functions', () => {
     });
 });
 
-// Test that the package builds correctly
 describe('Package Structure', () => {
     test('package should build without errors', () => {
         // If we get this far, the package structure is correct

--- a/packages/dockview-vue/src/__tests__/splitview.spec.ts
+++ b/packages/dockview-vue/src/__tests__/splitview.spec.ts
@@ -41,11 +41,9 @@ describe('SplitviewVue Component', () => {
     });
 
     test('should create splitview with Vue framework support', () => {
-        // Test that Vue-specific components can be created with proper type safety
         expect(typeof createSplitview).toBe('function');
         expect(typeof VueSplitviewPanelView).toBe('function');
 
-        // Test that a Vue splitview panel view can be instantiated
         const mockVueComponent = { template: '<div>Test</div>' } as any;
         const mockParent = {} as any;
 
@@ -62,7 +60,6 @@ describe('SplitviewVue Component', () => {
     });
 
     test('should handle Vue component integration', () => {
-        // Test Vue component factory creation for splitview
         const mockComponent = {
             template:
                 '<div class="vue-splitview-panel">{{ params.title }}</div>',

--- a/packages/dockview-vue/src/__tests__/utils.spec.ts
+++ b/packages/dockview-vue/src/__tests__/utils.spec.ts
@@ -304,7 +304,6 @@ describe('VuePart', () => {
     });
 
     test('should handle init call without throwing', () => {
-        // Test that init can be called without throwing
         // Note: may fail due to Vue environment setup but should not crash the test
         try {
             vuePart.init();
@@ -482,7 +481,6 @@ describe('VueHeaderActionsRenderer', () => {
 
         onDidAddPanel.fire(undefined);
 
-        // cloneVNode should have been called for the update
         expect(vueRenderMock).toHaveBeenCalled();
 
         renderer.dispose();
@@ -635,7 +633,6 @@ describe('VueHeaderActionsRenderer', () => {
 
         vueRenderMock.mockClear();
 
-        // Fire each event and check it triggers a render
         onDidAddPanel.fire(undefined);
         expect(vueRenderMock).toHaveBeenCalledTimes(1);
 

--- a/packages/dockview-vue/src/composables/useViewComponent.ts
+++ b/packages/dockview-vue/src/composables/useViewComponent.ts
@@ -73,8 +73,8 @@ export function useViewComponent<
 ): UseViewComponentReturn<TApi> {
     const el = ref<HTMLElement | null>(null);
     // Pin the ref type: `ref<TApi>()` would infer `Ref<UnwrapRef<TApi>>`,
-    // which both widens the public type and is what triggered the
-    // non-portable declaration (TS2742) this composable used to emit.
+    // which both widens the public type and produces a non-portable
+    // declaration (TS2742).
     const instance = ref<TApi | null>(null) as Ref<TApi | null>;
     const eventDisposables: DockviewIDisposable[] = [];
 

--- a/packages/dockview/src/index.ts
+++ b/packages/dockview/src/index.ts
@@ -2,7 +2,7 @@ export * from 'dockview-core';
 
 /**
  * `dockview` is the recommended free entry point: a thin re-export of
- * `dockview-core`. The separable enterprise feature modules now live in the
+ * `dockview-core`. The separable enterprise feature modules live in the
  * separately-published `dockview-enterprise` package (which depends on and
  * re-exports `dockview`); install that to opt into them.
  *


### PR DESCRIPTION
## Description

A codebase-wide audit to reduce accumulated over-commenting. The guiding principle: comments should be **concise and explain the code, not the change**, and only dig into detail where genuinely required.

Two commits:
- **`chore: trim over-commenting across the codebase`** — library source (`packages/*/src`): 38 files, ~146 comment lines removed, ~30 reworded.
- **`test: trim over-commenting across the test suites`** — unit + e2e tests: 61 files, ~395 removed, ~37 reworded.

**What was removed / tightened:**
- Comments that restate the adjacent line (`// Remove view`, `// Emit ready event`, `// Verify popup was opened`, `// should be 2` above the matching `expect`).
- `it()` / `test()` / `describe()` title echoes and Arrange/Act/Assert scaffolding labels.
- Edit-history narration (`previously…`, `we now…`, `before the fix this threw…`), reworded to present-tense rationale / the invariant under test.
- Bloated multi-line blocks and caveats echoed verbatim across many call sites (kept one, dropped the echoes).
- Incidental cruft: a stray `// }`, a duplicated doc block, an empty `//`, a typo'd comment.

**What was deliberately preserved:**
- Genuine *why* comments — DOM/browser/pointer quirks, ordering/timing constraints, coordinate/geometry math, module-optionality guards, accessibility reasoning.
- In tests: jsdom / fake-timer / rAF environment quirks, magic-number & coordinate rationale (why an expected index/size/position is that value), fixture-shape notes, e2e flakiness/wait rationale, and the specific bug/invariant each regression test guards (issue refs retained).
- Public-API TSDoc (tightened wording only where verbose), license headers, `eslint-*` / `@ts-*` / `biome-ignore` directives, URLs, and TODOs.

Every change is **comment-only** — verified programmatically that no code, assertion, selector, identifier, or formatting line was altered. Out of scope for this pass: the `packages/docs` website content.

## Type of change

- [x] Refactor / cleanup

## Affected packages

- [x] `dockview-core`
- [x] `dockview` (vanilla JS)
- [x] `dockview-react`
- [x] `dockview-vue`
- [x] `dockview-angular`
- [ ] `docs`

Also touches `dockview-enterprise` (not listed in the template).

## How to test

Changes are comment-only, so behavior is unchanged. To verify:
- `git diff master...HEAD` and confirm every hunk removes or rewords a comment, with the surrounding code identical.
- Hygiene was checked locally: no double blank lines and no trailing whitespace introduced (`git diff --check` clean). Biome does not reflow comment bodies, so `format:check` is unaffected.
- Existing `yarn test` / e2e suites should pass unchanged.

## Checklist

- [ ] `yarn lint:fix` passes — not run locally (dependencies not installed in this environment); comment-only changes, no lint-affecting edits
- [ ] `yarn format` passes — verified no whitespace/blank-line changes; biome leaves comment text untouched
- [ ] `npm run gen` has been run and generated files are up to date — N/A (no source of generated output changed)
- [ ] `yarn test` passes — not run locally; changes are comment-only and cannot affect test behavior
- [ ] I have added or updated tests where applicable — N/A
- [ ] Breaking changes are documented — N/A (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1CcbFhQ486PGuiLhRtZfJ)_