### PR TITLE
fix(core): tag programmatic layout mutations with origin 'api'

### DIFF
--- a/packages/dockview-core/src/__tests__/api/component.api.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/component.api.spec.ts
@@ -581,9 +581,11 @@ describe('component.api', () => {
             const panel = { id: 'p' } as any;
             const group = { id: 'g' } as any;
             const addPanel = jest.fn().mockReturnValue(panel);
+            const addGroup = jest.fn().mockReturnValue(group);
             const addPopoutGroup = jest.fn().mockResolvedValue(true);
             const component = createComponent({
                 addPanel,
+                addGroup,
                 removePanel: jest.fn(),
                 closeAllGroups: jest.fn(),
                 removeGroup: jest.fn(),
@@ -597,6 +599,10 @@ describe('component.api', () => {
             const addOptions = { id: 'p', component: 'c' } as any;
             expect(cut.addPanel(addOptions)).toBe(panel);
             expect(addPanel).toHaveBeenCalledWith(addOptions);
+
+            const addGroupOptions = { id: 'g' } as any;
+            expect(cut.addGroup(addGroupOptions)).toBe(group);
+            expect(addGroup).toHaveBeenCalledWith(addGroupOptions);
 
             cut.removePanel(panel);
             expect(component.removePanel).toHaveBeenCalledWith(panel);
@@ -634,7 +640,7 @@ describe('component.api', () => {
             }
         });
 
-        test('addGroup delegates directly (no origin wrapping)', () => {
+        test('addGroup runs inside withOrigin("api")', () => {
             const group = { id: 'g' } as any;
             const addGroup = jest.fn().mockReturnValue(group);
             const component = createComponent({ addGroup });
@@ -643,6 +649,10 @@ describe('component.api', () => {
             const options = { id: 'g' } as any;
             expect(cut.addGroup(options)).toBe(group);
             expect(addGroup).toHaveBeenCalledWith(options);
+            expect(component.withOrigin).toHaveBeenCalledWith(
+                'api',
+                expect.any(Function)
+            );
         });
 
         test('toJSON delegates to the component', () => {

--- a/packages/dockview-core/src/__tests__/api/component.api.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/component.api.spec.ts
@@ -593,6 +593,8 @@ describe('component.api', () => {
                 fromJSON: jest.fn(),
                 clear: jest.fn(),
                 addPopoutGroup,
+                maximizeGroup: jest.fn(),
+                exitMaximizedGroup: jest.fn(),
             });
             const cut = new DockviewApi(<DockviewComponent>component);
 
@@ -632,6 +634,12 @@ describe('component.api', () => {
             const popoutOptions = { position: {} } as any;
             void cut.addPopoutGroup(panel, popoutOptions);
             expect(addPopoutGroup).toHaveBeenCalledWith(panel, popoutOptions);
+
+            cut.maximizeGroup({ group } as any);
+            expect(component.maximizeGroup).toHaveBeenCalledWith(group);
+
+            cut.exitMaximizedGroup();
+            expect(component.exitMaximizedGroup).toHaveBeenCalledTimes(1);
 
             // Every mutating call went through withOrigin('api', ...)
             expect(component.withOrigin).toHaveBeenCalled();

--- a/packages/dockview-core/src/__tests__/api/dockviewGroupPanelApi.spec.ts
+++ b/packages/dockview-core/src/__tests__/api/dockviewGroupPanelApi.spec.ts
@@ -430,6 +430,7 @@ describe('DockviewGroupPanelApiImpl', () => {
             const accessor = fromPartial<DockviewComponent>({
                 addGroup: jest.fn(),
                 moveGroupOrPanel: jest.fn(),
+                withOrigin: jest.fn((_origin: any, fn: () => any) => fn()),
             });
             const cut = new DockviewGroupPanelApiImpl(
                 'test-id',
@@ -463,6 +464,7 @@ describe('DockviewGroupPanelApiImpl', () => {
             const accessor = fromPartial<DockviewComponent>({
                 addGroup: jest.fn(),
                 moveGroupOrPanel: jest.fn(),
+                withOrigin: jest.fn((_origin: any, fn: () => any) => fn()),
             });
             const cut = new DockviewGroupPanelApiImpl(
                 'test-id',
@@ -490,6 +492,7 @@ describe('DockviewGroupPanelApiImpl', () => {
             const accessor = fromPartial<DockviewComponent>({
                 addGroup: jest.fn().mockReturnValue(createdGroup),
                 moveGroupOrPanel: jest.fn(),
+                withOrigin: jest.fn((_origin: any, fn: () => any) => fn()),
             });
             const cut = new DockviewGroupPanelApiImpl(
                 'test-id',
@@ -522,6 +525,7 @@ describe('DockviewGroupPanelApiImpl', () => {
             const accessor = fromPartial<DockviewComponent>({
                 addGroup: jest.fn().mockReturnValue(createdGroup),
                 moveGroupOrPanel: jest.fn(),
+                withOrigin: jest.fn((_origin: any, fn: () => any) => fn()),
             });
             const cut = new DockviewGroupPanelApiImpl(
                 'test-id',

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -321,6 +321,11 @@ describe('layout mutation events', () => {
             expect(origins).toEqual(['api']);
         });
 
+        test('a programmatic api.addGroup() is tagged "api"', () => {
+            dockview.api.addGroup();
+            expect(origins).toEqual(['api']);
+        });
+
         test('a programmatic tab-group mutation is tagged "api"', () => {
             const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
             origins.length = 0;

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -353,7 +353,7 @@ describe('layout mutation events', () => {
             expect(origins).toEqual(['api']);
         });
 
-        test('a programmatic group.api.moveTo() is tagged "api"', () => {
+        test('a programmatic group.api.moveTo() into an explicit group is tagged "api"', () => {
             const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
             const p2 = dockview.addPanel({
                 id: 'p2',
@@ -365,6 +365,23 @@ describe('layout mutation events', () => {
             p1.group.api.moveTo({ group: p2.group, position: 'center' });
             // Every mutation bracketed by the move (incl. teardown of the
             // now-empty source group) must report the api origin.
+            expect(origins.every((o) => o === 'api')).toBe(true);
+            expect(origins.length).toBeGreaterThan(0);
+        });
+
+        test('a programmatic group.api.moveTo() that creates the target group is tagged "api"', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            dockview.addPanel({
+                id: 'p2',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            origins.length = 0;
+
+            // No target group: exercises the `addGroup` fallback inside
+            // `group.api.moveTo`, so the created group's `add` mutation must
+            // also carry the api origin.
+            p1.group.api.moveTo({ position: 'left' });
             expect(origins.every((o) => o === 'api')).toBe(true);
             expect(origins.length).toBeGreaterThan(0);
         });

--- a/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
+++ b/packages/dockview-core/src/__tests__/dockview/layoutMutation.spec.ts
@@ -326,6 +326,49 @@ describe('layout mutation events', () => {
             expect(origins).toEqual(['api']);
         });
 
+        test('a programmatic api.maximizeGroup() / exitMaximizedGroup() is tagged "api"', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            dockview.addPanel({
+                id: 'p2',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            origins.length = 0;
+
+            dockview.api.maximizeGroup(p1);
+            dockview.api.exitMaximizedGroup();
+            expect(origins).toEqual(['api', 'api']);
+        });
+
+        test('a programmatic panel.api.moveTo() is tagged "api"', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            const p2 = dockview.addPanel({
+                id: 'p2',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            origins.length = 0;
+
+            p1.api.moveTo({ group: p2.group, position: 'center' });
+            expect(origins).toEqual(['api']);
+        });
+
+        test('a programmatic group.api.moveTo() is tagged "api"', () => {
+            const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
+            const p2 = dockview.addPanel({
+                id: 'p2',
+                component: 'default',
+                position: { direction: 'right' },
+            });
+            origins.length = 0;
+
+            p1.group.api.moveTo({ group: p2.group, position: 'center' });
+            // Every mutation bracketed by the move (incl. teardown of the
+            // now-empty source group) must report the api origin.
+            expect(origins.every((o) => o === 'api')).toBe(true);
+            expect(origins.length).toBeGreaterThan(0);
+        });
+
         test('a programmatic tab-group mutation is tagged "api"', () => {
             const p1 = dockview.addPanel({ id: 'p1', component: 'default' });
             origins.length = 0;

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -1163,7 +1163,9 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
     }
 
     maximizeGroup(panel: IDockviewPanel): void {
-        this.component.maximizeGroup(panel.group);
+        this.component.withOrigin('api', () =>
+            this.component.maximizeGroup(panel.group)
+        );
     }
 
     hasMaximizedGroup(): boolean {
@@ -1171,7 +1173,9 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
     }
 
     exitMaximizedGroup(): void {
-        this.component.exitMaximizedGroup();
+        this.component.withOrigin('api', () =>
+            this.component.exitMaximizedGroup()
+        );
     }
 
     get onDidMaximizedGroupChange(): Event<DockviewMaximizedGroupChangeEvent> {

--- a/packages/dockview-core/src/api/component.api.ts
+++ b/packages/dockview-core/src/api/component.api.ts
@@ -985,7 +985,9 @@ export class DockviewApi implements CommonApi<SerializedDockview> {
      * Add a group and return the created object.
      */
     addGroup(options?: AddGroupOptions): DockviewGroupPanel {
-        return this.component.addGroup(options);
+        return this.component.withOrigin('api', () =>
+            this.component.addGroup(options)
+        );
     }
 
     /**

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -258,23 +258,29 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             throw new Error(NOT_INITIALIZED_MESSAGE);
         }
 
-        const group =
-            options.group ??
-            this.accessor.addGroup({
-                direction: positionToDirection(options.position ?? 'right'),
-                skipSetActive: options.skipSetActive ?? false,
-            });
+        // Programmatic relocation: tag it `'api'` so the `'move'` (and any
+        // fallback `'add'`) layout mutation reports the correct origin.
+        // User-gesture moves (DnD) drive `accessor.moveGroupOrPanel` directly
+        // and keep the default `'user'`.
+        this.accessor.withOrigin('api', () => {
+            const group =
+                options.group ??
+                this.accessor.addGroup({
+                    direction: positionToDirection(options.position ?? 'right'),
+                    skipSetActive: options.skipSetActive ?? false,
+                });
 
-        this.accessor.moveGroupOrPanel({
-            from: { groupId: this._group.id },
-            to: {
-                group,
-                position: options.group
-                    ? (options.position ?? 'center')
-                    : 'center',
-                index: options.index,
-            },
-            skipSetActive: options.skipSetActive,
+            this.accessor.moveGroupOrPanel({
+                from: { groupId: this._group!.id },
+                to: {
+                    group,
+                    position: options.group
+                        ? (options.position ?? 'center')
+                        : 'center',
+                    index: options.index,
+                },
+                skipSetActive: options.skipSetActive,
+            });
         });
     }
 

--- a/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewGroupPanelApi.ts
@@ -258,10 +258,6 @@ export class DockviewGroupPanelApiImpl extends GridviewPanelApiImpl {
             throw new Error(NOT_INITIALIZED_MESSAGE);
         }
 
-        // Programmatic relocation: tag it `'api'` so the `'move'` (and any
-        // fallback `'add'`) layout mutation reports the correct origin.
-        // User-gesture moves (DnD) drive `accessor.moveGroupOrPanel` directly
-        // and keep the default `'user'`.
         this.accessor.withOrigin('api', () => {
             const group =
                 options.group ??

--- a/packages/dockview-core/src/api/dockviewPanelApi.ts
+++ b/packages/dockview-core/src/api/dockviewPanelApi.ts
@@ -195,17 +195,22 @@ export class DockviewPanelApiImpl
     }
 
     moveTo(options: DockviewPanelMoveParams): void {
-        this.accessor.moveGroupOrPanel({
-            from: { groupId: this._group.id, panelId: this.panel.id },
-            to: {
-                group: options.group ?? this._group,
-                position: options.group
-                    ? (options.position ?? 'center')
-                    : 'center',
-                index: options.index,
-            },
-            skipSetActive: options.skipSetActive,
-        });
+        // Programmatic relocation: tag it `'api'` so the `'move'` layout
+        // mutation reports the correct origin. User-gesture moves (DnD) drive
+        // `accessor.moveGroupOrPanel` directly and keep the default `'user'`.
+        this.accessor.withOrigin('api', () =>
+            this.accessor.moveGroupOrPanel({
+                from: { groupId: this._group.id, panelId: this.panel.id },
+                to: {
+                    group: options.group ?? this._group,
+                    position: options.group
+                        ? (options.position ?? 'center')
+                        : 'center',
+                    index: options.index,
+                },
+                skipSetActive: options.skipSetActive,
+            })
+        );
     }
 
     setTitle(title: string): void {


### PR DESCRIPTION
## Description

`api.addGroup()` reported `origin: 'user'` on `onWillMutateLayout` / `onDidMutateLayout`, so a programmatic call looked like an end-user gesture — the exact feedback loop the origin flag exists to prevent (#1595). `addGroup` was the only mutating method on `DockviewApi` that delegated straight to the component without wrapping the call in `withOrigin('api')`; since the component's ambient origin defaults to `'user'`, the call inherited "a human did this".

While fixing it I spot-checked **every** origin-bearing code path — `mutation()` (which fires the layout-mutation events) and `fireActivePanelChange()` — back to its public entry point, and found three more programmatic-only methods with the identical defect. This PR wraps all of them:

- `DockviewApi.addGroup()` — fires `mutation('add')` *(the original #1595 report)*
- `DockviewApi.maximizeGroup()` / `exitMaximizedGroup()` — fire `mutation('maximize')`
- `panel.api.moveTo()` — fires `mutation('move')`
- `group.api.moveTo()` — fires `mutation('move')` (and, for the create-target fallback, `mutation('add')`); the whole body is wrapped so both report `'api'`

These match the methods that already wrap correctly: `addPanel`, `removePanel`, `removeGroup`, `closeAllGroups`, `addFloatingGroup`, `addPopoutGroup`, `fromJSON`, `clear`, and the four tab-group methods.

**Why this is safe:** none of the newly-wrapped methods are reached by a user gesture. Drag-and-drop drives `accessor.moveGroupOrPanel` directly, and the maximize/close UI paths route through `group.api` — all of which keep the default `'user'`. So stamping `'api'` on these programmatic entry points does not change gesture reporting.

**Deliberately left as-is:** the dual-path methods `panel.api.close()`, `group.api.close()`, and `group.api.maximize()` / `exitMaximized()` have real UI gesture callers (e.g. the tab ✕ button calls `panel.api.close()`), so they correctly report `'user'` today. Making those report `'api'` for programmatic callers would require matching `withOrigin('user')` at each gesture site (the pattern already used for `setActive`) — a broader change deferred out of this PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [x] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [ ] `docs`

## How to test

```js
api.onWillMutateLayout(e => console.log(e.kind, e.origin));

api.addPanel({ id: 'a', component: 'x' }); // add    api
api.addGroup();                            // add    api  (was: user)
api.maximizeGroup(api.getPanel('a'));      // maximize api (was: user)
api.exitMaximizedGroup();                  // maximize api (was: user)
api.getPanel('a').api.moveTo({ ... });     // move   api  (was: user)
```

Covered by tests:
- `layoutMutation.spec.ts` → `mutation origin` — new integration tests asserting `api.addGroup()`, `api.maximizeGroup()`/`exitMaximizedGroup()`, `panel.api.moveTo()` and `group.api.moveTo()` all report `origin: 'api'`.
- `component.api.spec.ts` — `maximizeGroup`/`exitMaximizedGroup` folded into the "every mutating call went through `withOrigin('api')`" assertion; the old test that codified the `addGroup` bug now asserts the wrap.
- `dockviewGroupPanelApi.spec.ts` — mocks updated to expose `withOrigin`.

## Checklist

- [x] `yarn test` passes (1693 passing; `tsc --noEmit` clean)
- [x] I have added or updated tests where applicable
- [ ] Breaking changes are documented <!-- n/a — no API surface change, event payload semantics corrected -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01GyAt6skBSRQ4JGM51uXEXm)_