### PR TITLE
feat(docs): feedback widget on the enterprise blog post

### DIFF
--- a/packages/docs/blog/2026-08-07-dockview-enterprise.md
+++ b/packages/docs/blog/2026-08-07-dockview-enterprise.md
@@ -77,3 +77,5 @@ Either way, email me at [matt@dockview.dev](mailto:matt@dockview.dev) before you
 Thanks for reading, and thanks for using Dockview.
 
 Matt
+
+<BlogFeedback page="blog:dockview-enterprise" />

--- a/packages/docs/blog/2026-08-07-dockview-enterprise.md
+++ b/packages/docs/blog/2026-08-07-dockview-enterprise.md
@@ -78,4 +78,4 @@ Thanks for reading, and thanks for using Dockview.
 
 Matt
 
-<BlogFeedback page="blog:dockview-enterprise" />
+<BlogFeedback id="v8-feedback" />

--- a/packages/docs/blog/2026-08-07-dockview-enterprise.md
+++ b/packages/docs/blog/2026-08-07-dockview-enterprise.md
@@ -16,6 +16,8 @@ If you are already using Dockview and you don't need the enterprise features, th
 
 <!-- truncate -->
 
+<BlogReaction id="v8-feedback" />
+
 ## Why enterprise?
 
 Dockview started as a pet project. I was looking for a good docking library, primarily for financial applications, and I couldn't find one. It has grown steadily since, and today Dockview is:

--- a/packages/docs/src/components/ui/feedback/blogFeedback.tsx
+++ b/packages/docs/src/components/ui/feedback/blogFeedback.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 
 // Anonymous page feedback: a one-click thumbs up/down reaction plus an optional
 // freeform message box. Both talk to the licensing worker's feedback API (the
-// same worker that serves /enterprise), reusing the Turnstile bot-check pattern
-// from the contact page for the message box. The thumbs vote is deliberately
-// frictionless (no bot-check), deduped per browser by a random client id kept
-// in localStorage.
+// same worker that serves /enterprise). Both are gated by Cloudflare Turnstile:
+// the message box uses the standard managed widget, the thumbs use an
+// interaction-only widget that stays invisible unless a challenge is needed, so
+// a vote is still one click for a real visitor. One vote per browser is kept
+// client-side in localStorage.
 
 // Public Turnstile site key (safe to expose, it's rendered into the page). The
 // matching secret lives only in the licensing worker (TURNSTILE_SECRET_KEY).
@@ -66,6 +67,7 @@ declare global {
                 el: HTMLElement,
                 opts: {
                     sitekey: string;
+                    appearance?: 'always' | 'execute' | 'interaction-only';
                     callback: (token: string) => void;
                     'expired-callback'?: () => void;
                     'error-callback'?: () => void;
@@ -74,6 +76,63 @@ declare global {
             reset: (id?: string) => void;
         };
     }
+}
+
+// Load the Turnstile script once and render a widget, exposing its token. The
+// managed widget is mostly automatic: with appearance 'interaction-only' it
+// stays invisible and issues a token in the background unless a real challenge
+// is needed. Tokens are single-use, so `reset` fetches a fresh one after a token
+// is spent. Multiple widgets can coexist on a page; each tracks its own id.
+function useTurnstileToken(appearance?: 'interaction-only'): {
+    token: string;
+    widgetRef: React.RefObject<HTMLDivElement>;
+    reset: () => void;
+} {
+    const [token, setToken] = React.useState('');
+    const widgetRef = React.useRef<HTMLDivElement>(null);
+    const widgetIdRef = React.useRef<string | null>(null);
+    const renderedRef = React.useRef(false);
+
+    React.useEffect(() => {
+        function render() {
+            if (renderedRef.current || !widgetRef.current || !window.turnstile)
+                return;
+            renderedRef.current = true;
+            widgetIdRef.current = window.turnstile.render(widgetRef.current, {
+                sitekey: turnstileSiteKey(),
+                appearance,
+                callback: setToken,
+                'expired-callback': () => setToken(''),
+                'error-callback': () => setToken(''),
+            });
+        }
+
+        if (window.turnstile) {
+            render();
+            return;
+        }
+        const existing = document.querySelector<HTMLScriptElement>(
+            `script[src="${TURNSTILE_SCRIPT}"]`
+        );
+        const script = existing ?? document.createElement('script');
+        script.src = TURNSTILE_SCRIPT;
+        script.async = true;
+        script.defer = true;
+        script.addEventListener('load', render);
+        if (!existing) document.head.appendChild(script);
+        return () => script.removeEventListener('load', render);
+    }, [appearance]);
+
+    const reset = React.useCallback(() => {
+        try {
+            window.turnstile?.reset(widgetIdRef.current ?? undefined);
+        } catch {
+            /* ignore */
+        }
+        setToken('');
+    }, []);
+
+    return { token, widgetRef, reset };
 }
 
 function ThumbIcon({ down }: { down?: boolean }): JSX.Element {
@@ -103,6 +162,10 @@ function Votes({ id }: { id: string }): JSX.Element {
     );
     const [mine, setMine] = React.useState<Vote | null>(null);
     const [busy, setBusy] = React.useState(false);
+    // A vote clicked before Turnstile has issued a token, held until it lands.
+    const [pending, setPending] = React.useState<Vote | null>(null);
+    // Invisible unless a challenge is needed, so a vote stays one click.
+    const { token, widgetRef, reset } = useTurnstileToken('interaction-only');
 
     React.useEffect(() => {
         // This browser's prior choice (if any) comes from localStorage; the
@@ -123,35 +186,49 @@ function Votes({ id }: { id: string }): JSX.Element {
         };
     }, [id]);
 
-    // A one-click counter: click a thumb to add to its tally. One vote per
-    // browser (remembered in localStorage), so once you've reacted the buttons
-    // lock in your choice. No submit step and no toggle, it just counts.
-    async function cast(vote: Vote) {
+    // Send the vote once a Turnstile token is in hand. The token is single-use,
+    // so we drop it afterwards; the browser is now locked, so no fresh one is
+    // needed.
+    const send = React.useCallback(
+        async (vote: Vote) => {
+            try {
+                const res = await fetch(feedbackApiUrl('vote'), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ id, vote, turnstileToken: token }),
+                });
+                if (res.ok) {
+                    const data = await res.json();
+                    setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
+                    setMine(vote);
+                    setVoted(id, vote);
+                }
+            } catch {
+                /* swallow — the buttons unlock and the visitor can retry */
+            } finally {
+                reset();
+                setBusy(false);
+            }
+        },
+        [id, token, reset]
+    );
+
+    // A click made before the token arrived fires the moment it does.
+    React.useEffect(() => {
+        if (pending && token) {
+            const vote = pending;
+            setPending(null);
+            void send(vote);
+        }
+    }, [pending, token, send]);
+
+    // One-click counter: click a thumb to add to its tally. One vote per browser
+    // (remembered in localStorage), so once you've reacted the buttons lock in.
+    function cast(vote: Vote) {
         if (busy || mine) return;
         setBusy(true);
-        // Optimistic bump so the click feels instant, and lock this browser in.
-        setMine(vote);
-        setVoted(id, vote);
-        setCounts((c) =>
-            c
-                ? { ...c, [vote]: c[vote] + 1 }
-                : { up: vote === 'up' ? 1 : 0, down: vote === 'down' ? 1 : 0 }
-        );
-        try {
-            const res = await fetch(feedbackApiUrl('vote'), {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ id, vote }),
-            });
-            if (res.ok) {
-                const data = await res.json();
-                setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
-            }
-        } catch {
-            /* keep the optimistic state; a later load reconciles */
-        } finally {
-            setBusy(false);
-        }
+        if (token) void send(vote);
+        else setPending(vote);
     }
 
     const voted = mine !== null;
@@ -176,47 +253,51 @@ function Votes({ id }: { id: string }): JSX.Element {
     });
 
     return (
-        <div
-            style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 12,
-                flexWrap: 'wrap',
-            }}
-        >
-            <span style={{ fontWeight: 600 }}>Was this helpful?</span>
-            <button
-                type="button"
-                onClick={() => cast('up')}
-                disabled={busy || voted}
-                aria-pressed={mine === 'up'}
-                aria-label="Yes, this was helpful"
-                style={btn(mine === 'up')}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 12,
+                    flexWrap: 'wrap',
+                }}
             >
-                <ThumbIcon />
-                {counts && <span>{counts.up}</span>}
-            </button>
-            <button
-                type="button"
-                onClick={() => cast('down')}
-                disabled={busy || voted}
-                aria-pressed={mine === 'down'}
-                aria-label="No, this was not helpful"
-                style={btn(mine === 'down')}
-            >
-                <ThumbIcon down />
-                {counts && <span>{counts.down}</span>}
-            </button>
-            {voted && (
-                <span
-                    style={{
-                        fontSize: '0.85rem',
-                        color: 'var(--ifm-color-content-secondary)',
-                    }}
+                <span style={{ fontWeight: 600 }}>Was this helpful?</span>
+                <button
+                    type="button"
+                    onClick={() => cast('up')}
+                    disabled={busy || voted}
+                    aria-pressed={mine === 'up'}
+                    aria-label="Yes, this was helpful"
+                    style={btn(mine === 'up')}
                 >
-                    Thanks!
-                </span>
-            )}
+                    <ThumbIcon />
+                    {counts && <span>{counts.up}</span>}
+                </button>
+                <button
+                    type="button"
+                    onClick={() => cast('down')}
+                    disabled={busy || voted}
+                    aria-pressed={mine === 'down'}
+                    aria-label="No, this was not helpful"
+                    style={btn(mine === 'down')}
+                >
+                    <ThumbIcon down />
+                    {counts && <span>{counts.down}</span>}
+                </button>
+                {voted && (
+                    <span
+                        style={{
+                            fontSize: '0.85rem',
+                            color: 'var(--ifm-color-content-secondary)',
+                        }}
+                    >
+                        Thanks!
+                    </span>
+                )}
+            </div>
+            {/* Invisible unless Turnstile needs to challenge the visitor. */}
+            <div ref={widgetRef} />
         </div>
     );
 }
@@ -270,39 +351,8 @@ function MessageBox({ id }: { id: string }): JSX.Element {
     const [company, setCompany] = React.useState('');
     const [error, setError] = React.useState('');
     const [status, setStatus] = React.useState<MessageStatus>('idle');
-    const [token, setToken] = React.useState('');
-    const widgetRef = React.useRef<HTMLDivElement>(null);
-    const renderedRef = React.useRef(false);
-
-    // Load the Turnstile script once and render the widget explicitly.
-    React.useEffect(() => {
-        function render() {
-            if (renderedRef.current || !widgetRef.current || !window.turnstile)
-                return;
-            renderedRef.current = true;
-            window.turnstile.render(widgetRef.current, {
-                sitekey: turnstileSiteKey(),
-                callback: setToken,
-                'expired-callback': () => setToken(''),
-                'error-callback': () => setToken(''),
-            });
-        }
-
-        if (window.turnstile) {
-            render();
-            return;
-        }
-        const existing = document.querySelector<HTMLScriptElement>(
-            `script[src="${TURNSTILE_SCRIPT}"]`
-        );
-        const script = existing ?? document.createElement('script');
-        script.src = TURNSTILE_SCRIPT;
-        script.async = true;
-        script.defer = true;
-        script.addEventListener('load', render);
-        if (!existing) document.head.appendChild(script);
-        return () => script.removeEventListener('load', render);
-    }, []);
+    // Standard managed widget (visible) for the freeform box.
+    const { token, widgetRef, reset } = useTurnstileToken();
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
@@ -348,8 +398,7 @@ function MessageBox({ id }: { id: string }): JSX.Element {
                     ? err.message
                     : 'Something went wrong. Please try again.'
             );
-            window.turnstile?.reset();
-            setToken('');
+            reset();
         }
     }
 

--- a/packages/docs/src/components/ui/feedback/blogFeedback.tsx
+++ b/packages/docs/src/components/ui/feedback/blogFeedback.tsx
@@ -1,0 +1,488 @@
+import React from 'react';
+
+// Anonymous page feedback: a one-click thumbs up/down reaction plus an optional
+// freeform message box. Both talk to the licensing worker's feedback API (the
+// same worker that serves /enterprise), reusing the Turnstile bot-check pattern
+// from the contact page for the message box. The thumbs vote is deliberately
+// frictionless (no bot-check), deduped per browser by a random client id kept
+// in localStorage.
+
+// Public Turnstile site key (safe to expose, it's rendered into the page). The
+// matching secret lives only in the licensing worker (TURNSTILE_SECRET_KEY).
+const TURNSTILE_SITE_KEY = '0x4AAAAAADx1eYe1Ro1u3YUq';
+// Cloudflare's visible "always passes" test key, used on localhost so local dev
+// doesn't depend on the real widget's domain allowlist.
+const TURNSTILE_TEST_SITE_KEY = '1x00000000000000000000AA';
+const TURNSTILE_SCRIPT =
+    'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+
+const CLIENT_ID_KEY = 'dockview-feedback-client-id';
+
+function isLocalhost(): boolean {
+    return (
+        typeof window !== 'undefined' &&
+        window.location.hostname === 'localhost'
+    );
+}
+
+function turnstileSiteKey(): string {
+    return isLocalhost() ? TURNSTILE_TEST_SITE_KEY : TURNSTILE_SITE_KEY;
+}
+
+// The feedback API lives on the licensing worker under /enterprise, same origin
+// as the docs site in production; in local dev the worker runs on :4000.
+function feedbackApiUrl(path: string): string {
+    const base = isLocalhost() ? 'http://localhost:4000/enterprise' : '/enterprise';
+    return `${base}/api/feedback/${path}`;
+}
+
+// A stable per-browser id so a thumbs vote counts once per browser. Best-effort:
+// if storage is unavailable (private mode) we fall back to a per-session id.
+function getClientId(): string {
+    try {
+        const existing = window.localStorage.getItem(CLIENT_ID_KEY);
+        if (existing) return existing;
+        const id = window.crypto.randomUUID();
+        window.localStorage.setItem(CLIENT_ID_KEY, id);
+        return id;
+    } catch {
+        return window.crypto?.randomUUID?.() ?? `anon-${Date.now()}`;
+    }
+}
+
+declare global {
+    interface Window {
+        turnstile?: {
+            render: (
+                el: HTMLElement,
+                opts: {
+                    sitekey: string;
+                    callback: (token: string) => void;
+                    'expired-callback'?: () => void;
+                    'error-callback'?: () => void;
+                }
+            ) => string;
+            reset: (id?: string) => void;
+        };
+    }
+}
+
+type Vote = 'up' | 'down';
+
+function ThumbIcon({ down }: { down?: boolean }): JSX.Element {
+    // A single thumbs-up path, flipped for the down variant.
+    return (
+        <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            style={{ transform: down ? 'rotate(180deg)' : undefined }}
+        >
+            <path d="M7 10v12" />
+            <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z" />
+        </svg>
+    );
+}
+
+function Votes({ page }: { page: string }): JSX.Element {
+    const [counts, setCounts] = React.useState<{ up: number; down: number } | null>(
+        null
+    );
+    const [mine, setMine] = React.useState<Vote | null>(null);
+    const [busy, setBusy] = React.useState(false);
+    const clientIdRef = React.useRef<string>('');
+
+    React.useEffect(() => {
+        clientIdRef.current = getClientId();
+        let cancelled = false;
+        fetch(
+            feedbackApiUrl(
+                `vote?page=${encodeURIComponent(page)}&clientId=${encodeURIComponent(
+                    clientIdRef.current
+                )}`
+            )
+        )
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+                if (cancelled || !data) return;
+                setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
+                setMine(data.vote ?? null);
+            })
+            .catch(() => {
+                /* counts stay hidden on failure */
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [page]);
+
+    async function cast(vote: Vote) {
+        if (busy) return;
+        // Clicking the already-selected thumb clears the vote.
+        const next = mine === vote ? null : vote;
+        setBusy(true);
+        // Optimistic update so the click feels instant.
+        setMine(next);
+        try {
+            const res = await fetch(feedbackApiUrl('vote'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    page,
+                    clientId: clientIdRef.current,
+                    vote: next,
+                }),
+            });
+            if (res.ok) {
+                const data = await res.json();
+                setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
+                setMine(data.vote ?? null);
+            }
+        } catch {
+            /* leave the optimistic state; a later load will reconcile */
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    const btn = (active: boolean): React.CSSProperties => ({
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '8px 14px',
+        borderRadius: 8,
+        border: `1px solid ${
+            active ? 'var(--ifm-color-primary)' : 'var(--ifm-color-emphasis-300)'
+        }`,
+        background: active
+            ? 'var(--ifm-color-primary)'
+            : 'var(--ifm-background-color)',
+        color: active ? '#fff' : 'var(--ifm-font-color-base)',
+        font: 'inherit',
+        fontSize: '0.9rem',
+        cursor: busy ? 'default' : 'pointer',
+    });
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                flexWrap: 'wrap',
+            }}
+        >
+            <span style={{ fontWeight: 600 }}>Was this helpful?</span>
+            <button
+                type="button"
+                onClick={() => cast('up')}
+                disabled={busy}
+                aria-pressed={mine === 'up'}
+                aria-label="Yes, this was helpful"
+                style={btn(mine === 'up')}
+            >
+                <ThumbIcon />
+                {counts && <span>{counts.up}</span>}
+            </button>
+            <button
+                type="button"
+                onClick={() => cast('down')}
+                disabled={busy}
+                aria-pressed={mine === 'down'}
+                aria-label="No, this was not helpful"
+                style={btn(mine === 'down')}
+            >
+                <ThumbIcon down />
+                {counts && <span>{counts.down}</span>}
+            </button>
+        </div>
+    );
+}
+
+type MessageStatus = 'idle' | 'submitting' | 'done' | 'error';
+
+function inputStyle(hasError: boolean): React.CSSProperties {
+    return {
+        width: '100%',
+        padding: '10px 12px',
+        borderRadius: 8,
+        border: `1px solid ${
+            hasError
+                ? 'var(--ifm-color-danger)'
+                : 'var(--ifm-color-emphasis-300)'
+        }`,
+        background: 'var(--ifm-background-color)',
+        color: 'var(--ifm-font-color-base)',
+        fontSize: '0.95rem',
+        fontFamily: 'inherit',
+    };
+}
+
+function labelStyle(): React.CSSProperties {
+    return {
+        display: 'block',
+        fontSize: '0.85rem',
+        fontWeight: 600,
+        marginBottom: 6,
+        color: 'var(--ifm-heading-color)',
+    };
+}
+
+function optional(): JSX.Element {
+    return (
+        <span
+            style={{
+                color: 'var(--ifm-color-content-secondary)',
+                fontWeight: 400,
+            }}
+        >
+            {' '}
+            (optional)
+        </span>
+    );
+}
+
+function MessageBox({ page }: { page: string }): JSX.Element {
+    const [message, setMessage] = React.useState('');
+    const [email, setEmail] = React.useState('');
+    const [company, setCompany] = React.useState('');
+    const [error, setError] = React.useState('');
+    const [status, setStatus] = React.useState<MessageStatus>('idle');
+    const [token, setToken] = React.useState('');
+    const widgetRef = React.useRef<HTMLDivElement>(null);
+    const renderedRef = React.useRef(false);
+
+    // Load the Turnstile script once and render the widget explicitly.
+    React.useEffect(() => {
+        function render() {
+            if (renderedRef.current || !widgetRef.current || !window.turnstile)
+                return;
+            renderedRef.current = true;
+            window.turnstile.render(widgetRef.current, {
+                sitekey: turnstileSiteKey(),
+                callback: setToken,
+                'expired-callback': () => setToken(''),
+                'error-callback': () => setToken(''),
+            });
+        }
+
+        if (window.turnstile) {
+            render();
+            return;
+        }
+        const existing = document.querySelector<HTMLScriptElement>(
+            `script[src="${TURNSTILE_SCRIPT}"]`
+        );
+        const script = existing ?? document.createElement('script');
+        script.src = TURNSTILE_SCRIPT;
+        script.async = true;
+        script.defer = true;
+        script.addEventListener('load', render);
+        if (!existing) document.head.appendChild(script);
+        return () => script.removeEventListener('load', render);
+    }, []);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        if (!message.trim()) {
+            setError('Please enter a message.');
+            return;
+        }
+        if (email.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
+            setError('Please enter a valid email address, or leave it blank.');
+            return;
+        }
+        if (!token) {
+            setStatus('error');
+            setError('Please complete the bot check and try again.');
+            return;
+        }
+
+        setStatus('submitting');
+        setError('');
+        try {
+            const res = await fetch(feedbackApiUrl('message'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    page,
+                    message: message.trim(),
+                    email: email.trim().toLowerCase() || undefined,
+                    company: company.trim() || undefined,
+                    turnstileToken: token,
+                }),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(
+                    data.error ?? 'Something went wrong. Please try again.'
+                );
+            }
+            setStatus('done');
+        } catch (err) {
+            setStatus('error');
+            setError(
+                err instanceof Error
+                    ? err.message
+                    : 'Something went wrong. Please try again.'
+            );
+            window.turnstile?.reset();
+            setToken('');
+        }
+    }
+
+    if (status === 'done') {
+        return (
+            <p
+                style={{
+                    margin: 0,
+                    color: 'var(--ifm-color-content-secondary)',
+                }}
+            >
+                Thanks for the feedback. We read every message.
+            </p>
+        );
+    }
+
+    return (
+        <form
+            onSubmit={handleSubmit}
+            style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+        >
+            <label style={{ display: 'block' }}>
+                <span style={labelStyle()}>Leave a message</span>
+                <textarea
+                    value={message}
+                    rows={4}
+                    placeholder="What did you think? What would you like to see next?"
+                    onChange={(e) => {
+                        setMessage(e.target.value);
+                        setError('');
+                    }}
+                    style={{ ...inputStyle(false), resize: 'vertical' }}
+                />
+            </label>
+            <div
+                style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gap: 16,
+                }}
+            >
+                <label style={{ display: 'block' }}>
+                    <span style={labelStyle()}>Email{optional()}</span>
+                    <input
+                        type="email"
+                        value={email}
+                        placeholder="jane@acme.com"
+                        onChange={(e) => setEmail(e.target.value)}
+                        style={inputStyle(false)}
+                    />
+                </label>
+                <label style={{ display: 'block' }}>
+                    <span style={labelStyle()}>Company{optional()}</span>
+                    <input
+                        type="text"
+                        value={company}
+                        placeholder="Acme Corp"
+                        onChange={(e) => setCompany(e.target.value)}
+                        style={inputStyle(false)}
+                    />
+                </label>
+            </div>
+
+            <div ref={widgetRef} />
+
+            {error && (
+                <div
+                    style={{
+                        color: 'var(--ifm-color-danger)',
+                        fontSize: '0.9rem',
+                    }}
+                >
+                    {error}
+                </div>
+            )}
+
+            <div>
+                <button
+                    type="submit"
+                    className="button button--primary"
+                    disabled={status === 'submitting'}
+                >
+                    {status === 'submitting' ? 'Sending…' : 'Send feedback'}
+                </button>
+            </div>
+            <p
+                style={{
+                    fontSize: '0.8rem',
+                    color: 'var(--ifm-color-content-secondary)',
+                    margin: 0,
+                }}
+            >
+                Leave your email only if you'd like a reply. By submitting you
+                agree to our <a href="/enterprise/privacy">privacy policy</a>.
+            </p>
+        </form>
+    );
+}
+
+// The `page` prop keys the feedback (votes are deduped, messages tagged) so one
+// widget can serve several posts. Defaults to the current path.
+export function BlogFeedback({ page }: { page?: string }): JSX.Element {
+    const [resolvedPage, setResolvedPage] = React.useState(page ?? '');
+
+    React.useEffect(() => {
+        if (!page && typeof window !== 'undefined') {
+            setResolvedPage(window.location.pathname);
+        }
+    }, [page]);
+
+    // Wait for a page key before hitting the API (avoids a spurious call with an
+    // empty key during the first client render when no prop is given).
+    const key = page ?? resolvedPage;
+
+    return (
+        <section
+            style={{
+                marginTop: 48,
+                border: '1px solid var(--ifm-color-emphasis-200)',
+                borderRadius: 12,
+                padding: '28px',
+                background: 'var(--ifm-card-background-color)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 24,
+            }}
+        >
+            {key && <Votes page={key} />}
+            <hr
+                style={{
+                    margin: 0,
+                    border: 0,
+                    borderTop: '1px solid var(--ifm-color-emphasis-200)',
+                }}
+            />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                <h3 style={{ margin: '0 0 4px' }}>Send us feedback</h3>
+                <p
+                    style={{
+                        margin: '0 0 12px',
+                        color: 'var(--ifm-color-content-secondary)',
+                    }}
+                >
+                    Have a question, a use case, or a feature you want? Tell us.
+                </p>
+                {key && <MessageBox page={key} />}
+            </div>
+        </section>
+    );
+}
+
+export default BlogFeedback;

--- a/packages/docs/src/components/ui/feedback/blogFeedback.tsx
+++ b/packages/docs/src/components/ui/feedback/blogFeedback.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 
 // Anonymous page feedback: a one-click thumbs up/down reaction plus an optional
 // freeform message box. Both talk to the licensing worker's feedback API (the
-// same worker that serves /enterprise). Both are gated by Cloudflare Turnstile:
-// the message box uses the standard managed widget, the thumbs use an
-// interaction-only widget that stays invisible unless a challenge is needed, so
-// a vote is still one click for a real visitor. One vote per browser is kept
-// client-side in localStorage.
+// same worker that serves /enterprise). Both are gated by Cloudflare Turnstile
+// using interaction-only widgets that stay invisible and mint a token in the
+// background, only surfacing if a visitor actually has to be challenged. So a
+// vote stays one click and the message box has no visible bot-check. Each action
+// keeps its own widget (tokens are single-use, so one can't cover both). One
+// vote per browser is kept client-side in localStorage.
 
 // Public Turnstile site key (safe to expose, it's rendered into the page). The
 // matching secret lives only in the licensing worker (TURNSTILE_SECRET_KEY).
@@ -351,10 +352,56 @@ function MessageBox({ id }: { id: string }): JSX.Element {
     const [company, setCompany] = React.useState('');
     const [error, setError] = React.useState('');
     const [status, setStatus] = React.useState<MessageStatus>('idle');
-    // Standard managed widget (visible) for the freeform box.
-    const { token, widgetRef, reset } = useTurnstileToken();
+    // A submit made before Turnstile has issued its token, held until it lands.
+    const [pendingSubmit, setPendingSubmit] = React.useState(false);
+    // Interaction-only, so nothing shows unless a challenge is actually needed.
+    const { token, widgetRef, reset } = useTurnstileToken('interaction-only');
 
-    async function handleSubmit(e: React.FormEvent) {
+    const doSubmit = React.useCallback(
+        async (turnstileToken: string) => {
+            setStatus('submitting');
+            setError('');
+            try {
+                const res = await fetch(feedbackApiUrl('message'), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        id,
+                        message: message.trim(),
+                        email: email.trim().toLowerCase() || undefined,
+                        company: company.trim() || undefined,
+                        turnstileToken,
+                    }),
+                });
+                if (!res.ok) {
+                    const data = await res.json().catch(() => ({}));
+                    throw new Error(
+                        data.error ?? 'Something went wrong. Please try again.'
+                    );
+                }
+                setStatus('done');
+            } catch (err) {
+                setStatus('error');
+                setError(
+                    err instanceof Error
+                        ? err.message
+                        : 'Something went wrong. Please try again.'
+                );
+                reset();
+            }
+        },
+        [id, message, email, company, reset]
+    );
+
+    // A submit queued before the token arrived fires the moment it does.
+    React.useEffect(() => {
+        if (pendingSubmit && token) {
+            setPendingSubmit(false);
+            void doSubmit(token);
+        }
+    }, [pendingSubmit, token, doSubmit]);
+
+    function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
         if (!message.trim()) {
             setError('Please enter a message.');
@@ -364,41 +411,14 @@ function MessageBox({ id }: { id: string }): JSX.Element {
             setError('Please enter a valid email address, or leave it blank.');
             return;
         }
-        if (!token) {
-            setStatus('error');
-            setError('Please complete the bot check and try again.');
-            return;
-        }
-
-        setStatus('submitting');
         setError('');
-        try {
-            const res = await fetch(feedbackApiUrl('message'), {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    id,
-                    message: message.trim(),
-                    email: email.trim().toLowerCase() || undefined,
-                    company: company.trim() || undefined,
-                    turnstileToken: token,
-                }),
-            });
-            if (!res.ok) {
-                const data = await res.json().catch(() => ({}));
-                throw new Error(
-                    data.error ?? 'Something went wrong. Please try again.'
-                );
-            }
-            setStatus('done');
-        } catch (err) {
-            setStatus('error');
-            setError(
-                err instanceof Error
-                    ? err.message
-                    : 'Something went wrong. Please try again.'
-            );
-            reset();
+        // The token is minted in the background. Send now if it's ready, else
+        // show the sending state and fire the moment it lands.
+        if (token) {
+            void doSubmit(token);
+        } else {
+            setStatus('submitting');
+            setPendingSubmit(true);
         }
     }
 

--- a/packages/docs/src/components/ui/feedback/blogFeedback.tsx
+++ b/packages/docs/src/components/ui/feedback/blogFeedback.tsx
@@ -122,13 +122,19 @@ function Votes({ page }: { page: string }): JSX.Element {
         };
     }, [page]);
 
+    // A one-click counter: click a thumb to add to its tally. One vote per
+    // browser, so once you've reacted the buttons lock in your choice. No submit
+    // step and no toggle, it just counts.
     async function cast(vote: Vote) {
-        if (busy) return;
-        // Clicking the already-selected thumb clears the vote.
-        const next = mine === vote ? null : vote;
+        if (busy || mine) return;
         setBusy(true);
-        // Optimistic update so the click feels instant.
-        setMine(next);
+        // Optimistic bump so the click feels instant.
+        setMine(vote);
+        setCounts((c) =>
+            c
+                ? { ...c, [vote]: c[vote] + 1 }
+                : { up: vote === 'up' ? 1 : 0, down: vote === 'down' ? 1 : 0 }
+        );
         try {
             const res = await fetch(feedbackApiUrl('vote'), {
                 method: 'POST',
@@ -136,20 +142,22 @@ function Votes({ page }: { page: string }): JSX.Element {
                 body: JSON.stringify({
                     page,
                     clientId: clientIdRef.current,
-                    vote: next,
+                    vote,
                 }),
             });
             if (res.ok) {
                 const data = await res.json();
                 setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
-                setMine(data.vote ?? null);
+                setMine(data.vote ?? vote);
             }
         } catch {
-            /* leave the optimistic state; a later load will reconcile */
+            /* keep the optimistic state; a later load reconciles */
         } finally {
             setBusy(false);
         }
     }
+
+    const voted = mine !== null;
 
     const btn = (active: boolean): React.CSSProperties => ({
         display: 'inline-flex',
@@ -166,7 +174,8 @@ function Votes({ page }: { page: string }): JSX.Element {
         color: active ? '#fff' : 'var(--ifm-font-color-base)',
         font: 'inherit',
         fontSize: '0.9rem',
-        cursor: busy ? 'default' : 'pointer',
+        cursor: busy || voted ? 'default' : 'pointer',
+        opacity: voted && !active ? 0.6 : 1,
     });
 
     return (
@@ -182,7 +191,7 @@ function Votes({ page }: { page: string }): JSX.Element {
             <button
                 type="button"
                 onClick={() => cast('up')}
-                disabled={busy}
+                disabled={busy || voted}
                 aria-pressed={mine === 'up'}
                 aria-label="Yes, this was helpful"
                 style={btn(mine === 'up')}
@@ -193,7 +202,7 @@ function Votes({ page }: { page: string }): JSX.Element {
             <button
                 type="button"
                 onClick={() => cast('down')}
-                disabled={busy}
+                disabled={busy || voted}
                 aria-pressed={mine === 'down'}
                 aria-label="No, this was not helpful"
                 style={btn(mine === 'down')}
@@ -201,6 +210,16 @@ function Votes({ page }: { page: string }): JSX.Element {
                 <ThumbIcon down />
                 {counts && <span>{counts.down}</span>}
             </button>
+            {voted && (
+                <span
+                    style={{
+                        fontSize: '0.85rem',
+                        color: 'var(--ifm-color-content-secondary)',
+                    }}
+                >
+                    Thanks!
+                </span>
+            )}
         </div>
     );
 }
@@ -433,20 +452,21 @@ function MessageBox({ page }: { page: string }): JSX.Element {
     );
 }
 
-// The `page` prop keys the feedback (votes are deduped, messages tagged) so one
-// widget can serve several posts. Defaults to the current path.
-export function BlogFeedback({ page }: { page?: string }): JSX.Element {
-    const [resolvedPage, setResolvedPage] = React.useState(page ?? '');
+// The `id` prop keys the feedback (votes are deduped, messages tagged) so one
+// widget can serve several pages, e.g. id="v8-feedback". Defaults to the current
+// path when omitted.
+export function BlogFeedback({ id }: { id?: string }): JSX.Element {
+    const [resolvedId, setResolvedId] = React.useState(id ?? '');
 
     React.useEffect(() => {
-        if (!page && typeof window !== 'undefined') {
-            setResolvedPage(window.location.pathname);
+        if (!id && typeof window !== 'undefined') {
+            setResolvedId(window.location.pathname);
         }
-    }, [page]);
+    }, [id]);
 
-    // Wait for a page key before hitting the API (avoids a spurious call with an
+    // Wait for a key before hitting the API (avoids a spurious call with an
     // empty key during the first client render when no prop is given).
-    const key = page ?? resolvedPage;
+    const key = id ?? resolvedId;
 
     return (
         <section

--- a/packages/docs/src/components/ui/feedback/blogFeedback.tsx
+++ b/packages/docs/src/components/ui/feedback/blogFeedback.tsx
@@ -16,7 +16,9 @@ const TURNSTILE_TEST_SITE_KEY = '1x00000000000000000000AA';
 const TURNSTILE_SCRIPT =
     'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
 
-const CLIENT_ID_KEY = 'dockview-feedback-client-id';
+const VOTED_KEY_PREFIX = 'dockview-feedback-voted:';
+
+type Vote = 'up' | 'down';
 
 function isLocalhost(): boolean {
     return (
@@ -36,17 +38,24 @@ function feedbackApiUrl(path: string): string {
     return `${base}/api/feedback/${path}`;
 }
 
-// A stable per-browser id so a thumbs vote counts once per browser. Best-effort:
-// if storage is unavailable (private mode) we fall back to a per-session id.
-function getClientId(): string {
+// Remember whether this browser already reacted to a given feedback id, so the
+// counter locks to one vote per browser. Honour-based: the tallies live in a
+// single shared counter server-side with no per-voter record, so this is the
+// only dedup. Best-effort (a no-op if storage is unavailable, e.g. private mode).
+function getVoted(id: string): Vote | null {
     try {
-        const existing = window.localStorage.getItem(CLIENT_ID_KEY);
-        if (existing) return existing;
-        const id = window.crypto.randomUUID();
-        window.localStorage.setItem(CLIENT_ID_KEY, id);
-        return id;
+        const v = window.localStorage.getItem(VOTED_KEY_PREFIX + id);
+        return v === 'up' || v === 'down' ? v : null;
     } catch {
-        return window.crypto?.randomUUID?.() ?? `anon-${Date.now()}`;
+        return null;
+    }
+}
+
+function setVoted(id: string, vote: Vote): void {
+    try {
+        window.localStorage.setItem(VOTED_KEY_PREFIX + id, vote);
+    } catch {
+        /* ignore */
     }
 }
 
@@ -66,8 +75,6 @@ declare global {
         };
     }
 }
-
-type Vote = 'up' | 'down';
 
 function ThumbIcon({ down }: { down?: boolean }): JSX.Element {
     // A single thumbs-up path, flipped for the down variant.
@@ -90,29 +97,23 @@ function ThumbIcon({ down }: { down?: boolean }): JSX.Element {
     );
 }
 
-function Votes({ page }: { page: string }): JSX.Element {
+function Votes({ id }: { id: string }): JSX.Element {
     const [counts, setCounts] = React.useState<{ up: number; down: number } | null>(
         null
     );
     const [mine, setMine] = React.useState<Vote | null>(null);
     const [busy, setBusy] = React.useState(false);
-    const clientIdRef = React.useRef<string>('');
 
     React.useEffect(() => {
-        clientIdRef.current = getClientId();
+        // This browser's prior choice (if any) comes from localStorage; the
+        // tallies come from the shared counter.
+        setMine(getVoted(id));
         let cancelled = false;
-        fetch(
-            feedbackApiUrl(
-                `vote?page=${encodeURIComponent(page)}&clientId=${encodeURIComponent(
-                    clientIdRef.current
-                )}`
-            )
-        )
+        fetch(feedbackApiUrl(`vote?id=${encodeURIComponent(id)}`))
             .then((r) => (r.ok ? r.json() : null))
             .then((data) => {
                 if (cancelled || !data) return;
                 setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
-                setMine(data.vote ?? null);
             })
             .catch(() => {
                 /* counts stay hidden on failure */
@@ -120,16 +121,17 @@ function Votes({ page }: { page: string }): JSX.Element {
         return () => {
             cancelled = true;
         };
-    }, [page]);
+    }, [id]);
 
     // A one-click counter: click a thumb to add to its tally. One vote per
-    // browser, so once you've reacted the buttons lock in your choice. No submit
-    // step and no toggle, it just counts.
+    // browser (remembered in localStorage), so once you've reacted the buttons
+    // lock in your choice. No submit step and no toggle, it just counts.
     async function cast(vote: Vote) {
         if (busy || mine) return;
         setBusy(true);
-        // Optimistic bump so the click feels instant.
+        // Optimistic bump so the click feels instant, and lock this browser in.
         setMine(vote);
+        setVoted(id, vote);
         setCounts((c) =>
             c
                 ? { ...c, [vote]: c[vote] + 1 }
@@ -139,16 +141,11 @@ function Votes({ page }: { page: string }): JSX.Element {
             const res = await fetch(feedbackApiUrl('vote'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    page,
-                    clientId: clientIdRef.current,
-                    vote,
-                }),
+                body: JSON.stringify({ id, vote }),
             });
             if (res.ok) {
                 const data = await res.json();
                 setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
-                setMine(data.vote ?? vote);
             }
         } catch {
             /* keep the optimistic state; a later load reconciles */
@@ -267,7 +264,7 @@ function optional(): JSX.Element {
     );
 }
 
-function MessageBox({ page }: { page: string }): JSX.Element {
+function MessageBox({ id }: { id: string }): JSX.Element {
     const [message, setMessage] = React.useState('');
     const [email, setEmail] = React.useState('');
     const [company, setCompany] = React.useState('');
@@ -330,7 +327,7 @@ function MessageBox({ page }: { page: string }): JSX.Element {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    page,
+                    id,
                     message: message.trim(),
                     email: email.trim().toLowerCase() || undefined,
                     company: company.trim() || undefined,
@@ -481,7 +478,7 @@ export function BlogFeedback({ id }: { id?: string }): JSX.Element {
                 gap: 24,
             }}
         >
-            {key && <Votes page={key} />}
+            {key && <Votes id={key} />}
             <hr
                 style={{
                     margin: 0,
@@ -499,7 +496,7 @@ export function BlogFeedback({ id }: { id?: string }): JSX.Element {
                 >
                     Have a question, a use case, or a feature you want? Tell us.
                 </p>
-                {key && <MessageBox page={key} />}
+                {key && <MessageBox id={key} />}
             </div>
         </section>
     );

--- a/packages/docs/src/components/ui/feedback/blogFeedback.tsx
+++ b/packages/docs/src/components/ui/feedback/blogFeedback.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 
 // Anonymous page feedback: a one-click thumbs up/down reaction plus an optional
-// freeform message box. Both talk to the licensing worker's feedback API (the
-// same worker that serves /enterprise). Both are gated by Cloudflare Turnstile
-// using interaction-only widgets that stay invisible and mint a token in the
-// background, only surfacing if a visitor actually has to be challenged. So a
-// vote stays one click and the message box has no visible bot-check. Each action
-// keeps its own widget (tokens are single-use, so one can't cover both). One
-// vote per browser is kept client-side in localStorage.
+// freeform message box. They ship as two components, given the same id:
+// <BlogReaction> for the top of a post, where every reader passes it, and
+// <BlogFeedback> for the end, which repeats the vote for anyone who waited until
+// they'd read the argument and follows it with the message form. Voting in either
+// box locks both (see the subscriber registry below).
+//
+// Both talk to the licensing worker's feedback API (the same worker that serves
+// /enterprise), and both are gated by Cloudflare Turnstile using interaction-only
+// widgets that stay invisible and mint a token in the background, only surfacing
+// if a visitor actually has to be challenged. So a vote stays one click and the
+// message box has no visible bot-check. Each action keeps its own widget (tokens
+// are single-use, so one can't cover both).
+//
+// The running score is private: nothing here reads or displays the tallies, which
+// are visible only on the worker's /admin dashboard. All a visitor sees is
+// whether they personally reacted, kept client-side in localStorage.
 
 // Public Turnstile site key (safe to expose, it's rendered into the page). The
 // matching secret lives only in the licensing worker (TURNSTILE_SECRET_KEY).
@@ -61,6 +70,31 @@ function setVoted(id: string, vote: Vote): void {
     }
 }
 
+// A page can show the same feedback id in more than one place (a reaction box at
+// the top of a post and another at the end). Each keeps its own React state, so a
+// vote cast in one has to be announced to the others or they would sit there
+// looking unvoted until the next reload. Storage events don't help: the browser
+// doesn't fire them in the tab that wrote the value. So mounted widgets subscribe
+// here by id and the writer publishes to them directly.
+const voteSubscribers = new Map<string, Set<(vote: Vote) => void>>();
+
+function subscribeToVote(id: string, fn: (vote: Vote) => void): () => void {
+    let subscribers = voteSubscribers.get(id);
+    if (!subscribers) {
+        subscribers = new Set();
+        voteSubscribers.set(id, subscribers);
+    }
+    subscribers.add(fn);
+    return () => {
+        subscribers.delete(fn);
+        if (subscribers.size === 0) voteSubscribers.delete(id);
+    };
+}
+
+function publishVote(id: string, vote: Vote): void {
+    voteSubscribers.get(id)?.forEach((fn) => fn(vote));
+}
+
 declare global {
     interface Window {
         turnstile?: {
@@ -75,6 +109,7 @@ declare global {
                 }
             ) => string;
             reset: (id?: string) => void;
+            remove: (id?: string) => void;
         };
     }
 }
@@ -83,11 +118,13 @@ declare global {
 // managed widget is mostly automatic: with appearance 'interaction-only' it
 // stays invisible and issues a token in the background unless a real challenge
 // is needed. Tokens are single-use, so `reset` fetches a fresh one after a token
-// is spent. Multiple widgets can coexist on a page; each tracks its own id.
+// is spent, and `remove` retires the widget once no further token will be needed.
+// Multiple widgets can coexist on a page; each tracks its own id.
 function useTurnstileToken(appearance?: 'interaction-only'): {
     token: string;
     widgetRef: React.RefObject<HTMLDivElement>;
     reset: () => void;
+    remove: () => void;
 } {
     const [token, setToken] = React.useState('');
     const widgetRef = React.useRef<HTMLDivElement>(null);
@@ -124,6 +161,25 @@ function useTurnstileToken(appearance?: 'interaction-only'): {
         return () => script.removeEventListener('load', render);
     }, [appearance]);
 
+    // Retire the widget. Turnstile holds its own reference to the container, so a
+    // widget whose node React has since dropped (the message box swaps the form
+    // for a thank-you, and docs navigation is a SPA) would otherwise keep
+    // refreshing against a detached node and log "Cannot find Widget".
+    const remove = React.useCallback(() => {
+        if (widgetIdRef.current === null) return;
+        try {
+            window.turnstile?.remove(widgetIdRef.current);
+        } catch {
+            /* ignore */
+        }
+        widgetIdRef.current = null;
+        renderedRef.current = false;
+        setToken('');
+    }, []);
+
+    // Also retire it if the host unmounts with the widget still live.
+    React.useEffect(() => remove, [remove]);
+
     const reset = React.useCallback(() => {
         try {
             window.turnstile?.reset(widgetIdRef.current ?? undefined);
@@ -133,7 +189,7 @@ function useTurnstileToken(appearance?: 'interaction-only'): {
         setToken('');
     }, []);
 
-    return { token, widgetRef, reset };
+    return { token, widgetRef, reset, remove };
 }
 
 function ThumbIcon({ down }: { down?: boolean }): JSX.Element {
@@ -158,40 +214,32 @@ function ThumbIcon({ down }: { down?: boolean }): JSX.Element {
 }
 
 function Votes({ id }: { id: string }): JSX.Element {
-    const [counts, setCounts] = React.useState<{ up: number; down: number } | null>(
-        null
-    );
     const [mine, setMine] = React.useState<Vote | null>(null);
     const [busy, setBusy] = React.useState(false);
     // A vote clicked before Turnstile has issued a token, held until it lands.
     const [pending, setPending] = React.useState<Vote | null>(null);
     // Invisible unless a challenge is needed, so a vote stays one click.
-    const { token, widgetRef, reset } = useTurnstileToken('interaction-only');
+    const { token, widgetRef, reset, remove } = useTurnstileToken(
+        'interaction-only'
+    );
 
+    // Whether this browser already reacted. The tallies are deliberately not
+    // fetched: they're private to the admin dashboard, so there is nothing to
+    // show here and no public read to make. Staying subscribed keeps a second
+    // box for the same id in step when the other one is used.
     React.useEffect(() => {
-        // This browser's prior choice (if any) comes from localStorage; the
-        // tallies come from the shared counter.
         setMine(getVoted(id));
-        let cancelled = false;
-        fetch(feedbackApiUrl(`vote?id=${encodeURIComponent(id)}`))
-            .then((r) => (r.ok ? r.json() : null))
-            .then((data) => {
-                if (cancelled || !data) return;
-                setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
-            })
-            .catch(() => {
-                /* counts stay hidden on failure */
-            });
-        return () => {
-            cancelled = true;
-        };
-    }, [id]);
+        return subscribeToVote(id, (vote) => {
+            setMine(vote);
+            // Another box spent the vote, so this widget's token never will be.
+            remove();
+        });
+    }, [id, remove]);
 
-    // Send the vote once a Turnstile token is in hand. The token is single-use,
-    // so we drop it afterwards; the browser is now locked, so no fresh one is
-    // needed.
+    // Send the vote once a Turnstile token is in hand.
     const send = React.useCallback(
         async (vote: Vote) => {
+            let landed = false;
             try {
                 const res = await fetch(feedbackApiUrl('vote'), {
                     method: 'POST',
@@ -199,19 +247,24 @@ function Votes({ id }: { id: string }): JSX.Element {
                     body: JSON.stringify({ id, vote, turnstileToken: token }),
                 });
                 if (res.ok) {
-                    const data = await res.json();
-                    setCounts({ up: data.up ?? 0, down: data.down ?? 0 });
-                    setMine(vote);
                     setVoted(id, vote);
+                    // Sets our own `mine` too, via the subscription above.
+                    publishVote(id, vote);
+                    landed = true;
                 }
             } catch {
                 /* swallow — the buttons unlock and the visitor can retry */
             } finally {
-                reset();
+                // The token is spent either way. Once the vote lands this browser
+                // is locked out, so retire the widget rather than have it solve
+                // another challenge nobody will spend; on failure swap in a fresh
+                // token so a retry can go through.
+                if (landed) remove();
+                else reset();
                 setBusy(false);
             }
         },
-        [id, token, reset]
+        [id, token, reset, remove]
     );
 
     // A click made before the token arrived fires the moment it does.
@@ -223,7 +276,7 @@ function Votes({ id }: { id: string }): JSX.Element {
         }
     }, [pending, token, send]);
 
-    // One-click counter: click a thumb to add to its tally. One vote per browser
+    // One click adds to a tally the visitor never sees. One vote per browser
     // (remembered in localStorage), so once you've reacted the buttons lock in.
     function cast(vote: Vote) {
         if (busy || mine) return;
@@ -263,28 +316,30 @@ function Votes({ id }: { id: string }): JSX.Element {
                     flexWrap: 'wrap',
                 }}
             >
-                <span style={{ fontWeight: 600 }}>Was this helpful?</span>
+                <span style={{ fontWeight: 600 }}>
+                    Is this a positive change?
+                </span>
                 <button
                     type="button"
                     onClick={() => cast('up')}
                     disabled={busy || voted}
                     aria-pressed={mine === 'up'}
-                    aria-label="Yes, this was helpful"
+                    aria-label="Yes, this is a positive change"
                     style={btn(mine === 'up')}
                 >
                     <ThumbIcon />
-                    {counts && <span>{counts.up}</span>}
+                    <span>Yes</span>
                 </button>
                 <button
                     type="button"
                     onClick={() => cast('down')}
                     disabled={busy || voted}
                     aria-pressed={mine === 'down'}
-                    aria-label="No, this was not helpful"
+                    aria-label="No, this is not a positive change"
                     style={btn(mine === 'down')}
                 >
                     <ThumbIcon down />
-                    {counts && <span>{counts.down}</span>}
+                    <span>No</span>
                 </button>
                 {voted && (
                     <span
@@ -355,7 +410,9 @@ function MessageBox({ id }: { id: string }): JSX.Element {
     // A submit made before Turnstile has issued its token, held until it lands.
     const [pendingSubmit, setPendingSubmit] = React.useState(false);
     // Interaction-only, so nothing shows unless a challenge is actually needed.
-    const { token, widgetRef, reset } = useTurnstileToken('interaction-only');
+    const { token, widgetRef, reset, remove } = useTurnstileToken(
+        'interaction-only'
+    );
 
     const doSubmit = React.useCallback(
         async (turnstileToken: string) => {
@@ -379,6 +436,9 @@ function MessageBox({ id }: { id: string }): JSX.Element {
                         data.error ?? 'Something went wrong. Please try again.'
                     );
                 }
+                // Retire the widget while its container is still mounted: the
+                // 'done' branch below replaces the whole form with a thank-you.
+                remove();
                 setStatus('done');
             } catch (err) {
                 setStatus('error');
@@ -390,7 +450,7 @@ function MessageBox({ id }: { id: string }): JSX.Element {
                 reset();
             }
         },
-        [id, message, email, company, reset]
+        [id, message, email, company, reset, remove]
     );
 
     // A submit queued before the token arrived fires the moment it does.
@@ -518,10 +578,15 @@ function MessageBox({ id }: { id: string }): JSX.Element {
     );
 }
 
-// The `id` prop keys the feedback (votes are deduped, messages tagged) so one
-// widget can serve several pages, e.g. id="v8-feedback". Defaults to the current
-// path when omitted.
-export function BlogFeedback({ id }: { id?: string }): JSX.Element {
+// The anchor the reaction box links down to, so a reader who wants to say more
+// than a thumb can jump straight to the message form.
+const MESSAGE_ANCHOR = 'feedback';
+
+// The `id` prop keys the feedback (the vote tally, and the tag on each message)
+// so one widget can serve several pages, e.g. id="v8-feedback". Defaults to the
+// current path when omitted. Returns '' until a key is known, which holds the
+// API call back during the first client render when no prop was given.
+function useFeedbackId(id?: string): string {
     const [resolvedId, setResolvedId] = React.useState(id ?? '');
 
     React.useEffect(() => {
@@ -530,18 +595,60 @@ export function BlogFeedback({ id }: { id?: string }): JSX.Element {
         }
     }, [id]);
 
-    // Wait for a key before hitting the API (avoids a spurious call with an
-    // empty key during the first client render when no prop is given).
-    const key = id ?? resolvedId;
+    return id ?? resolvedId;
+}
+
+function cardStyle(padding: string): React.CSSProperties {
+    return {
+        border: '1px solid var(--ifm-color-emphasis-200)',
+        borderRadius: 12,
+        padding,
+        background: 'var(--ifm-card-background-color)',
+    };
+}
+
+// The reaction box, meant for the top of a post: a one-click read on how people
+// feel about what they've just read, plus a pointer to the message form at the
+// end for anyone with more to say. Pair it with <BlogFeedback> on the same id.
+export function BlogReaction({ id }: { id?: string }): JSX.Element {
+    const key = useFeedbackId(id);
+
+    return (
+        <div
+            style={{
+                ...cardStyle('20px 24px'),
+                marginBottom: 32,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 10,
+            }}
+        >
+            {key && <Votes id={key} />}
+            <p
+                style={{
+                    margin: 0,
+                    fontSize: '0.85rem',
+                    color: 'var(--ifm-color-content-secondary)',
+                }}
+            >
+                Got more to say?{' '}
+                <a href={`#${MESSAGE_ANCHOR}`}>Leave a message at the end</a>.
+            </p>
+        </div>
+    );
+}
+
+// The closing section, meant for the end of a post: the same vote again for
+// anyone who waited until they'd read the argument, then the message form. Shares
+// its id with <BlogReaction>, so voting in either box locks both.
+export function BlogFeedback({ id }: { id?: string }): JSX.Element {
+    const key = useFeedbackId(id);
 
     return (
         <section
             style={{
+                ...cardStyle('28px'),
                 marginTop: 48,
-                border: '1px solid var(--ifm-color-emphasis-200)',
-                borderRadius: 12,
-                padding: '28px',
-                background: 'var(--ifm-card-background-color)',
                 display: 'flex',
                 flexDirection: 'column',
                 gap: 24,
@@ -555,7 +662,18 @@ export function BlogFeedback({ id }: { id?: string }): JSX.Element {
                     borderTop: '1px solid var(--ifm-color-emphasis-200)',
                 }}
             />
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {/* The anchor sits on the form, not the section, so the reaction
+                box's "leave a message" link lands on what it promises rather
+                than on the vote. scrollMarginTop clears the sticky navbar. */}
+            <div
+                id={MESSAGE_ANCHOR}
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 4,
+                    scrollMarginTop: 90,
+                }}
+            >
                 <h3 style={{ margin: '0 0 4px' }}>Send us feedback</h3>
                 <p
                     style={{
@@ -563,7 +681,7 @@ export function BlogFeedback({ id }: { id?: string }): JSX.Element {
                         color: 'var(--ifm-color-content-secondary)',
                     }}
                 >
-                    Have a question, a use case, or a feature you want? Tell us.
+                    Tell us what you make of the change, or ask a question.
                 </p>
                 {key && <MessageBox id={key} />}
             </div>

--- a/packages/docs/src/pages/contact.tsx
+++ b/packages/docs/src/pages/contact.tsx
@@ -43,12 +43,14 @@ declare global {
                 el: HTMLElement,
                 opts: {
                     sitekey: string;
+                    appearance?: 'always' | 'execute' | 'interaction-only';
                     callback: (token: string) => void;
                     'expired-callback'?: () => void;
                     'error-callback'?: () => void;
                 }
             ) => string;
             reset: (id?: string) => void;
+            remove: (id?: string) => void;
         };
     }
 }

--- a/packages/docs/src/pages/newsletter.tsx
+++ b/packages/docs/src/pages/newsletter.tsx
@@ -42,12 +42,14 @@ declare global {
                 el: HTMLElement,
                 opts: {
                     sitekey: string;
+                    appearance?: 'always' | 'execute' | 'interaction-only';
                     callback: (token: string) => void;
                     'expired-callback'?: () => void;
                     'error-callback'?: () => void;
                 }
             ) => string;
             reset: (id?: string) => void;
+            remove: (id?: string) => void;
         };
     }
 }

--- a/packages/docs/src/pages/trial.tsx
+++ b/packages/docs/src/pages/trial.tsx
@@ -42,12 +42,14 @@ declare global {
                 el: HTMLElement,
                 opts: {
                     sitekey: string;
+                    appearance?: 'always' | 'execute' | 'interaction-only';
                     callback: (token: string) => void;
                     'expired-callback'?: () => void;
                     'error-callback'?: () => void;
                 }
             ) => string;
             reset: (id?: string) => void;
+            remove: (id?: string) => void;
         };
     }
 }

--- a/packages/docs/src/theme/MDXComponents.js
+++ b/packages/docs/src/theme/MDXComponents.js
@@ -3,6 +3,7 @@ import React from 'react';
 import MDXComponents from '@theme-original/MDXComponents';
 import { FrameworkSpecific } from '@site/src/components/frameworkSpecific';
 import { CodeRunner } from '../components/ui/codeRunner';
+import { BlogFeedback } from '../components/ui/feedback/blogFeedback';
 
 export default {
     // Re-use the default mapping
@@ -11,4 +12,5 @@ export default {
     // `Highlight` will receive all props that were passed to `<Highlight>` in MDX
     FrameworkSpecific,
     CodeRunner,
+    BlogFeedback,
 };

--- a/packages/docs/src/theme/MDXComponents.js
+++ b/packages/docs/src/theme/MDXComponents.js
@@ -3,7 +3,10 @@ import React from 'react';
 import MDXComponents from '@theme-original/MDXComponents';
 import { FrameworkSpecific } from '@site/src/components/frameworkSpecific';
 import { CodeRunner } from '../components/ui/codeRunner';
-import { BlogFeedback } from '../components/ui/feedback/blogFeedback';
+import {
+    BlogFeedback,
+    BlogReaction,
+} from '../components/ui/feedback/blogFeedback';
 
 export default {
     // Re-use the default mapping
@@ -13,4 +16,5 @@ export default {
     FrameworkSpecific,
     CodeRunner,
     BlogFeedback,
+    BlogReaction,
 };


### PR DESCRIPTION
## Description

Adds a feedback surface to the enterprise announcement post. A sentiment reaction ("Is this a positive change?", Yes/No) appears at the top of the post (`<BlogReaction>`, below the truncate marker so it stays off the blog index) and is repeated at the end alongside a freeform message form (`<BlogFeedback>`). Both share one id (`v8-feedback`); voting in either box locks both, kept in step by a module-level subscriber registry.

The reaction is write-only: tallies are never shown or fetched, they're private to the licensing worker's `/admin` dashboard, so the page makes no request until a thumb is clicked. The message form takes an optional email and company. Both post to the licensing worker's new `/enterprise/api/feedback` endpoints.

Depends on the backend PR: **mathuo/dockview-licencing#19**.

## Type of change

- [x] New feature
- [x] Documentation

## Affected packages

- [x] `docs`

## How to test

1. Run the licensing worker on `:4000` with migration `0006` applied (see mathuo/dockview-licencing#19).
2. `npm start` in `packages/docs`, open `/blog/dockview-enterprise`.
3. Click a thumb in either the top or bottom box: both lock in step. Submit a message with optional email/company. Turnstile stays invisible (the localhost test key auto-passes).
4. Confirm the vote counter and message rows appear on the worker's `/enterprise/admin` dashboard.

## Checklist

- `packages/docs` is deliberately excluded from Prettier / `nx format` (see `packages/docs/CLAUDE.md`), so the format/lint-fix steps don't apply to these files.
- No generated files affected (`npm run gen` not needed).
- No unit tests added: this is an interactive UI component. Verified with `typecheck` locally; the Docusaurus build is left to CI.
- Also adds `appearance` and `remove` to the `Window.turnstile` global declaration in `contact.tsx` / `newsletter.tsx` / `trial.tsx`, so the merged interface stays consistent across files (otherwise TS2717). `remove` lets the Turnstile hook deregister a widget whose container React has dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbogqsRG33XHTEFsg3wpbb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbogqsRG33XHTEFsg3wpbb)_