### PR TITLE
fix(docs): stop the demo loading overlay covering the dock

### DIFF
--- a/packages/docs/src/pages/demo.module.css
+++ b/packages/docs/src/pages/demo.module.css
@@ -36,7 +36,13 @@
     pointer-events: none;
 }
 
-.loaderHidden {
+/* Compounded with .loader on purpose. cssnano (Docusaurus's production CSS
+   minifier) merges rules that share a declaration, and it hoists this
+   `opacity: 0` into a rule far earlier in the bundle than .loader's
+   `opacity: 1`. At equal specificity the later rule wins, so a plain
+   .loaderHidden leaves the overlay opaque forever and the demo never appears.
+   The extra class outranks .loader whatever order the two end up in. */
+.loader.loaderHidden {
     opacity: 0;
 }
 


### PR DESCRIPTION
## Problem

https://dockview.dev/demo renders as an empty panel below the header. The dock is actually fine — it mounts, sizes, and is fully present in the DOM — but the branded loading overlay (`.loader`, an opaque `--ifm-background-color` panel at `z-index: 5`) never fades out and covers it.

## Cause

cssnano, Docusaurus's production CSS minifier, merges rules that share a declaration. It folded `.loaderHidden`'s `opacity: 0` into a rule belonging to the cookie banner stylesheet, which lands ~440 rules earlier in the bundle than `.loader`:

| index in `styles.b9b92860.css` | rule |
| --- | --- |
| 961 | `#cc-main .section__toggle:checked ~ .toggle__icon .toggle__icon-off, .loaderHidden_EYmy { opacity: 0 }` |
| 1400 | `.loader_fLFv { … opacity: 1 … }` |

Both selectors are a single class, so at equal specificity the later `.loader { opacity: 1 }` wins. React applies `loaderHidden` correctly once `onReady` fires, but the computed opacity stays at `1` forever.

Only the minified build is affected — the dev server keeps source order, so `npm start` looks correct. The loader landed in `cbaf1d487` (9 Jul) and the `#cc-main` CSS it gets merged with in `529a7f811` (10 Jul).

## Fix

Compound the two classes. Two classes outrank one, so whatever order the minifier settles on, the hidden state wins.

## Verification

Built the docs locally and confirmed the minifier still hoists the rule, but now emits it as `.loader_fLFv.loaderHidden_EYmy{opacity:0}`. Served the build and confirmed the demo renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)