### PR TITLE
docs: link the LinkedIn page from the enterprise post and v8 notes

### DIFF
--- a/packages/docs/blog/2026-08-07-dockview-enterprise.md
+++ b/packages/docs/blog/2026-08-07-dockview-enterprise.md
@@ -76,6 +76,8 @@ Either way, email me at [matt@dockview.dev](mailto:matt@dockview.dev) before you
 
 ---
 
+Consider [following Dockview on LinkedIn](https://www.linkedin.com/company/dockviewjs) for updates.
+
 Thanks for reading, and thanks for using Dockview.
 
 Matt

--- a/packages/docs/blog/2026-08-07-dockview-enterprise.md
+++ b/packages/docs/blog/2026-08-07-dockview-enterprise.md
@@ -76,7 +76,7 @@ Either way, email me at [matt@dockview.dev](mailto:matt@dockview.dev) before you
 
 ---
 
-If you would like to keep up to date with Dockview, consider [following us on LinkedIn](https://www.linkedin.com/company/dockviewjs).
+If you would like to keep up to date with Dockview consider [following us on LinkedIn](https://www.linkedin.com/company/dockviewjs).
 
 Thanks for reading, and thanks for using Dockview.
 

--- a/packages/docs/blog/2026-08-07-dockview-enterprise.md
+++ b/packages/docs/blog/2026-08-07-dockview-enterprise.md
@@ -76,7 +76,7 @@ Either way, email me at [matt@dockview.dev](mailto:matt@dockview.dev) before you
 
 ---
 
-Consider [following Dockview on LinkedIn](https://www.linkedin.com/company/dockviewjs) for updates.
+If you would like to keep up to date with Dockview, consider [following us on LinkedIn](https://www.linkedin.com/company/dockviewjs).
 
 Thanks for reading, and thanks for using Dockview.
 

--- a/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
@@ -157,3 +157,8 @@ in [Migrating to v8](/docs/releases/migrating/migrating-to-v8):
   relocating a panel. The old names still work as **deprecated aliases**, so no
   code breaks today; update at your convenience before they are removed in a
   future major.
+
+## Staying up to date
+
+Consider [following Dockview on LinkedIn](https://www.linkedin.com/company/dockviewjs)
+for updates.

--- a/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
@@ -160,5 +160,5 @@ in [Migrating to v8](/docs/releases/migrating/migrating-to-v8):
 
 ## Follow Dockview
 
-If you would like to keep up to date with Dockview, consider
+If you would like to keep up to date with Dockview consider
 [following us on LinkedIn](https://www.linkedin.com/company/dockviewjs).

--- a/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
+++ b/packages/docs/docs/releases/whats-new/whats-new-v8.mdx
@@ -158,7 +158,7 @@ in [Migrating to v8](/docs/releases/migrating/migrating-to-v8):
   code breaks today; update at your convenience before they are removed in a
   future major.
 
-## Staying up to date
+## Follow Dockview
 
-Consider [following Dockview on LinkedIn](https://www.linkedin.com/company/dockviewjs)
-for updates.
+If you would like to keep up to date with Dockview, consider
+[following us on LinkedIn](https://www.linkedin.com/company/dockviewjs).


### PR DESCRIPTION
Adds a short "follow us on LinkedIn" line to the two pages people read when they want to know what happens next:

- the end of the [Dockview launches an enterprise version](/blog/dockview-enterprise) post, just above the sign-off
- a new `Staying up to date` section at the end of [What's new in v8](/docs/releases/whats-new/whats-new-v8)

Both link to https://www.linkedin.com/company/dockviewjs, which until now was only reachable from the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)