### PR TITLE
fix(dockview-core): stop PositionCache retaining detached panel DOM

### DIFF
--- a/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
+++ b/packages/dockview-core/src/__tests__/overlay/overlayRenderContainer.spec.ts
@@ -761,4 +761,86 @@ describe('overlayRenderContainer', () => {
 
         expect(() => cut.dispose()).not.toThrow();
     });
+
+    test('detatch(...) leaves no strong reference to the measured reference element (#1596)', async () => {
+        // The position cache measures the reference container's element during
+        // attach. A strong Map entry outlives detatch()/fromJSON and pins the
+        // detached panel/group DOM (and, through parent pointers, the whole
+        // previous layout tree) for the lifetime of the component. Walk every
+        // strongly-held property reachable from the container and assert the
+        // element is gone once the panel is detatched. (A WeakMap is invisible
+        // to this walk precisely because it cannot retain its keys.)
+        const reachableFrom = (root: unknown, needle: unknown): boolean => {
+            const seen = new Set<object>();
+            const queue: unknown[] = [root];
+            while (queue.length > 0) {
+                const value = queue.pop();
+                if (!value || typeof value !== 'object') {
+                    continue;
+                }
+                if (value === needle) {
+                    return true;
+                }
+                if (seen.has(value)) {
+                    continue;
+                }
+                seen.add(value);
+                if (value instanceof Map) {
+                    for (const [key, entry] of value) {
+                        queue.push(key, entry);
+                    }
+                } else if (value instanceof Set) {
+                    for (const entry of value) {
+                        queue.push(entry);
+                    }
+                }
+                for (const key of Object.getOwnPropertyNames(value)) {
+                    try {
+                        queue.push((value as Record<string, unknown>)[key]);
+                    } catch {
+                        // Accessor threw; irrelevant for retention.
+                    }
+                }
+            }
+            return false;
+        };
+
+        const cut = new OverlayRenderContainer(
+            parentContainer,
+            fromPartial<DockviewComponent>({})
+        );
+
+        const panelContentEl = document.createElement('div');
+        const onDidVisibilityChange = new Emitter<any>();
+        const onDidDimensionsChange = new Emitter<any>();
+        const onDidLocationChange = new Emitter<any>();
+
+        const panel = fromPartial<IDockviewPanel>({
+            api: {
+                id: 'test_panel_id',
+                onDidVisibilityChange: onDidVisibilityChange.event,
+                onDidDimensionsChange: onDidDimensionsChange.event,
+                onDidLocationChange: onDidLocationChange.event,
+                isVisible: true,
+                location: { type: 'grid' },
+            },
+            view: { content: { element: panelContentEl } },
+            group: { api: { location: { type: 'grid' } } },
+        });
+
+        cut.attach({ panel, referenceContainer });
+
+        // Let the scheduled positioning run so the reference element is measured
+        // (and therefore enters the position cache).
+        await exhaustMicrotaskQueue();
+        await exhaustAnimationFrame();
+
+        // Sanity-check the walker against an element the container legitimately
+        // holds for its lifetime.
+        expect(reachableFrom(cut, parentContainer)).toBe(true);
+
+        cut.detatch(panel);
+
+        expect(reachableFrom(cut, referenceContainer.element)).toBe(false);
+    });
 });

--- a/packages/dockview-core/src/overlay/overlayRenderContainer.ts
+++ b/packages/dockview-core/src/overlay/overlayRenderContainer.ts
@@ -11,7 +11,15 @@ import { IDockviewPanel } from '../dockview/dockviewPanel';
 import { DockviewComponent } from '../dockview/dockviewComponent';
 
 class PositionCache {
-    private readonly cache = new Map<
+    /**
+     * A WeakMap so an entry never extends the lifetime of its element: entries
+     * are only ever read back within the frame they were written (`frameId`
+     * guard below), so once an element is detached — `detatch()`, `fromJSON`,
+     * group disposal — its entry is garbage. A strong `Map` here retained the
+     * detached panel/group DOM (and, through parent pointers, the whole
+     * previous layout tree) for the lifetime of the component (#1596).
+     */
+    private readonly cache = new WeakMap<
         Element,
         {
             rect: { left: number; top: number; width: number; height: number };


### PR DESCRIPTION
Fixes #1596.

## What

One-line semantic change: `PositionCache`'s backing store becomes a `WeakMap`, plus a regression test.

## Why

The cache strongly held every element it had ever measured, for the lifetime of the component:

- entries are only ever read back **within the frame they were written** (the `frameId` guard), so an entry from a previous frame has no consumer;
- nothing evicted entries: `detatch()` deletes the overlay map entry but not the cache entry, `invalidate()` only bumps the frame id;
- consequently every `renderer: 'always'` panel pinned its detached reference element after `removePanel()` / `fromJSON()` churn — and, through DOM parent pointers, the entire previous layout tree, including sibling `onlyWhenVisible` panels' content.

Evidence, repros (public-API-only, plus two on the docs site's own pages driven purely through their UI) and production-scale numbers are in #1596. Our long-lived 74-panel workbench went from ~+360 MB heap per layout-churn round to flat with exactly this change (we currently run it as a pnpm patch against 8.0.0).

`WeakMap` is a drop-in here: the cache is get/set-only (no iteration, no `size`), so the same-frame measurement dedup that fixed #988 ("Windows shaking") is preserved exactly — the existing test asserting `getBoundingClientRect` call counts within a frame still passes unchanged.

## Test

Added `detatch(...) leaves no strong reference to the measured reference element (#1596)`: attaches an `always` panel, lets the scheduled positioning measure it into the cache, detatches, then walks every strongly-held property reachable from the container (including `Map`/`Set` contents) and asserts the reference element is no longer reachable. The walker is sanity-checked against an element the container legitimately owns.

- Red on the previous `Map` implementation (verified by stashing the fix): `Tests: 1 failed, 10 passed`.
- Green with this change.

Full `dockview-core` suite: **90 suites / 1690 tests pass**; `nx run dockview-core:types:check` passes.
