### PR TITLE
fix(docs): stop the demo styling dockview's tab close buttons

### DIFF
--- a/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.scss
+++ b/packages/docs/sandboxes/react/dockview/demo-dockview/src/app.scss
@@ -164,7 +164,14 @@
         }
     }
 
-    button {
+    // Dockview renders the tab close control as a real <button> (it was a div
+    // before v8), so it matches this bare selector and picks up the accent
+    // outline and the fixed height meant for the demo's own chrome. The dock
+    // styles its own controls, so exclude them. The demo's controls are
+    // unclassed buttons and rely on the rule, which is why this excludes the
+    // one dock control rather than everything carrying a dv- class: the side
+    // panel kit uses dv-sb- names of its own.
+    button:not(.dv-default-tab-action) {
         height: 25px;
         display: flex;
         align-items: center;


### PR DESCRIPTION
## Problem

Every tab in https://dockview.dev/demo has a blue box around its close icon.

## Cause

`app.scss` styles the demo chrome with bare element selectors:

```scss
.dockview-demo {
    button {
        height: 25px;
        outline: 1px solid var(--demo-accent);
        …
    }
}
```

Dockview renders the tab close control as a real `<button>` now (it was a `div` before v8), so all 13 close controls in the demo match that selector. `background` and `color` don't leak, because `.dv-tab .dv-default-tab .dv-default-tab-action` outranks it, but nothing in dockview sets `outline` or `height` on that element, so the accent outline and the 25px height land on it.

The file already carries a workaround for the same leak in the side panel (`.dv-sb-panel button { outline: none !important }`), so this is the same class of problem reaching a new element.

## Fix

Exclude the dock's own control from the bare selector.

Excluding just this one control rather than everything with a `dv-` class is deliberate: the demo's own buttons are unclassed and depend on this rule for their sizing, and the side panel kit uses `dv-sb-` prefixed names of its own, so a prefix-based exclusion would strip styling the demo needs.

## Verification

Applied the equivalent override against the deployed demo and confirmed the close controls render correctly, then rebuilt the docs and confirmed the emitted CSS carries the exclusion on the base, `:hover` and `:focus` variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)