### PR TITLE
ci: build dockview-enterprise in the deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
                       ${{ runner.os }}-node-
 
             - run: yarn install
-            - run: npx nx run-many -t build,build:bundle --projects=dockview-core,dockview,dockview-vue,dockview-react,dockview-angular
+            - run: npx nx run-many -t build,build:bundle --projects=dockview-core,dockview,dockview-enterprise,dockview-vue,dockview-react,dockview-angular
             - run: npm run build
               working-directory: packages/docs
             - run: npm run docs


### PR DESCRIPTION
## Problem

The `Deploy Docs` workflow fails at the `npm run build` step in `packages/docs`:

```
Module not found: Error: Package path . is exported from package
.../node_modules/dockview-enterprise, but no valid target file was found
(see exports field in .../dockview-enterprise/package.json)
```

([failing run](https://github.com/dockview/dockview/actions/runs/31420659161/job/93560315894))

## Cause

The docs site imports `dockview-enterprise` (e.g. `sandboxes/react/dockview/demo-dockview`, `docusaurus.config.js`). As a workspace package it resolves via symlink to `packages/dockview-enterprise`, whose `exports["."]` points at `dist/package/main.esm.mjs` / `main.cjs.js` — both produced by the `build:bundle` (rolldown) target. The workflow's `nx run-many` project list omitted `dockview-enterprise`, so those files never exist and the docusaurus client bundle fails.

`e19ad64bc` added `dockview-enterprise` to the project lists in `main.yml`, but `deploy-docs.yml` was missed.

## Fix

Add `dockview-enterprise` to the project list. The step already runs both `build` and `build:bundle`, so no target changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)