### PR TITLE
fix(core): stop spurious ContextMenu enterprise warning for non-enterprise consumers (#1594)

### DIFF
--- a/packages/dockview-angular/src/__tests__/noEnterpriseWarningOnMount.spec.ts
+++ b/packages/dockview-angular/src/__tests__/noEnterpriseWarningOnMount.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DockviewAngularComponent } from '../lib/dockview/dockview-angular.component';
+import { setupTestBed, getTestComponents } from './__test_utils__/test-helpers';
+
+// Guards #1594 for the Angular wrapper: initialising the component without
+// dockview-enterprise must not log a missing-module error. The wrapper installs
+// framework bridges such as `createContextMenuItemComponent` unconditionally,
+// and none may be read as declared intent for an enterprise module. Kept in its
+// own file so the process-global missing-module dedup cache is empty for this
+// first init.
+describe('DockviewAngularComponent bare mount', () => {
+    let component: DockviewAngularComponent;
+    let fixture: ComponentFixture<DockviewAngularComponent>;
+
+    beforeEach(async () => {
+        setupTestBed();
+        await TestBed.compileComponents();
+
+        fixture = TestBed.createComponent(DockviewAngularComponent);
+        component = fixture.componentInstance;
+        component.components = getTestComponents();
+    });
+
+    afterEach(() => {
+        component?.getDockviewApi()?.dispose();
+        fixture?.destroy();
+    });
+
+    it('does not warn about a missing dockview-enterprise module (#1594)', () => {
+        const errorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        try {
+            component.ngOnInit();
+
+            const enterpriseWarnings = errorSpy.mock.calls
+                .map((call) => String(call[0]))
+                .filter((message) => message.includes('dockview-enterprise'));
+
+            expect(enterpriseWarnings).toEqual([]);
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+});

--- a/packages/dockview-angular/src/__tests__/noEnterpriseWarningOnMount.spec.ts
+++ b/packages/dockview-angular/src/__tests__/noEnterpriseWarningOnMount.spec.ts
@@ -2,12 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DockviewAngularComponent } from '../lib/dockview/dockview-angular.component';
 import { setupTestBed, getTestComponents } from './__test_utils__/test-helpers';
 
-// Guards #1594 for the Angular wrapper: initialising the component without
-// dockview-enterprise must not log a missing-module error. The wrapper installs
-// framework bridges such as `createContextMenuItemComponent` unconditionally,
-// and none may be read as declared intent for an enterprise module. Kept in its
-// own file so the process-global missing-module dedup cache is empty for this
-// first init.
+// #1594: initialising without dockview-enterprise must not log a missing-module
+// error. Own file so the process-global missing-module dedup cache is empty and
+// this is the first init that could surface the message.
 describe('DockviewAngularComponent bare mount', () => {
     let component: DockviewAngularComponent;
     let fixture: ComponentFixture<DockviewAngularComponent>;

--- a/packages/dockview-core/src/__tests__/dockview/optionsModules.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/optionsModules.spec.ts
@@ -116,8 +116,7 @@ describe('validateOptionModules', () => {
     });
 
     test('createContextMenuItemComponent alone does not demand enterprise', () => {
-        // The framework wrappers install this bridge unconditionally; on its own
-        // it is inert and must not prompt for enterprise (#1594).
+        // #1594: the wrappers set this bridge unconditionally; inert on its own.
         validateOptionModules(
             options({ createContextMenuItemComponent: () => undefined }),
             nothingRegistered
@@ -126,8 +125,7 @@ describe('validateOptionModules', () => {
     });
 
     test('getTabContextMenuItems still reports ContextMenu', () => {
-        // Real context-menu intent is expressed through the getters, so the
-        // ContextMenu diagnostic still fires for an app that asks for menus.
+        // The getters carry the real intent, so they still report ContextMenu.
         validateOptionModules(
             options({ getTabContextMenuItems: () => [] }),
             nothingRegistered

--- a/packages/dockview-core/src/__tests__/dockview/optionsModules.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/optionsModules.spec.ts
@@ -115,6 +115,26 @@ describe('validateOptionModules', () => {
         expect(consoleError).not.toHaveBeenCalled();
     });
 
+    test('createContextMenuItemComponent alone does not demand enterprise', () => {
+        // The framework wrappers install this bridge unconditionally; on its own
+        // it is inert and must not prompt for enterprise (#1594).
+        validateOptionModules(
+            options({ createContextMenuItemComponent: () => undefined }),
+            nothingRegistered
+        );
+        expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    test('getTabContextMenuItems still reports ContextMenu', () => {
+        // Real context-menu intent is expressed through the getters, so the
+        // ContextMenu diagnostic still fires for an app that asks for menus.
+        validateOptionModules(
+            options({ getTabContextMenuItems: () => [] }),
+            nothingRegistered
+        );
+        expect(consoleError.mock.calls[0][0]).toMatch(/ContextMenu/);
+    });
+
     test('an explicitly disabled feature is silent', () => {
         validateOptionModules(
             options({

--- a/packages/dockview-core/src/dockview/optionsModules.ts
+++ b/packages/dockview-core/src/dockview/optionsModules.ts
@@ -148,12 +148,15 @@ export const OPTION_MODULE_RULES: OptionModuleRule[] = [
         moduleName: 'ContextMenu',
         when: (o) => o.getTabGroupChipContextMenuItems != null,
     },
-    {
-        optionKey: 'createContextMenuItemComponent',
-        reason: 'createContextMenuItemComponent',
-        moduleName: 'ContextMenu',
-        when: (o) => o.createContextMenuItemComponent != null,
-    },
+    // No rule for `createContextMenuItemComponent`: like `edgeGroupPeek` above,
+    // it is inert alone. The factory only ever runs to render a menu item whose
+    // config carries a `component`, and the app supplies those items through
+    // `getTabContextMenuItems` / `getTabGroupChipContextMenuItems` — so the two
+    // rules above already name ContextMenu whenever a real app needs it. On top
+    // of that the factory is a bridge the framework wrappers (React/Vue/Angular)
+    // install unconditionally, not something the app sets, so a rule here fired
+    // for every wrapper consumer who asked for nothing (#1594). It carries no
+    // intent the getter rules don't, so it gets no rule of its own.
     {
         optionKey: 'dndCompass',
         reason: 'dndCompass',

--- a/packages/dockview-core/src/dockview/optionsModules.ts
+++ b/packages/dockview-core/src/dockview/optionsModules.ts
@@ -149,14 +149,10 @@ export const OPTION_MODULE_RULES: OptionModuleRule[] = [
         when: (o) => o.getTabGroupChipContextMenuItems != null,
     },
     // No rule for `createContextMenuItemComponent`: like `edgeGroupPeek` above,
-    // it is inert alone. The factory only ever runs to render a menu item whose
-    // config carries a `component`, and the app supplies those items through
-    // `getTabContextMenuItems` / `getTabGroupChipContextMenuItems` — so the two
-    // rules above already name ContextMenu whenever a real app needs it. On top
-    // of that the factory is a bridge the framework wrappers (React/Vue/Angular)
-    // install unconditionally, not something the app sets, so a rule here fired
-    // for every wrapper consumer who asked for nothing (#1594). It carries no
-    // intent the getter rules don't, so it gets no rule of its own.
+    // it is inert alone. It only renders a menu item whose config carries a
+    // `component`, supplied via the getters above, whose rules already name
+    // ContextMenu. The framework wrappers also set it unconditionally, so a rule
+    // here would warn consumers that never asked for a menu.
     {
         optionKey: 'dndCompass',
         reason: 'dndCompass',

--- a/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
@@ -2124,10 +2124,8 @@ describe('ContextMenuController', () => {
             expect(Object.keys(ContextMenuModule.services ?? {})).toContain(
                 'contextMenuService'
             );
-            // Only the getters are listed. `createContextMenuItemComponent` is
-            // deliberately excluded (see the module's `options` comment and
-            // optionsModules.ts / #1594): it is an inert framework bridge, so it
-            // must not drive a missing-module diagnostic of its own.
+            // `createContextMenuItemComponent` is excluded (inert framework
+            // bridge); see the module's `options` comment.
             expect(ContextMenuModule.options).toEqual([
                 'getTabContextMenuItems',
                 'getTabGroupChipContextMenuItems',

--- a/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
+++ b/packages/dockview-enterprise/src/__tests__/contextMenu.spec.ts
@@ -2124,13 +2124,14 @@ describe('ContextMenuController', () => {
             expect(Object.keys(ContextMenuModule.services ?? {})).toContain(
                 'contextMenuService'
             );
-            expect(ContextMenuModule.options).toEqual(
-                expect.arrayContaining([
-                    'getTabContextMenuItems',
-                    'getTabGroupChipContextMenuItems',
-                    'createContextMenuItemComponent',
-                ])
-            );
+            // Only the getters are listed. `createContextMenuItemComponent` is
+            // deliberately excluded (see the module's `options` comment and
+            // optionsModules.ts / #1594): it is an inert framework bridge, so it
+            // must not drive a missing-module diagnostic of its own.
+            expect(ContextMenuModule.options).toEqual([
+                'getTabContextMenuItems',
+                'getTabGroupChipContextMenuItems',
+            ]);
         });
     });
 });

--- a/packages/dockview-enterprise/src/contextMenu.ts
+++ b/packages/dockview-enterprise/src/contextMenu.ts
@@ -487,11 +487,9 @@ export const ContextMenuModule = defineModule<
     IContextMenuHost
 >({
     name: 'ContextMenu',
-    // `createContextMenuItemComponent` is intentionally absent: it is the
-    // framework-render bridge, inert without a `component`-bearing item from the
-    // getters below, and the wrappers install it unconditionally. Listing it
-    // would demand a diagnostic rule that fires for consumers who asked for
-    // nothing (#1594). The getters carry the real intent.
+    // `createContextMenuItemComponent` is intentionally absent: it is an inert
+    // framework-render bridge the wrappers set unconditionally, so a rule for it
+    // would warn consumers that never asked for a menu. The getters carry intent.
     options: ['getTabContextMenuItems', 'getTabGroupChipContextMenuItems'],
     serviceKey: 'contextMenuService',
     create: (host) => new ContextMenuController(host),

--- a/packages/dockview-enterprise/src/contextMenu.ts
+++ b/packages/dockview-enterprise/src/contextMenu.ts
@@ -487,11 +487,12 @@ export const ContextMenuModule = defineModule<
     IContextMenuHost
 >({
     name: 'ContextMenu',
-    options: [
-        'getTabContextMenuItems',
-        'getTabGroupChipContextMenuItems',
-        'createContextMenuItemComponent',
-    ],
+    // `createContextMenuItemComponent` is intentionally absent: it is the
+    // framework-render bridge, inert without a `component`-bearing item from the
+    // getters below, and the wrappers install it unconditionally. Listing it
+    // would demand a diagnostic rule that fires for consumers who asked for
+    // nothing (#1594). The getters carry the real intent.
+    options: ['getTabContextMenuItems', 'getTabGroupChipContextMenuItems'],
     serviceKey: 'contextMenuService',
     create: (host) => new ContextMenuController(host),
 });

--- a/packages/dockview-react/src/__tests__/dockview/noEnterpriseWarningOnMount.spec.tsx
+++ b/packages/dockview-react/src/__tests__/dockview/noEnterpriseWarningOnMount.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import {
+    DockviewApi,
+    DockviewReadyEvent,
+    IDockviewPanelProps,
+} from 'dockview';
+import { DockviewReact } from '../../dockview/dockview';
+
+// Guards #1594: a bare DockviewReact (no dockview-enterprise) must mount without
+// logging a missing-module error. The wrapper installs framework bridges such as
+// `createContextMenuItemComponent` unconditionally, and none of them may be read
+// as declared intent for an enterprise module. Kept in its own file so the
+// once-per-process missing-module dedup cache starts empty and this mount is the
+// first that could surface the message.
+describe('DockviewReact bare mount', () => {
+    test('does not warn about a missing dockview-enterprise module (#1594)', async () => {
+        const errorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        try {
+            const components = {
+                default: (_props: IDockviewPanelProps) => <div />,
+            };
+
+            let api: DockviewApi | undefined;
+            render(
+                <DockviewReact
+                    components={components}
+                    onReady={(event: DockviewReadyEvent) => {
+                        api = event.api;
+                    }}
+                />
+            );
+
+            await waitFor(() => expect(api).toBeTruthy());
+
+            const enterpriseWarnings = errorSpy.mock.calls
+                .map((call) => String(call[0]))
+                .filter((message) => message.includes('dockview-enterprise'));
+
+            expect(enterpriseWarnings).toEqual([]);
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+});

--- a/packages/dockview-react/src/__tests__/dockview/noEnterpriseWarningOnMount.spec.tsx
+++ b/packages/dockview-react/src/__tests__/dockview/noEnterpriseWarningOnMount.spec.tsx
@@ -3,12 +3,9 @@ import { render, waitFor } from '@testing-library/react';
 import { DockviewApi, DockviewReadyEvent, IDockviewPanelProps } from 'dockview';
 import { DockviewReact } from '../../dockview/dockview';
 
-// Guards #1594: a bare DockviewReact (no dockview-enterprise) must mount without
-// logging a missing-module error. The wrapper installs framework bridges such as
-// `createContextMenuItemComponent` unconditionally, and none of them may be read
-// as declared intent for an enterprise module. Kept in its own file so the
-// once-per-process missing-module dedup cache starts empty and this mount is the
-// first that could surface the message.
+// #1594: a bare mount without dockview-enterprise must not log a missing-module
+// error. Own file so the process-global missing-module dedup cache is empty and
+// this is the first mount that could surface the message.
 describe('DockviewReact bare mount', () => {
     test('does not warn about a missing dockview-enterprise module (#1594)', async () => {
         const errorSpy = jest

--- a/packages/dockview-react/src/__tests__/dockview/noEnterpriseWarningOnMount.spec.tsx
+++ b/packages/dockview-react/src/__tests__/dockview/noEnterpriseWarningOnMount.spec.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
-import {
-    DockviewApi,
-    DockviewReadyEvent,
-    IDockviewPanelProps,
-} from 'dockview';
+import { DockviewApi, DockviewReadyEvent, IDockviewPanelProps } from 'dockview';
 import { DockviewReact } from '../../dockview/dockview';
 
 // Guards #1594: a bare DockviewReact (no dockview-enterprise) must mount without

--- a/packages/dockview-vue/src/__tests__/noEnterpriseWarningOnMount.spec.ts
+++ b/packages/dockview-vue/src/__tests__/noEnterpriseWarningOnMount.spec.ts
@@ -9,11 +9,9 @@ const MockPanel = defineComponent({
     template: '<div class="mock-panel">Panel</div>',
 });
 
-// Guards #1594 for the Vue wrapper: a bare mount without dockview-enterprise must
-// not log a missing-module error. The wrapper installs framework bridges such as
-// `createContextMenuItemComponent` unconditionally, and none may be read as
-// declared intent for an enterprise module. Kept in its own file so the
-// process-global missing-module dedup cache is empty for this first mount.
+// #1594: a bare mount without dockview-enterprise must not log a missing-module
+// error. Own file so the process-global missing-module dedup cache is empty and
+// this is the first mount that could surface the message.
 describe('DockviewVue bare mount', () => {
     afterEach(() => {
         vi.restoreAllMocks();

--- a/packages/dockview-vue/src/__tests__/noEnterpriseWarningOnMount.spec.ts
+++ b/packages/dockview-vue/src/__tests__/noEnterpriseWarningOnMount.spec.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import DockviewVue from '../dockview/dockview.vue';
+
+const MockPanel = defineComponent({
+    name: 'MockPanel',
+    props: ['params'],
+    template: '<div class="mock-panel">Panel</div>',
+});
+
+// Guards #1594 for the Vue wrapper: a bare mount without dockview-enterprise must
+// not log a missing-module error. The wrapper installs framework bridges such as
+// `createContextMenuItemComponent` unconditionally, and none may be read as
+// declared intent for an enterprise module. Kept in its own file so the
+// process-global missing-module dedup cache is empty for this first mount.
+describe('DockviewVue bare mount', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test('does not warn about a missing dockview-enterprise module (#1594)', async () => {
+        const errorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => undefined);
+
+        const wrapper = mount(DockviewVue, {
+            attachTo: document.body,
+            global: { components: { MockPanel } },
+        });
+
+        await flushPromises();
+
+        const enterpriseWarnings = errorSpy.mock.calls
+            .map((call) => String(call[0]))
+            .filter((message) => message.includes('dockview-enterprise'));
+
+        expect(enterpriseWarnings).toEqual([]);
+
+        wrapper.unmount();
+    });
+});


### PR DESCRIPTION
## Description

Fixes #1594.

Every `dockview-react` / `dockview-vue` / `dockview-angular` consumer *without* `dockview-enterprise` got a `console.error` on mount, having asked for nothing:

```
dockview: `createContextMenuItemComponent` requires the "ContextMenu" module, which ships in dockview-enterprise.
```

**Cause.** The framework wrappers install `createContextMenuItemComponent` unconditionally as a render bridge (unlike `createWatermarkComponent` et al., which are gated on a user prop). `OPTION_MODULE_RULES` treated the presence of that option as declared intent for the enterprise `ContextMenu` module, so construction-time validation logged a missing-module error for consumers who never requested context menus. `dockview-core`/vanilla `dockview` were unaffected — they never set the option.

**Fix (core-side).** The factory is inert on its own: it only runs to render a menu item whose config carries a `component`, and apps supply those items through `getTabContextMenuItems` / `getTabGroupChipContextMenuItems` — whose rules already name `ContextMenu`. So the `createContextMenuItemComponent` rule never added a signal a real app didn't already have, and only ever produced false positives. Removed it (mirroring the existing `edgeGroupPeek` "inert alone → no rule" precedent) and dropped the key from `ContextMenuModule.options` so the core/enterprise sync test stays balanced. Genuine context-menu intent still warns exactly as before via the getters.

A project-wide sweep confirmed `createContextMenuItemComponent` was the *only* enterprise-gated option any wrapper fabricates: every other gated option is plain user data forwarded only when its prop is set, and no other enterprise module declares a `create*` factory bridge. Added a bare-mount guard test per wrapper to lock this in at the wrapper boundary.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [x] `dockview-react`
- [x] `dockview-vue`
- [x] `dockview-angular`
- [ ] `docs`

_(also `dockview-enterprise` — no checkbox in the template: `ContextMenuModule.options` and its module spec.)_

## How to test

- Before this change, mounting a bare `<DockviewReact />` (or the Vue/Angular equivalent) without `dockview-enterprise` logs the ContextMenu missing-module `console.error`. After it, the mount is silent.
- New regression coverage:
  - `dockview-core`: `optionsModules.spec.ts` — `createContextMenuItemComponent` alone stays silent; `getTabContextMenuItems` still reports `ContextMenu`.
  - Each wrapper: `noEnterpriseWarningOnMount.spec` — bare mount logs no `dockview-enterprise` message. (Verified non-vacuous via a negative control: re-adding the rule makes the React guard fail.)
- Suites run green: `dockview-core` (1691), `dockview-enterprise` (479), plus the three new wrapper guards and the existing React/Vue mount suites.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [x] `yarn test` passes _(affected suites verified individually; full `yarn test` not run in this environment)_
- [x] I have added or updated tests where applicable
- [x] Breaking changes are documented _(none — no public API change)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLT1p1W4X8F3LSqPyJmW9k)_