### PR TITLE
fix(docs): report analytics correctly once consent is given

### DIFF
--- a/packages/docs/src/consent.js
+++ b/packages/docs/src/consent.js
@@ -19,6 +19,7 @@ import 'vanilla-cookieconsent/dist/cookieconsent.css';
 const GA_MEASUREMENT_ID = 'G-KXGC1C9ZHC';
 
 let gaLoaded = false;
+let analyticsAllowed = false;
 
 // Inject gtag.js and initialise the GA4 property. Idempotent, so repeated
 // consent callbacks are harmless.
@@ -27,9 +28,15 @@ function loadGoogleAnalytics() {
     gaLoaded = true;
 
     window.dataLayer = window.dataLayer || [];
-    const gtag = (...args) => {
-        window.dataLayer.push(args);
-    };
+    // gtag.js recognises a command by the pushed value being an `arguments`
+    // object; anything else, including a plain array, is treated as a
+    // data-layer variable merge. A rest-parameter version therefore pushes
+    // `['config', 'G-...']` as data and the config command never runs, so the
+    // property receives nothing. Keep this a normal function that pushes
+    // `arguments`, exactly as Google's snippet does.
+    function gtag() {
+        window.dataLayer.push(arguments);
+    }
     window.gtag = gtag;
 
     gtag('js', new Date());
@@ -55,11 +62,19 @@ function initConsent() {
                 : host;
 
         const syncAnalytics = () => {
-            if (
+            analyticsAllowed =
                 CookieConsent.acceptedCategory('analytics') &&
-                process.env.NODE_ENV === 'production'
-            ) {
+                process.env.NODE_ENV === 'production';
+
+            if (analyticsAllowed) {
                 loadGoogleAnalytics();
+            } else if (gaLoaded && typeof window.gtag === 'function') {
+                // Consent was withdrawn after gtag.js was injected. The script
+                // cannot be removed from the page, so tell it to stop using
+                // storage; onRouteDidUpdate below stops reporting too.
+                window.gtag('consent', 'update', {
+                    analytics_storage: 'denied',
+                });
             }
         };
 
@@ -174,15 +189,46 @@ function initConsent() {
     });
 }
 
+// gtag.js reports a page_view only for the document it was loaded into.
+// Docusaurus is a single page app, so every in-site navigation after that is
+// invisible to GA unless we report it ourselves. @docusaurus/plugin-google-gtag
+// used to do this; it went away when analytics moved behind the consent gate.
+export function onRouteDidUpdate({ location, previousLocation }) {
+    if (!analyticsAllowed || typeof window.gtag !== 'function') return;
+    if (!previousLocation) return;
+
+    // A hash-only change is an anchor jump within the same page, not a view.
+    if (
+        location.pathname === previousLocation.pathname &&
+        location.search === previousLocation.search
+    ) {
+        return;
+    }
+
+    // Let react-helmet apply the new <title> before we read it.
+    setTimeout(() => {
+        window.gtag('event', 'page_view', {
+            page_title: document.title,
+            page_location: window.location.href,
+            page_path: location.pathname + location.search,
+        });
+    }, 0);
+}
+
 if (ExecutionEnvironment.canUseDOM && !started) {
     started = true;
-    // Defer until after the page has loaded and Docusaurus has hydrated, so the
-    // banner is initialised against a settled DOM rather than mid-render.
+    // Defer a couple of frames so the banner is initialised against a settled
+    // DOM rather than mid-render. Deliberately not `load`: that waits for every
+    // sub-resource, and doc pages embed <CodeRunner> iframes, which delays the
+    // banner and the first page_view by seconds on exactly the pages that carry
+    // the most traffic. Hydration timing no longer matters here because the
+    // modal classes are mirrored onto <body> and the preferences trigger is
+    // delegated from the document.
     const start = () =>
         requestAnimationFrame(() => requestAnimationFrame(initConsent));
-    if (document.readyState === 'complete') {
-        start();
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start, { once: true });
     } else {
-        window.addEventListener('load', start, { once: true });
+        start();
     }
 }


### PR DESCRIPTION
## Description

Investigating unusually low analytics on the docs site. The consent gate itself is fine and is not over-blocking; the measurement behind it was broken, so even visitors who accepted analytics were barely counted. Three separate problems in `packages/docs/src/consent.js`:

**1. GA was never configured.** The local `gtag` helper was a rest-parameter arrow that pushed a plain array:

```js
const gtag = (...args) => { window.dataLayer.push(args); };
```

gtag.js only treats a pushed value as a command when it is an `arguments` object; anything else, including an array, is treated as a data-layer variable merge. So `gtag('js', ...)` and `gtag('config', 'G-KXGC1C9ZHC')` were swallowed. gtag.js loaded, consent was granted, and the property still received nothing. Restored to Google's snippet form (a normal function pushing `arguments`).

**2. No page views for client-side navigation.** gtag.js reports a page_view only for the document it loads into. Docusaurus is a single page app, and `@docusaurus/plugin-google-gtag`, which used to report route changes, was dropped when analytics moved behind the consent gate with nothing replacing it. Only the first page of each session was counted. Added an `onRouteDidUpdate` client-module export that sends `page_view`, skipping hash-only changes so heading anchors do not inflate counts.

**3. Consent init waited on `window.load`.** That waits for every sub-resource, including the `<CodeRunner>` example iframes embedded on doc pages, so the banner and the first page_view were delayed by seconds on the highest-traffic pages. Now starts on `DOMContentLoaded` plus the existing two-frame defer. Hydration timing no longer matters here: the modal classes are already mirrored onto `<body>` and the preferences trigger is delegated from the document, which is why waiting for a fully settled DOM was needed in the first place.

Also fixed: withdrawing consent after gtag.js had loaded left it reporting, since the injected script cannot be removed. It now gets `analytics_storage: 'denied'` and route reporting stops.

### Deliberately not changed

- **The consent gate.** Analytics off by default, gtag.js not fetched until acceptance, production only, `autoClear` on `_ga*`. That matches `/enterprise/privacy` and is the right posture for UK/EU. Rejecting visitors being invisible is the cost of that choice, not a bug. Loading gtag with Consent Mode defaults instead would change that, but it is a policy decision, not a fix.
- **`revision` is unset**, so it defaults to `0`. The file header says the revision must stay identical to the consent manager in the licensing app, which is a separate repo. If that side declares a non-zero revision, every visitor who accepted there is treated as having invalid consent here, gets re-prompted, and `acceptedCategory('analytics')` returns false until they accept again. Worth checking, along with the category names. Not changed here because a wrong value invalidates everyone's stored consent and re-prompts the whole site.

### Follow-up outside this repo

If the GA4 data stream has enhanced measurement "page changes based on browser history events" enabled, it will now double-count SPA navigations alongside the manual `page_view` above. That setting should be turned off, which is the same requirement the built-in gtag plugin had.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling

## Affected packages

- [ ] `dockview-core`
- [ ] `dockview` (vanilla JS)
- [ ] `dockview-react`
- [ ] `dockview-vue`
- [ ] `dockview-angular`
- [x] `docs`

## How to test

On a preview deploy (the gate is production-only, so `NODE_ENV=production` is required):

1. Accept analytics in the banner, then open GA4 DebugView. A `page_view` should arrive for the landing page. Before this change, nothing arrived at all.
2. Navigate between doc pages without a full reload. One `page_view` per navigation, with the correct `page_title` and `page_location`.
3. Click a heading anchor on a page. No extra `page_view`.
4. Open a doc page with a `<CodeRunner>` embed as a first visit. The banner should appear promptly rather than after the example iframes finish loading.
5. Withdraw analytics consent via the footer "Cookie settings". `_ga*` cookies are cleared and further navigation sends nothing.

## Checklist

- [ ] `yarn lint:fix` passes
- [ ] `yarn format` passes
- [ ] `npm run gen` has been run and generated files are up to date
- [ ] `yarn test` passes
- [ ] I have added or updated tests where applicable
- [ ] Breaking changes are documented

Boxes left unticked deliberately rather than assumed: `packages/docs` is excluded from biome and from Prettier / `nx format`, and there are no tests covering this module. Dependencies could not be installed in the environment this was written in, so the change is syntax-checked only and has not been run against a real build. Worth confirming in GA4 DebugView on a preview deploy before trusting the numbers.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ohwGk2nnHo6xyFfoCH6eF)_